### PR TITLE
feat: textDocument/hover for Laravel patterns + Blade variables

### DIFF
--- a/laravel-lsp/src/blade_props.rs
+++ b/laravel-lsp/src/blade_props.rs
@@ -1,0 +1,90 @@
+//! Extract `@props([...])` declarations from Blade view source.
+//!
+//! Hover uses this to surface the variables a view expects. The extractor
+//! is paren-balanced and string-aware so multi-line `@props([...])` blocks
+//! with embedded parentheses inside string keys/defaults are captured
+//! intact — for example:
+//!
+//! ```text
+//! @props([
+//!     'note' => 'something (with parens)',
+//!     'count' => 0,
+//! ])
+//! ```
+//!
+//! …returns the full multi-line declaration without truncation at the first
+//! `)` it sees.
+
+use std::path::Path;
+
+/// Read a Blade file and extract its first `@props([...])` declaration.
+/// Returns `None` when the file doesn't exist, can't be read, or has no
+/// `@props(...)` directive.
+///
+/// The returned string starts with `@props(` and ends with the matching
+/// `)` — multi-line declarations are preserved verbatim so the hover code
+/// block reads the same as the source.
+pub fn extract_props_directive(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    extract_props_directive_from_source(&content)
+}
+
+/// Source-only variant used for unit tests — operates on an in-memory
+/// string rather than reading from disk.
+pub fn extract_props_directive_from_source(content: &str) -> Option<String> {
+    let bytes = content.as_bytes();
+    let needle = b"@props";
+    let mut i = 0;
+    while i + needle.len() < bytes.len() {
+        if &bytes[i..i + needle.len()] != needle {
+            i += 1;
+            continue;
+        }
+        // Word boundary after `@props` — reject `@propsExtended` or similar.
+        let after = i + needle.len();
+        let mut j = after;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if j >= bytes.len() || bytes[j] != b'(' {
+            i = after;
+            continue;
+        }
+        // Paren-balance to find the matching `)`, tracking string literals
+        // so embedded `(` / `)` characters don't throw off the count.
+        let mut depth = 1i32;
+        let mut k = j + 1;
+        let mut in_string: Option<u8> = None;
+        while k < bytes.len() {
+            let b = bytes[k];
+            if let Some(q) = in_string {
+                if b == b'\\' && k + 1 < bytes.len() {
+                    k += 2;
+                    continue;
+                }
+                if b == q {
+                    in_string = None;
+                }
+                k += 1;
+                continue;
+            }
+            match b {
+                b'\'' | b'"' => in_string = Some(b),
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(content[i..=k].to_string());
+                    }
+                }
+                _ => {}
+            }
+            k += 1;
+        }
+        return None;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/blade_props/tests.rs
+++ b/laravel-lsp/src/blade_props/tests.rs
@@ -1,0 +1,74 @@
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn captures_single_line_declaration() {
+    let src = "<div>\n@props(['user' => null, 'showAvatar' => true])\n<h1>...</h1>\n</div>\n";
+    let got = extract_props_directive_from_source(src).expect("should find @props");
+    assert_eq!(got, "@props(['user' => null, 'showAvatar' => true])");
+}
+
+#[test]
+fn captures_multiline_declaration() {
+    let src = "@props([\n    'user' => null,\n    'showAvatar' => true,\n])\n<div></div>\n";
+    let got = extract_props_directive_from_source(src).expect("should find @props");
+    assert!(got.starts_with("@props(["));
+    assert!(got.ends_with("])"));
+    assert!(got.contains("'user' => null"));
+    assert!(got.contains("'showAvatar' => true"));
+}
+
+#[test]
+fn returns_none_when_directive_absent() {
+    let src = "<div>no props here</div>\n";
+    assert_eq!(extract_props_directive_from_source(src), None);
+}
+
+#[test]
+fn ignores_strings_containing_parens() {
+    // Embedded `(` / `)` inside a string literal must not throw off the
+    // paren balancer — we should capture all the way to the matching close.
+    let src = "@props(['note' => 'something (parens) inside', 'count' => 0])\n";
+    let got = extract_props_directive_from_source(src).expect("should find @props");
+    assert!(got.contains("'something (parens) inside'"));
+    assert!(got.ends_with("])"));
+}
+
+#[test]
+fn does_not_match_propsextended_substring() {
+    // `@propsExtended(...)` starts with `@props` but is a different directive.
+    // The word-boundary check should reject it.
+    let src = "@propsExtended(['x' => 1])\n@props(['y' => 2])\n";
+    let got = extract_props_directive_from_source(src).expect("should find @props");
+    assert!(got.contains("'y' => 2"));
+    assert!(
+        !got.contains("'x' => 1"),
+        "must not match @propsExtended: {}",
+        got
+    );
+}
+
+#[test]
+fn captures_first_directive_when_multiple_present() {
+    // A file can technically have multiple `@props` (rare, but possible
+    // across components). We only return the first.
+    let src = "@props(['a' => 1])\n@props(['b' => 2])\n";
+    let got = extract_props_directive_from_source(src).expect("should find @props");
+    assert!(got.contains("'a' => 1"));
+}
+
+#[test]
+fn reads_from_file() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("view.blade.php");
+    fs::write(&path, "@props(['user' => null])\n").unwrap();
+    let got = extract_props_directive(&path).expect("should find @props");
+    assert_eq!(got, "@props(['user' => null])");
+}
+
+#[test]
+fn returns_none_for_nonexistent_file() {
+    let nonexistent = std::path::PathBuf::from("/nonexistent/view.blade.php");
+    assert_eq!(extract_props_directive(&nonexistent), None);
+}

--- a/laravel-lsp/src/config_lookup.rs
+++ b/laravel-lsp/src/config_lookup.rs
@@ -1,0 +1,256 @@
+//! Resolve dotted Laravel config keys to their source-text values.
+//!
+//! `resolve_value(root, "app.name")` reads `config/app.php`, finds the
+//! `'name' => ...` entry in the returned array, and returns the source text
+//! of the value (e.g. `"env('APP_NAME', 'Laravel')"`).
+//!
+//! Nested keys recurse into nested array literals — `"database.connections.mysql.host"`
+//! walks through three levels of nesting. The resolver is deliberately
+//! conservative: when the path leads through something other than an array
+//! literal (a function-call result, a constant, an object), it returns `None`
+//! and the caller falls back to a less-specific hover.
+//!
+//! Pure parsing — no I/O outside the initial `read_to_string`. Easy to unit-test
+//! with synthetic PHP source.
+
+use std::path::Path;
+
+/// Resolve a dotted Laravel config key (`"app.name"`) against a project root.
+/// Returns the source text of the resolved value, trimmed of surrounding
+/// whitespace. `None` when the file or key is missing.
+pub fn resolve_value(root: &Path, dotted_key: &str) -> Option<String> {
+    let mut parts = dotted_key.split('.');
+    let file = parts.next()?;
+    let key_path: Vec<&str> = parts.collect();
+
+    let config_path = root.join("config").join(format!("{}.php", file));
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    resolve_in_source(&content, &key_path)
+}
+
+/// Source-only variant for unit tests — operates on a string rather than
+/// reading from disk.
+pub fn resolve_in_source(source: &str, key_path: &[&str]) -> Option<String> {
+    let bytes = source.as_bytes();
+    let array_open = find_return_array_open(bytes)?;
+    let raw = walk_path(bytes, array_open, key_path)?;
+    Some(raw.trim().to_string())
+}
+
+/// Locate the opening `[` of the `return [...];` literal at the top of a
+/// Laravel config file. Skips strings, line comments, and block comments so
+/// stray `return`s in docblocks or in strings don't confuse the search.
+fn find_return_array_open(bytes: &[u8]) -> Option<usize> {
+    let mut i = 0usize;
+    let mut in_string: Option<u8> = None;
+    while i < bytes.len() {
+        if let Some(quote) = in_string {
+            if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                i += 2;
+                continue;
+            }
+            if bytes[i] == quote {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        // Comments
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'/' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i = i.saturating_add(2);
+            continue;
+        }
+        // Strings
+        if bytes[i] == b'\'' || bytes[i] == b'"' {
+            in_string = Some(bytes[i]);
+            i += 1;
+            continue;
+        }
+        // Match `return` with word boundaries.
+        if i + 6 <= bytes.len() && &bytes[i..i + 6] == b"return" {
+            let before_ok = i == 0 || !is_identifier_byte(bytes[i - 1]);
+            let after_ok = i + 6 >= bytes.len() || !is_identifier_byte(bytes[i + 6]);
+            if before_ok && after_ok {
+                let mut j = i + 6;
+                while j < bytes.len() {
+                    let b = bytes[j];
+                    if b == b'[' {
+                        return Some(j + 1);
+                    }
+                    if b == b';' {
+                        return None;
+                    }
+                    j += 1;
+                }
+                return None;
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Walk down the key path within the array starting at byte `array_open`
+/// (which points to the first byte AFTER the opening `[`). Returns the raw
+/// source bytes of the matched value, untrimmed.
+fn walk_path(bytes: &[u8], array_open: usize, path: &[&str]) -> Option<String> {
+    if path.is_empty() {
+        return None;
+    }
+    let head = path[0];
+    let tail = &path[1..];
+    let mut i = array_open;
+
+    while i < bytes.len() {
+        skip_ws_and_comments(bytes, &mut i);
+        if i >= bytes.len() || bytes[i] == b']' {
+            return None;
+        }
+
+        let (key, after_key) = read_string_key(bytes, i)?;
+        i = after_key;
+        skip_ws_and_comments(bytes, &mut i);
+
+        if i + 2 > bytes.len() || &bytes[i..i + 2] != b"=>" {
+            return None;
+        }
+        i += 2;
+        skip_ws_and_comments(bytes, &mut i);
+
+        let value_start = i;
+        let value_end = read_value_end(bytes, i);
+
+        if key == head {
+            if tail.is_empty() {
+                let s = std::str::from_utf8(&bytes[value_start..value_end]).ok()?;
+                return Some(s.to_string());
+            }
+            // Recurse into a nested array literal.
+            let mut j = value_start;
+            skip_ws_and_comments(bytes, &mut j);
+            if j < bytes.len() && bytes[j] == b'[' {
+                return walk_path(bytes, j + 1, tail);
+            }
+            return None;
+        }
+
+        i = value_end;
+        if i < bytes.len() && bytes[i] == b',' {
+            i += 1;
+        }
+    }
+    None
+}
+
+/// Skip whitespace, `//` line comments, `/* */` block comments, and `#` shell
+/// comments. Advances `i` until the next significant byte.
+fn skip_ws_and_comments(bytes: &[u8], i: &mut usize) {
+    loop {
+        while *i < bytes.len() && bytes[*i].is_ascii_whitespace() {
+            *i += 1;
+        }
+        if *i + 1 < bytes.len() && bytes[*i] == b'/' && bytes[*i + 1] == b'/' {
+            while *i < bytes.len() && bytes[*i] != b'\n' {
+                *i += 1;
+            }
+            continue;
+        }
+        if *i + 1 < bytes.len() && bytes[*i] == b'/' && bytes[*i + 1] == b'*' {
+            *i += 2;
+            while *i + 1 < bytes.len() && !(bytes[*i] == b'*' && bytes[*i + 1] == b'/') {
+                *i += 1;
+            }
+            *i = i.saturating_add(2);
+            continue;
+        }
+        if *i < bytes.len() && bytes[*i] == b'#' {
+            while *i < bytes.len() && bytes[*i] != b'\n' {
+                *i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+}
+
+/// Parse a quoted string key at `start`. Returns the unescaped key and the
+/// byte offset just past the closing quote. `None` for non-string keys
+/// (integers, constants) — those aren't supported for hover lookup yet.
+fn read_string_key(bytes: &[u8], start: usize) -> Option<(String, usize)> {
+    if start >= bytes.len() {
+        return None;
+    }
+    let quote = bytes[start];
+    if quote != b'\'' && quote != b'"' {
+        return None;
+    }
+    let mut i = start + 1;
+    let mut out = String::new();
+    while i < bytes.len() && bytes[i] != quote {
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            out.push(bytes[i + 1] as char);
+            i += 2;
+            continue;
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    if i >= bytes.len() {
+        return None;
+    }
+    Some((out, i + 1))
+}
+
+/// Find the byte offset where the current value ends — at the next `,` or `]`
+/// at depth 0, skipping over nested parens/brackets/braces and string literals.
+fn read_value_end(bytes: &[u8], start: usize) -> usize {
+    let mut i = start;
+    let mut depth = 0i32;
+    let mut in_string: Option<u8> = None;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(quote) = in_string {
+            if b == b'\\' && i + 1 < bytes.len() {
+                i += 2;
+                continue;
+            }
+            if b == quote {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' | b'"' => in_string = Some(b),
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b'}' => depth -= 1,
+            b']' => {
+                if depth == 0 {
+                    return i;
+                }
+                depth -= 1;
+            }
+            b',' if depth == 0 => return i,
+            _ => {}
+        }
+        i += 1;
+    }
+    i
+}
+
+fn is_identifier_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/config_lookup/tests.rs
+++ b/laravel-lsp/src/config_lookup/tests.rs
@@ -1,0 +1,163 @@
+use super::*;
+
+#[test]
+fn resolves_top_level_string_value() {
+    let src = r#"<?php
+return [
+    'name' => 'Laravel',
+    'env' => 'production',
+];
+"#;
+    assert_eq!(
+        resolve_in_source(src, &["name"]).as_deref(),
+        Some("'Laravel'")
+    );
+    assert_eq!(
+        resolve_in_source(src, &["env"]).as_deref(),
+        Some("'production'")
+    );
+}
+
+#[test]
+fn resolves_value_with_env_helper() {
+    let src = r#"<?php
+return [
+    'name' => env('APP_NAME', 'Laravel'),
+];
+"#;
+    assert_eq!(
+        resolve_in_source(src, &["name"]).as_deref(),
+        Some("env('APP_NAME', 'Laravel')")
+    );
+}
+
+#[test]
+fn resolves_double_quoted_key() {
+    let src = r#"<?php
+return [
+    "name" => "Laravel",
+];
+"#;
+    assert_eq!(
+        resolve_in_source(src, &["name"]).as_deref(),
+        Some("\"Laravel\"")
+    );
+}
+
+#[test]
+fn resolves_nested_two_levels() {
+    let src = r#"<?php
+return [
+    'from' => [
+        'address' => 'hello@example.com',
+        'name' => 'Example',
+    ],
+];
+"#;
+    assert_eq!(
+        resolve_in_source(src, &["from", "address"]).as_deref(),
+        Some("'hello@example.com'")
+    );
+    assert_eq!(
+        resolve_in_source(src, &["from", "name"]).as_deref(),
+        Some("'Example'")
+    );
+}
+
+#[test]
+fn resolves_nested_three_levels() {
+    let src = r#"<?php
+return [
+    'connections' => [
+        'mysql' => [
+            'host' => '127.0.0.1',
+            'port' => 3306,
+        ],
+    ],
+];
+"#;
+    assert_eq!(
+        resolve_in_source(src, &["connections", "mysql", "host"]).as_deref(),
+        Some("'127.0.0.1'")
+    );
+    assert_eq!(
+        resolve_in_source(src, &["connections", "mysql", "port"]).as_deref(),
+        Some("3306")
+    );
+}
+
+#[test]
+fn returns_none_for_missing_key() {
+    let src = "<?php\nreturn ['name' => 'Laravel'];\n";
+    assert_eq!(resolve_in_source(src, &["missing"]), None);
+}
+
+#[test]
+fn returns_none_when_path_passes_through_non_array() {
+    // 'name' resolves to a string, but we tried to drill into it as if it were an array.
+    let src = "<?php\nreturn ['name' => 'Laravel'];\n";
+    assert_eq!(resolve_in_source(src, &["name", "deeper"]), None);
+}
+
+#[test]
+fn skips_line_and_block_comments_before_return() {
+    let src = r#"<?php
+// This is a config file.
+/* Block comment with the word return inside.
+   Should not confuse the parser. */
+return [
+    'key' => 'value',
+];
+"#;
+    assert_eq!(resolve_in_source(src, &["key"]).as_deref(), Some("'value'"));
+}
+
+#[test]
+fn resolves_top_level_array_value() {
+    let src = r#"<?php
+return [
+    'providers' => [
+        Provider::class,
+    ],
+];
+"#;
+    let result = resolve_in_source(src, &["providers"]);
+    assert!(result.is_some(), "should return the inner array text");
+    assert!(
+        result.unwrap().contains("Provider::class"),
+        "should include the array contents"
+    );
+}
+
+#[test]
+fn returns_none_for_non_existent_file_when_resolving_via_root() {
+    use std::path::PathBuf;
+    let nonexistent = PathBuf::from("/nonexistent/path/to/laravel/project");
+    assert_eq!(resolve_value(&nonexistent, "app.name"), None);
+}
+
+#[test]
+fn handles_keys_with_dots_in_values() {
+    // The value 'foo.bar' contains a dot but is a single string — it should
+    // round-trip unchanged, and key splitting should not be confused.
+    let src = "<?php\nreturn ['x' => 'foo.bar.baz'];\n";
+    assert_eq!(
+        resolve_in_source(src, &["x"]).as_deref(),
+        Some("'foo.bar.baz'")
+    );
+}
+
+#[test]
+fn handles_escaped_quotes_in_key() {
+    // Backslash escapes inside the key — the parser must unescape so the key
+    // comparison succeeds.
+    let src = r#"<?php
+return [
+    'has\'quote' => 'matched',
+];
+"#;
+    assert_eq!(
+        resolve_in_source(src, &["has'quote"]).as_deref(),
+        Some("'matched'")
+    );
+}

--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -319,7 +319,7 @@ pub fn format_blade_variable(input: &BladeVariableHover<'_>) -> String {
         out.push_str(&t);
     }
     if let Some(src) = input.defined_in {
-        out.push_str(&format!("\n\nat `{}`", src));
+        out.push_str(&format!("\n\nat {}", src));
     }
     out
 }
@@ -420,7 +420,7 @@ fn finish(
         out.push_str(&c);
     }
     if let Some(s) = source_display {
-        out.push_str(&format!("\n\nat `{}`", s));
+        out.push_str(&format!("\n\nat {}", s));
     }
     if let Some(t) = trailer {
         out.push_str("\n\n");
@@ -435,6 +435,21 @@ fn missing_file_note(resolved_display_path: Option<&str>) -> Option<&'static str
         Some("*(file not found)*")
     } else {
         None
+    }
+}
+
+/// Build the markdown link string used for the `at <link>` source-line at
+/// the bottom of every hover. The label is the display path (relative to the
+/// project root, optionally with `:line`); the URL is a `file://` URI that
+/// Zed and other LSP clients resolve to "open this file at this line".
+///
+/// Caller is expected to pre-resolve the absolute file URL via
+/// [`tower_lsp::lsp_types::Url::from_file_path`] so percent-encoding for
+/// spaces and other URL-unsafe path bytes is handled correctly.
+pub fn source_link(display: &str, file_url: &str, line: Option<u32>) -> String {
+    match line {
+        Some(l) => format!("[`{}:{}`]({}#L{})", display, l, file_url, l),
+        None => format!("[`{}`]({})", display, file_url),
     }
 }
 

--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -1,0 +1,452 @@
+//! Hover content — pure formatters and a small dispatch enum.
+//!
+//! The LSP `hover()` handler delegates to this module after its Salsa lookups:
+//! caller-side code resolves whatever extra data is needed (file paths, env
+//! values, route definitions, property declarations) and hands it to one of
+//! the `format_*` functions here. Formatters are pure — given the same
+//! arguments they always produce the same markdown.
+//!
+//! The [`HoverTarget`] enum lets `Backend::hover()` route both Salsa-indexed
+//! Laravel patterns and ad-hoc Blade variables through a single dispatch
+//! point. Blade variables aren't part of [`crate::salsa_impl::PatternAtPosition`]
+//! because they're identified by line scanning rather than by Salsa
+//! extraction, but functionally they're the same kind of "thing the cursor is
+//! sitting on" — modelling them as peer variants of the same enum keeps the
+//! handler honest.
+//!
+//! # Output format
+//!
+//! Every hover follows the intelephense-style layout: a **bold header line**
+//! naming the construct, an optional description paragraph, an optional code
+//! block showing the actual declaration / value, optional rendered PHPDoc
+//! tags, and an ``at `path:line` `` bottom-line source reference. This
+//! matches what `intelephense` itself produces in Zed for PHP language
+//! constructs, so the two sets of hovers feel consistent next to each other.
+
+use crate::livewire_resolver::extract_blade_variable_at_cursor;
+use crate::php_class::PropertyDeclaration;
+use crate::route_discovery::RouteDefinition;
+use crate::salsa_impl::{ParsedPatternsData, PatternAtPosition};
+
+/// Anything the cursor might be hovering. Pattern variants come straight from
+/// the Salsa position index; the Blade-variable variant is extracted by line
+/// scanning, and only matters in `.blade.php` files.
+pub enum HoverTarget {
+    Pattern(PatternAtPosition),
+    BladeVariable {
+        var_name: String,
+        property: Option<String>,
+    },
+}
+
+/// Decide what (if anything) the cursor is on. Patterns take precedence;
+/// Blade-variable extraction is only attempted on Blade files when no pattern
+/// matched. Returns `None` when neither lookup finds something hoverable.
+pub fn find_hover_target(
+    patterns: &ParsedPatternsData,
+    line_text: &str,
+    line: u32,
+    column: u32,
+    is_blade: bool,
+) -> Option<HoverTarget> {
+    if let Some(p) = patterns.find_at_position(line, column) {
+        return Some(HoverTarget::Pattern(p));
+    }
+    if is_blade {
+        if let Some((var_name, property)) = extract_blade_variable_at_cursor(line_text, column) {
+            return Some(HoverTarget::BladeVariable { var_name, property });
+        }
+    }
+    None
+}
+
+// ============================================================================
+// Laravel-pattern formatters
+//
+// All Laravel constructs use the same shape:
+//
+//   **<call-site form>**
+//
+//   <optional value / signature line — inline markdown or php code fence>
+//
+//   at `<source path>[:line]`
+//
+// `<call-site form>` is what you'd literally type in PHP/Blade to reference
+// the thing — `view('users.profile')`, `route('users.show')`, `<x-button>`,
+// `__('validation.required')`. Matches intelephense's "show the user what
+// they're hovering, formatted the way they'd write it."
+// ============================================================================
+
+/// Hover for a view reference.
+pub fn format_view(name: &str, resolved_display_path: Option<&str>) -> String {
+    let header = format!("**view('{}')**", name);
+    finish(
+        &header,
+        None,
+        None,
+        resolved_display_path,
+        missing_file_note(resolved_display_path),
+    )
+}
+
+/// Hover for a Blade component reference. `tag_name` already carries the
+/// `x-` prefix as captured by the tree-sitter query — do not re-add it.
+pub fn format_component(tag_name: &str, resolved_display_path: Option<&str>) -> String {
+    let header = format!("**`<{}>`**", tag_name);
+    finish(
+        &header,
+        None,
+        None,
+        resolved_display_path,
+        missing_file_note(resolved_display_path),
+    )
+}
+
+/// Hover for a Livewire component reference.
+pub fn format_livewire(name: &str, resolved_display_path: Option<&str>) -> String {
+    let header = format!("**`<livewire:{}>`**", name);
+    finish(
+        &header,
+        None,
+        None,
+        resolved_display_path,
+        missing_file_note(resolved_display_path),
+    )
+}
+
+/// Hover for a route reference. `source_display` is the relative path of the
+/// file containing the `->name(...)` callsite, optionally `:line` suffix.
+pub fn format_route(
+    name: &str,
+    def: Option<&RouteDefinition>,
+    source_display: Option<&str>,
+) -> String {
+    let header = format!("**route('{}')**", name);
+    let Some(d) = def else {
+        return finish(
+            &header,
+            None,
+            None,
+            None,
+            Some("*(route not found in index)*"),
+        );
+    };
+    let method = d
+        .method
+        .as_deref()
+        .map(|m| m.to_uppercase())
+        .unwrap_or_else(|| "?".to_string());
+    let uri = d.uri.as_deref().unwrap_or("?");
+    let action = d.action.as_deref().unwrap_or("?");
+    let detail = format!("`{} {}` → `{}`", method, uri, action);
+    finish(&header, Some(detail), None, source_display, None)
+}
+
+/// Hover for a `config('app.name')` reference. Resolved value is shown as a
+/// PHP code block (most config values are PHP expressions like
+/// `env('APP_NAME', 'Laravel')`).
+pub fn format_config(key: &str, resolved_value: Option<&str>, source_file: Option<&str>) -> String {
+    let header = format!("**config('{}')**", key);
+    let code = resolved_value.map(|v| php_block(truncate_for_display(v, 200).as_str()));
+    let trailer = if resolved_value.is_none() {
+        Some("*(value not found)*")
+    } else {
+        None
+    };
+    finish(&header, None, code, source_file, trailer)
+}
+
+/// Hover for an `env('APP_NAME')` reference. The value is shown as a plain
+/// (no-language) code block since `.env` values are literal strings.
+pub fn format_env(name: &str, env_var: Option<EnvHoverInput<'_>>) -> String {
+    let header = format!("**env('{}')**", name);
+    match env_var {
+        Some(EnvHoverInput {
+            is_commented: true,
+            source_file,
+            ..
+        }) => finish(
+            &header,
+            Some("*(commented out)*".to_string()),
+            None,
+            source_file,
+            None,
+        ),
+        Some(EnvHoverInput {
+            value, source_file, ..
+        }) => {
+            let code = plain_block(value);
+            finish(&header, None, Some(code), source_file, None)
+        }
+        None => finish(&header, None, None, None, Some("*(not defined in .env)*")),
+    }
+}
+
+/// Lightweight view over an env-var record — just the fields hover cares about.
+/// Avoids coupling [`format_env`] to any particular struct in the salsa layer.
+#[derive(Debug, Clone, Copy)]
+pub struct EnvHoverInput<'a> {
+    pub value: &'a str,
+    pub is_commented: bool,
+    /// The .env file the value was read from (`.env`, `.env.local`, etc.) —
+    /// rendered as a display-friendly path. `None` to omit the source line.
+    pub source_file: Option<&'a str>,
+}
+
+/// Hover for a `__('validation.required')` / `__('Welcome')` reference. The
+/// translated string is rendered as a plain code block — it's content, not
+/// PHP code.
+pub fn format_translation(
+    key: &str,
+    resolved_value: Option<&str>,
+    source_file: Option<&str>,
+) -> String {
+    let header = format!("**__('{}')**", key);
+    let code = resolved_value.map(|v| {
+        // Strip outer quotes from the PHP-literal representation
+        // (`'foo'` → `foo`) for nicer in-block display.
+        let v = v.trim();
+        let unquoted = v
+            .strip_prefix('\'')
+            .and_then(|s| s.strip_suffix('\''))
+            .or_else(|| v.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
+            .unwrap_or(v);
+        plain_block(&truncate_for_display(unquoted, 200))
+    });
+    let trailer = if resolved_value.is_none() {
+        Some("*(translation not found for default locale)*")
+    } else {
+        None
+    };
+    finish(&header, None, code, source_file, trailer)
+}
+
+/// Hover for a `->middleware('auth')` reference. `class_fqn` is the fully
+/// qualified class name behind the alias.
+pub fn format_middleware(
+    alias: &str,
+    class_fqn: Option<&str>,
+    source_file: Option<&str>,
+) -> String {
+    let header = format!("**middleware('{}')**", alias);
+    let code = class_fqn.map(php_block);
+    let trailer = if class_fqn.is_none() {
+        Some("*(alias not registered)*")
+    } else {
+        None
+    };
+    finish(&header, None, code, source_file, trailer)
+}
+
+/// Hover for an `app('cache')` / `App::make('cache')` reference. Concrete
+/// class shown as a PHP code block.
+pub fn format_binding(alias: &str, class_fqn: Option<&str>, source_file: Option<&str>) -> String {
+    let header = format!("**app('{}')**", alias);
+    let code = class_fqn.map(php_block);
+    let trailer = if class_fqn.is_none() {
+        Some("*(binding not registered)*")
+    } else {
+        None
+    };
+    finish(&header, None, code, source_file, trailer)
+}
+
+/// Hover for an asset reference — `asset('css/app.css')`,
+/// `Vite::asset('resources/js/app.js')`, `mix('app.css')`, `public_path('x')`,
+/// etc. `helper_label` is the user-facing function/method call form so the
+/// bold header reads like what the developer wrote.
+pub fn format_asset(path: &str, helper_label: &str, resolved_display_path: Option<&str>) -> String {
+    let header = format!("**{}('{}')**", helper_label, path);
+    finish(
+        &header,
+        None,
+        None,
+        resolved_display_path,
+        missing_file_note(resolved_display_path),
+    )
+}
+
+/// Hover for a `url('/path')` reference. Resolves relative to `public/`.
+pub fn format_url(path: &str, resolved_display_path: Option<&str>) -> String {
+    let header = format!("**url('{}')**", path);
+    finish(
+        &header,
+        None,
+        None,
+        resolved_display_path,
+        missing_file_note(resolved_display_path),
+    )
+}
+
+// ============================================================================
+// Blade variable formatter — the intelephense-style flagship
+// ============================================================================
+
+/// Hover for a Blade variable reference (`$user`, `$user->email`). Renders in
+/// intelephense's hover style: bold `Class::$prop` header, PHPDoc description
+/// paragraph, ```php block with the actual declaration line, then PHPDoc tag
+/// lines (when present), then source location.
+///
+/// Falls back to simpler shapes when class-side data isn't available.
+pub fn format_blade_variable(input: &BladeVariableHover<'_>) -> String {
+    let header = blade_variable_header(input);
+    let description = input.declaration.and_then(|d| d.description.clone());
+    let code = input.declaration.map(|d| php_block(&d.declaration_text));
+
+    let mut tags_section: Option<String> = None;
+    if let Some(decl) = input.declaration {
+        if !decl.phpdoc_tags.is_empty() {
+            let lines: Vec<String> = decl
+                .phpdoc_tags
+                .iter()
+                .map(|t| format!("*{}*", t))
+                .collect();
+            tags_section = Some(lines.join("\n\n"));
+        }
+    }
+
+    let mut out = header;
+    if let Some(d) = description {
+        out.push_str("\n\n");
+        out.push_str(&d);
+    }
+    if let Some(c) = code {
+        out.push_str("\n\n");
+        out.push_str(&c);
+    }
+    if let Some(t) = tags_section {
+        out.push_str("\n\n");
+        out.push_str(&t);
+    }
+    if let Some(src) = input.defined_in {
+        out.push_str(&format!("\n\nat `{}`", src));
+    }
+    out
+}
+
+/// Caller-supplied inputs for [`format_blade_variable`]. Building a struct
+/// rather than threading six positional `Option<&str>` arguments through.
+#[derive(Debug, Default)]
+pub struct BladeVariableHover<'a> {
+    pub var_name: &'a str,
+    pub property: Option<&'a str>,
+    /// Resolved variable type — class FQN (e.g. `App\Models\User`) or a
+    /// primitive type name (`mixed`, `string`). [`is_class_like_type`]
+    /// disambiguates.
+    pub var_type: Option<&'a str>,
+    /// Property declaration + PHPDoc, when the variable's type resolved to a
+    /// class and we could find the property on it.
+    pub declaration: Option<&'a PropertyDeclaration>,
+    /// Display path of the defining file (relative to project root,
+    /// optionally with `:line` suffix).
+    pub defined_in: Option<&'a str>,
+}
+
+/// Build the bold header line for a Blade variable hover. Picks between
+/// class-qualified (`**App\Models\User::$email**`) and `$var->prop`
+/// (`**$user->email**`) forms based on whether we have a class-like parent
+/// type to qualify with.
+fn blade_variable_header(input: &BladeVariableHover<'_>) -> String {
+    match (input.var_type, input.property) {
+        // Have both a class-like parent and a property — intelephense shape.
+        (Some(class), Some(prop)) if is_class_like_type(class) => {
+            format!("**{}::${}**", class, prop)
+        }
+        // Property access but parent is a primitive / unknown — fall back to
+        // `$var->prop` form. Avoids weird strings like `mixed::$prop`.
+        (_, Some(prop)) => format!("**$`{}->{}`**", input.var_name, prop),
+        // No property, class-like type known — render as a typed variable.
+        (Some(class), None) if is_class_like_type(class) => {
+            format!("**${}** : `{}`", input.var_name, class)
+        }
+        // No property, primitive type — show the type next to the variable.
+        (Some(prim), None) => format!("**${}** : `{}`", input.var_name, prim),
+        // Bare variable, no type info.
+        (None, None) => format!("**${}**", input.var_name),
+    }
+}
+
+/// Heuristic: a type string represents a class (rather than a PHP primitive)
+/// if it contains a namespace separator OR its first character is an
+/// uppercase ASCII letter. Catches `App\Models\User`, `Carbon`, `Collection`
+/// while excluding `mixed`, `string`, `int`, `?int`, `null`, etc.
+///
+/// `pub` because the LSP server uses this predicate to decide whether to
+/// run a `find_php_class_file` lookup on a resolved variable type — calling
+/// it for primitive sentinels like `"mixed"` always misses.
+pub fn is_class_like_type(t: &str) -> bool {
+    let t = t.trim_start_matches('?').trim_start_matches('\\');
+    if t.contains('\\') {
+        return true;
+    }
+    t.chars()
+        .next()
+        .map(|c| c.is_ascii_uppercase())
+        .unwrap_or(false)
+}
+
+// ============================================================================
+// Internals — code blocks, finish-assembly, truncation
+// ============================================================================
+
+/// PHP-tagged fenced code block. Zed renders these with PHP syntax
+/// highlighting in hover.
+fn php_block(content: &str) -> String {
+    format!("```php\n{}\n```", content)
+}
+
+/// Plain (no-language) fenced code block. Use for raw values where PHP
+/// syntax highlighting would be misleading (env values, translated strings).
+fn plain_block(content: &str) -> String {
+    format!("```\n{}\n```", content)
+}
+
+/// Assemble the standard Laravel-pattern hover shape:
+/// header / [detail-line] / [code-block] / [at-path] / [trailer].
+fn finish(
+    header: &str,
+    detail: Option<String>,
+    code: Option<String>,
+    source_display: Option<&str>,
+    trailer: Option<&str>,
+) -> String {
+    let mut out = header.to_string();
+    if let Some(d) = detail {
+        out.push_str("\n\n");
+        out.push_str(&d);
+    }
+    if let Some(c) = code {
+        out.push_str("\n\n");
+        out.push_str(&c);
+    }
+    if let Some(s) = source_display {
+        out.push_str(&format!("\n\nat `{}`", s));
+    }
+    if let Some(t) = trailer {
+        out.push_str("\n\n");
+        out.push_str(t);
+    }
+    out
+}
+
+/// Standard `*(file not found)*` trailer when no resolved path was available.
+fn missing_file_note(resolved_display_path: Option<&str>) -> Option<&'static str> {
+    if resolved_display_path.is_none() {
+        Some("*(file not found)*")
+    } else {
+        None
+    }
+}
+
+/// Truncate strings longer than `limit` chars with a `…` ellipsis. Operates
+/// on chars (not bytes) so it never splits a multibyte character.
+fn truncate_for_display(s: &str, limit: usize) -> String {
+    if s.chars().count() <= limit {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(limit).collect();
+    format!("{}…", head)
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -77,13 +77,21 @@ pub fn find_hover_target(
 // they're hovering, formatted the way they'd write it."
 // ============================================================================
 
-/// Hover for a view reference.
-pub fn format_view(name: &str, resolved_display_path: Option<&str>) -> String {
+/// Hover for a view reference. `snippet` is an optional excerpt from the
+/// resolved view file (typically the `@props([...])` declaration) — when
+/// provided, rendered as a ```php fenced block above the source line so the
+/// reader can see at-a-glance what variables the view expects.
+pub fn format_view(
+    name: &str,
+    resolved_display_path: Option<&str>,
+    snippet: Option<&str>,
+) -> String {
     let header = format!("**view('{}')**", name);
+    let code = snippet.map(php_block);
     finish(
         &header,
         None,
-        None,
+        code,
         resolved_display_path,
         missing_file_note(resolved_display_path),
     )
@@ -91,35 +99,51 @@ pub fn format_view(name: &str, resolved_display_path: Option<&str>) -> String {
 
 /// Hover for a Blade component reference. `tag_name` already carries the
 /// `x-` prefix as captured by the tree-sitter query — do not re-add it.
-pub fn format_component(tag_name: &str, resolved_display_path: Option<&str>) -> String {
+/// `snippet` mirrors [`format_view`]: typically the `@props([...])` line.
+pub fn format_component(
+    tag_name: &str,
+    resolved_display_path: Option<&str>,
+    snippet: Option<&str>,
+) -> String {
     let header = format!("**`<{}>`**", tag_name);
+    let code = snippet.map(php_block);
     finish(
         &header,
         None,
-        None,
+        code,
         resolved_display_path,
         missing_file_note(resolved_display_path),
     )
 }
 
-/// Hover for a Livewire component reference.
-pub fn format_livewire(name: &str, resolved_display_path: Option<&str>) -> String {
+/// Hover for a Livewire component reference. `snippet` is typically the
+/// `class Foo extends Component` signature line so the reader sees the
+/// component class without leaving the hover.
+pub fn format_livewire(
+    name: &str,
+    resolved_display_path: Option<&str>,
+    snippet: Option<&str>,
+) -> String {
     let header = format!("**`<livewire:{}>`**", name);
+    let code = snippet.map(php_block);
     finish(
         &header,
         None,
-        None,
+        code,
         resolved_display_path,
         missing_file_note(resolved_display_path),
     )
 }
 
-/// Hover for a route reference. `source_display` is the relative path of the
-/// file containing the `->name(...)` callsite, optionally `:line` suffix.
+/// Hover for a route reference. `source_display` is the markdown link for
+/// the file:line of the `->name(...)` callsite. `snippet` is typically the
+/// actual `Route::verb(...)->name(...)` source line — rendered as a ```php
+/// block above the source line.
 pub fn format_route(
     name: &str,
     def: Option<&RouteDefinition>,
     source_display: Option<&str>,
+    snippet: Option<&str>,
 ) -> String {
     let header = format!("**route('{}')**", name);
     let Some(d) = def else {
@@ -139,7 +163,8 @@ pub fn format_route(
     let uri = d.uri.as_deref().unwrap_or("?");
     let action = d.action.as_deref().unwrap_or("?");
     let detail = format!("`{} {}` → `{}`", method, uri, action);
-    finish(&header, Some(detail), None, source_display, None)
+    let code = snippet.map(php_block);
+    finish(&header, Some(detail), code, source_display, None)
 }
 
 /// Hover for a `config('app.name')` reference. Resolved value is shown as a

--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -1,31 +1,39 @@
-//! Hover content — pure formatters and a small dispatch enum.
+//! Hover content — a single rendering template plus the dispatch enum.
 //!
 //! The LSP `hover()` handler delegates to this module after its Salsa lookups:
-//! caller-side code resolves whatever extra data is needed (file paths, env
-//! values, route definitions, property declarations) and hands it to one of
-//! the `format_*` functions here. Formatters are pure — given the same
-//! arguments they always produce the same markdown.
+//! caller-side code resolves whatever data each pattern needs (file paths,
+//! env values, route definitions, property declarations, class FQNs) and
+//! hands them to [`render`] via a [`HoverContent`] struct. Sections of the
+//! template that aren't supplied are simply omitted — the same template
+//! covers every pattern (view, route, env, Blade variable on property, …)
+//! purely by which fields the caller populates.
+//!
+//! Earlier revisions had per-pattern `format_*` functions; that was overkill
+//! since the visual style is uniform across patterns. Pattern variation
+//! lives entirely in *what data we pass*, not *how it renders*.
 //!
 //! The [`HoverTarget`] enum lets `Backend::hover()` route both Salsa-indexed
-//! Laravel patterns and ad-hoc Blade variables through a single dispatch
-//! point. Blade variables aren't part of [`crate::salsa_impl::PatternAtPosition`]
-//! because they're identified by line scanning rather than by Salsa
-//! extraction, but functionally they're the same kind of "thing the cursor is
-//! sitting on" — modelling them as peer variants of the same enum keeps the
-//! handler honest.
+//! Laravel patterns and ad-hoc Blade variables through one dispatch.
 //!
-//! # Output format
+//! # Template
 //!
-//! Every hover follows the intelephense-style layout: a **bold header line**
-//! naming the construct, an optional description paragraph, an optional code
-//! block showing the actual declaration / value, optional rendered PHPDoc
-//! tags, and an ``at `path:line` `` bottom-line source reference. This
-//! matches what `intelephense` itself produces in Zed for PHP language
-//! constructs, so the two sets of hovers feel consistent next to each other.
+//! Sections, rendered in order with `\n\n` separators (paragraph breaks in
+//! markdown). Each section is omitted entirely when absent:
+//!
+//! 1. **Bold header** — typically a fully-qualified class name. Wrap-free
+//!    text; [`render`] adds the `**…**` markdown.
+//! 2. **Detail line** — short inline markdown beneath the header
+//!    (e.g. `` `GET /uri` → `Controller@show` ``).
+//! 3. **Description** — a paragraph of prose (PHPDoc summary, etc.).
+//! 4. **Code block** — fenced code with language hint. PHP-tagged blocks get
+//!    the `<?php` opener prepended so Zed's `tree-sitter-php` grammar can
+//!    parse them (the standard grammar variant requires the opening tag).
+//! 5. **Tag lines** — one italic line per PHPDoc tag (`@param`, `@return`).
+//! 6. **Source link** — markdown link to the source location, rendered
+//!    verbatim (no prefix, no extra backticks; caller builds the link).
+//! 7. **Trailer** — italic note like `*(file not found)*`.
 
 use crate::livewire_resolver::extract_blade_variable_at_cursor;
-use crate::php_class::PropertyDeclaration;
-use crate::route_discovery::RouteDefinition;
 use crate::salsa_impl::{ParsedPatternsData, PatternAtPosition};
 
 /// Anything the cursor might be hovering. Pattern variants come straight from
@@ -61,335 +69,96 @@ pub fn find_hover_target(
 }
 
 // ============================================================================
-// Laravel-pattern formatters
-//
-// All Laravel constructs use the same shape:
-//
-//   **<call-site form>**
-//
-//   <optional value / signature line — inline markdown or php code fence>
-//
-//   at `<source path>[:line]`
-//
-// `<call-site form>` is what you'd literally type in PHP/Blade to reference
-// the thing — `view('users.profile')`, `route('users.show')`, `<x-button>`,
-// `__('validation.required')`. Matches intelephense's "show the user what
-// they're hovering, formatted the way they'd write it."
+// The unified template
 // ============================================================================
 
-/// Hover for a view reference. `snippet` is an optional excerpt from the
-/// resolved view file (typically the `@props([...])` declaration) — when
-/// provided, rendered as a ```php fenced block above the source line so the
-/// reader can see at-a-glance what variables the view expects.
-pub fn format_view(
-    name: &str,
-    resolved_display_path: Option<&str>,
-    snippet: Option<&str>,
-) -> String {
-    let header = format!("**view('{}')**", name);
-    let code = snippet.map(php_block);
-    finish(
-        &header,
-        None,
-        code,
-        resolved_display_path,
-        missing_file_note(resolved_display_path),
-    )
+/// All data a hover can carry. Every field is optional — [`render`] omits
+/// any section whose field is `None` / empty. Build one of these per
+/// pattern at the dispatch site and call [`render`].
+#[derive(Debug, Default, Clone)]
+pub struct HoverContent<'a> {
+    /// Bold header — typically a fully-qualified class name
+    /// (e.g. `App\Livewire\Counter`). `**…**` wrapping is added by render.
+    pub header: Option<&'a str>,
+    /// Detail line under the header. Free-form inline markdown.
+    pub detail: Option<&'a str>,
+    /// Free-form description paragraph (e.g. PHPDoc summary).
+    pub description: Option<&'a str>,
+    /// Fenced code block with language hint.
+    pub code: Option<CodeBlock<'a>>,
+    /// Italic tag lines (`@param`, `@return`, `@throws`).
+    pub tags: &'a [String],
+    /// Pre-built markdown link string for the source location (e.g.
+    /// `[app/Models/User.php:42](file:///abs/path)`). Rendered verbatim
+    /// — no `at` prefix, no surrounding backticks.
+    pub source_link: Option<&'a str>,
+    /// Italic trailer (`*(file not found)*`, `*(commented out)*`).
+    pub trailer: Option<&'a str>,
 }
 
-/// Hover for a Blade component reference. `tag_name` already carries the
-/// `x-` prefix as captured by the tree-sitter query — do not re-add it.
-/// `snippet` mirrors [`format_view`]: typically the `@props([...])` line.
-pub fn format_component(
-    tag_name: &str,
-    resolved_display_path: Option<&str>,
-    snippet: Option<&str>,
-) -> String {
-    let header = format!("**`<{}>`**", tag_name);
-    let code = snippet.map(php_block);
-    finish(
-        &header,
-        None,
-        code,
-        resolved_display_path,
-        missing_file_note(resolved_display_path),
-    )
-}
-
-/// Hover for a Livewire component reference. `snippet` is typically the
-/// `class Foo extends Component` signature line so the reader sees the
-/// component class without leaving the hover.
-pub fn format_livewire(
-    name: &str,
-    resolved_display_path: Option<&str>,
-    snippet: Option<&str>,
-) -> String {
-    let header = format!("**`<livewire:{}>`**", name);
-    let code = snippet.map(php_block);
-    finish(
-        &header,
-        None,
-        code,
-        resolved_display_path,
-        missing_file_note(resolved_display_path),
-    )
-}
-
-/// Hover for a route reference. `source_display` is the markdown link for
-/// the file:line of the `->name(...)` callsite. `snippet` is typically the
-/// actual `Route::verb(...)->name(...)` source line — rendered as a ```php
-/// block above the source line.
-pub fn format_route(
-    name: &str,
-    def: Option<&RouteDefinition>,
-    source_display: Option<&str>,
-    snippet: Option<&str>,
-) -> String {
-    let header = format!("**route('{}')**", name);
-    let Some(d) = def else {
-        return finish(
-            &header,
-            None,
-            None,
-            None,
-            Some("*(route not found in index)*"),
-        );
-    };
-    let method = d
-        .method
-        .as_deref()
-        .map(|m| m.to_uppercase())
-        .unwrap_or_else(|| "?".to_string());
-    let uri = d.uri.as_deref().unwrap_or("?");
-    let action = d.action.as_deref().unwrap_or("?");
-    let detail = format!("`{} {}` → `{}`", method, uri, action);
-    let code = snippet.map(php_block);
-    finish(&header, Some(detail), code, source_display, None)
-}
-
-/// Hover for a `config('app.name')` reference. Resolved value is shown as a
-/// PHP code block (most config values are PHP expressions like
-/// `env('APP_NAME', 'Laravel')`).
-pub fn format_config(key: &str, resolved_value: Option<&str>, source_file: Option<&str>) -> String {
-    let header = format!("**config('{}')**", key);
-    let code = resolved_value.map(|v| php_block(truncate_for_display(v, 200).as_str()));
-    let trailer = if resolved_value.is_none() {
-        Some("*(value not found)*")
-    } else {
-        None
-    };
-    finish(&header, None, code, source_file, trailer)
-}
-
-/// Hover for an `env('APP_NAME')` reference. The value is shown as a plain
-/// (no-language) code block since `.env` values are literal strings.
-pub fn format_env(name: &str, env_var: Option<EnvHoverInput<'_>>) -> String {
-    let header = format!("**env('{}')**", name);
-    match env_var {
-        Some(EnvHoverInput {
-            is_commented: true,
-            source_file,
-            ..
-        }) => finish(
-            &header,
-            Some("*(commented out)*".to_string()),
-            None,
-            source_file,
-            None,
-        ),
-        Some(EnvHoverInput {
-            value, source_file, ..
-        }) => {
-            let code = plain_block(value);
-            finish(&header, None, Some(code), source_file, None)
-        }
-        None => finish(&header, None, None, None, Some("*(not defined in .env)*")),
-    }
-}
-
-/// Lightweight view over an env-var record — just the fields hover cares about.
-/// Avoids coupling [`format_env`] to any particular struct in the salsa layer.
+/// A fenced code block. [`CodeLanguage::Php`] auto-prepends `<?php\n` so
+/// Zed's `tree-sitter-php` grammar (which requires the opening tag) parses
+/// the snippet and applies highlighting.
 #[derive(Debug, Clone, Copy)]
-pub struct EnvHoverInput<'a> {
-    pub value: &'a str,
-    pub is_commented: bool,
-    /// The .env file the value was read from (`.env`, `.env.local`, etc.) —
-    /// rendered as a display-friendly path. `None` to omit the source line.
-    pub source_file: Option<&'a str>,
+pub struct CodeBlock<'a> {
+    pub language: CodeLanguage,
+    pub content: &'a str,
 }
 
-/// Hover for a `__('validation.required')` / `__('Welcome')` reference. The
-/// translated string is rendered as a plain code block — it's content, not
-/// PHP code.
-pub fn format_translation(
-    key: &str,
-    resolved_value: Option<&str>,
-    source_file: Option<&str>,
-) -> String {
-    let header = format!("**__('{}')**", key);
-    let code = resolved_value.map(|v| {
-        // Strip outer quotes from the PHP-literal representation
-        // (`'foo'` → `foo`) for nicer in-block display.
-        let v = v.trim();
-        let unquoted = v
-            .strip_prefix('\'')
-            .and_then(|s| s.strip_suffix('\''))
-            .or_else(|| v.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
-            .unwrap_or(v);
-        plain_block(&truncate_for_display(unquoted, 200))
-    });
-    let trailer = if resolved_value.is_none() {
-        Some("*(translation not found for default locale)*")
-    } else {
-        None
-    };
-    finish(&header, None, code, source_file, trailer)
+#[derive(Debug, Clone, Copy)]
+pub enum CodeLanguage {
+    /// `php` fence with a `<?php\n` opener prepended.
+    Php,
+    /// Plain fence (no language tag) — for raw values, translated strings,
+    /// `.env` content where PHP highlighting would be misleading.
+    Plain,
 }
 
-/// Hover for a `->middleware('auth')` reference. `class_fqn` is the fully
-/// qualified class name behind the alias.
-pub fn format_middleware(
-    alias: &str,
-    class_fqn: Option<&str>,
-    source_file: Option<&str>,
-) -> String {
-    let header = format!("**middleware('{}')**", alias);
-    let code = class_fqn.map(php_block);
-    let trailer = if class_fqn.is_none() {
-        Some("*(alias not registered)*")
-    } else {
-        None
-    };
-    finish(&header, None, code, source_file, trailer)
-}
+/// Render a [`HoverContent`] into the final hover markdown. Sections are
+/// emitted in the documented order, joined with `\n\n`. Returns an empty
+/// string when every field is absent — caller should treat that as
+/// "no hover".
+pub fn render(content: &HoverContent<'_>) -> String {
+    let mut sections: Vec<String> = Vec::new();
 
-/// Hover for an `app('cache')` / `App::make('cache')` reference. Concrete
-/// class shown as a PHP code block.
-pub fn format_binding(alias: &str, class_fqn: Option<&str>, source_file: Option<&str>) -> String {
-    let header = format!("**app('{}')**", alias);
-    let code = class_fqn.map(php_block);
-    let trailer = if class_fqn.is_none() {
-        Some("*(binding not registered)*")
-    } else {
-        None
-    };
-    finish(&header, None, code, source_file, trailer)
-}
+    if let Some(h) = content.header {
+        sections.push(format!("**{}**", h));
+    }
+    if let Some(d) = content.detail {
+        sections.push(d.to_string());
+    }
+    if let Some(d) = content.description {
+        sections.push(d.to_string());
+    }
+    if let Some(code) = &content.code {
+        let block = match code.language {
+            CodeLanguage::Php => format!("```php\n<?php\n{}\n```", code.content),
+            CodeLanguage::Plain => format!("```\n{}\n```", code.content),
+        };
+        sections.push(block);
+    }
+    if !content.tags.is_empty() {
+        let tag_lines = content
+            .tags
+            .iter()
+            .map(|t| format!("*{}*", t))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        sections.push(tag_lines);
+    }
+    if let Some(link) = content.source_link {
+        sections.push(link.to_string());
+    }
+    if let Some(t) = content.trailer {
+        sections.push(t.to_string());
+    }
 
-/// Hover for an asset reference — `asset('css/app.css')`,
-/// `Vite::asset('resources/js/app.js')`, `mix('app.css')`, `public_path('x')`,
-/// etc. `helper_label` is the user-facing function/method call form so the
-/// bold header reads like what the developer wrote.
-pub fn format_asset(path: &str, helper_label: &str, resolved_display_path: Option<&str>) -> String {
-    let header = format!("**{}('{}')**", helper_label, path);
-    finish(
-        &header,
-        None,
-        None,
-        resolved_display_path,
-        missing_file_note(resolved_display_path),
-    )
-}
-
-/// Hover for a `url('/path')` reference. Resolves relative to `public/`.
-pub fn format_url(path: &str, resolved_display_path: Option<&str>) -> String {
-    let header = format!("**url('{}')**", path);
-    finish(
-        &header,
-        None,
-        None,
-        resolved_display_path,
-        missing_file_note(resolved_display_path),
-    )
+    sections.join("\n\n")
 }
 
 // ============================================================================
-// Blade variable formatter — the intelephense-style flagship
+// Caller utilities
 // ============================================================================
-
-/// Hover for a Blade variable reference (`$user`, `$user->email`). Renders in
-/// intelephense's hover style: bold `Class::$prop` header, PHPDoc description
-/// paragraph, ```php block with the actual declaration line, then PHPDoc tag
-/// lines (when present), then source location.
-///
-/// Falls back to simpler shapes when class-side data isn't available.
-pub fn format_blade_variable(input: &BladeVariableHover<'_>) -> String {
-    let header = blade_variable_header(input);
-    let description = input.declaration.and_then(|d| d.description.clone());
-    let code = input.declaration.map(|d| php_block(&d.declaration_text));
-
-    let mut tags_section: Option<String> = None;
-    if let Some(decl) = input.declaration {
-        if !decl.phpdoc_tags.is_empty() {
-            let lines: Vec<String> = decl
-                .phpdoc_tags
-                .iter()
-                .map(|t| format!("*{}*", t))
-                .collect();
-            tags_section = Some(lines.join("\n\n"));
-        }
-    }
-
-    let mut out = header;
-    if let Some(d) = description {
-        out.push_str("\n\n");
-        out.push_str(&d);
-    }
-    if let Some(c) = code {
-        out.push_str("\n\n");
-        out.push_str(&c);
-    }
-    if let Some(t) = tags_section {
-        out.push_str("\n\n");
-        out.push_str(&t);
-    }
-    if let Some(src) = input.defined_in {
-        out.push_str(&format!("\n\nat {}", src));
-    }
-    out
-}
-
-/// Caller-supplied inputs for [`format_blade_variable`]. Building a struct
-/// rather than threading six positional `Option<&str>` arguments through.
-#[derive(Debug, Default)]
-pub struct BladeVariableHover<'a> {
-    pub var_name: &'a str,
-    pub property: Option<&'a str>,
-    /// Resolved variable type — class FQN (e.g. `App\Models\User`) or a
-    /// primitive type name (`mixed`, `string`). [`is_class_like_type`]
-    /// disambiguates.
-    pub var_type: Option<&'a str>,
-    /// Property declaration + PHPDoc, when the variable's type resolved to a
-    /// class and we could find the property on it.
-    pub declaration: Option<&'a PropertyDeclaration>,
-    /// Display path of the defining file (relative to project root,
-    /// optionally with `:line` suffix).
-    pub defined_in: Option<&'a str>,
-}
-
-/// Build the bold header line for a Blade variable hover. Picks between
-/// class-qualified (`**App\Models\User::$email**`) and `$var->prop`
-/// (`**$user->email**`) forms based on whether we have a class-like parent
-/// type to qualify with.
-fn blade_variable_header(input: &BladeVariableHover<'_>) -> String {
-    match (input.var_type, input.property) {
-        // Have both a class-like parent and a property — intelephense shape.
-        (Some(class), Some(prop)) if is_class_like_type(class) => {
-            format!("**{}::${}**", class, prop)
-        }
-        // Property access but parent is a primitive / unknown — fall back to
-        // `$var->prop` form. Avoids weird strings like `mixed::$prop`.
-        (_, Some(prop)) => format!("**$`{}->{}`**", input.var_name, prop),
-        // No property, class-like type known — render as a typed variable.
-        (Some(class), None) if is_class_like_type(class) => {
-            format!("**${}** : `{}`", input.var_name, class)
-        }
-        // No property, primitive type — show the type next to the variable.
-        (Some(prim), None) => format!("**${}** : `{}`", input.var_name, prim),
-        // Bare variable, no type info.
-        (None, None) => format!("**${}**", input.var_name),
-    }
-}
 
 /// Heuristic: a type string represents a class (rather than a PHP primitive)
 /// if it contains a namespace separator OR its first character is an
@@ -410,77 +179,31 @@ pub fn is_class_like_type(t: &str) -> bool {
         .unwrap_or(false)
 }
 
-// ============================================================================
-// Internals — code blocks, finish-assembly, truncation
-// ============================================================================
-
-/// PHP-tagged fenced code block. Zed renders these with PHP syntax
-/// highlighting in hover.
-fn php_block(content: &str) -> String {
-    format!("```php\n{}\n```", content)
-}
-
-/// Plain (no-language) fenced code block. Use for raw values where PHP
-/// syntax highlighting would be misleading (env values, translated strings).
-fn plain_block(content: &str) -> String {
-    format!("```\n{}\n```", content)
-}
-
-/// Assemble the standard Laravel-pattern hover shape:
-/// header / [detail-line] / [code-block] / [at-path] / [trailer].
-fn finish(
-    header: &str,
-    detail: Option<String>,
-    code: Option<String>,
-    source_display: Option<&str>,
-    trailer: Option<&str>,
-) -> String {
-    let mut out = header.to_string();
-    if let Some(d) = detail {
-        out.push_str("\n\n");
-        out.push_str(&d);
-    }
-    if let Some(c) = code {
-        out.push_str("\n\n");
-        out.push_str(&c);
-    }
-    if let Some(s) = source_display {
-        out.push_str(&format!("\n\nat {}", s));
-    }
-    if let Some(t) = trailer {
-        out.push_str("\n\n");
-        out.push_str(t);
-    }
-    out
-}
-
-/// Standard `*(file not found)*` trailer when no resolved path was available.
-fn missing_file_note(resolved_display_path: Option<&str>) -> Option<&'static str> {
-    if resolved_display_path.is_none() {
-        Some("*(file not found)*")
-    } else {
-        None
-    }
-}
-
-/// Build the markdown link string used for the `at <link>` source-line at
-/// the bottom of every hover. The label is the display path (relative to the
-/// project root, optionally with `:line`); the URL is a `file://` URI that
-/// Zed and other LSP clients resolve to "open this file at this line".
+/// Build the markdown link string used for the bottom-line source location.
+/// The label is the display path (relative to the project root, optionally
+/// with `:line`); the URL is a `file://` URI that Zed resolves to "open
+/// this file at this line".
+///
+/// Label is rendered as plain markdown link text — NOT wrapped in backticks
+/// — so it doesn't pick up the inline-code background/styling and looks
+/// like a normal hyperlink.
 ///
 /// Caller is expected to pre-resolve the absolute file URL via
 /// [`tower_lsp::lsp_types::Url::from_file_path`] so percent-encoding for
 /// spaces and other URL-unsafe path bytes is handled correctly.
 pub fn source_link(display: &str, file_url: &str, line: Option<u32>) -> String {
     match line {
-        Some(l) => format!("[`{}:{}`]({}#L{})", display, l, file_url, l),
-        None => format!("[`{}`]({})", display, file_url),
+        Some(l) => format!("[{}:{}]({}#L{})", display, l, file_url, l),
+        None => format!("[{}]({})", display, file_url),
     }
 }
 
 /// Truncate strings longer than `limit` chars with a `…` ellipsis. Operates
 /// on chars (not bytes) so it never splits a multibyte character.
-fn truncate_for_display(s: &str, limit: usize) -> String {
+///
+/// Used by config/translation dispatch code to clip long resolved values
+/// before stuffing them into a code block.
+pub fn truncate_for_display(s: &str, limit: usize) -> String {
     if s.chars().count() <= limit {
         return s.to_string();
     }

--- a/laravel-lsp/src/hover/tests.rs
+++ b/laravel-lsp/src/hover/tests.rs
@@ -1,0 +1,408 @@
+use super::*;
+use crate::php_class::PropertyDeclaration;
+use crate::route_discovery::{RouteDefinition, PRIORITY_APP};
+use std::path::PathBuf;
+
+// All hovers share an intelephense-style shape:
+//   **<bold header — call form>**
+//   [optional detail / description]
+//   [optional fenced code block — value or declaration]
+//   at `<source path>`
+//   [optional *(trailer)*]
+//
+// Tests assert on user-visible substrings.
+
+// ============================================================================
+// View / component / Livewire
+// ============================================================================
+
+#[test]
+fn view_hover_uses_call_form_header() {
+    let out = format_view(
+        "users.profile",
+        Some("resources/views/users/profile.blade.php"),
+    );
+    assert!(out.contains("**view('users.profile')**"));
+    assert!(out.contains("at `resources/views/users/profile.blade.php`"));
+}
+
+#[test]
+fn view_hover_without_path_shows_missing_trailer() {
+    let out = format_view("users.missing", None);
+    assert!(out.contains("**view('users.missing')**"));
+    assert!(out.contains("*(file not found)*"));
+}
+
+#[test]
+fn component_hover_does_not_double_prefix() {
+    let out = format_component(
+        "x-button",
+        Some("resources/views/components/button.blade.php"),
+    );
+    assert!(out.contains("`<x-button>`"));
+    assert!(!out.contains("<x-x-"));
+}
+
+#[test]
+fn livewire_hover_uses_tag_form_header() {
+    let out = format_livewire("counter", Some("app/Livewire/Counter.php"));
+    assert!(out.contains("`<livewire:counter>`"));
+    assert!(out.contains("at `app/Livewire/Counter.php`"));
+}
+
+// ============================================================================
+// Route
+// ============================================================================
+
+fn route_def(method: &str, uri: &str, action: &str) -> RouteDefinition {
+    RouteDefinition {
+        file: PathBuf::from("/fake/routes/web.php"),
+        line: 0,
+        column: 0,
+        end_column: 0,
+        priority: PRIORITY_APP,
+        method: Some(method.to_string()),
+        uri: Some(uri.to_string()),
+        action: Some(action.to_string()),
+    }
+}
+
+#[test]
+fn route_hover_shows_method_uri_action() {
+    let def = route_def("get", "/users/{user}", "UserController@show");
+    let out = format_route("users.show", Some(&def), Some("routes/web.php:42"));
+    assert!(out.contains("**route('users.show')**"));
+    assert!(out.contains("`GET /users/{user}`"));
+    assert!(out.contains("`UserController@show`"));
+    assert!(out.contains("at `routes/web.php:42`"));
+}
+
+#[test]
+fn route_hover_handles_missing_index_entry() {
+    let out = format_route("orphan", None, None);
+    assert!(out.contains("**route('orphan')**"));
+    assert!(out.contains("*(route not found in index)*"));
+}
+
+// ============================================================================
+// Config
+// ============================================================================
+
+#[test]
+fn config_hover_shows_value_in_php_block() {
+    let out = format_config(
+        "app.name",
+        Some("env('APP_NAME', 'Laravel')"),
+        Some("config/app.php"),
+    );
+    assert!(out.contains("**config('app.name')**"));
+    assert!(out.contains("```php"));
+    assert!(out.contains("env('APP_NAME', 'Laravel')"));
+    assert!(out.contains("at `config/app.php`"));
+}
+
+#[test]
+fn config_hover_without_value() {
+    let out = format_config("app.unknown", None, Some("config/app.php"));
+    assert!(out.contains("**config('app.unknown')**"));
+    assert!(out.contains("*(value not found)*"));
+}
+
+#[test]
+fn config_hover_truncates_long_values() {
+    let long = "x".repeat(500);
+    let out = format_config("some.key", Some(&long), None);
+    assert!(out.contains('…'));
+    assert_eq!(
+        out.chars().filter(|c| *c == 'x').count(),
+        200,
+        "200 char cap"
+    );
+}
+
+// ============================================================================
+// Env
+// ============================================================================
+
+fn env_input<'a>(value: &'a str, source_file: Option<&'a str>) -> EnvHoverInput<'a> {
+    EnvHoverInput {
+        value,
+        is_commented: false,
+        source_file,
+    }
+}
+
+#[test]
+fn env_hover_shows_value_in_plain_block() {
+    let out = format_env("APP_NAME", Some(env_input("Laravel", Some(".env"))));
+    assert!(out.contains("**env('APP_NAME')**"));
+    // Plain ``` (no `php` lang) — env values aren't PHP code.
+    assert!(out.contains("```\nLaravel\n```"));
+    assert!(out.contains("at `.env`"));
+}
+
+#[test]
+fn env_hover_shows_secret_value_plainly() {
+    let out = format_env(
+        "APP_KEY",
+        Some(env_input("base64:abcdef1234567890", Some(".env"))),
+    );
+    assert!(out.contains("base64:abcdef1234567890"));
+    assert!(!out.contains("•"));
+    assert!(!out.contains("masked"));
+}
+
+#[test]
+fn env_hover_marks_commented_value() {
+    let out = format_env(
+        "APP_DEBUG",
+        Some(EnvHoverInput {
+            value: "true",
+            is_commented: true,
+            source_file: Some(".env"),
+        }),
+    );
+    assert!(out.contains("*(commented out)*"));
+    assert!(out.contains(".env"));
+}
+
+#[test]
+fn env_hover_without_definition() {
+    let out = format_env("UNKNOWN", None);
+    assert!(out.contains("**env('UNKNOWN')**"));
+    assert!(out.contains("*(not defined in .env)*"));
+}
+
+// ============================================================================
+// Translation / middleware / binding
+// ============================================================================
+
+#[test]
+fn translation_hover_strips_outer_quotes_in_block() {
+    let out = format_translation(
+        "validation.required",
+        Some("'The :attribute field is required.'"),
+        Some("lang/en/validation.php"),
+    );
+    assert!(out.contains("**__('validation.required')**"));
+    // Outer quotes stripped from the block.
+    assert!(out.contains("```\nThe :attribute field is required.\n```"));
+    assert!(out.contains("at `lang/en/validation.php`"));
+}
+
+#[test]
+fn translation_hover_with_vendor_source() {
+    let out = format_translation(
+        "filament-tables::table.actions.filter.label",
+        Some("'Filter'"),
+        Some("lang/vendor/filament-tables/en/table.php"),
+    );
+    assert!(out.contains("**__('filament-tables::table.actions.filter.label')**"));
+    assert!(out.contains("at `lang/vendor/filament-tables/en/table.php`"));
+}
+
+#[test]
+fn translation_hover_without_value() {
+    let out = format_translation("validation.missing", None, None);
+    assert!(out.contains("**__('validation.missing')**"));
+    assert!(out.contains("*(translation not found for default locale)*"));
+}
+
+#[test]
+fn middleware_hover_with_class_and_source() {
+    let out = format_middleware(
+        "auth",
+        Some("App\\Http\\Middleware\\Authenticate"),
+        Some("bootstrap/app.php"),
+    );
+    assert!(out.contains("**middleware('auth')**"));
+    assert!(out.contains("```php"));
+    assert!(out.contains("App\\Http\\Middleware\\Authenticate"));
+    assert!(out.contains("at `bootstrap/app.php`"));
+}
+
+#[test]
+fn middleware_hover_without_class() {
+    let out = format_middleware("ghost", None, None);
+    assert!(out.contains("*(alias not registered)*"));
+}
+
+#[test]
+fn asset_hover_with_vite_helper_label() {
+    // Vite::asset path. The helper label is what the developer typed at the
+    // callsite, so the bold header reads like the actual PHP/Blade.
+    let out = format_asset(
+        "resources/js/app.js",
+        "Vite::asset",
+        Some("resources/js/app.js"),
+    );
+    assert!(out.contains("**Vite::asset('resources/js/app.js')**"));
+    assert!(out.contains("at `resources/js/app.js`"));
+}
+
+#[test]
+fn asset_hover_with_plain_asset_helper() {
+    let out = format_asset("css/app.css", "asset", Some("public/css/app.css"));
+    assert!(out.contains("**asset('css/app.css')**"));
+    assert!(out.contains("at `public/css/app.css`"));
+}
+
+#[test]
+fn asset_hover_without_resolved_path() {
+    let out = format_asset("missing.css", "asset", None);
+    assert!(out.contains("**asset('missing.css')**"));
+    assert!(out.contains("*(file not found)*"));
+}
+
+#[test]
+fn url_hover_with_resolved_path() {
+    let out = format_url("/favicon.ico", Some("public/favicon.ico"));
+    assert!(out.contains("**url('/favicon.ico')**"));
+    assert!(out.contains("at `public/favicon.ico`"));
+}
+
+#[test]
+fn url_hover_without_resolved_path() {
+    let out = format_url("/missing", None);
+    assert!(out.contains("**url('/missing')**"));
+    assert!(out.contains("*(file not found)*"));
+}
+
+#[test]
+fn binding_hover_with_class() {
+    let out = format_binding(
+        "cache",
+        Some("Illuminate\\Cache\\Repository"),
+        Some("app/Providers/AppServiceProvider.php"),
+    );
+    assert!(out.contains("**app('cache')**"));
+    assert!(out.contains("Illuminate\\Cache\\Repository"));
+    assert!(!out.contains("Concrete"));
+}
+
+// ============================================================================
+// Blade variable — the intelephense-shape one
+// ============================================================================
+
+fn property_decl(
+    text: &str,
+    line: u32,
+    description: Option<&str>,
+    tags: &[&str],
+) -> PropertyDeclaration {
+    PropertyDeclaration {
+        declaration_text: text.to_string(),
+        line,
+        description: description.map(|s| s.to_string()),
+        phpdoc_tags: tags.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+#[test]
+fn blade_variable_property_with_class_and_declaration() {
+    let decl = property_decl(
+        "public string $email;",
+        41,
+        Some("The user's email address."),
+        &[],
+    );
+    let out = format_blade_variable(&BladeVariableHover {
+        var_name: "user",
+        property: Some("email"),
+        var_type: Some("App\\Models\\User"),
+        declaration: Some(&decl),
+        defined_in: Some("app/Models/User.php:42"),
+    });
+    assert!(
+        out.contains("**App\\Models\\User::$email**"),
+        "expected class-qualified header, got: {}",
+        out
+    );
+    assert!(out.contains("The user's email address."));
+    assert!(out.contains("```php\npublic string $email;\n```"));
+    assert!(out.contains("at `app/Models/User.php:42`"));
+}
+
+#[test]
+fn blade_variable_renders_phpdoc_tags() {
+    let decl = property_decl(
+        "public function authorize($ability, $arguments = [])",
+        24,
+        Some("Authorize a given action for the current user."),
+        &[
+            "@param mixed $ability",
+            "@param mixed $arguments",
+            "@return \\Illuminate\\Auth\\Access\\Response",
+            "@throws \\Illuminate\\Auth\\Access\\AuthorizationException",
+        ],
+    );
+    let out = format_blade_variable(&BladeVariableHover {
+        var_name: "controller",
+        property: Some("authorize"),
+        var_type: Some("App\\Http\\Controllers\\Controller"),
+        declaration: Some(&decl),
+        defined_in: Some("app/Http/Controllers/Controller.php:25"),
+    });
+    assert!(out.contains("Authorize a given action for the current user."));
+    assert!(out.contains("@param mixed $ability"));
+    assert!(out.contains("@return \\Illuminate\\Auth\\Access\\Response"));
+    assert!(out.contains("@throws \\Illuminate\\Auth\\Access\\AuthorizationException"));
+}
+
+#[test]
+fn blade_variable_primitive_parent_uses_var_arrow_prop() {
+    // Parent type is `mixed` (primitive). Don't render `mixed::$username` —
+    // fall back to the `$user->username` shape.
+    let out = format_blade_variable(&BladeVariableHover {
+        var_name: "user",
+        property: Some("username"),
+        var_type: Some("mixed"),
+        declaration: None,
+        defined_in: None,
+    });
+    assert!(!out.contains("mixed::"), "got: {}", out);
+    assert!(out.contains("$`user->username`"));
+}
+
+#[test]
+fn blade_variable_root_with_class_type() {
+    let out = format_blade_variable(&BladeVariableHover {
+        var_name: "form",
+        property: None,
+        var_type: Some("App\\Livewire\\ContactForm"),
+        declaration: None,
+        defined_in: Some("app/Livewire/ContactForm.php"),
+    });
+    assert!(out.contains("**$form** : `App\\Livewire\\ContactForm`"));
+    assert!(out.contains("at `app/Livewire/ContactForm.php`"));
+}
+
+#[test]
+fn blade_variable_unresolved() {
+    let out = format_blade_variable(&BladeVariableHover {
+        var_name: "orphan",
+        property: None,
+        var_type: None,
+        declaration: None,
+        defined_in: None,
+    });
+    assert!(out.contains("**$orphan**"));
+    assert!(!out.contains("at `"));
+    assert!(!out.contains("Type:"));
+}
+
+#[test]
+fn is_class_like_type_distinguishes_classes_from_primitives() {
+    assert!(is_class_like_type("App\\Models\\User"));
+    assert!(is_class_like_type("\\App\\Models\\User"));
+    assert!(is_class_like_type("Carbon"));
+    assert!(is_class_like_type("Collection"));
+    assert!(is_class_like_type("?Carbon"));
+
+    assert!(!is_class_like_type("mixed"));
+    assert!(!is_class_like_type("string"));
+    assert!(!is_class_like_type("int"));
+    assert!(!is_class_like_type("?int"));
+    assert!(!is_class_like_type("null"));
+    assert!(!is_class_like_type("array"));
+}

--- a/laravel-lsp/src/hover/tests.rs
+++ b/laravel-lsp/src/hover/tests.rs
@@ -1,454 +1,148 @@
 use super::*;
-use crate::php_class::PropertyDeclaration;
-use crate::route_discovery::{RouteDefinition, PRIORITY_APP};
-use std::path::PathBuf;
-
-// All hovers share an intelephense-style shape:
-//   **<bold header — call form>**
-//   [optional detail / description]
-//   [optional fenced code block — value or declaration]
-//   at <source path>
-//   [optional *(trailer)*]
-//
-// Tests assert on user-visible substrings.
 
 // ============================================================================
-// View / component / Livewire
+// render — section presence, ordering, omission
 // ============================================================================
 
 #[test]
-fn view_hover_uses_call_form_header() {
-    let out = format_view(
-        "users.profile",
-        Some("resources/views/users/profile.blade.php"),
-        None,
-    );
-    assert!(out.contains("**view('users.profile')**"));
-    assert!(out.contains("at resources/views/users/profile.blade.php"));
+fn render_empty_content_returns_empty_string() {
+    let out = render(&HoverContent::default());
+    assert_eq!(out, "");
 }
 
 #[test]
-fn view_hover_with_snippet_renders_php_block() {
-    let out = format_view(
-        "users.profile",
-        Some("resources/views/users/profile.blade.php"),
-        Some("@props(['user' => null])"),
-    );
-    assert!(out.contains("```php"));
-    assert!(out.contains("@props(['user' => null])"));
+fn render_header_only() {
+    let out = render(&HoverContent {
+        header: Some("App\\Models\\User"),
+        ..Default::default()
+    });
+    assert_eq!(out, "**App\\Models\\User**");
 }
 
 #[test]
-fn view_hover_without_path_shows_missing_trailer() {
-    let out = format_view("users.missing", None, None);
-    assert!(out.contains("**view('users.missing')**"));
-    assert!(out.contains("*(file not found)*"));
+fn render_source_link_only() {
+    let out = render(&HoverContent {
+        source_link: Some("[app/Models/User.php](file:///abs/User.php)"),
+        ..Default::default()
+    });
+    // No `at ` prefix — the link renders verbatim. No backticks around the
+    // label either — those would give it inline-code styling.
+    assert_eq!(out, "[app/Models/User.php](file:///abs/User.php)");
 }
 
 #[test]
-fn component_hover_does_not_double_prefix() {
-    let out = format_component(
-        "x-button",
-        Some("resources/views/components/button.blade.php"),
-        None,
-    );
-    assert!(out.contains("`<x-button>`"));
-    assert!(!out.contains("<x-x-"));
-}
-
-#[test]
-fn livewire_hover_uses_tag_form_header() {
-    let out = format_livewire("counter", Some("app/Livewire/Counter.php"), None);
-    assert!(out.contains("`<livewire:counter>`"));
-    assert!(out.contains("at app/Livewire/Counter.php"));
-}
-
-#[test]
-fn livewire_hover_renders_class_signature_snippet() {
-    let out = format_livewire(
-        "counter",
-        Some("app/Livewire/Counter.php"),
-        Some("class Counter extends Component"),
-    );
-    assert!(out.contains("```php"));
-    assert!(out.contains("class Counter extends Component"));
-}
-
-// ============================================================================
-// Route
-// ============================================================================
-
-fn route_def(method: &str, uri: &str, action: &str) -> RouteDefinition {
-    RouteDefinition {
-        file: PathBuf::from("/fake/routes/web.php"),
-        line: 0,
-        column: 0,
-        end_column: 0,
-        priority: PRIORITY_APP,
-        method: Some(method.to_string()),
-        uri: Some(uri.to_string()),
-        action: Some(action.to_string()),
-    }
-}
-
-#[test]
-fn route_hover_shows_method_uri_action() {
-    let def = route_def("get", "/users/{user}", "UserController@show");
-    let out = format_route("users.show", Some(&def), Some("routes/web.php:42"), None);
-    assert!(out.contains("**route('users.show')**"));
-    assert!(out.contains("`GET /users/{user}`"));
-    assert!(out.contains("`UserController@show`"));
-    assert!(out.contains("at routes/web.php:42"));
-}
-
-#[test]
-fn route_hover_renders_source_line_snippet() {
-    let def = route_def("get", "/users/{user}", "UserController@show");
-    let snippet =
-        "Route::get('/users/{user}', [UserController::class, 'show'])->name('users.show');";
-    let out = format_route(
-        "users.show",
-        Some(&def),
-        Some("routes/web.php:42"),
-        Some(snippet),
-    );
-    assert!(out.contains("```php"));
-    assert!(out.contains(snippet));
-}
-
-#[test]
-fn route_hover_handles_missing_index_entry() {
-    let out = format_route("orphan", None, None, None);
-    assert!(out.contains("**route('orphan')**"));
-    assert!(out.contains("*(route not found in index)*"));
-}
-
-// ============================================================================
-// Config
-// ============================================================================
-
-#[test]
-fn config_hover_shows_value_in_php_block() {
-    let out = format_config(
-        "app.name",
-        Some("env('APP_NAME', 'Laravel')"),
-        Some("config/app.php"),
-    );
-    assert!(out.contains("**config('app.name')**"));
-    assert!(out.contains("```php"));
-    assert!(out.contains("env('APP_NAME', 'Laravel')"));
-    assert!(out.contains("at config/app.php"));
-}
-
-#[test]
-fn config_hover_without_value() {
-    let out = format_config("app.unknown", None, Some("config/app.php"));
-    assert!(out.contains("**config('app.unknown')**"));
-    assert!(out.contains("*(value not found)*"));
-}
-
-#[test]
-fn config_hover_truncates_long_values() {
-    let long = "x".repeat(500);
-    let out = format_config("some.key", Some(&long), None);
-    assert!(out.contains('…'));
-    assert_eq!(
-        out.chars().filter(|c| *c == 'x').count(),
-        200,
-        "200 char cap"
-    );
-}
-
-// ============================================================================
-// Env
-// ============================================================================
-
-fn env_input<'a>(value: &'a str, source_file: Option<&'a str>) -> EnvHoverInput<'a> {
-    EnvHoverInput {
-        value,
-        is_commented: false,
-        source_file,
-    }
-}
-
-#[test]
-fn env_hover_shows_value_in_plain_block() {
-    let out = format_env("APP_NAME", Some(env_input("Laravel", Some(".env"))));
-    assert!(out.contains("**env('APP_NAME')**"));
-    // Plain ``` (no `php` lang) — env values aren't PHP code.
-    assert!(out.contains("```\nLaravel\n```"));
-    assert!(out.contains("at .env"));
-}
-
-#[test]
-fn env_hover_shows_secret_value_plainly() {
-    let out = format_env(
-        "APP_KEY",
-        Some(env_input("base64:abcdef1234567890", Some(".env"))),
-    );
-    assert!(out.contains("base64:abcdef1234567890"));
-    assert!(!out.contains("•"));
-    assert!(!out.contains("masked"));
-}
-
-#[test]
-fn env_hover_marks_commented_value() {
-    let out = format_env(
-        "APP_DEBUG",
-        Some(EnvHoverInput {
-            value: "true",
-            is_commented: true,
-            source_file: Some(".env"),
+fn render_php_code_block_prepends_php_opening_tag() {
+    // The opening tag is required for Zed's tree-sitter-php grammar to
+    // parse the snippet (the standard `php` grammar variant requires it).
+    let out = render(&HoverContent {
+        code: Some(CodeBlock {
+            language: CodeLanguage::Php,
+            content: "public string $email;",
         }),
-    );
-    assert!(out.contains("*(commented out)*"));
-    assert!(out.contains(".env"));
+        ..Default::default()
+    });
+    assert_eq!(out, "```php\n<?php\npublic string $email;\n```");
 }
 
 #[test]
-fn env_hover_without_definition() {
-    let out = format_env("UNKNOWN", None);
-    assert!(out.contains("**env('UNKNOWN')**"));
-    assert!(out.contains("*(not defined in .env)*"));
+fn render_plain_code_block_omits_language() {
+    let out = render(&HoverContent {
+        code: Some(CodeBlock {
+            language: CodeLanguage::Plain,
+            content: "Laravel",
+        }),
+        ..Default::default()
+    });
+    assert_eq!(out, "```\nLaravel\n```");
+}
+
+#[test]
+fn render_full_section_set_in_order() {
+    let tags = vec![
+        "@param mixed $x".to_string(),
+        "@return Response".to_string(),
+    ];
+    let out = render(&HoverContent {
+        header: Some("App\\Foo::bar"),
+        detail: Some("Some detail line"),
+        description: Some("Description prose."),
+        code: Some(CodeBlock {
+            language: CodeLanguage::Php,
+            content: "public function bar()",
+        }),
+        tags: &tags,
+        source_link: Some("[app/Foo.php:10](file:///abs/Foo.php#L10)"),
+        trailer: None,
+    });
+    let expected = "**App\\Foo::bar**\n\
+                    \n\
+                    Some detail line\n\
+                    \n\
+                    Description prose.\n\
+                    \n\
+                    ```php\n\
+                    <?php\n\
+                    public function bar()\n\
+                    ```\n\
+                    \n\
+                    *@param mixed $x*\n\
+                    \n\
+                    *@return Response*\n\
+                    \n\
+                    [app/Foo.php:10](file:///abs/Foo.php#L10)";
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn render_skips_absent_sections() {
+    let out = render(&HoverContent {
+        header: Some("App\\Foo"),
+        // no detail, no description, no code, no tags
+        source_link: Some("[app/Foo.php](file:///abs/Foo.php)"),
+        ..Default::default()
+    });
+    let expected = "**App\\Foo**\n\n[app/Foo.php](file:///abs/Foo.php)";
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn render_trailer_appears_last() {
+    let out = render(&HoverContent {
+        trailer: Some("*(not registered)*"),
+        ..Default::default()
+    });
+    assert_eq!(out, "*(not registered)*");
+}
+
+#[test]
+fn render_empty_tags_slice_omits_section() {
+    let tags: Vec<String> = Vec::new();
+    let out = render(&HoverContent {
+        header: Some("App\\Foo"),
+        tags: &tags,
+        ..Default::default()
+    });
+    assert_eq!(out, "**App\\Foo**");
+}
+
+#[test]
+fn render_multiple_tags_separated_by_blank_line() {
+    let tags = vec![
+        "@param mixed $a".to_string(),
+        "@param mixed $b".to_string(),
+        "@return Response".to_string(),
+    ];
+    let out = render(&HoverContent {
+        tags: &tags,
+        ..Default::default()
+    });
+    let expected = "*@param mixed $a*\n\n*@param mixed $b*\n\n*@return Response*";
+    assert_eq!(out, expected);
 }
 
 // ============================================================================
-// Translation / middleware / binding
+// Utility predicates
 // ============================================================================
-
-#[test]
-fn translation_hover_strips_outer_quotes_in_block() {
-    let out = format_translation(
-        "validation.required",
-        Some("'The :attribute field is required.'"),
-        Some("lang/en/validation.php"),
-    );
-    assert!(out.contains("**__('validation.required')**"));
-    // Outer quotes stripped from the block.
-    assert!(out.contains("```\nThe :attribute field is required.\n```"));
-    assert!(out.contains("at lang/en/validation.php"));
-}
-
-#[test]
-fn translation_hover_with_vendor_source() {
-    let out = format_translation(
-        "filament-tables::table.actions.filter.label",
-        Some("'Filter'"),
-        Some("lang/vendor/filament-tables/en/table.php"),
-    );
-    assert!(out.contains("**__('filament-tables::table.actions.filter.label')**"));
-    assert!(out.contains("at lang/vendor/filament-tables/en/table.php"));
-}
-
-#[test]
-fn translation_hover_without_value() {
-    let out = format_translation("validation.missing", None, None);
-    assert!(out.contains("**__('validation.missing')**"));
-    assert!(out.contains("*(translation not found for default locale)*"));
-}
-
-#[test]
-fn middleware_hover_with_class_and_source() {
-    let out = format_middleware(
-        "auth",
-        Some("App\\Http\\Middleware\\Authenticate"),
-        Some("bootstrap/app.php"),
-    );
-    assert!(out.contains("**middleware('auth')**"));
-    assert!(out.contains("```php"));
-    assert!(out.contains("App\\Http\\Middleware\\Authenticate"));
-    assert!(out.contains("at bootstrap/app.php"));
-}
-
-#[test]
-fn middleware_hover_without_class() {
-    let out = format_middleware("ghost", None, None);
-    assert!(out.contains("*(alias not registered)*"));
-}
-
-#[test]
-fn asset_hover_with_vite_helper_label() {
-    // Vite::asset path. The helper label is what the developer typed at the
-    // callsite, so the bold header reads like the actual PHP/Blade.
-    let out = format_asset(
-        "resources/js/app.js",
-        "Vite::asset",
-        Some("resources/js/app.js"),
-    );
-    assert!(out.contains("**Vite::asset('resources/js/app.js')**"));
-    assert!(out.contains("at resources/js/app.js"));
-}
-
-#[test]
-fn asset_hover_with_plain_asset_helper() {
-    let out = format_asset("css/app.css", "asset", Some("public/css/app.css"));
-    assert!(out.contains("**asset('css/app.css')**"));
-    assert!(out.contains("at public/css/app.css"));
-}
-
-#[test]
-fn asset_hover_without_resolved_path() {
-    let out = format_asset("missing.css", "asset", None);
-    assert!(out.contains("**asset('missing.css')**"));
-    assert!(out.contains("*(file not found)*"));
-}
-
-#[test]
-fn url_hover_with_resolved_path() {
-    let out = format_url("/favicon.ico", Some("public/favicon.ico"));
-    assert!(out.contains("**url('/favicon.ico')**"));
-    assert!(out.contains("at public/favicon.ico"));
-}
-
-#[test]
-fn url_hover_without_resolved_path() {
-    let out = format_url("/missing", None);
-    assert!(out.contains("**url('/missing')**"));
-    assert!(out.contains("*(file not found)*"));
-}
-
-#[test]
-fn binding_hover_with_class() {
-    let out = format_binding(
-        "cache",
-        Some("Illuminate\\Cache\\Repository"),
-        Some("app/Providers/AppServiceProvider.php"),
-    );
-    assert!(out.contains("**app('cache')**"));
-    assert!(out.contains("Illuminate\\Cache\\Repository"));
-    assert!(!out.contains("Concrete"));
-}
-
-// ============================================================================
-// Blade variable — the intelephense-shape one
-// ============================================================================
-
-fn property_decl(
-    text: &str,
-    line: u32,
-    description: Option<&str>,
-    tags: &[&str],
-) -> PropertyDeclaration {
-    PropertyDeclaration {
-        declaration_text: text.to_string(),
-        line,
-        description: description.map(|s| s.to_string()),
-        phpdoc_tags: tags.iter().map(|s| s.to_string()).collect(),
-    }
-}
-
-#[test]
-fn blade_variable_property_with_class_and_declaration() {
-    let decl = property_decl(
-        "public string $email;",
-        41,
-        Some("The user's email address."),
-        &[],
-    );
-    let out = format_blade_variable(&BladeVariableHover {
-        var_name: "user",
-        property: Some("email"),
-        var_type: Some("App\\Models\\User"),
-        declaration: Some(&decl),
-        defined_in: Some("app/Models/User.php:42"),
-    });
-    assert!(
-        out.contains("**App\\Models\\User::$email**"),
-        "expected class-qualified header, got: {}",
-        out
-    );
-    assert!(out.contains("The user's email address."));
-    assert!(out.contains("```php\npublic string $email;\n```"));
-    assert!(out.contains("at app/Models/User.php:42"));
-}
-
-#[test]
-fn blade_variable_renders_phpdoc_tags() {
-    let decl = property_decl(
-        "public function authorize($ability, $arguments = [])",
-        24,
-        Some("Authorize a given action for the current user."),
-        &[
-            "@param mixed $ability",
-            "@param mixed $arguments",
-            "@return \\Illuminate\\Auth\\Access\\Response",
-            "@throws \\Illuminate\\Auth\\Access\\AuthorizationException",
-        ],
-    );
-    let out = format_blade_variable(&BladeVariableHover {
-        var_name: "controller",
-        property: Some("authorize"),
-        var_type: Some("App\\Http\\Controllers\\Controller"),
-        declaration: Some(&decl),
-        defined_in: Some("app/Http/Controllers/Controller.php:25"),
-    });
-    assert!(out.contains("Authorize a given action for the current user."));
-    assert!(out.contains("@param mixed $ability"));
-    assert!(out.contains("@return \\Illuminate\\Auth\\Access\\Response"));
-    assert!(out.contains("@throws \\Illuminate\\Auth\\Access\\AuthorizationException"));
-}
-
-#[test]
-fn blade_variable_primitive_parent_uses_var_arrow_prop() {
-    // Parent type is `mixed` (primitive). Don't render `mixed::$username` —
-    // fall back to the `$user->username` shape.
-    let out = format_blade_variable(&BladeVariableHover {
-        var_name: "user",
-        property: Some("username"),
-        var_type: Some("mixed"),
-        declaration: None,
-        defined_in: None,
-    });
-    assert!(!out.contains("mixed::"), "got: {}", out);
-    assert!(out.contains("$`user->username`"));
-}
-
-#[test]
-fn blade_variable_root_with_class_type() {
-    let out = format_blade_variable(&BladeVariableHover {
-        var_name: "form",
-        property: None,
-        var_type: Some("App\\Livewire\\ContactForm"),
-        declaration: None,
-        defined_in: Some("app/Livewire/ContactForm.php"),
-    });
-    assert!(out.contains("**$form** : `App\\Livewire\\ContactForm`"));
-    assert!(out.contains("at app/Livewire/ContactForm.php"));
-}
-
-#[test]
-fn blade_variable_unresolved() {
-    let out = format_blade_variable(&BladeVariableHover {
-        var_name: "orphan",
-        property: None,
-        var_type: None,
-        declaration: None,
-        defined_in: None,
-    });
-    assert!(out.contains("**$orphan**"));
-    assert!(
-        !out.contains("\n\nat "),
-        "no source line when no defined_in info"
-    );
-    assert!(!out.contains("Type:"));
-}
-
-#[test]
-fn at_line_renders_passed_string_verbatim() {
-    // The formatter renders `at <source_display>` verbatim — caller is
-    // responsible for wrapping in backticks, markdown links, etc. This is
-    // what enables the hover dispatcher (in main.rs) to pass full
-    // `file://`-clickable links straight through.
-    let link = "[`app/Models/User.php:42`](file:///Users/mike/project/app/Models/User.php#L42)";
-    let out = format_view("users.profile", Some(link), None);
-    assert!(
-        out.contains(&format!("at {}", link)),
-        "expected raw link, got: {}",
-        out
-    );
-    // The link contains a `file://` URL so Zed renders it as clickable.
-    assert!(out.contains("file:///"));
-}
 
 #[test]
 fn is_class_like_type_distinguishes_classes_from_primitives() {
@@ -464,4 +158,41 @@ fn is_class_like_type_distinguishes_classes_from_primitives() {
     assert!(!is_class_like_type("?int"));
     assert!(!is_class_like_type("null"));
     assert!(!is_class_like_type("array"));
+}
+
+#[test]
+fn source_link_with_line_includes_fragment() {
+    let link = source_link("app/Foo.php", "file:///abs/Foo.php", Some(42));
+    // No backticks around the label — those would render as inline code.
+    assert_eq!(link, "[app/Foo.php:42](file:///abs/Foo.php#L42)");
+}
+
+#[test]
+fn source_link_without_line_omits_fragment() {
+    let link = source_link("app/Foo.php", "file:///abs/Foo.php", None);
+    assert_eq!(link, "[app/Foo.php](file:///abs/Foo.php)");
+}
+
+#[test]
+fn truncate_for_display_clips_long_strings() {
+    let long = "x".repeat(500);
+    let out = truncate_for_display(&long, 200);
+    assert!(out.ends_with('…'));
+    assert_eq!(out.chars().filter(|c| *c == 'x').count(), 200);
+}
+
+#[test]
+fn truncate_for_display_passes_short_strings_through() {
+    let short = "short";
+    let out = truncate_for_display(short, 200);
+    assert_eq!(out, "short");
+}
+
+#[test]
+fn truncate_for_display_handles_multibyte_chars_at_boundary() {
+    // 200 multibyte chars — make sure we count chars not bytes
+    let s: String = "日".repeat(300);
+    let out = truncate_for_display(&s, 200);
+    assert!(out.ends_with('…'));
+    assert_eq!(out.chars().count(), 201); // 200 + ellipsis
 }

--- a/laravel-lsp/src/hover/tests.rs
+++ b/laravel-lsp/src/hover/tests.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 //   **<bold header — call form>**
 //   [optional detail / description]
 //   [optional fenced code block — value or declaration]
-//   at `<source path>`
+//   at <source path>
 //   [optional *(trailer)*]
 //
 // Tests assert on user-visible substrings.
@@ -23,7 +23,7 @@ fn view_hover_uses_call_form_header() {
         Some("resources/views/users/profile.blade.php"),
     );
     assert!(out.contains("**view('users.profile')**"));
-    assert!(out.contains("at `resources/views/users/profile.blade.php`"));
+    assert!(out.contains("at resources/views/users/profile.blade.php"));
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn component_hover_does_not_double_prefix() {
 fn livewire_hover_uses_tag_form_header() {
     let out = format_livewire("counter", Some("app/Livewire/Counter.php"));
     assert!(out.contains("`<livewire:counter>`"));
-    assert!(out.contains("at `app/Livewire/Counter.php`"));
+    assert!(out.contains("at app/Livewire/Counter.php"));
 }
 
 // ============================================================================
@@ -74,7 +74,7 @@ fn route_hover_shows_method_uri_action() {
     assert!(out.contains("**route('users.show')**"));
     assert!(out.contains("`GET /users/{user}`"));
     assert!(out.contains("`UserController@show`"));
-    assert!(out.contains("at `routes/web.php:42`"));
+    assert!(out.contains("at routes/web.php:42"));
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn config_hover_shows_value_in_php_block() {
     assert!(out.contains("**config('app.name')**"));
     assert!(out.contains("```php"));
     assert!(out.contains("env('APP_NAME', 'Laravel')"));
-    assert!(out.contains("at `config/app.php`"));
+    assert!(out.contains("at config/app.php"));
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn env_hover_shows_value_in_plain_block() {
     assert!(out.contains("**env('APP_NAME')**"));
     // Plain ``` (no `php` lang) — env values aren't PHP code.
     assert!(out.contains("```\nLaravel\n```"));
-    assert!(out.contains("at `.env`"));
+    assert!(out.contains("at .env"));
 }
 
 #[test]
@@ -187,7 +187,7 @@ fn translation_hover_strips_outer_quotes_in_block() {
     assert!(out.contains("**__('validation.required')**"));
     // Outer quotes stripped from the block.
     assert!(out.contains("```\nThe :attribute field is required.\n```"));
-    assert!(out.contains("at `lang/en/validation.php`"));
+    assert!(out.contains("at lang/en/validation.php"));
 }
 
 #[test]
@@ -198,7 +198,7 @@ fn translation_hover_with_vendor_source() {
         Some("lang/vendor/filament-tables/en/table.php"),
     );
     assert!(out.contains("**__('filament-tables::table.actions.filter.label')**"));
-    assert!(out.contains("at `lang/vendor/filament-tables/en/table.php`"));
+    assert!(out.contains("at lang/vendor/filament-tables/en/table.php"));
 }
 
 #[test]
@@ -218,7 +218,7 @@ fn middleware_hover_with_class_and_source() {
     assert!(out.contains("**middleware('auth')**"));
     assert!(out.contains("```php"));
     assert!(out.contains("App\\Http\\Middleware\\Authenticate"));
-    assert!(out.contains("at `bootstrap/app.php`"));
+    assert!(out.contains("at bootstrap/app.php"));
 }
 
 #[test]
@@ -237,14 +237,14 @@ fn asset_hover_with_vite_helper_label() {
         Some("resources/js/app.js"),
     );
     assert!(out.contains("**Vite::asset('resources/js/app.js')**"));
-    assert!(out.contains("at `resources/js/app.js`"));
+    assert!(out.contains("at resources/js/app.js"));
 }
 
 #[test]
 fn asset_hover_with_plain_asset_helper() {
     let out = format_asset("css/app.css", "asset", Some("public/css/app.css"));
     assert!(out.contains("**asset('css/app.css')**"));
-    assert!(out.contains("at `public/css/app.css`"));
+    assert!(out.contains("at public/css/app.css"));
 }
 
 #[test]
@@ -258,7 +258,7 @@ fn asset_hover_without_resolved_path() {
 fn url_hover_with_resolved_path() {
     let out = format_url("/favicon.ico", Some("public/favicon.ico"));
     assert!(out.contains("**url('/favicon.ico')**"));
-    assert!(out.contains("at `public/favicon.ico`"));
+    assert!(out.contains("at public/favicon.ico"));
 }
 
 #[test]
@@ -320,7 +320,7 @@ fn blade_variable_property_with_class_and_declaration() {
     );
     assert!(out.contains("The user's email address."));
     assert!(out.contains("```php\npublic string $email;\n```"));
-    assert!(out.contains("at `app/Models/User.php:42`"));
+    assert!(out.contains("at app/Models/User.php:42"));
 }
 
 #[test]
@@ -374,7 +374,7 @@ fn blade_variable_root_with_class_type() {
         defined_in: Some("app/Livewire/ContactForm.php"),
     });
     assert!(out.contains("**$form** : `App\\Livewire\\ContactForm`"));
-    assert!(out.contains("at `app/Livewire/ContactForm.php`"));
+    assert!(out.contains("at app/Livewire/ContactForm.php"));
 }
 
 #[test]
@@ -387,8 +387,28 @@ fn blade_variable_unresolved() {
         defined_in: None,
     });
     assert!(out.contains("**$orphan**"));
-    assert!(!out.contains("at `"));
+    assert!(
+        !out.contains("\n\nat "),
+        "no source line when no defined_in info"
+    );
     assert!(!out.contains("Type:"));
+}
+
+#[test]
+fn at_line_renders_passed_string_verbatim() {
+    // The formatter renders `at <source_display>` verbatim — caller is
+    // responsible for wrapping in backticks, markdown links, etc. This is
+    // what enables the hover dispatcher (in main.rs) to pass full
+    // `file://`-clickable links straight through.
+    let link = "[`app/Models/User.php:42`](file:///Users/mike/project/app/Models/User.php#L42)";
+    let out = format_view("users.profile", Some(link));
+    assert!(
+        out.contains(&format!("at {}", link)),
+        "expected raw link, got: {}",
+        out
+    );
+    // The link contains a `file://` URL so Zed renders it as clickable.
+    assert!(out.contains("file:///"));
 }
 
 #[test]

--- a/laravel-lsp/src/hover/tests.rs
+++ b/laravel-lsp/src/hover/tests.rs
@@ -21,14 +21,26 @@ fn view_hover_uses_call_form_header() {
     let out = format_view(
         "users.profile",
         Some("resources/views/users/profile.blade.php"),
+        None,
     );
     assert!(out.contains("**view('users.profile')**"));
     assert!(out.contains("at resources/views/users/profile.blade.php"));
 }
 
 #[test]
+fn view_hover_with_snippet_renders_php_block() {
+    let out = format_view(
+        "users.profile",
+        Some("resources/views/users/profile.blade.php"),
+        Some("@props(['user' => null])"),
+    );
+    assert!(out.contains("```php"));
+    assert!(out.contains("@props(['user' => null])"));
+}
+
+#[test]
 fn view_hover_without_path_shows_missing_trailer() {
-    let out = format_view("users.missing", None);
+    let out = format_view("users.missing", None, None);
     assert!(out.contains("**view('users.missing')**"));
     assert!(out.contains("*(file not found)*"));
 }
@@ -38,6 +50,7 @@ fn component_hover_does_not_double_prefix() {
     let out = format_component(
         "x-button",
         Some("resources/views/components/button.blade.php"),
+        None,
     );
     assert!(out.contains("`<x-button>`"));
     assert!(!out.contains("<x-x-"));
@@ -45,9 +58,20 @@ fn component_hover_does_not_double_prefix() {
 
 #[test]
 fn livewire_hover_uses_tag_form_header() {
-    let out = format_livewire("counter", Some("app/Livewire/Counter.php"));
+    let out = format_livewire("counter", Some("app/Livewire/Counter.php"), None);
     assert!(out.contains("`<livewire:counter>`"));
     assert!(out.contains("at app/Livewire/Counter.php"));
+}
+
+#[test]
+fn livewire_hover_renders_class_signature_snippet() {
+    let out = format_livewire(
+        "counter",
+        Some("app/Livewire/Counter.php"),
+        Some("class Counter extends Component"),
+    );
+    assert!(out.contains("```php"));
+    assert!(out.contains("class Counter extends Component"));
 }
 
 // ============================================================================
@@ -70,7 +94,7 @@ fn route_def(method: &str, uri: &str, action: &str) -> RouteDefinition {
 #[test]
 fn route_hover_shows_method_uri_action() {
     let def = route_def("get", "/users/{user}", "UserController@show");
-    let out = format_route("users.show", Some(&def), Some("routes/web.php:42"));
+    let out = format_route("users.show", Some(&def), Some("routes/web.php:42"), None);
     assert!(out.contains("**route('users.show')**"));
     assert!(out.contains("`GET /users/{user}`"));
     assert!(out.contains("`UserController@show`"));
@@ -78,8 +102,23 @@ fn route_hover_shows_method_uri_action() {
 }
 
 #[test]
+fn route_hover_renders_source_line_snippet() {
+    let def = route_def("get", "/users/{user}", "UserController@show");
+    let snippet =
+        "Route::get('/users/{user}', [UserController::class, 'show'])->name('users.show');";
+    let out = format_route(
+        "users.show",
+        Some(&def),
+        Some("routes/web.php:42"),
+        Some(snippet),
+    );
+    assert!(out.contains("```php"));
+    assert!(out.contains(snippet));
+}
+
+#[test]
 fn route_hover_handles_missing_index_entry() {
-    let out = format_route("orphan", None, None);
+    let out = format_route("orphan", None, None, None);
     assert!(out.contains("**route('orphan')**"));
     assert!(out.contains("*(route not found in index)*"));
 }
@@ -401,7 +440,7 @@ fn at_line_renders_passed_string_verbatim() {
     // what enables the hover dispatcher (in main.rs) to pass full
     // `file://`-clickable links straight through.
     let link = "[`app/Models/User.php:42`](file:///Users/mike/project/app/Models/User.php#L42)";
-    let out = format_view("users.profile", Some(link));
+    let out = format_view("users.profile", Some(link), None);
     assert!(
         out.contains(&format!("at {}", link)),
         "expected raw link, got: {}",

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -12,6 +12,7 @@
 // Core modules
 pub mod blade_loops;
 pub mod blade_php_block;
+pub mod blade_props;
 pub mod cache_manager;
 pub mod class_locator;
 pub mod config;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -15,7 +15,9 @@ pub mod blade_php_block;
 pub mod cache_manager;
 pub mod class_locator;
 pub mod config;
+pub mod config_lookup;
 pub mod database;
+pub mod hover;
 pub mod livewire_resolver;
 pub mod middleware_parser;
 pub mod model_analyzer;
@@ -25,7 +27,9 @@ pub mod queries;
 pub mod route_binding;
 pub mod route_discovery;
 pub mod slot_navigation;
+pub mod translation_lookup;
 pub mod validation_rules;
+pub mod vendor_translations;
 
 // Salsa 0.25 implementation (incremental computation)
 pub mod salsa_impl;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -12968,34 +12968,37 @@ return [
             PatternAtPosition::Route(route) => {
                 let idx_guard = self.route_index.read().await;
                 let def = idx_guard.as_ref().and_then(|idx| idx.get(&route.name));
-                let source_display = match def {
-                    Some(d) => {
-                        let path_display = self.relative_display_path(&d.file).await;
-                        // Routes carry their `->name(` line in the definition;
-                        // render 1-based for humans.
-                        Some(format!("{}:{}", path_display, d.line + 1))
-                    }
+                let source_link = match def {
+                    // Routes carry the `->name(` line in the definition;
+                    // render 1-based for humans (LSP positions are 0-based
+                    // internally).
+                    Some(d) => Some(self.source_link(&d.file, Some(d.line + 1)).await),
                     None => None,
                 };
                 Some(hover::format_route(
                     &route.name,
                     def,
-                    source_display.as_deref(),
+                    source_link.as_deref(),
                 ))
             }
             PatternAtPosition::ConfigRef(cfg) => {
                 let value = root
                     .as_ref()
                     .and_then(|r| laravel_lsp::config_lookup::resolve_value(r, &cfg.key));
-                let source_file = cfg
-                    .key
-                    .split('.')
-                    .next()
-                    .map(|group| format!("config/{}.php", group));
+                // Config lookups resolve through `config/<group>.php` by
+                // convention — build the link by appending the group name
+                // to the project's config directory.
+                let source_link = match (root.as_ref(), cfg.key.split('.').next()) {
+                    (Some(r), Some(group)) => {
+                        let path = r.join("config").join(format!("{}.php", group));
+                        Some(self.source_link(&path, None).await)
+                    }
+                    _ => None,
+                };
                 Some(hover::format_config(
                     &cfg.key,
                     value.as_deref(),
-                    source_file.as_deref(),
+                    source_link.as_deref(),
                 ))
             }
             PatternAtPosition::EnvRef(env) => {
@@ -13005,17 +13008,14 @@ return [
                     .await
                     .ok()
                     .flatten();
-                let source_display = var
-                    .as_ref()
-                    .map(|v| self.relative_display_path(&v.source_file));
-                let source_display = match source_display {
-                    Some(fut) => Some(fut.await),
+                let source_link = match var.as_ref() {
+                    Some(v) => Some(self.source_link(&v.source_file, None).await),
                     None => None,
                 };
                 let input = var.as_ref().map(|v| hover::EnvHoverInput {
                     value: v.value.as_str(),
                     is_commented: v.is_commented,
-                    source_file: source_display.as_deref(),
+                    source_file: source_link.as_deref(),
                 });
                 Some(hover::format_env(&env.name, input))
             }
@@ -13033,14 +13033,14 @@ return [
                     }
                     None => None,
                 };
-                let source_file = match &resolution {
-                    Some(res) => Some(self.relative_display_path(&res.source_file).await),
+                let source_link = match &resolution {
+                    Some(res) => Some(self.source_link(&res.source_file, None).await),
                     None => None,
                 };
                 Some(hover::format_translation(
                     &trans.key,
                     resolution.as_ref().map(|r| r.value.as_str()),
-                    source_file.as_deref(),
+                    source_link.as_deref(),
                 ))
             }
             PatternAtPosition::Middleware(mw) => {
@@ -13049,14 +13049,14 @@ return [
                 let source_path = cached
                     .as_ref()
                     .and_then(|(_, _, source_file, _)| source_file.as_ref());
-                let source_display = match source_path {
-                    Some(p) => Some(self.relative_display_path(p).await),
+                let source_link = match source_path {
+                    Some(p) => Some(self.source_link(p, None).await),
                     None => None,
                 };
                 Some(hover::format_middleware(
                     &mw.name,
                     class_fqn,
-                    source_display.as_deref(),
+                    source_link.as_deref(),
                 ))
             }
             PatternAtPosition::Binding(binding) => {
@@ -13065,14 +13065,14 @@ return [
                 let source_path = cached
                     .as_ref()
                     .and_then(|(_, _, source_file, _)| source_file.as_ref());
-                let source_display = match source_path {
-                    Some(p) => Some(self.relative_display_path(p).await),
+                let source_link = match source_path {
+                    Some(p) => Some(self.source_link(p, None).await),
                     None => None,
                 };
                 Some(hover::format_binding(
                     &binding.name,
                     class_fqn,
-                    source_display.as_deref(),
+                    source_link.as_deref(),
                 ))
             }
             PatternAtPosition::Asset(asset) => {
@@ -13140,22 +13140,21 @@ return [
         };
         let asset_path = base.join(&asset.path);
         if self.file_exists_cached(&asset_path).await {
-            Some(self.relative_display_path(&asset_path).await)
+            Some(self.source_link(&asset_path, None).await)
         } else {
             None
         }
     }
 
-    /// Resolve a `url('/path')` reference to its on-disk file under `public/`.
-    /// Returns `None` when the file doesn't exist (the URL might point to a
-    /// dynamic route, not a static asset — that's fine, we just don't show
-    /// a source line).
+    /// Resolve a `url('/path')` reference to a click-to-open link for the
+    /// matching file under `public/`. Returns `None` when nothing matches
+    /// (the URL might point to a dynamic route, not a static asset).
     async fn resolve_display_path_for_url(&self, url_path: &str) -> Option<String> {
         let root = self.root_path.read().await.clone()?;
         let path = url_path.trim_start_matches('/');
         let candidate = root.join("public").join(path);
         if self.file_exists_cached(&candidate).await {
-            Some(self.relative_display_path(&candidate).await)
+            Some(self.source_link(&candidate, None).await)
         } else {
             None
         }
@@ -13214,20 +13213,16 @@ return [
             _ => None,
         };
 
-        // Source-line display priority:
-        //   1. Class file + property line (`app/Models/User.php:42`) — best
-        //   2. Class file alone (`app/Models/User.php`) — class found but no
-        //      explicit property declaration on it (common for Eloquent
-        //      columns that aren't in $casts/$fillable as keys)
-        //   3. Blade-file origin (`resources/views/foo.blade.php:7`) — when
-        //      the variable's type is unknown/`mixed`, surface where it was
-        //      introduced in the current Blade file: @foreach, @props, etc.
+        // Source-line link priority:
+        //   1. Class file + property line — most useful jump target
+        //   2. Class file alone — class found but no explicit property
+        //      declaration (Eloquent columns not in $casts/$fillable)
+        //   3. Blade-file origin — when the variable's type is unknown
+        //      (`mixed` sentinel), surface the @foreach / @props line that
+        //      introduced the variable in the current Blade file
         let defined_in_display = match (class_path.as_ref(), declaration.as_ref()) {
-            (Some(path), Some(decl)) => {
-                let p = self.relative_display_path(path).await;
-                Some(format!("{}:{}", p, decl.line + 1))
-            }
-            (Some(path), None) => Some(self.relative_display_path(path).await),
+            (Some(path), Some(decl)) => Some(self.source_link(path, Some(decl.line + 1)).await),
+            (Some(path), None) => Some(self.source_link(path, None).await),
             _ => self.find_blade_variable_origin(uri, var_name).await,
         };
 
@@ -13257,8 +13252,10 @@ return [
         if let Ok(Some(blocks)) = self.salsa.get_loop_blocks(file_path.clone()).await {
             for block in blocks.iter() {
                 if block.variables.iter().any(|(n, _)| n == var_name) {
-                    let display = self.relative_display_path(&file_path).await;
-                    return Some(format!("{}:{}", display, block.start_line + 1));
+                    return Some(
+                        self.source_link(&file_path, Some(block.start_line as u32 + 1))
+                            .await,
+                    );
                 }
             }
         }
@@ -13269,21 +13266,23 @@ return [
             None => std::fs::read_to_string(&file_path).unwrap_or_default(),
         };
         if let Some(line) = find_props_declaration_line(&content, var_name) {
-            let display = self.relative_display_path(&file_path).await;
-            return Some(format!("{}:{}", display, line + 1));
+            return Some(self.source_link(&file_path, Some(line + 1)).await);
         }
 
         None
     }
 
-    /// Resolve a view name to a display-friendly file path (relative to the
-    /// project root when possible, absolute otherwise). Returns `None` when
-    /// no candidate file exists on disk.
+    /// Resolve a view name to a click-to-open source link. Returns `None`
+    /// when no candidate file exists on disk.
+    ///
+    /// The returned string is full markdown link syntax —
+    /// `` [`resources/views/foo.blade.php`](file:///abs/path) `` — to be
+    /// embedded directly into the hover's bottom-line `at <link>` section.
     async fn resolve_display_path_for_view(&self, name: &str) -> Option<String> {
         let config = self.get_cached_config().await?;
         for path in config.resolve_view_path(name) {
             if self.file_exists_cached(&path).await {
-                return Some(self.relative_display_path(&path).await);
+                return Some(self.source_link(&path, None).await);
             }
         }
         None
@@ -13295,7 +13294,7 @@ return [
         let config = self.get_cached_config().await?;
         for path in config.resolve_component_path(name) {
             if self.file_exists_cached(&path).await {
-                return Some(self.relative_display_path(&path).await);
+                return Some(self.source_link(&path, None).await);
             }
         }
         None
@@ -13307,7 +13306,7 @@ return [
         let config = self.get_cached_config().await?;
         let path = config.resolve_livewire_path(name)?;
         if self.file_exists_cached(&path).await {
-            Some(self.relative_display_path(&path).await)
+            Some(self.source_link(&path, None).await)
         } else {
             None
         }
@@ -13323,6 +13322,23 @@ return [
             }
         }
         path.to_string_lossy().to_string()
+    }
+
+    /// Build the bottom-of-hover `at <link>` markdown string for a resolved
+    /// file path and optional 1-based line. The link is a `file://` URL so
+    /// Zed (and other LSP clients with markdown link support) treat it as
+    /// click-to-open. Falls back to an unlinked monospace path when the
+    /// path can't be converted to a URL (extremely rare — only relative or
+    /// invalid UTF-8 paths fail).
+    async fn source_link(&self, abs_path: &Path, line: Option<u32>) -> String {
+        let display = self.relative_display_path(abs_path).await;
+        match Url::from_file_path(abs_path) {
+            Ok(url) => laravel_lsp::hover::source_link(&display, url.as_str(), line),
+            Err(_) => match line {
+                Some(l) => format!("`{}:{}`", display, l),
+                None => format!("`{}`", display),
+            },
+        }
     }
 
     /// Return the cached vendor translation-namespace map, building it on

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -12954,16 +12954,53 @@ return [
 
         match pattern {
             PatternAtPosition::View(view) => {
-                let display = self.resolve_display_path_for_view(&view.name).await;
-                Some(hover::format_view(&view.name, display.as_deref()))
+                let path = self.resolve_view_file(&view.name).await;
+                let link = match &path {
+                    Some(p) => Some(self.source_link(p, None).await),
+                    None => None,
+                };
+                // `@props([...])` summarises what variables the view expects,
+                // which is the most useful at-a-glance snippet.
+                let snippet = path
+                    .as_deref()
+                    .and_then(laravel_lsp::blade_props::extract_props_directive);
+                Some(hover::format_view(
+                    &view.name,
+                    link.as_deref(),
+                    snippet.as_deref(),
+                ))
             }
             PatternAtPosition::Component(comp) => {
-                let display = self.resolve_display_path_for_component(&comp.name).await;
-                Some(hover::format_component(&comp.tag_name, display.as_deref()))
+                let path = self.resolve_component_file(&comp.name).await;
+                let link = match &path {
+                    Some(p) => Some(self.source_link(p, None).await),
+                    None => None,
+                };
+                let snippet = path
+                    .as_deref()
+                    .and_then(laravel_lsp::blade_props::extract_props_directive);
+                Some(hover::format_component(
+                    &comp.tag_name,
+                    link.as_deref(),
+                    snippet.as_deref(),
+                ))
             }
             PatternAtPosition::Livewire(lw) => {
-                let display = self.resolve_display_path_for_livewire(&lw.name).await;
-                Some(hover::format_livewire(&lw.name, display.as_deref()))
+                let path = self.resolve_livewire_file(&lw.name).await;
+                let link = match &path {
+                    Some(p) => Some(self.source_link(p, None).await),
+                    None => None,
+                };
+                // `class Foo extends Component` signature line — gives the
+                // reader the component class at a glance.
+                let snippet = path
+                    .as_deref()
+                    .and_then(laravel_lsp::php_class::extract_class_signature);
+                Some(hover::format_livewire(
+                    &lw.name,
+                    link.as_deref(),
+                    snippet.as_deref(),
+                ))
             }
             PatternAtPosition::Route(route) => {
                 let idx_guard = self.route_index.read().await;
@@ -12975,10 +13012,16 @@ return [
                     Some(d) => Some(self.source_link(&d.file, Some(d.line + 1)).await),
                     None => None,
                 };
+                // Pull the actual `Route::verb(...)->name(...)` line from
+                // source so the hover shows what the developer wrote, not
+                // just the parsed verb/URI/action.
+                let snippet =
+                    def.and_then(|d| laravel_lsp::php_class::read_line_from_file(&d.file, d.line));
                 Some(hover::format_route(
                     &route.name,
                     def,
                     source_link.as_deref(),
+                    snippet.as_deref(),
                 ))
             }
             PatternAtPosition::ConfigRef(cfg) => {
@@ -13272,41 +13315,37 @@ return [
         None
     }
 
-    /// Resolve a view name to a click-to-open source link. Returns `None`
-    /// when no candidate file exists on disk.
-    ///
-    /// The returned string is full markdown link syntax —
-    /// `` [`resources/views/foo.blade.php`](file:///abs/path) `` — to be
-    /// embedded directly into the hover's bottom-line `at <link>` section.
-    async fn resolve_display_path_for_view(&self, name: &str) -> Option<String> {
+    /// Resolve a view name to its on-disk file path. Returns `None` when no
+    /// candidate file exists on disk. The hover dispatch then builds the
+    /// `source_link` markdown AND the `@props(...)` source snippet from the
+    /// same path.
+    async fn resolve_view_file(&self, name: &str) -> Option<PathBuf> {
         let config = self.get_cached_config().await?;
         for path in config.resolve_view_path(name) {
             if self.file_exists_cached(&path).await {
-                return Some(self.source_link(&path, None).await);
+                return Some(path);
             }
         }
         None
     }
 
-    /// Same shape as [`Self::resolve_display_path_for_view`] but for Blade
-    /// component references.
-    async fn resolve_display_path_for_component(&self, name: &str) -> Option<String> {
+    /// Same shape as [`Self::resolve_view_file`] but for Blade components.
+    async fn resolve_component_file(&self, name: &str) -> Option<PathBuf> {
         let config = self.get_cached_config().await?;
         for path in config.resolve_component_path(name) {
             if self.file_exists_cached(&path).await {
-                return Some(self.source_link(&path, None).await);
+                return Some(path);
             }
         }
         None
     }
 
-    /// Same shape as [`Self::resolve_display_path_for_view`] but for Livewire
-    /// component references.
-    async fn resolve_display_path_for_livewire(&self, name: &str) -> Option<String> {
+    /// Same shape as [`Self::resolve_view_file`] but for Livewire components.
+    async fn resolve_livewire_file(&self, name: &str) -> Option<PathBuf> {
         let config = self.get_cached_config().await?;
         let path = config.resolve_livewire_path(name)?;
         if self.file_exists_cached(&path).await {
-            Some(self.source_link(&path, None).await)
+            Some(path)
         } else {
             None
         }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -12945,203 +12945,422 @@ return [
         let pattern = match target {
             hover::HoverTarget::Pattern(p) => p,
             hover::HoverTarget::BladeVariable { var_name, property } => {
-                return Some(
-                    self.format_blade_variable_hover(uri, &var_name, property)
-                        .await,
-                );
+                return self
+                    .build_blade_variable_hover_content(uri, &var_name, property)
+                    .await;
             }
         };
 
-        match pattern {
-            PatternAtPosition::View(view) => {
-                let path = self.resolve_view_file(&view.name).await;
-                let link = match &path {
-                    Some(p) => Some(self.source_link(p, None).await),
-                    None => None,
-                };
-                // `@props([...])` summarises what variables the view expects,
-                // which is the most useful at-a-glance snippet.
-                let snippet = path
-                    .as_deref()
-                    .and_then(laravel_lsp::blade_props::extract_props_directive);
-                Some(hover::format_view(
-                    &view.name,
-                    link.as_deref(),
-                    snippet.as_deref(),
-                ))
-            }
-            PatternAtPosition::Component(comp) => {
-                let path = self.resolve_component_file(&comp.name).await;
-                let link = match &path {
-                    Some(p) => Some(self.source_link(p, None).await),
-                    None => None,
-                };
-                let snippet = path
-                    .as_deref()
-                    .and_then(laravel_lsp::blade_props::extract_props_directive);
-                Some(hover::format_component(
-                    &comp.tag_name,
-                    link.as_deref(),
-                    snippet.as_deref(),
-                ))
-            }
-            PatternAtPosition::Livewire(lw) => {
-                let path = self.resolve_livewire_file(&lw.name).await;
-                let link = match &path {
-                    Some(p) => Some(self.source_link(p, None).await),
-                    None => None,
-                };
-                // `class Foo extends Component` signature line — gives the
-                // reader the component class at a glance.
-                let snippet = path
-                    .as_deref()
-                    .and_then(laravel_lsp::php_class::extract_class_signature);
-                Some(hover::format_livewire(
-                    &lw.name,
-                    link.as_deref(),
-                    snippet.as_deref(),
-                ))
-            }
-            PatternAtPosition::Route(route) => {
-                let idx_guard = self.route_index.read().await;
-                let def = idx_guard.as_ref().and_then(|idx| idx.get(&route.name));
-                let source_link = match def {
-                    // Routes carry the `->name(` line in the definition;
-                    // render 1-based for humans (LSP positions are 0-based
-                    // internally).
-                    Some(d) => Some(self.source_link(&d.file, Some(d.line + 1)).await),
-                    None => None,
-                };
-                // Pull the actual `Route::verb(...)->name(...)` line from
-                // source so the hover shows what the developer wrote, not
-                // just the parsed verb/URI/action.
-                let snippet =
-                    def.and_then(|d| laravel_lsp::php_class::read_line_from_file(&d.file, d.line));
-                Some(hover::format_route(
-                    &route.name,
-                    def,
-                    source_link.as_deref(),
-                    snippet.as_deref(),
-                ))
-            }
+        // Each arm builds a HoverContent for the unified template. Per-pattern
+        // work is purely data fetching — the rendering is identical across
+        // all patterns and lives in `hover::render`.
+        let rendered = match pattern {
+            PatternAtPosition::View(view) => self.hover_for_view(&view.name).await,
+            // Pass `comp.name` (bare, without `x-` prefix) — `tag_name`
+            // includes the prefix which would break path resolution.
+            PatternAtPosition::Component(comp) => self.hover_for_component(&comp.name).await,
+            PatternAtPosition::Livewire(lw) => self.hover_for_livewire(&lw.name).await,
+            PatternAtPosition::Route(route) => self.hover_for_route(&route.name).await,
             PatternAtPosition::ConfigRef(cfg) => {
-                let value = root
-                    .as_ref()
-                    .and_then(|r| laravel_lsp::config_lookup::resolve_value(r, &cfg.key));
-                // Config lookups resolve through `config/<group>.php` by
-                // convention — build the link by appending the group name
-                // to the project's config directory.
-                let source_link = match (root.as_ref(), cfg.key.split('.').next()) {
-                    (Some(r), Some(group)) => {
-                        let path = r.join("config").join(format!("{}.php", group));
-                        Some(self.source_link(&path, None).await)
-                    }
-                    _ => None,
-                };
-                Some(hover::format_config(
-                    &cfg.key,
-                    value.as_deref(),
-                    source_link.as_deref(),
-                ))
+                self.hover_for_config(&cfg.key, root.as_deref()).await
             }
-            PatternAtPosition::EnvRef(env) => {
-                let var = self
-                    .salsa
-                    .get_parsed_env_var(env.name.clone())
-                    .await
-                    .ok()
-                    .flatten();
-                let source_link = match var.as_ref() {
-                    Some(v) => Some(self.source_link(&v.source_file, None).await),
-                    None => None,
-                };
-                let input = var.as_ref().map(|v| hover::EnvHoverInput {
-                    value: v.value.as_str(),
-                    is_commented: v.is_commented,
-                    source_file: source_link.as_deref(),
-                });
-                Some(hover::format_env(&env.name, input))
-            }
+            PatternAtPosition::EnvRef(env) => self.hover_for_env(&env.name).await,
             PatternAtPosition::Translation(trans) => {
-                // For namespaced keys, also consult the vendor scan so we
-                // can resolve translations from packages whose translations
-                // haven't been published into the project's `lang/vendor/`.
-                let resolution = match root.as_ref() {
-                    Some(r) => {
-                        let vendor_map = self.vendor_translation_namespaces_for(r).await;
-                        let map_ref = vendor_map.as_ref().map(|m| m.as_ref());
-                        laravel_lsp::translation_lookup::resolve_translation_detailed(
-                            r, &trans.key, "en", map_ref,
-                        )
-                    }
-                    None => None,
-                };
-                let source_link = match &resolution {
-                    Some(res) => Some(self.source_link(&res.source_file, None).await),
-                    None => None,
-                };
-                Some(hover::format_translation(
-                    &trans.key,
-                    resolution.as_ref().map(|r| r.value.as_str()),
-                    source_link.as_deref(),
-                ))
+                self.hover_for_translation(&trans.key, root.as_deref())
+                    .await
             }
-            PatternAtPosition::Middleware(mw) => {
-                let cached = self.get_cached_middleware(&mw.name).await;
-                let class_fqn = cached.as_ref().map(|(class, _, _, _)| class.as_str());
-                let source_path = cached
-                    .as_ref()
-                    .and_then(|(_, _, source_file, _)| source_file.as_ref());
-                let source_link = match source_path {
-                    Some(p) => Some(self.source_link(p, None).await),
-                    None => None,
-                };
-                Some(hover::format_middleware(
-                    &mw.name,
-                    class_fqn,
-                    source_link.as_deref(),
-                ))
-            }
-            PatternAtPosition::Binding(binding) => {
-                let cached = self.get_cached_binding(&binding.name).await;
-                let class_fqn = cached.as_ref().map(|(class, _, _, _)| class.as_str());
-                let source_path = cached
-                    .as_ref()
-                    .and_then(|(_, _, source_file, _)| source_file.as_ref());
-                let source_link = match source_path {
-                    Some(p) => Some(self.source_link(p, None).await),
-                    None => None,
-                };
-                Some(hover::format_binding(
-                    &binding.name,
-                    class_fqn,
-                    source_link.as_deref(),
-                ))
-            }
-            PatternAtPosition::Asset(asset) => {
-                let helper_label = Self::asset_helper_label(asset.helper_type);
-                let resolved = self.resolve_display_path_for_asset(&asset).await;
-                Some(hover::format_asset(
-                    &asset.path,
-                    helper_label,
-                    resolved.as_deref(),
-                ))
-            }
-            PatternAtPosition::Url(url) => {
-                let resolved = self.resolve_display_path_for_url(&url.path).await;
-                Some(hover::format_url(&url.path, resolved.as_deref()))
-            }
-            // Patterns we don't yet surface in hover — silently drop so the
-            // editor doesn't display an empty tooltip.
+            PatternAtPosition::Middleware(mw) => self.hover_for_middleware(&mw.name).await,
+            PatternAtPosition::Binding(binding) => self.hover_for_binding(&binding.name).await,
+            PatternAtPosition::Asset(asset) => self.hover_for_asset(&asset).await,
+            PatternAtPosition::Url(url) => self.hover_for_url(&url.path).await,
+            // Patterns we don't yet surface in hover — silently drop.
             PatternAtPosition::Directive(_)
             | PatternAtPosition::Action(_)
-            | PatternAtPosition::Feature(_) => None,
+            | PatternAtPosition::Feature(_) => return None,
+        };
+
+        if rendered.is_empty() {
+            None
+        } else {
+            Some(rendered)
         }
     }
 
+    /// View — `@props([...])` snippet + resolved file link.
+    async fn hover_for_view(&self, name: &str) -> String {
+        use laravel_lsp::hover;
+        let path = self.resolve_view_file(name).await;
+        let link = match &path {
+            Some(p) => Some(self.source_link(p, None).await),
+            None => None,
+        };
+        let snippet = path
+            .as_deref()
+            .and_then(laravel_lsp::blade_props::extract_props_directive);
+        let trailer = if link.is_none() {
+            Some("*(file not found)*")
+        } else {
+            None
+        };
+        hover::render(&hover::HoverContent {
+            code: snippet.as_deref().map(|s| hover::CodeBlock {
+                language: hover::CodeLanguage::Php,
+                content: s,
+            }),
+            source_link: link.as_deref(),
+            trailer,
+            ..Default::default()
+        })
+    }
+
+    /// Blade component — distinguishes class-backed components (Laravel
+    /// renders these via an `app/View/Components/<Pascal>.php` class) from
+    /// anonymous Blade components (just a `.blade.php` template).
+    ///
+    /// - **Class-backed** → class FQN as header + `class Foo extends
+    ///   Component` signature snippet + link to the class file.
+    /// - **Anonymous** → no header + `@props([...])` snippet from the
+    ///   Blade file + link to that file.
+    ///
+    /// Class detection: look for `app/View/Components/<PascalCase(name)>.php`
+    /// on disk. Dots in the component name become path separators, kebab
+    /// segments get pascal-cased — `<x-forms.input-text>` →
+    /// `app/View/Components/Forms/InputText.php`.
+    async fn hover_for_component(&self, name: &str) -> String {
+        use laravel_lsp::hover;
+        let class_path = self.resolve_component_class_file(name).await;
+        let blade_path = self.resolve_component_file(name).await;
+
+        // Class-backed wins when its file exists — Laravel resolves
+        // class-backed components first at runtime too.
+        if let Some(ref class_file) = class_path {
+            let class_fqn = laravel_lsp::php_class::extract_class_fqn(class_file);
+            let snippet = laravel_lsp::php_class::extract_class_signature(class_file);
+            let link = self.source_link(class_file, None).await;
+            return hover::render(&hover::HoverContent {
+                header: class_fqn.as_deref(),
+                code: snippet.as_deref().map(|s| hover::CodeBlock {
+                    language: hover::CodeLanguage::Php,
+                    content: s,
+                }),
+                source_link: Some(&link),
+                ..Default::default()
+            });
+        }
+
+        // Fall through to anonymous-component shape.
+        let link = match &blade_path {
+            Some(p) => Some(self.source_link(p, None).await),
+            None => None,
+        };
+        let snippet = blade_path
+            .as_deref()
+            .and_then(laravel_lsp::blade_props::extract_props_directive);
+        let trailer = if link.is_none() {
+            Some("*(file not found)*")
+        } else {
+            None
+        };
+        hover::render(&hover::HoverContent {
+            code: snippet.as_deref().map(|s| hover::CodeBlock {
+                language: hover::CodeLanguage::Php,
+                content: s,
+            }),
+            source_link: link.as_deref(),
+            trailer,
+            ..Default::default()
+        })
+    }
+
+    /// Look up the conventional class-backed component file for a tag name.
+    /// Returns `app/View/Components/<PascalCase(name)>.php` if it exists on
+    /// disk, otherwise `None`. Handles dotted names (`forms.input` →
+    /// `Forms/Input.php`) and kebab segments (`alert-box` → `AlertBox.php`).
+    async fn resolve_component_class_file(&self, name: &str) -> Option<PathBuf> {
+        let root = self.root_path.read().await.clone()?;
+        let class_path = name
+            .split('.')
+            .map(laravel_lsp::config::kebab_to_pascal_case)
+            .collect::<Vec<_>>()
+            .join("/");
+        let candidate = root
+            .join("app/View/Components")
+            .join(format!("{}.php", class_path));
+        if self.file_exists_cached(&candidate).await {
+            Some(candidate)
+        } else {
+            None
+        }
+    }
+
+    /// Livewire — class FQN header, class signature snippet, file link.
+    async fn hover_for_livewire(&self, name: &str) -> String {
+        use laravel_lsp::hover;
+        let path = self.resolve_livewire_file(name).await;
+        let link = match &path {
+            Some(p) => Some(self.source_link(p, None).await),
+            None => None,
+        };
+        let snippet = path
+            .as_deref()
+            .and_then(laravel_lsp::php_class::extract_class_signature);
+        let class_fqn = path
+            .as_deref()
+            .and_then(laravel_lsp::php_class::extract_class_fqn);
+        let trailer = if link.is_none() {
+            Some("*(file not found)*")
+        } else {
+            None
+        };
+        hover::render(&hover::HoverContent {
+            header: class_fqn.as_deref(),
+            code: snippet.as_deref().map(|s| hover::CodeBlock {
+                language: hover::CodeLanguage::Php,
+                content: s,
+            }),
+            source_link: link.as_deref(),
+            trailer,
+            ..Default::default()
+        })
+    }
+
+    /// Route — detail line (verb + URI + action) + the route registration
+    /// line from source + link to the `->name(` callsite.
+    async fn hover_for_route(&self, name: &str) -> String {
+        use laravel_lsp::hover;
+        let idx_guard = self.route_index.read().await;
+        let def = idx_guard.as_ref().and_then(|idx| idx.get(name));
+        let Some(def) = def else {
+            return hover::render(&hover::HoverContent {
+                trailer: Some("*(route not found in index)*"),
+                ..Default::default()
+            });
+        };
+        let method = def
+            .method
+            .as_deref()
+            .map(|m| m.to_uppercase())
+            .unwrap_or_else(|| "?".to_string());
+        let uri = def.uri.as_deref().unwrap_or("?");
+        let action = def.action.as_deref().unwrap_or("?");
+        let detail = format!("`{} {}` → `{}`", method, uri, action);
+        let snippet = laravel_lsp::php_class::read_line_from_file(&def.file, def.line);
+        let link = self.source_link(&def.file, Some(def.line + 1)).await;
+        // Drop the lock on route_index before awaiting other things in render.
+        drop(idx_guard);
+        hover::render(&hover::HoverContent {
+            detail: Some(&detail),
+            code: snippet.as_deref().map(|s| hover::CodeBlock {
+                language: hover::CodeLanguage::Php,
+                content: s,
+            }),
+            source_link: Some(&link),
+            ..Default::default()
+        })
+    }
+
+    /// Config — resolved value as a `php` code block, link to the
+    /// `config/<group>.php` file.
+    async fn hover_for_config(&self, key: &str, root: Option<&Path>) -> String {
+        use laravel_lsp::hover;
+        let value = root.and_then(|r| laravel_lsp::config_lookup::resolve_value(r, key));
+        let link = match (root, key.split('.').next()) {
+            (Some(r), Some(group)) => {
+                let path = r.join("config").join(format!("{}.php", group));
+                Some(self.source_link(&path, None).await)
+            }
+            _ => None,
+        };
+        let truncated = value
+            .as_deref()
+            .map(|v| laravel_lsp::hover::truncate_for_display(v, 200));
+        let trailer = if value.is_none() {
+            Some("*(value not found)*")
+        } else {
+            None
+        };
+        hover::render(&hover::HoverContent {
+            code: truncated.as_deref().map(|s| hover::CodeBlock {
+                language: hover::CodeLanguage::Php,
+                content: s,
+            }),
+            source_link: link.as_deref(),
+            trailer,
+            ..Default::default()
+        })
+    }
+
+    /// Env — value as a plain code block, link to the `.env` file it was
+    /// read from. Commented-out entries render as a detail note.
+    async fn hover_for_env(&self, name: &str) -> String {
+        use laravel_lsp::hover;
+        let var = self
+            .salsa
+            .get_parsed_env_var(name.to_string())
+            .await
+            .ok()
+            .flatten();
+        let Some(var) = var else {
+            return hover::render(&hover::HoverContent {
+                trailer: Some("*(not defined in .env)*"),
+                ..Default::default()
+            });
+        };
+        let link = self.source_link(&var.source_file, None).await;
+        if var.is_commented {
+            hover::render(&hover::HoverContent {
+                detail: Some("*(commented out)*"),
+                source_link: Some(&link),
+                ..Default::default()
+            })
+        } else {
+            hover::render(&hover::HoverContent {
+                code: Some(hover::CodeBlock {
+                    language: hover::CodeLanguage::Plain,
+                    content: &var.value,
+                }),
+                source_link: Some(&link),
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Translation — resolved value (with outer quotes stripped) as a plain
+    /// code block, link to the lang file.
+    async fn hover_for_translation(&self, key: &str, root: Option<&Path>) -> String {
+        use laravel_lsp::hover;
+        let resolution = match root {
+            Some(r) => {
+                let vendor_map = self.vendor_translation_namespaces_for(r).await;
+                let map_ref = vendor_map.as_ref().map(|m| m.as_ref());
+                laravel_lsp::translation_lookup::resolve_translation_detailed(r, key, "en", map_ref)
+            }
+            None => None,
+        };
+        let link = match &resolution {
+            Some(res) => Some(self.source_link(&res.source_file, None).await),
+            None => None,
+        };
+        // Translation values are PHP literals (`'foo'`) — strip the outer
+        // quotes for nicer in-block display.
+        let unquoted = resolution.as_ref().map(|r| {
+            let v = r.value.trim();
+            v.strip_prefix('\'')
+                .and_then(|s| s.strip_suffix('\''))
+                .or_else(|| v.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
+                .unwrap_or(v)
+                .to_string()
+        });
+        let truncated = unquoted
+            .as_deref()
+            .map(|s| laravel_lsp::hover::truncate_for_display(s, 200));
+        let trailer = if resolution.is_none() {
+            Some("*(translation not found for default locale)*")
+        } else {
+            None
+        };
+        hover::render(&hover::HoverContent {
+            code: truncated.as_deref().map(|s| hover::CodeBlock {
+                language: hover::CodeLanguage::Plain,
+                content: s,
+            }),
+            source_link: link.as_deref(),
+            trailer,
+            ..Default::default()
+        })
+    }
+
+    /// Middleware — header is the alias's class FQN (the new info beyond
+    /// the cursor's `'auth'` string).
+    async fn hover_for_middleware(&self, name: &str) -> String {
+        use laravel_lsp::hover;
+        let cached = self.get_cached_middleware(name).await;
+        let class_fqn = cached.as_ref().map(|(class, _, _, _)| class.as_str());
+        let source_path = cached
+            .as_ref()
+            .and_then(|(_, _, source_file, _)| source_file.as_ref());
+        let link = match source_path {
+            Some(p) => Some(self.source_link(p, None).await),
+            None => None,
+        };
+        let trailer = if class_fqn.is_none() {
+            Some("*(alias not registered)*")
+        } else {
+            None
+        };
+        hover::render(&hover::HoverContent {
+            header: class_fqn,
+            source_link: link.as_deref(),
+            trailer,
+            ..Default::default()
+        })
+    }
+
+    /// Container binding — header is the concrete class FQN bound to the
+    /// alias.
+    async fn hover_for_binding(&self, name: &str) -> String {
+        use laravel_lsp::hover;
+        let cached = self.get_cached_binding(name).await;
+        let class_fqn = cached.as_ref().map(|(class, _, _, _)| class.as_str());
+        let source_path = cached
+            .as_ref()
+            .and_then(|(_, _, source_file, _)| source_file.as_ref());
+        let link = match source_path {
+            Some(p) => Some(self.source_link(p, None).await),
+            None => None,
+        };
+        let trailer = if class_fqn.is_none() {
+            Some("*(binding not registered)*")
+        } else {
+            None
+        };
+        hover::render(&hover::HoverContent {
+            header: class_fqn,
+            source_link: link.as_deref(),
+            trailer,
+            ..Default::default()
+        })
+    }
+
+    /// Asset (`asset()`, `Vite::asset()`, `mix()`, `public_path()`, etc.) —
+    /// just the resolved file link.
+    async fn hover_for_asset(&self, asset: &laravel_lsp::salsa_impl::AssetReferenceData) -> String {
+        use laravel_lsp::hover;
+        let resolved = self.resolve_display_path_for_asset(asset).await;
+        let trailer = if resolved.is_none() {
+            Some("*(file not found)*")
+        } else {
+            None
+        };
+        hover::render(&hover::HoverContent {
+            source_link: resolved.as_deref(),
+            trailer,
+            ..Default::default()
+        })
+    }
+
+    /// `url('/path')` — same shape as asset.
+    async fn hover_for_url(&self, url_path: &str) -> String {
+        use laravel_lsp::hover;
+        let resolved = self.resolve_display_path_for_url(url_path).await;
+        let trailer = if resolved.is_none() {
+            Some("*(file not found)*")
+        } else {
+            None
+        };
+        hover::render(&hover::HoverContent {
+            source_link: resolved.as_deref(),
+            trailer,
+            ..Default::default()
+        })
+    }
+
     /// Map a Salsa `AssetHelperType` to the function-call form a developer
-    /// would have literally written. Used as the bold header label in
-    /// [`laravel_lsp::hover::format_asset`].
+    /// would have literally written. No current caller (asset hovers don't
+    /// surface the helper label anymore now that the unified template
+    /// dropped the call-form header) but kept available for future use —
+    /// e.g. a completion item that wants to render the helper name.
+    #[allow(dead_code)]
     fn asset_helper_label(t: laravel_lsp::salsa_impl::AssetHelperType) -> &'static str {
         use laravel_lsp::salsa_impl::AssetHelperType;
         match t {
@@ -13203,38 +13422,35 @@ return [
         }
     }
 
-    /// Resolve a Blade variable hover and produce intelephense-style
-    /// markdown. Combines:
+    /// Resolve a Blade variable hover into rendered markdown. Builds a
+    /// [`hover::HoverContent`] from:
     ///
     /// - **Variable type resolution** (existing `resolve_blade_variable_type`)
     ///   — class FQN, primitive, or `None`.
     /// - **Class file lookup** — `class_locator::find_php_class_file`.
     /// - **Property declaration + PHPDoc** — pulled from the class source so
-    ///   the hover shows `public string $email;` and any leading PHPDoc
-    ///   description, mirroring what intelephense does for first-party PHP
-    ///   hovers.
-    async fn format_blade_variable_hover(
+    ///   the hover shows `public string $email;` plus any leading docblock.
+    ///
+    /// The bold header is set ONLY when we have a class-like FQN to qualify
+    /// the variable / property with (avoids echoing `$user` or
+    /// `$user->email` as a redundant header).
+    async fn build_blade_variable_hover_content(
         &self,
         uri: &Url,
         var_name: &str,
         property: Option<String>,
-    ) -> String {
+    ) -> Option<String> {
+        use laravel_lsp::hover;
         let var_dollar = format!("${}", var_name);
         let resolved_var_type = self.resolve_blade_variable_type(uri, &var_dollar).await;
 
-        // Decide whether the resolved type is "really a class" we should look
-        // up on disk. The Blade variable resolver returns `"mixed"` as a
-        // sentinel for loop variables whose iterable element type couldn't be
-        // inferred (and similar fallbacks). Treating those as classes would
-        // call `find_php_class_file("mixed")` which always returns None,
-        // discarding any source info we *could* surface from the Blade file
-        // itself.
+        // `"mixed"` is a sentinel from the loop-variable resolver — calling
+        // `find_php_class_file("mixed")` always misses, throwing away any
+        // useful Blade-file fallback we could surface.
         let class_fqn_for_lookup = resolved_var_type
             .as_deref()
-            .filter(|t| laravel_lsp::hover::is_class_like_type(t));
+            .filter(|t| hover::is_class_like_type(t));
 
-        // Look up the class's file path AND its source for the property
-        // declaration extraction below.
         let (class_source, class_path) = match class_fqn_for_lookup {
             Some(class_fqn) => {
                 let root = self.root_path.read().await.clone();
@@ -13247,8 +13463,6 @@ return [
             None => (None, None),
         };
 
-        // Pull the property's declaration line + PHPDoc when we have a class
-        // source on disk AND the cursor is on a specific property.
         let declaration = match (property.as_deref(), class_source.as_deref()) {
             (Some(prop), Some(source)) => {
                 laravel_lsp::php_class::extract_property_declaration(source, prop)
@@ -13256,26 +13470,53 @@ return [
             _ => None,
         };
 
-        // Source-line link priority:
-        //   1. Class file + property line — most useful jump target
-        //   2. Class file alone — class found but no explicit property
-        //      declaration (Eloquent columns not in $casts/$fillable)
-        //   3. Blade-file origin — when the variable's type is unknown
-        //      (`mixed` sentinel), surface the @foreach / @props line that
-        //      introduced the variable in the current Blade file
-        let defined_in_display = match (class_path.as_ref(), declaration.as_ref()) {
+        // Source-link priority:
+        //   1. Class file + property line — best jump target
+        //   2. Class file alone — class found but no explicit property line
+        //      (Eloquent columns not in $casts/$fillable)
+        //   3. Blade-file origin (`@foreach`/`@props` line) — when type
+        //      didn't resolve to a class
+        let link = match (class_path.as_ref(), declaration.as_ref()) {
             (Some(path), Some(decl)) => Some(self.source_link(path, Some(decl.line + 1)).await),
             (Some(path), None) => Some(self.source_link(path, None).await),
             _ => self.find_blade_variable_origin(uri, var_name).await,
         };
 
-        laravel_lsp::hover::format_blade_variable(&laravel_lsp::hover::BladeVariableHover {
-            var_name,
-            property: property.as_deref(),
-            var_type: resolved_var_type.as_deref(),
-            declaration: declaration.as_ref(),
-            defined_in: defined_in_display.as_deref(),
-        })
+        // Bold header — only when we have a class FQN. Otherwise no header
+        // (echoing `$var` or `$var->prop` as bold adds no info beyond the
+        // cursor).
+        let header_owned = match (resolved_var_type.as_deref(), property.as_deref()) {
+            (Some(class), Some(prop)) if hover::is_class_like_type(class) => {
+                Some(format!("{}::${}", class, prop))
+            }
+            (Some(class), None) if hover::is_class_like_type(class) => {
+                Some(format!("${} : `{}`", var_name, class))
+            }
+            _ => None,
+        };
+
+        let description = declaration.as_ref().and_then(|d| d.description.clone());
+        let tags: Vec<String> = declaration
+            .as_ref()
+            .map(|d| d.phpdoc_tags.clone())
+            .unwrap_or_default();
+
+        let rendered = hover::render(&hover::HoverContent {
+            header: header_owned.as_deref(),
+            description: description.as_deref(),
+            code: declaration.as_ref().map(|d| hover::CodeBlock {
+                language: hover::CodeLanguage::Php,
+                content: &d.declaration_text,
+            }),
+            tags: &tags,
+            source_link: link.as_deref(),
+            ..Default::default()
+        });
+        if rendered.is_empty() {
+            None
+        } else {
+            Some(rendered)
+        }
     }
 
     /// Scan the current Blade file for where `var_name` was introduced —
@@ -14061,12 +14302,12 @@ impl LanguageServer for LaravelLanguageServer {
                     return Ok(None);
                 };
                 let value = self
-                    .format_blade_variable_hover(uri, &var_name, property)
+                    .build_blade_variable_hover_content(uri, &var_name, property)
                     .await;
-                return Ok(Some(Hover {
+                return Ok(value.map(|v| Hover {
                     contents: HoverContents::Markup(MarkupContent {
                         kind: MarkupKind::Markdown,
-                        value,
+                        value: v,
                     }),
                     range: None,
                 }));

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -1,3 +1,9 @@
+// The LSP server holds a number of deeply-nested Arc/RwLock state fields
+// (caches, route indexes, vendor maps). Extracting type aliases for each
+// would be more noise than signal; allow the complex types crate-wide to
+// match the same opt-out already in place on the library at lib.rs:10.
+#![allow(clippy::type_complexity)]
+
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -66,6 +72,45 @@ fn extract_middleware_imports(content: &str, root: &Path) -> Vec<PathBuf> {
     }
 
     files
+}
+
+/// Scan Blade source for `@props([..., 'var_name', ...])` and return the
+/// 0-based line where the declaration sits. Recognises both single- and
+/// double-quoted keys, both with and without `=> default` defaults.
+///
+/// Used by the hover handler as a fallback source location when a Blade
+/// variable's type can't be resolved to a class — at least point the user at
+/// `@props` so they know where the variable was declared in this template.
+fn find_props_declaration_line(content: &str, var_name: &str) -> Option<u32> {
+    use lazy_static::lazy_static;
+    use regex::Regex;
+    lazy_static! {
+        // `@props(` followed by anything up to `)` — captured greedily but
+        // bounded by `)` so we don't span past the directive.
+        static ref PROPS_RE: Regex = Regex::new(r"@props\s*\(([^)]*)\)").unwrap();
+    }
+    for cap in PROPS_RE.captures_iter(content) {
+        let body = cap.get(1)?.as_str();
+        // Check for `'var_name'` or `"var_name"` as either an array value
+        // (no `=>` after) or an array key (`=> default`).
+        let single = format!("'{}'", var_name);
+        let double = format!("\"{}\"", var_name);
+        if body.contains(&single) || body.contains(&double) {
+            // Compute the 0-based line of the match start.
+            let match_start = cap.get(0)?.start();
+            let mut line = 0u32;
+            for (i, ch) in content.char_indices() {
+                if i >= match_start {
+                    break;
+                }
+                if ch == '\n' {
+                    line += 1;
+                }
+            }
+            return Some(line);
+        }
+    }
+    None
 }
 
 /// Resolve a class name to a vendor file path using PSR-4 conventions
@@ -1789,6 +1834,15 @@ struct LaravelLanguageServer {
     /// Populated at init by walking routes/, vendor/*/routes/, and content-matched
     /// vendor PHP files. Replaces the legacy hard-coded route-file scan.
     route_index: Arc<RwLock<Option<RouteIndex>>>,
+
+    /// Cached map of translation `namespace → absolute lang directory` for
+    /// unpublished vendor packages. Lazily populated on the first translation
+    /// hover that needs it; subsequent hovers reuse the cached map. See
+    /// [`laravel_lsp::vendor_translations`] for the scan implementation.
+    /// `None` means "not yet scanned"; `Some(map)` means "scanned, here's
+    /// what we found" (the map can be empty if no packages register).
+    /// Wrapped in `Arc` so clones share memory across hover calls.
+    vendor_translation_namespaces: Arc<RwLock<Option<Arc<HashMap<String, PathBuf>>>>>,
 }
 
 /// Default Salsa debounce delay in milliseconds
@@ -2690,6 +2744,7 @@ impl LaravelLanguageServer {
             database_schema: Arc::new(RwLock::new(None)),
             database_diagnostic_shown: Arc::new(RwLock::new(false)),
             route_index: Arc::new(RwLock::new(None)),
+            vendor_translation_namespaces: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -6171,6 +6226,11 @@ impl LaravelLanguageServer {
     /// locator to find the class file, then scans for `public Type $prop`.
     /// Returns `None` when the class can't be found or the property isn't
     /// declared with a recognizable type.
+    ///
+    /// Kept available even though the hover handler no longer calls it
+    /// directly — completion / diagnostic code may grow to use it, and the
+    /// resolution logic is non-trivial enough that I don't want to delete it.
+    #[allow(dead_code)]
     async fn resolve_property_type_on_class(
         &self,
         class_name: &str,
@@ -11770,6 +11830,7 @@ return [
             database_schema: self.database_schema.clone(),
             database_diagnostic_shown: self.database_diagnostic_shown.clone(),
             route_index: self.route_index.clone(),
+            vendor_translation_namespaces: self.vendor_translation_namespaces.clone(),
         }
     }
 
@@ -12862,6 +12923,434 @@ return [
             .await;
         info!("   ✅ Diagnostics published successfully");
     }
+
+    /// Resolve a [`HoverTarget`] into the markdown body that should appear in
+    /// the editor's hover tooltip. Each pattern branch performs its own data
+    /// resolution (file existence, cached config values, env vars, route
+    /// metadata, etc.) and then hands the resolved data to a pure formatter
+    /// in [`laravel_lsp::hover`].
+    ///
+    /// Returns `None` when neither the cursor's pattern nor the variable
+    /// fallback produced something worth displaying.
+    async fn build_hover_markdown(
+        &self,
+        target: laravel_lsp::hover::HoverTarget,
+        uri: &Url,
+    ) -> Option<String> {
+        use laravel_lsp::hover;
+        use laravel_lsp::salsa_impl::PatternAtPosition;
+
+        let root = self.root_path.read().await.clone();
+
+        let pattern = match target {
+            hover::HoverTarget::Pattern(p) => p,
+            hover::HoverTarget::BladeVariable { var_name, property } => {
+                return Some(
+                    self.format_blade_variable_hover(uri, &var_name, property)
+                        .await,
+                );
+            }
+        };
+
+        match pattern {
+            PatternAtPosition::View(view) => {
+                let display = self.resolve_display_path_for_view(&view.name).await;
+                Some(hover::format_view(&view.name, display.as_deref()))
+            }
+            PatternAtPosition::Component(comp) => {
+                let display = self.resolve_display_path_for_component(&comp.name).await;
+                Some(hover::format_component(&comp.tag_name, display.as_deref()))
+            }
+            PatternAtPosition::Livewire(lw) => {
+                let display = self.resolve_display_path_for_livewire(&lw.name).await;
+                Some(hover::format_livewire(&lw.name, display.as_deref()))
+            }
+            PatternAtPosition::Route(route) => {
+                let idx_guard = self.route_index.read().await;
+                let def = idx_guard.as_ref().and_then(|idx| idx.get(&route.name));
+                let source_display = match def {
+                    Some(d) => {
+                        let path_display = self.relative_display_path(&d.file).await;
+                        // Routes carry their `->name(` line in the definition;
+                        // render 1-based for humans.
+                        Some(format!("{}:{}", path_display, d.line + 1))
+                    }
+                    None => None,
+                };
+                Some(hover::format_route(
+                    &route.name,
+                    def,
+                    source_display.as_deref(),
+                ))
+            }
+            PatternAtPosition::ConfigRef(cfg) => {
+                let value = root
+                    .as_ref()
+                    .and_then(|r| laravel_lsp::config_lookup::resolve_value(r, &cfg.key));
+                let source_file = cfg
+                    .key
+                    .split('.')
+                    .next()
+                    .map(|group| format!("config/{}.php", group));
+                Some(hover::format_config(
+                    &cfg.key,
+                    value.as_deref(),
+                    source_file.as_deref(),
+                ))
+            }
+            PatternAtPosition::EnvRef(env) => {
+                let var = self
+                    .salsa
+                    .get_parsed_env_var(env.name.clone())
+                    .await
+                    .ok()
+                    .flatten();
+                let source_display = var
+                    .as_ref()
+                    .map(|v| self.relative_display_path(&v.source_file));
+                let source_display = match source_display {
+                    Some(fut) => Some(fut.await),
+                    None => None,
+                };
+                let input = var.as_ref().map(|v| hover::EnvHoverInput {
+                    value: v.value.as_str(),
+                    is_commented: v.is_commented,
+                    source_file: source_display.as_deref(),
+                });
+                Some(hover::format_env(&env.name, input))
+            }
+            PatternAtPosition::Translation(trans) => {
+                // For namespaced keys, also consult the vendor scan so we
+                // can resolve translations from packages whose translations
+                // haven't been published into the project's `lang/vendor/`.
+                let resolution = match root.as_ref() {
+                    Some(r) => {
+                        let vendor_map = self.vendor_translation_namespaces_for(r).await;
+                        let map_ref = vendor_map.as_ref().map(|m| m.as_ref());
+                        laravel_lsp::translation_lookup::resolve_translation_detailed(
+                            r, &trans.key, "en", map_ref,
+                        )
+                    }
+                    None => None,
+                };
+                let source_file = match &resolution {
+                    Some(res) => Some(self.relative_display_path(&res.source_file).await),
+                    None => None,
+                };
+                Some(hover::format_translation(
+                    &trans.key,
+                    resolution.as_ref().map(|r| r.value.as_str()),
+                    source_file.as_deref(),
+                ))
+            }
+            PatternAtPosition::Middleware(mw) => {
+                let cached = self.get_cached_middleware(&mw.name).await;
+                let class_fqn = cached.as_ref().map(|(class, _, _, _)| class.as_str());
+                let source_path = cached
+                    .as_ref()
+                    .and_then(|(_, _, source_file, _)| source_file.as_ref());
+                let source_display = match source_path {
+                    Some(p) => Some(self.relative_display_path(p).await),
+                    None => None,
+                };
+                Some(hover::format_middleware(
+                    &mw.name,
+                    class_fqn,
+                    source_display.as_deref(),
+                ))
+            }
+            PatternAtPosition::Binding(binding) => {
+                let cached = self.get_cached_binding(&binding.name).await;
+                let class_fqn = cached.as_ref().map(|(class, _, _, _)| class.as_str());
+                let source_path = cached
+                    .as_ref()
+                    .and_then(|(_, _, source_file, _)| source_file.as_ref());
+                let source_display = match source_path {
+                    Some(p) => Some(self.relative_display_path(p).await),
+                    None => None,
+                };
+                Some(hover::format_binding(
+                    &binding.name,
+                    class_fqn,
+                    source_display.as_deref(),
+                ))
+            }
+            PatternAtPosition::Asset(asset) => {
+                let helper_label = Self::asset_helper_label(asset.helper_type);
+                let resolved = self.resolve_display_path_for_asset(&asset).await;
+                Some(hover::format_asset(
+                    &asset.path,
+                    helper_label,
+                    resolved.as_deref(),
+                ))
+            }
+            PatternAtPosition::Url(url) => {
+                let resolved = self.resolve_display_path_for_url(&url.path).await;
+                Some(hover::format_url(&url.path, resolved.as_deref()))
+            }
+            // Patterns we don't yet surface in hover — silently drop so the
+            // editor doesn't display an empty tooltip.
+            PatternAtPosition::Directive(_)
+            | PatternAtPosition::Action(_)
+            | PatternAtPosition::Feature(_) => None,
+        }
+    }
+
+    /// Map a Salsa `AssetHelperType` to the function-call form a developer
+    /// would have literally written. Used as the bold header label in
+    /// [`laravel_lsp::hover::format_asset`].
+    fn asset_helper_label(t: laravel_lsp::salsa_impl::AssetHelperType) -> &'static str {
+        use laravel_lsp::salsa_impl::AssetHelperType;
+        match t {
+            AssetHelperType::Asset => "asset",
+            AssetHelperType::PublicPath => "public_path",
+            AssetHelperType::Mix => "mix",
+            AssetHelperType::BasePath => "base_path",
+            AssetHelperType::AppPath => "app_path",
+            AssetHelperType::StoragePath => "storage_path",
+            AssetHelperType::DatabasePath => "database_path",
+            AssetHelperType::LangPath => "lang_path",
+            AssetHelperType::ConfigPath => "config_path",
+            AssetHelperType::ResourcePath => "resource_path",
+            AssetHelperType::ViteAsset => "Vite::asset",
+        }
+    }
+
+    /// Resolve an asset reference to its on-disk file path. Mirrors the
+    /// directory mapping used by `create_asset_location_from_salsa` for
+    /// goto-definition — `asset()`/`Vite::asset()` look under `public/` or
+    /// `resources/` depending on which helper produced the reference.
+    async fn resolve_display_path_for_asset(
+        &self,
+        asset: &laravel_lsp::salsa_impl::AssetReferenceData,
+    ) -> Option<String> {
+        use laravel_lsp::salsa_impl::AssetHelperType;
+        let root = self.root_path.read().await.clone()?;
+        let base = match asset.helper_type {
+            AssetHelperType::Asset | AssetHelperType::PublicPath | AssetHelperType::Mix => {
+                root.join("public")
+            }
+            AssetHelperType::BasePath => root.clone(),
+            AssetHelperType::AppPath => root.join("app"),
+            AssetHelperType::StoragePath => root.join("storage"),
+            AssetHelperType::DatabasePath => root.join("database"),
+            AssetHelperType::LangPath => root.join("lang"),
+            AssetHelperType::ConfigPath => root.join("config"),
+            AssetHelperType::ResourcePath | AssetHelperType::ViteAsset => root.join("resources"),
+        };
+        let asset_path = base.join(&asset.path);
+        if self.file_exists_cached(&asset_path).await {
+            Some(self.relative_display_path(&asset_path).await)
+        } else {
+            None
+        }
+    }
+
+    /// Resolve a `url('/path')` reference to its on-disk file under `public/`.
+    /// Returns `None` when the file doesn't exist (the URL might point to a
+    /// dynamic route, not a static asset — that's fine, we just don't show
+    /// a source line).
+    async fn resolve_display_path_for_url(&self, url_path: &str) -> Option<String> {
+        let root = self.root_path.read().await.clone()?;
+        let path = url_path.trim_start_matches('/');
+        let candidate = root.join("public").join(path);
+        if self.file_exists_cached(&candidate).await {
+            Some(self.relative_display_path(&candidate).await)
+        } else {
+            None
+        }
+    }
+
+    /// Resolve a Blade variable hover and produce intelephense-style
+    /// markdown. Combines:
+    ///
+    /// - **Variable type resolution** (existing `resolve_blade_variable_type`)
+    ///   — class FQN, primitive, or `None`.
+    /// - **Class file lookup** — `class_locator::find_php_class_file`.
+    /// - **Property declaration + PHPDoc** — pulled from the class source so
+    ///   the hover shows `public string $email;` and any leading PHPDoc
+    ///   description, mirroring what intelephense does for first-party PHP
+    ///   hovers.
+    async fn format_blade_variable_hover(
+        &self,
+        uri: &Url,
+        var_name: &str,
+        property: Option<String>,
+    ) -> String {
+        let var_dollar = format!("${}", var_name);
+        let resolved_var_type = self.resolve_blade_variable_type(uri, &var_dollar).await;
+
+        // Decide whether the resolved type is "really a class" we should look
+        // up on disk. The Blade variable resolver returns `"mixed"` as a
+        // sentinel for loop variables whose iterable element type couldn't be
+        // inferred (and similar fallbacks). Treating those as classes would
+        // call `find_php_class_file("mixed")` which always returns None,
+        // discarding any source info we *could* surface from the Blade file
+        // itself.
+        let class_fqn_for_lookup = resolved_var_type
+            .as_deref()
+            .filter(|t| laravel_lsp::hover::is_class_like_type(t));
+
+        // Look up the class's file path AND its source for the property
+        // declaration extraction below.
+        let (class_source, class_path) = match class_fqn_for_lookup {
+            Some(class_fqn) => {
+                let root = self.root_path.read().await.clone();
+                let path = root
+                    .as_ref()
+                    .and_then(|r| laravel_lsp::class_locator::find_php_class_file(class_fqn, r));
+                let source = path.as_ref().and_then(|p| std::fs::read_to_string(p).ok());
+                (source, path)
+            }
+            None => (None, None),
+        };
+
+        // Pull the property's declaration line + PHPDoc when we have a class
+        // source on disk AND the cursor is on a specific property.
+        let declaration = match (property.as_deref(), class_source.as_deref()) {
+            (Some(prop), Some(source)) => {
+                laravel_lsp::php_class::extract_property_declaration(source, prop)
+            }
+            _ => None,
+        };
+
+        // Source-line display priority:
+        //   1. Class file + property line (`app/Models/User.php:42`) — best
+        //   2. Class file alone (`app/Models/User.php`) — class found but no
+        //      explicit property declaration on it (common for Eloquent
+        //      columns that aren't in $casts/$fillable as keys)
+        //   3. Blade-file origin (`resources/views/foo.blade.php:7`) — when
+        //      the variable's type is unknown/`mixed`, surface where it was
+        //      introduced in the current Blade file: @foreach, @props, etc.
+        let defined_in_display = match (class_path.as_ref(), declaration.as_ref()) {
+            (Some(path), Some(decl)) => {
+                let p = self.relative_display_path(path).await;
+                Some(format!("{}:{}", p, decl.line + 1))
+            }
+            (Some(path), None) => Some(self.relative_display_path(path).await),
+            _ => self.find_blade_variable_origin(uri, var_name).await,
+        };
+
+        laravel_lsp::hover::format_blade_variable(&laravel_lsp::hover::BladeVariableHover {
+            var_name,
+            property: property.as_deref(),
+            var_type: resolved_var_type.as_deref(),
+            declaration: declaration.as_ref(),
+            defined_in: defined_in_display.as_deref(),
+        })
+    }
+
+    /// Scan the current Blade file for where `var_name` was introduced —
+    /// either by a loop directive (`@foreach (... as $name)`) or by a
+    /// `@props([..., 'name'])` declaration. Returns a `path:line` string
+    /// suitable for the hover's bottom-line source reference.
+    ///
+    /// Used as a fallback when the variable's *type* doesn't resolve to a
+    /// findable class — e.g. loop variables with unresolved element types
+    /// (the `"mixed"` sentinel). Telling the user "this variable was
+    /// introduced by the `@foreach` on line 7" is more useful than an empty
+    /// hover.
+    async fn find_blade_variable_origin(&self, uri: &Url, var_name: &str) -> Option<String> {
+        let file_path = uri.to_file_path().ok()?;
+
+        // 1. Loop blocks (cheapest — Salsa already cached them for the resolver).
+        if let Ok(Some(blocks)) = self.salsa.get_loop_blocks(file_path.clone()).await {
+            for block in blocks.iter() {
+                if block.variables.iter().any(|(n, _)| n == var_name) {
+                    let display = self.relative_display_path(&file_path).await;
+                    return Some(format!("{}:{}", display, block.start_line + 1));
+                }
+            }
+        }
+
+        // 2. `@props([..., 'name' ...])` declaration in the Blade source.
+        let content = match self.documents.read().await.get(uri).cloned() {
+            Some((c, _)) => c,
+            None => std::fs::read_to_string(&file_path).unwrap_or_default(),
+        };
+        if let Some(line) = find_props_declaration_line(&content, var_name) {
+            let display = self.relative_display_path(&file_path).await;
+            return Some(format!("{}:{}", display, line + 1));
+        }
+
+        None
+    }
+
+    /// Resolve a view name to a display-friendly file path (relative to the
+    /// project root when possible, absolute otherwise). Returns `None` when
+    /// no candidate file exists on disk.
+    async fn resolve_display_path_for_view(&self, name: &str) -> Option<String> {
+        let config = self.get_cached_config().await?;
+        for path in config.resolve_view_path(name) {
+            if self.file_exists_cached(&path).await {
+                return Some(self.relative_display_path(&path).await);
+            }
+        }
+        None
+    }
+
+    /// Same shape as [`Self::resolve_display_path_for_view`] but for Blade
+    /// component references.
+    async fn resolve_display_path_for_component(&self, name: &str) -> Option<String> {
+        let config = self.get_cached_config().await?;
+        for path in config.resolve_component_path(name) {
+            if self.file_exists_cached(&path).await {
+                return Some(self.relative_display_path(&path).await);
+            }
+        }
+        None
+    }
+
+    /// Same shape as [`Self::resolve_display_path_for_view`] but for Livewire
+    /// component references.
+    async fn resolve_display_path_for_livewire(&self, name: &str) -> Option<String> {
+        let config = self.get_cached_config().await?;
+        let path = config.resolve_livewire_path(name)?;
+        if self.file_exists_cached(&path).await {
+            Some(self.relative_display_path(&path).await)
+        } else {
+            None
+        }
+    }
+
+    /// Render a path as a string relative to the project root when possible.
+    /// Falls back to the absolute path string when no root is set or when the
+    /// path lies outside the root (vendor/, package directories).
+    async fn relative_display_path(&self, path: &Path) -> String {
+        if let Some(root) = self.root_path.read().await.as_ref() {
+            if let Ok(rel) = path.strip_prefix(root) {
+                return rel.to_string_lossy().to_string();
+            }
+        }
+        path.to_string_lossy().to_string()
+    }
+
+    /// Return the cached vendor translation-namespace map, building it on
+    /// first call. The scan walks `vendor/` for service providers calling
+    /// `loadTranslationsFrom(...)` — see [`laravel_lsp::vendor_translations`].
+    /// Subsequent hover calls reuse the cached Arc without re-scanning.
+    async fn vendor_translation_namespaces_for(
+        &self,
+        root: &Path,
+    ) -> Option<Arc<HashMap<String, PathBuf>>> {
+        {
+            let guard = self.vendor_translation_namespaces.read().await;
+            if let Some(ref existing) = *guard {
+                return Some(existing.clone());
+            }
+        }
+        // Cache miss — scan and store. Done under spawn_blocking so the
+        // walkdir traversal doesn't block the LSP event loop.
+        let root_clone = root.to_path_buf();
+        let scanned = tokio::task::spawn_blocking(move || {
+            laravel_lsp::vendor_translations::scan_vendor_translation_namespaces(&root_clone)
+        })
+        .await
+        .ok()?;
+        let arc = Arc::new(scanned);
+        *self.vendor_translation_namespaces.write().await = Some(arc.clone());
+        Some(arc)
+    }
 }
 
 #[tower_lsp::async_trait]
@@ -13482,10 +13971,14 @@ impl LanguageServer for LaravelLanguageServer {
             Some(s) => s,
             None => return Ok(None),
         };
-        if !path.ends_with(".blade.php") {
+        let is_blade = path.ends_with(".blade.php");
+        let is_php = path.ends_with(".php");
+        if !is_blade && !is_php {
             return Ok(None);
         }
 
+        // Pull the current document for the line-text needed by the Blade
+        // variable fallback (also gives us the file as the LSP saw it last).
         let content = match self.documents.read().await.get(uri).cloned() {
             Some((c, _version)) => c,
             None => std::fs::read_to_string(path).unwrap_or_default(),
@@ -13496,42 +13989,55 @@ impl LanguageServer for LaravelLanguageServer {
             .unwrap_or("")
             .to_string();
 
-        let Some((var_name, property)) =
-            extract_blade_variable_at_cursor(&line_text, position.character)
-        else {
-            return Ok(None);
+        // Salsa pattern lookup. The target dispatch in `find_hover_target`
+        // tries patterns first and only falls back to Blade variables when
+        // nothing matched at the cursor.
+        let patterns = match self.salsa.get_patterns(file_path).await {
+            Ok(Some(p)) => p,
+            _ => {
+                // No cached patterns — Blade-variable hover can still fire on
+                // a .blade.php file when the cursor sits on a `$var` token.
+                if !is_blade {
+                    return Ok(None);
+                }
+                let Some((var_name, property)) =
+                    extract_blade_variable_at_cursor(&line_text, position.character)
+                else {
+                    return Ok(None);
+                };
+                let value = self
+                    .format_blade_variable_hover(uri, &var_name, property)
+                    .await;
+                return Ok(Some(Hover {
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value,
+                    }),
+                    range: None,
+                }));
+            }
         };
 
-        let var_dollar = format!("${}", var_name);
-        let resolved_var_type = self.resolve_blade_variable_type(uri, &var_dollar).await;
+        let target = match laravel_lsp::hover::find_hover_target(
+            &patterns,
+            &line_text,
+            position.line,
+            position.character,
+            is_blade,
+        ) {
+            Some(t) => t,
+            None => return Ok(None),
+        };
 
-        let hover_markdown = match (resolved_var_type, property) {
-            (Some(var_type), Some(prop_name)) => {
-                let prop_type = self
-                    .resolve_property_type_on_class(&var_type, &prop_name)
-                    .await;
-                let type_line = prop_type
-                    .clone()
-                    .unwrap_or_else(|| "undetermined".to_string());
-                format!(
-                    "**${}->{}**\n\n- Type: `{}`\n- Value: `undetermined`",
-                    var_name, prop_name, type_line
-                )
-            }
-            (Some(var_type), None) => format!(
-                "**${}**\n\n- Type: `{}`\n- Value: `undetermined`",
-                var_name, var_type
-            ),
-            (None, _) => format!(
-                "**${}**\n\n- Type: `undetermined`\n- Value: `undetermined`",
-                var_name
-            ),
+        let value = match self.build_hover_markdown(target, uri).await {
+            Some(v) => v,
+            None => return Ok(None),
         };
 
         Ok(Some(Hover {
             contents: HoverContents::Markup(MarkupContent {
                 kind: MarkupKind::Markdown,
-                value: hover_markdown,
+                value,
             }),
             range: None,
         }))

--- a/laravel-lsp/src/php_class.rs
+++ b/laravel-lsp/src/php_class.rs
@@ -443,6 +443,41 @@ pub fn read_line_from_file(path: &std::path::Path, line: u32) -> Option<String> 
     Some(target.trim_end().to_string())
 }
 
+/// Extract the fully qualified class name from a PHP source file. Combines
+/// the `namespace ...;` declaration (when present) with the first `class
+/// Foo`/`interface Foo`/`trait Foo` declaration.
+///
+/// Returns `Some("App\\Livewire\\Counter")` or `None` when neither piece can
+/// be found. Used by hovers that want to surface the FQN as their bold
+/// header — gives the reader a fully-resolved type they don't see at the
+/// cursor (`<livewire:counter>` → `App\Livewire\Counter`).
+pub fn extract_class_fqn(path: &std::path::Path) -> Option<String> {
+    use lazy_static::lazy_static;
+    use regex::Regex;
+    lazy_static! {
+        static ref NS_RE: Regex =
+            Regex::new(r"(?m)^\s*namespace\s+([A-Za-z_][A-Za-z0-9_\\]*)\s*;").unwrap();
+        static ref CLASS_NAME_RE: Regex = Regex::new(
+            r"(?m)^\s*(?:(?:final|abstract|readonly)\s+)*(?:class|interface|trait|enum)\s+(\w+)",
+        )
+        .unwrap();
+    }
+    let content = std::fs::read_to_string(path).ok()?;
+    let class_name = CLASS_NAME_RE
+        .captures(&content)?
+        .get(1)?
+        .as_str()
+        .to_string();
+    let namespace = NS_RE
+        .captures(&content)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str());
+    Some(match namespace {
+        Some(ns) => format!("{}\\{}", ns, class_name),
+        None => class_name,
+    })
+}
+
 /// Extract the first `class Foo extends Bar` signature line from a PHP class
 /// file. Skips PHP attributes (`#[...]`), PHPDoc, `namespace`, and `use`
 /// statements that precede the class declaration. Returns the single line

--- a/laravel-lsp/src/php_class.rs
+++ b/laravel-lsp/src/php_class.rs
@@ -376,6 +376,170 @@ pub fn find_property_declaration_position(
     Some((line, start_col, end_col))
 }
 
+/// Find the 0-based line number where a property is first defined on a class.
+/// Used by the Blade-variable hover to render `Defined at: <file>:<line>`.
+///
+/// Recognises the following shapes (whichever matches earliest in the file
+/// wins — when an Eloquent model declares the same column in both `$casts`
+/// and `$fillable`, the cast usually appears first and is the more useful
+/// landing spot):
+///
+/// - **Visibility-modified property**: `public Type $foo`, `protected $foo`,
+///   `private static ?Foo $foo`.
+/// - **PHPDoc property tag**: `@property Type $foo`, `@property-read`,
+///   `@property-write`.
+/// - **Array key in a property block**: `'foo' =>` — captures `$casts`,
+///   `$fillable`, `$attributes`, and any other class-level array literal that
+///   uses the property as a key.
+/// - **Method**: `public function foo(...)` — catches Eloquent relationship
+///   methods accessed as properties (`$user->posts`).
+pub fn find_property_definition_line(content: &str, property: &str) -> Option<u32> {
+    let escaped = regex::escape(property);
+    let patterns = [
+        // (a) visibility-modified declaration
+        format!(
+            r"\b(?:public|private|protected)\s+(?:static\s+)?(?:\??\\?[A-Za-z_][A-Za-z0-9_\\|]*(?:<[^>]*>)?\s+)?\${}\b",
+            escaped
+        ),
+        // (b) @property PHPDoc
+        format!(r"@property(?:-read|-write)?\s+\S+\s+\${}\b", escaped),
+        // (c) array-key form — catches $casts, $fillable, $attributes
+        format!(r#"['"]{}['"]\s*=>"#, escaped),
+        // (d) method definition (matches relationship methods accessed as props)
+        format!(r"\bfunction\s+{}\s*\(", escaped),
+    ];
+
+    let mut best_offset: Option<usize> = None;
+    for pat in &patterns {
+        let Ok(re) = regex::Regex::new(pat) else {
+            continue;
+        };
+        if let Some(m) = re.find(content) {
+            best_offset = Some(best_offset.map_or(m.start(), |b| b.min(m.start())));
+        }
+    }
+
+    let offset = best_offset?;
+    let mut line = 0u32;
+    for (i, ch) in content.char_indices() {
+        if i >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+        }
+    }
+    Some(line)
+}
+
+/// Rich information about a property/method declaration extracted from a
+/// PHP class source — declaration text, PHPDoc summary, and tags. Used by
+/// the Blade-variable hover to render intelephense-style tooltips.
+#[derive(Debug, Clone)]
+pub struct PropertyDeclaration {
+    /// The single line of source containing the declaration, trimmed.
+    /// For methods, this is just the signature line (not the body).
+    pub declaration_text: String,
+    /// 0-based line number of the declaration.
+    pub line: u32,
+    /// Free-form description from any PHPDoc block immediately above the
+    /// declaration. `None` when there's no PHPDoc or it has only tags.
+    pub description: Option<String>,
+    /// Parsed PHPDoc tag lines in document order (e.g. `@param mixed $x`,
+    /// `@return Response`, `@throws AuthException`). Each entry is the
+    /// full tag text without the leading `*` decoration.
+    pub phpdoc_tags: Vec<String>,
+}
+
+/// Locate a property's declaration and parse the PHPDoc block above it.
+/// Builds on [`find_property_definition_line`] for the position lookup, then
+/// extracts the declaration line and any preceding `/** ... */` block.
+///
+/// The PHPDoc parser is intentionally loose: it strips leading `*` and
+/// concatenates description lines, then collects any `@tag` lines verbatim.
+/// Mirrors what intelephense's hover does — show the user the same prose the
+/// PHPDoc author wrote, without imposing a strict tag schema.
+pub fn extract_property_declaration(content: &str, property: &str) -> Option<PropertyDeclaration> {
+    let line = find_property_definition_line(content, property)?;
+    let lines: Vec<&str> = content.lines().collect();
+    let declaration_text = lines.get(line as usize)?.trim().to_string();
+
+    // Walk backward looking for a PHPDoc block (`/** ... */`) immediately
+    // above. Skip blank lines, but anything else (other code, attributes)
+    // breaks the association.
+    let mut phpdoc_lines: Vec<&str> = Vec::new();
+    if (line as usize) > 0 {
+        let mut idx = line as usize;
+        // Skip blank lines between declaration and a potential PHPDoc close.
+        while idx > 0 {
+            idx -= 1;
+            let l = lines[idx].trim();
+            if l.is_empty() {
+                continue;
+            }
+            if l.ends_with("*/") {
+                // Walk back to the matching `/**` opener.
+                phpdoc_lines.push(l);
+                while idx > 0 {
+                    idx -= 1;
+                    let pl = lines[idx];
+                    phpdoc_lines.push(pl);
+                    if pl.trim_start().starts_with("/**") {
+                        break;
+                    }
+                }
+                phpdoc_lines.reverse();
+            }
+            break;
+        }
+    }
+    let (description, phpdoc_tags) = parse_phpdoc(&phpdoc_lines);
+
+    Some(PropertyDeclaration {
+        declaration_text,
+        line,
+        description,
+        phpdoc_tags,
+    })
+}
+
+/// Split a captured PHPDoc block into (description, tags). Strips
+/// `/**`, `*/`, and leading `*` decoration from each line. Description
+/// stops at the first `@tag` line.
+fn parse_phpdoc(lines: &[&str]) -> (Option<String>, Vec<String>) {
+    let mut description_parts: Vec<String> = Vec::new();
+    let mut tags: Vec<String> = Vec::new();
+    let mut in_tags = false;
+
+    for raw in lines {
+        // Strip block delimiters and leading * decoration.
+        let cleaned = raw
+            .trim()
+            .trim_start_matches("/**")
+            .trim_end_matches("*/")
+            .trim()
+            .trim_start_matches('*')
+            .trim();
+
+        if cleaned.is_empty() {
+            continue;
+        }
+        if let Some(stripped) = cleaned.strip_prefix('@') {
+            in_tags = true;
+            tags.push(format!("@{}", stripped));
+        } else if !in_tags {
+            description_parts.push(cleaned.to_string());
+        }
+    }
+
+    let description = if description_parts.is_empty() {
+        None
+    } else {
+        Some(description_parts.join(" "))
+    };
+    (description, tags)
+}
+
 /// Iterate every typed parameter across all `function mount(...)` signatures
 /// in `content`. Untyped params are skipped (see `find_mount_param_type` for
 /// the rationale). Duplicates by name keep the first occurrence.

--- a/laravel-lsp/src/php_class.rs
+++ b/laravel-lsp/src/php_class.rs
@@ -432,6 +432,41 @@ pub fn find_property_definition_line(content: &str, property: &str) -> Option<u3
     Some(line)
 }
 
+/// Read a single line (0-based) from a file, with trailing whitespace
+/// trimmed but leading whitespace preserved (so indentation context is
+/// kept in hover snippets). Returns `None` on I/O failure or out-of-range
+/// line numbers. Used by the route hover to pull the
+/// `Route::verb(...)->name(...)` line straight from source.
+pub fn read_line_from_file(path: &std::path::Path, line: u32) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let target = content.lines().nth(line as usize)?;
+    Some(target.trim_end().to_string())
+}
+
+/// Extract the first `class Foo extends Bar` signature line from a PHP class
+/// file. Skips PHP attributes (`#[...]`), PHPDoc, `namespace`, and `use`
+/// statements that precede the class declaration. Returns the single line
+/// containing the `class` keyword, trimmed.
+///
+/// Used by the Livewire hover to show the component's class signature so
+/// the reader sees the type at a glance — same vibe as intelephense's
+/// hover showing a class signature line in a `php` code block.
+///
+/// Recognises `final class Foo`, `abstract class Foo`, `readonly class Foo`,
+/// and combinations. Anchored at start-of-line so `class` substrings inside
+/// string literals or comments don't trigger false matches.
+pub fn extract_class_signature(path: &std::path::Path) -> Option<String> {
+    use lazy_static::lazy_static;
+    use regex::Regex;
+    lazy_static! {
+        static ref CLASS_RE: Regex =
+            Regex::new(r"(?m)^\s*(?:(?:final|abstract|readonly)\s+)*class\s+\w+[^{\n]*").unwrap();
+    }
+    let content = std::fs::read_to_string(path).ok()?;
+    let m = CLASS_RE.find(&content)?;
+    Some(m.as_str().trim().to_string())
+}
+
 /// Rich information about a property/method declaration extracted from a
 /// PHP class source — declaration text, PHPDoc summary, and tags. Used by
 /// the Blade-variable hover to render intelephense-style tooltips.

--- a/laravel-lsp/src/route_discovery.rs
+++ b/laravel-lsp/src/route_discovery.rs
@@ -18,6 +18,20 @@ use std::path::{Path, PathBuf};
 
 use walkdir::WalkDir;
 
+/// A route group's contribution to its child routes' names. Built once per
+/// source file by [`find_route_groups`] and consulted by
+/// [`extract_named_routes`] when composing the final name of a `->name('X')`
+/// callsite that lives inside one or more enclosing groups.
+#[derive(Debug, Clone)]
+struct RouteGroupSpan {
+    /// Name prefix this group contributes — `"admin."`, `"api.v1."`, etc.
+    prefix: String,
+    /// Byte offset just past the opening `{` of the group's closure body.
+    body_start: usize,
+    /// Byte offset of the matching closing `}` of the group's closure body.
+    body_end: usize,
+}
+
 /// A located route definition. Stored in [`RouteIndex`] keyed by route name.
 #[derive(Debug, Clone)]
 pub struct RouteDefinition {
@@ -31,6 +45,22 @@ pub struct RouteDefinition {
     pub end_column: u32,
     /// Source priority. Higher wins on conflict (app overrides package overrides framework).
     pub priority: u8,
+    /// HTTP method extracted from the route declaration (lowercased: "get", "post",
+    /// "any", "match", "view", "redirect", etc.). `None` when the verb can't be
+    /// resolved statically — e.g. inside a `Route::macro(...)` body or for
+    /// programmatically-built routes.
+    pub method: Option<String>,
+    /// URI extracted from the first string argument of the verb call.
+    /// `None` when the first argument isn't a string literal.
+    pub uri: Option<String>,
+    /// Controller@action extracted from the second argument. Common shapes:
+    /// `[UserController::class, 'show']` → `"UserController@show"`,
+    /// `'OldController@method'` → `"OldController@method"`,
+    /// `UserController::class` (invokable) → `"UserController"`,
+    /// `function/fn closure` → `"Closure"`.
+    /// `None` when the second argument is missing or unresolvable (e.g. `Route::view`,
+    /// `Route::redirect`).
+    pub action: Option<String>,
 }
 
 /// Priority levels used when multiple files define the same route name.
@@ -181,6 +211,13 @@ pub fn extract_named_routes(
 ) -> Vec<(Option<String>, RouteDefinition)> {
     let mut results = Vec::new();
     let bytes = content.as_bytes();
+
+    // Build group-span index once per file. Each span tells us "any
+    // `->name('X')` inside body_start..body_end gets `prefix` prepended."
+    // Nested groups are handled by accumulating every span that encloses the
+    // callsite, ordered outermost-first.
+    let groups = find_route_groups(bytes);
+
     let pattern = b"->name";
     let mut i = 0;
 
@@ -226,7 +263,7 @@ pub fn extract_named_routes(
             i += 1;
             continue;
         }
-        let name = match std::str::from_utf8(&bytes[str_start..j]) {
+        let literal_name = match std::str::from_utf8(&bytes[str_start..j]) {
             Ok(s) => s.to_string(),
             Err(_) => {
                 i += 1;
@@ -234,8 +271,25 @@ pub fn extract_named_routes(
             }
         };
 
+        // Compose the final route name from enclosing group prefixes plus the
+        // literal `->name('X')` value. Groups are pre-sorted by body_start so
+        // iterating in order yields outermost-first.
+        let mut name = String::new();
+        for grp in &groups {
+            if grp.body_start <= i && i < grp.body_end {
+                name.push_str(&grp.prefix);
+            }
+        }
+        name.push_str(&literal_name);
+
         let (line, column) = byte_to_line_col(bytes, i);
         let end_column = column + (j - i + 1) as u32; // include closing quote
+
+        // Scan backward from the `->name(` callsite to find the verb call that
+        // started this route's fluent chain. Captures HTTP method, URI, and the
+        // controller@action target for hover display.
+        let metadata = extract_route_metadata(bytes, i);
+
         results.push((
             Some(name),
             RouteDefinition {
@@ -244,6 +298,9 @@ pub fn extract_named_routes(
                 column,
                 end_column,
                 priority,
+                method: metadata.method,
+                uri: metadata.uri,
+                action: metadata.action,
             },
         ));
 
@@ -251,6 +308,295 @@ pub fn extract_named_routes(
     }
 
     results
+}
+
+/// Resolved data describing the verb call that opens a route's fluent chain.
+/// Each field can be `None` when static extraction can't pin it down — callers
+/// must handle missing data gracefully (typically by omitting it from display).
+#[derive(Debug, Default, Clone)]
+pub struct RouteMetadata {
+    pub method: Option<String>,
+    pub uri: Option<String>,
+    pub action: Option<String>,
+}
+
+/// HTTP verbs (and verb-shaped methods like `view`, `redirect`) that Laravel's
+/// router exposes for registering routes. Matched against `Route::<verb>(` and
+/// `->name`-chained `<receiver>-><verb>(` callsites when reconstructing route
+/// metadata. Lowercased — comparisons are case-sensitive against PHP source.
+const HTTP_VERBS: &[&str] = &[
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "options",
+    "any",
+    "match",
+    "view",
+    "redirect",
+    "permanentRedirect",
+];
+
+/// Walk forward from the start of the statement that contains `name_callsite_offset`
+/// to find the verb call that opens the fluent chain, then parse its first two
+/// arguments (URI + action).
+///
+/// Statement boundaries are detected with full string-literal and depth tracking
+/// (parens, brackets, braces) so `{user}` route parameters and closure bodies
+/// don't fool the scan. Returns a partial result whenever a piece is missing —
+/// a closure-based route still resolves method + URI.
+pub fn extract_route_metadata(bytes: &[u8], name_callsite_offset: usize) -> RouteMetadata {
+    let (stmt_start, _stmt_end) = statement_containing(bytes, name_callsite_offset);
+    let Some((method, args_start)) = find_verb_call(bytes, stmt_start, name_callsite_offset) else {
+        return RouteMetadata::default();
+    };
+
+    // Walk forward from the verb's opening `(` to grab arg 1 (URI) and arg 2
+    // (action). Both are optional — `Route::view('/x', 'view.name')` has no
+    // action, `Route::redirect(...)` has only a URI.
+    let (uri_slice, after_uri) = read_arg(bytes, args_start);
+    let uri = uri_slice.and_then(parse_string_literal);
+
+    let action = if let Some(after_uri_idx) = after_uri {
+        let (action_slice, _) = read_arg(bytes, after_uri_idx);
+        action_slice.and_then(parse_action_argument)
+    } else {
+        None
+    };
+
+    RouteMetadata {
+        method: Some(method),
+        uri,
+        action,
+    }
+}
+
+/// Return `(start, end)` of the PHP statement that contains `offset`. Walks
+/// forward from byte 0, tracking string literals and combined brace/paren/bracket
+/// depth so that `;` is only treated as a separator when depth is zero and we're
+/// not inside a string.
+fn statement_containing(bytes: &[u8], offset: usize) -> (usize, usize) {
+    let mut stmt_start = 0usize;
+    let mut depth = 0i32;
+    let mut in_string: Option<u8> = None;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(quote) = in_string {
+            if b == b'\\' && i + 1 < bytes.len() {
+                i += 2;
+                continue;
+            }
+            if b == quote {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' | b'"' => in_string = Some(b),
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b';' if depth == 0 => {
+                if i >= offset {
+                    return (stmt_start, i);
+                }
+                stmt_start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    (stmt_start, bytes.len())
+}
+
+/// Find the first `<receiver>-><verb>(` or `Route::<verb>(` whose verb appears
+/// in [`HTTP_VERBS`]. Returns the verb name and the byte offset of the first
+/// character inside the `(`.
+fn find_verb_call(bytes: &[u8], start: usize, end: usize) -> Option<(String, usize)> {
+    let mut i = start;
+    while i < end {
+        for &verb in HTTP_VERBS {
+            let vb = verb.as_bytes();
+            if i + vb.len() > end || &bytes[i..i + vb.len()] != vb {
+                continue;
+            }
+            // Verb must be preceded by `->` or `::` — this is the left
+            // word-boundary check (the `>` / `:` is not an identifier byte).
+            let prefix_ok = i >= 2 && (&bytes[i - 2..i] == b"->" || &bytes[i - 2..i] == b"::");
+            if !prefix_ok {
+                continue;
+            }
+            // Verb must not be followed by an identifier byte (otherwise
+            // `->getUser(` would match `get`).
+            let after_verb = i + vb.len();
+            if after_verb < end && is_identifier_byte(bytes[after_verb]) {
+                continue;
+            }
+            let mut j = after_verb;
+            while j < end && (bytes[j] == b' ' || bytes[j] == b'\t') {
+                j += 1;
+            }
+            if j < end && bytes[j] == b'(' {
+                return Some((verb.to_string(), j + 1));
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+fn is_identifier_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Read a single argument starting at `start` from a (paren-balanced) argument
+/// list. Returns (`Some(slice)` of the argument bytes, `Some(idx)` of the byte
+/// after the separating comma — or `None` if the closing `)` was reached).
+fn read_arg(bytes: &[u8], start: usize) -> (Option<&[u8]>, Option<usize>) {
+    let mut depth_paren = 0i32;
+    let mut depth_bracket = 0i32;
+    let mut depth_brace = 0i32;
+    let mut in_string: Option<u8> = None;
+    let mut i = start;
+    let arg_start = i;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(quote) = in_string {
+            if b == b'\\' && i + 1 < bytes.len() {
+                i += 2;
+                continue;
+            }
+            if b == quote {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' | b'"' => in_string = Some(b),
+            b'(' => depth_paren += 1,
+            b')' => {
+                if depth_paren == 0 && depth_bracket == 0 && depth_brace == 0 {
+                    let slice = trimmed_slice(bytes, arg_start, i);
+                    return (slice, None);
+                }
+                depth_paren -= 1;
+            }
+            b'[' => depth_bracket += 1,
+            b']' => depth_bracket -= 1,
+            b'{' => depth_brace += 1,
+            b'}' => depth_brace -= 1,
+            b',' if depth_paren == 0 && depth_bracket == 0 && depth_brace == 0 => {
+                let slice = trimmed_slice(bytes, arg_start, i);
+                return (slice, Some(i + 1));
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    (None, None)
+}
+
+fn trimmed_slice(bytes: &[u8], start: usize, end: usize) -> Option<&[u8]> {
+    let mut s = start;
+    let mut e = end;
+    while s < e && bytes[s].is_ascii_whitespace() {
+        s += 1;
+    }
+    while e > s && bytes[e - 1].is_ascii_whitespace() {
+        e -= 1;
+    }
+    if s >= e {
+        None
+    } else {
+        Some(&bytes[s..e])
+    }
+}
+
+/// Decode a single-quoted or double-quoted string literal into the raw inner text.
+/// Returns `None` for non-string-literal arguments (variables, expressions, etc.).
+fn parse_string_literal(slice: &[u8]) -> Option<String> {
+    if slice.len() < 2 {
+        return None;
+    }
+    let quote = slice[0];
+    if quote != b'\'' && quote != b'"' {
+        return None;
+    }
+    if *slice.last()? != quote {
+        return None;
+    }
+    let inner = &slice[1..slice.len() - 1];
+    let mut out = String::with_capacity(inner.len());
+    let mut i = 0;
+    while i < inner.len() {
+        let b = inner[i];
+        if b == b'\\' && i + 1 < inner.len() {
+            out.push(inner[i + 1] as char);
+            i += 2;
+            continue;
+        }
+        out.push(b as char);
+        i += 1;
+    }
+    Some(out)
+}
+
+/// Parse the second argument of a route registration into a human-readable
+/// `Controller@action` string. Handles the four shapes Laravel accepts plus
+/// the closure case. Returns `None` when the argument is something we can't
+/// statically resolve (e.g. a variable).
+fn parse_action_argument(slice: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(slice).ok()?.trim();
+    if text.is_empty() {
+        return None;
+    }
+
+    // Shape 1: closure literal — `function (...) { ... }` or `fn(...) => ...`
+    if text.starts_with("function") || text.starts_with("fn(") || text.starts_with("fn ") {
+        return Some("Closure".to_string());
+    }
+
+    // Shape 2: `[Controller::class, 'method']`
+    if text.starts_with('[') && text.ends_with(']') {
+        let inner = &text[1..text.len() - 1];
+        let parts: Vec<&str> = inner.splitn(2, ',').map(str::trim).collect();
+        if parts.len() == 2 {
+            let class = parts[0].trim_end_matches("::class");
+            let class_short = short_class_name(class);
+            if let Some(method) = parse_string_literal(parts[1].as_bytes()) {
+                return Some(format!("{}@{}", class_short, method));
+            }
+        }
+        return None;
+    }
+
+    // Shape 3: `Controller::class` — single-action / invokable controller
+    if let Some(class) = text.strip_suffix("::class") {
+        return Some(short_class_name(class).to_string());
+    }
+
+    // Shape 4: `'Controller@method'` — legacy string syntax
+    if let Some(s) = parse_string_literal(text.as_bytes()) {
+        if s.contains('@') {
+            // Render short class name in the @method form.
+            let mut parts = s.splitn(2, '@');
+            if let (Some(class), Some(method)) = (parts.next(), parts.next()) {
+                return Some(format!("{}@{}", short_class_name(class), method));
+            }
+        }
+        return Some(s);
+    }
+
+    None
+}
+
+/// Take the last `\`-separated segment of a PHP FQN. `App\Http\UserController` → `UserController`.
+fn short_class_name(fqn: &str) -> &str {
+    fqn.rsplit('\\').next().unwrap_or(fqn)
 }
 
 /// Quick content check — does this file likely register named routes?
@@ -366,6 +712,376 @@ fn byte_to_line_col(bytes: &[u8], byte_offset: usize) -> (u32, u32) {
     }
     let column = (byte_offset as i64 - last_newline - 1) as u32;
     (line, column)
+}
+
+// ============================================================================
+// Route-group resolution — composing route names across nested groups
+// ============================================================================
+//
+// Laravel route groups contribute a name prefix to every route declared inside
+// the group's closure body:
+//
+//   Route::name('admin.')->group(function () {
+//       Route::get('/users', ...)->name('users.index');  // → "admin.users.index"
+//   });
+//
+// Groups also accept attributes in array form:
+//
+//   Route::group(['as' => 'api.'], function () {
+//       Route::get('/users', ...)->name('users.index');  // → "api.users.index"
+//   });
+//
+// Groups can nest arbitrarily. To compose the final name we:
+//   1. Find every `->group(...)` callsite, extracting its prefix contribution
+//      and the byte range of its closure body.
+//   2. When `extract_named_routes` sees a `->name('X')` callsite at offset O,
+//      concatenate every group's prefix whose body range encloses O.
+
+/// Scan `bytes` for every `->group(...)` callsite, returning the spans of
+/// those that contribute a name prefix. Forward scan produces spans ordered
+/// by `body_start` ascending, so iterating in order is outermost-first when
+/// resolving an enclosed `->name(...)`.
+fn find_route_groups(bytes: &[u8]) -> Vec<RouteGroupSpan> {
+    let paren_pairs = build_paren_pairs(bytes);
+    let mut groups = Vec::new();
+    // Look for the `group` keyword preceded by either `->` (chained: `->group(`)
+    // or `::` (facade: `Route::group(`). Both forms register route groups in
+    // Laravel; restricting to `->group` (as the first draft did) missed every
+    // `Route::group(['as' => ...], ...)` callsite.
+    let keyword = b"group";
+    let mut i = 0usize;
+
+    while i + keyword.len() < bytes.len() {
+        if &bytes[i..i + keyword.len()] != keyword {
+            i += 1;
+            continue;
+        }
+        // Word boundary BEFORE: must be `->` or `::`.
+        if i < 2 {
+            i += 1;
+            continue;
+        }
+        let connector = &bytes[i - 2..i];
+        if connector != b"->" && connector != b"::" {
+            i += 1;
+            continue;
+        }
+        // Word boundary AFTER: must not be `groupBy`, `groupName`, etc.
+        let after_g = i + keyword.len();
+        if after_g < bytes.len() && is_identifier_byte(bytes[after_g]) {
+            i = after_g;
+            continue;
+        }
+        // Find the `(` opening the group's arg list.
+        let mut j = after_g;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if j >= bytes.len() || bytes[j] != b'(' {
+            i = j.max(i + 1);
+            continue;
+        }
+        let args_open = j;
+        let Some(&args_close) = paren_pairs.get(&args_open) else {
+            i = args_open + 1;
+            continue;
+        };
+
+        // Prefix can come from one of:
+        //   (a) a `->name('X')` link earlier in the same fluent chain
+        //   (b) an `['as' => 'X', ...]` array literal as the first arg
+        //
+        // Use the connector position (start of `->`/`::`) so the chain walker
+        // sees this call's left edge correctly.
+        let group_offset = i - 2;
+        let chain_prefix = extract_chain_name_prefix(bytes, group_offset, &paren_pairs);
+        let array_prefix = extract_array_as_prefix(bytes, args_open + 1, args_close);
+        let prefix = chain_prefix.or(array_prefix);
+
+        // Closure body: `function (...) { ... }` between args_open+1 and args_close.
+        let body = find_function_body(bytes, args_open + 1, args_close);
+
+        if let (Some(prefix), Some((body_start, body_end))) = (prefix, body) {
+            groups.push(RouteGroupSpan {
+                prefix,
+                body_start,
+                body_end,
+            });
+        }
+
+        // Continue scanning forward — including INSIDE this group's body, so
+        // nested groups get picked up. (Skipping to args_close + 1 would lose
+        // every nested `->group(...)`.)
+        i += 1;
+    }
+
+    groups
+}
+
+/// Walk backward from a `->group(` offset through prior chain links looking
+/// for a `->name('X')` whose string argument should prefix routes in this
+/// group. Returns the prefix string (e.g. `"admin."`).
+///
+/// The walk skips over each intervening `->method(...)` link by paren-balancing
+/// — that's why we need the pre-computed paren_pairs map.
+fn extract_chain_name_prefix(
+    bytes: &[u8],
+    group_offset: usize,
+    paren_pairs: &HashMap<usize, usize>,
+) -> Option<String> {
+    let mut cursor = group_offset;
+    loop {
+        if cursor < 2 {
+            return None;
+        }
+        // The byte just before `->` should be `)` closing the previous link.
+        let mut k = cursor;
+        while k > 0 && bytes[k - 1].is_ascii_whitespace() {
+            k -= 1;
+        }
+        if k == 0 || bytes[k - 1] != b')' {
+            return None;
+        }
+        let close_paren = k - 1;
+        let open_paren = *paren_pairs
+            .iter()
+            .find(|(_, &v)| v == close_paren)
+            .map(|(k, _)| k)?;
+
+        // Walk back from `(` over the method name.
+        let mut name_end = open_paren;
+        while name_end > 0 && bytes[name_end - 1].is_ascii_whitespace() {
+            name_end -= 1;
+        }
+        let mut name_start = name_end;
+        while name_start > 0 && is_identifier_byte(bytes[name_start - 1]) {
+            name_start -= 1;
+        }
+        if name_start == name_end {
+            return None;
+        }
+        let method = std::str::from_utf8(&bytes[name_start..name_end]).ok()?;
+
+        // The 2 bytes before the method name must be `->` or `::`.
+        if name_start < 2 {
+            return None;
+        }
+        let connector = &bytes[name_start - 2..name_start];
+        if connector != b"->" && connector != b"::" {
+            return None;
+        }
+
+        if method == "name" {
+            // Extract the string literal first-argument from the `()`.
+            return read_first_string_literal(bytes, open_paren + 1, close_paren);
+        }
+
+        // Not `name` — continue walking back from the connector position.
+        cursor = name_start - 2;
+    }
+}
+
+/// Read the first string literal in `[start..end]`. Returns the unescaped
+/// inner text. Skips leading whitespace; ignores subsequent arguments.
+fn read_first_string_literal(bytes: &[u8], start: usize, end: usize) -> Option<String> {
+    let mut i = start;
+    while i < end && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if i >= end {
+        return None;
+    }
+    let quote = bytes[i];
+    if quote != b'\'' && quote != b'"' {
+        return None;
+    }
+    i += 1;
+    let mut out = String::new();
+    while i < end && bytes[i] != quote {
+        if bytes[i] == b'\\' && i + 1 < end {
+            out.push(bytes[i + 1] as char);
+            i += 2;
+            continue;
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    if i >= end {
+        return None;
+    }
+    Some(out)
+}
+
+/// Look for `['as' => 'X', ...]` in the group's first argument. Returns the
+/// value of the `as` key when found.
+fn extract_array_as_prefix(bytes: &[u8], start: usize, end: usize) -> Option<String> {
+    // First arg must start with `[`.
+    let mut i = start;
+    while i < end && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if i >= end || bytes[i] != b'[' {
+        return None;
+    }
+
+    // Scan within the array literal for `'as'` (or `"as"`) followed by `=>`
+    // and a string. Operates within the args range, ignoring nested arrays
+    // and strings via depth-tracking.
+    let patterns: [&[u8]; 2] = [b"'as'", b"\"as\""];
+    for pat in patterns {
+        let mut j = i;
+        let mut in_string: Option<u8> = None;
+        while j + pat.len() < end {
+            let b = bytes[j];
+            if let Some(q) = in_string {
+                if b == b'\\' && j + 1 < end {
+                    j += 2;
+                    continue;
+                }
+                if b == q {
+                    in_string = None;
+                }
+                j += 1;
+                continue;
+            }
+            if b == b'\'' || b == b'"' {
+                // Check if this is the start of the pattern we want
+                if j + pat.len() <= end && &bytes[j..j + pat.len()] == pat {
+                    // Look past the pattern for `=>` then a string literal.
+                    let mut k = j + pat.len();
+                    while k < end && bytes[k].is_ascii_whitespace() {
+                        k += 1;
+                    }
+                    if k + 2 <= end && &bytes[k..k + 2] == b"=>" {
+                        let value = read_first_string_literal(bytes, k + 2, end);
+                        if value.is_some() {
+                            return value;
+                        }
+                    }
+                }
+                in_string = Some(b);
+                j += 1;
+                continue;
+            }
+            j += 1;
+        }
+    }
+    None
+}
+
+/// Find the byte range of a `function (...) { ... }` body inside the group's
+/// arg list. Returns `(body_start, body_end)` — body_start points to the byte
+/// right after the opening `{`, body_end to the matching `}` byte.
+fn find_function_body(bytes: &[u8], start: usize, end: usize) -> Option<(usize, usize)> {
+    let kw = b"function";
+    let mut i = start;
+    let mut in_string: Option<u8> = None;
+    while i + kw.len() < end {
+        let b = bytes[i];
+        if let Some(q) = in_string {
+            if b == b'\\' && i + 1 < end {
+                i += 2;
+                continue;
+            }
+            if b == q {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        if b == b'\'' || b == b'"' {
+            in_string = Some(b);
+            i += 1;
+            continue;
+        }
+        if i + kw.len() <= end && &bytes[i..i + kw.len()] == kw {
+            let before_ok = i == 0 || !is_identifier_byte(bytes[i - 1]);
+            let after = i + kw.len();
+            let after_ok = after >= bytes.len() || !is_identifier_byte(bytes[after]);
+            if before_ok && after_ok {
+                // Walk forward to the `{`. PHP's `function () use ($x) {`
+                // and other variants all end with a `{`.
+                let mut j = after;
+                while j < end && bytes[j] != b'{' {
+                    j += 1;
+                }
+                if j >= end {
+                    return None;
+                }
+                let body_start = j + 1;
+                // Brace-balance from j to find the close.
+                let mut depth = 1i32;
+                let mut k = body_start;
+                let mut in_s: Option<u8> = None;
+                while k < bytes.len() {
+                    let bc = bytes[k];
+                    if let Some(q) = in_s {
+                        if bc == b'\\' && k + 1 < bytes.len() {
+                            k += 2;
+                            continue;
+                        }
+                        if bc == q {
+                            in_s = None;
+                        }
+                        k += 1;
+                        continue;
+                    }
+                    match bc {
+                        b'\'' | b'"' => in_s = Some(bc),
+                        b'{' => depth += 1,
+                        b'}' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                return Some((body_start, k));
+                            }
+                        }
+                        _ => {}
+                    }
+                    k += 1;
+                }
+                return None;
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Pre-compute open `(` → close `)` pairs across the entire file. Skips
+/// quoted strings so parens inside string literals don't mis-balance. Used
+/// for backward chain walks where naive byte scanning would get confused by
+/// nested calls.
+fn build_paren_pairs(bytes: &[u8]) -> HashMap<usize, usize> {
+    let mut pairs = HashMap::new();
+    let mut stack: Vec<usize> = Vec::new();
+    let mut in_string: Option<u8> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(q) = in_string {
+            if b == b'\\' && i + 1 < bytes.len() {
+                i += 2;
+                continue;
+            }
+            if b == q {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' | b'"' => in_string = Some(b),
+            b'(' => stack.push(i),
+            b')' => {
+                if let Some(open) = stack.pop() {
+                    pairs.insert(open, i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    pairs
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -92,6 +92,9 @@ fn route_index_resolves_priority_collision() {
             column: 0,
             end_column: 10,
             priority: PRIORITY_PACKAGE,
+            method: None,
+            uri: None,
+            action: None,
         },
     );
     idx.insert(
@@ -102,6 +105,9 @@ fn route_index_resolves_priority_collision() {
             column: 0,
             end_column: 10,
             priority: PRIORITY_APP,
+            method: None,
+            uri: None,
+            action: None,
         },
     );
 
@@ -124,6 +130,9 @@ fn route_index_keeps_lower_when_higher_does_not_redefine() {
             column: 0,
             end_column: 10,
             priority: PRIORITY_PACKAGE,
+            method: None,
+            uri: None,
+            action: None,
         },
     );
     let def = idx
@@ -212,4 +221,321 @@ fn priority_for_vendor_path_distinguishes_framework() {
         )),
         PRIORITY_PACKAGE
     );
+}
+
+// ============================================================================
+// Route metadata extraction (method / URI / action)
+// ============================================================================
+
+/// Convenience: run a full extraction over `src` and return the first
+/// `RouteDefinition`. Tests are about extraction shape, not file paths.
+fn first_def(src: &str) -> RouteDefinition {
+    let path = PathBuf::from("/fake/routes/web.php");
+    let mut results = extract_named_routes(src, &path, PRIORITY_APP);
+    assert!(
+        !results.is_empty(),
+        "expected at least one route definition"
+    );
+    results.remove(0).1
+}
+
+#[test]
+fn metadata_extracts_array_action() {
+    let def = first_def(
+        "<?php\nRoute::get('/users', [UserController::class, 'show'])->name('users.show');\n",
+    );
+    assert_eq!(def.method.as_deref(), Some("get"));
+    assert_eq!(def.uri.as_deref(), Some("/users"));
+    assert_eq!(def.action.as_deref(), Some("UserController@show"));
+}
+
+#[test]
+fn metadata_extracts_legacy_string_action() {
+    let def =
+        first_def("<?php\nRoute::post('/login', 'LoginController@authenticate')->name('login');\n");
+    assert_eq!(def.method.as_deref(), Some("post"));
+    assert_eq!(def.uri.as_deref(), Some("/login"));
+    assert_eq!(def.action.as_deref(), Some("LoginController@authenticate"));
+}
+
+#[test]
+fn metadata_extracts_invokable_action() {
+    let def =
+        first_def("<?php\nRoute::get('/dashboard', DashboardController::class)->name('dash');\n");
+    assert_eq!(def.method.as_deref(), Some("get"));
+    assert_eq!(def.uri.as_deref(), Some("/dashboard"));
+    assert_eq!(def.action.as_deref(), Some("DashboardController"));
+}
+
+#[test]
+fn metadata_extracts_closure_action() {
+    let def = first_def(
+        "<?php\nRoute::get('/closure', function () { return 'hi'; })->name('closure');\n",
+    );
+    assert_eq!(def.method.as_deref(), Some("get"));
+    assert_eq!(def.uri.as_deref(), Some("/closure"));
+    assert_eq!(def.action.as_deref(), Some("Closure"));
+}
+
+#[test]
+fn metadata_extracts_arrow_function_action() {
+    let def = first_def("<?php\nRoute::get('/arrow', fn() => 'hi')->name('arrow');\n");
+    assert_eq!(def.action.as_deref(), Some("Closure"));
+}
+
+#[test]
+fn metadata_handles_namespaced_controller_in_array() {
+    let def = first_def(
+        "<?php\nRoute::get('/x', [\\App\\Http\\Controllers\\UserController::class, 'index'])->name('x');\n",
+    );
+    assert_eq!(def.action.as_deref(), Some("UserController@index"));
+}
+
+#[test]
+fn metadata_handles_view_route_without_action() {
+    let def = first_def("<?php\nRoute::view('/static', 'view.name')->name('view');\n");
+    assert_eq!(def.method.as_deref(), Some("view"));
+    assert_eq!(def.uri.as_deref(), Some("/static"));
+    // 'view.name' is the second argument — but in Route::view, it's a view name,
+    // not an action. We pass it through as a string for now; consumers can decide.
+    assert_eq!(def.action.as_deref(), Some("view.name"));
+}
+
+#[test]
+fn metadata_handles_redirect_route_without_action() {
+    let def = first_def("<?php\nRoute::redirect('/from', '/to')->name('redir');\n");
+    assert_eq!(def.method.as_deref(), Some("redirect"));
+    assert_eq!(def.uri.as_deref(), Some("/from"));
+    assert_eq!(def.action.as_deref(), Some("/to"));
+}
+
+#[test]
+fn metadata_handles_chained_middleware_before_name() {
+    let def = first_def(
+        "<?php\nRoute::get('/admin', [AdminController::class, 'index'])->middleware('auth')->name('admin');\n",
+    );
+    assert_eq!(def.method.as_deref(), Some("get"));
+    assert_eq!(def.uri.as_deref(), Some("/admin"));
+    assert_eq!(def.action.as_deref(), Some("AdminController@index"));
+}
+
+#[test]
+fn metadata_handles_multiline_route_declaration() {
+    let src = r#"<?php
+Route::get(
+    '/users/{user}',
+    [UserController::class, 'show'],
+)->name('users.show');
+"#;
+    let def = first_def(src);
+    assert_eq!(def.method.as_deref(), Some("get"));
+    assert_eq!(def.uri.as_deref(), Some("/users/{user}"));
+    assert_eq!(def.action.as_deref(), Some("UserController@show"));
+}
+
+#[test]
+fn metadata_handles_this_router_macro_style() {
+    let src = r#"<?php
+$this->get('login', [LoginController::class, 'show'])->name('login');
+"#;
+    let def = first_def(src);
+    assert_eq!(def.method.as_deref(), Some("get"));
+    assert_eq!(def.uri.as_deref(), Some("login"));
+    assert_eq!(def.action.as_deref(), Some("LoginController@show"));
+}
+
+#[test]
+fn metadata_skips_unrelated_verb_calls_in_other_statements() {
+    // Two statements; the first contains `Route::post(...)`, the second contains
+    // `->name('x')`. They must not bleed into each other.
+    let src = r#"<?php
+Route::post('/wrong', [Wrong::class, 'wrong']);
+Route::get('/right', [Right::class, 'right'])->name('right');
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    assert_eq!(results.len(), 1);
+    let def = &results[0].1;
+    assert_eq!(def.method.as_deref(), Some("get"));
+    assert_eq!(def.uri.as_deref(), Some("/right"));
+    assert_eq!(def.action.as_deref(), Some("Right@right"));
+}
+
+#[test]
+fn metadata_returns_none_when_verb_call_missing() {
+    // A `->name(` callsite without any verb call upstream — e.g. someone building
+    // routes through a builder we don't recognise.
+    let src = "<?php\n$builder->name('orphan');\n";
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    // content_registers_named_routes filters this in the discovery pipeline, but
+    // the raw extractor still surfaces the name with empty metadata.
+    assert_eq!(results.len(), 1);
+    let def = &results[0].1;
+    assert!(def.method.is_none());
+    assert!(def.uri.is_none());
+    assert!(def.action.is_none());
+}
+
+#[test]
+fn metadata_does_not_match_longer_verb_lookalike() {
+    // `->getUser(...)` should not match the `get` verb. The extractor must
+    // enforce a word boundary after the verb.
+    let src = "<?php\n$obj->getUser('/x', SomeController::class)->name('user');\n";
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    assert_eq!(results.len(), 1);
+    let def = &results[0].1;
+    assert!(
+        def.method.is_none(),
+        "verb match must require a word boundary"
+    );
+}
+
+// ============================================================================
+// Route group name compositing
+// ============================================================================
+
+#[test]
+fn route_group_chain_name_prefixes_child_route() {
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    Route::get('/users', [UserController::class, 'index'])->name('users.index');
+});
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
+    assert_eq!(names, vec!["admin.users.index"]);
+}
+
+#[test]
+fn route_group_array_as_prefixes_child_route() {
+    let src = r#"<?php
+Route::group(['as' => 'api.', 'prefix' => 'api'], function () {
+    Route::get('/users', [UserController::class, 'index'])->name('users.index');
+});
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
+    assert_eq!(names, vec!["api.users.index"]);
+}
+
+#[test]
+fn route_group_chain_handles_intervening_middleware_call() {
+    // `->middleware(...)` sits between `->name('admin.')` and `->group(...)`.
+    // The backward chain walk must step over middleware() and still find name().
+    let src = r#"<?php
+Route::name('admin.')->middleware(['auth', 'verified'])->group(function () {
+    Route::get('/users', [UserController::class, 'index'])->name('users.index');
+});
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
+    assert_eq!(names, vec!["admin.users.index"]);
+}
+
+#[test]
+fn route_group_nested_two_levels() {
+    let src = r#"<?php
+Route::name('api.')->group(function () {
+    Route::name('v1.')->group(function () {
+        Route::get('/users', [UserController::class, 'index'])->name('users.index');
+    });
+});
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
+    assert_eq!(names, vec!["api.v1.users.index"]);
+}
+
+#[test]
+fn route_group_nested_five_levels_real_world() {
+    // Modelled on the case Mike reported during manual testing:
+    // `decision-cloud.lead-settings.management-systems.decisioner-settings.edit`
+    let src = r#"<?php
+Route::name('decision-cloud.')->group(function () {
+    Route::name('lead-settings.')->group(function () {
+        Route::name('management-systems.')->group(function () {
+            Route::name('decisioner-settings.')->group(function () {
+                Route::get('/edit', [Controller::class, 'edit'])->name('edit');
+            });
+        });
+    });
+});
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
+    assert_eq!(
+        names,
+        vec!["decision-cloud.lead-settings.management-systems.decisioner-settings.edit"]
+    );
+}
+
+#[test]
+fn route_group_mixed_chain_and_array_styles() {
+    let src = r#"<?php
+Route::name('api.')->group(function () {
+    Route::group(['as' => 'v1.'], function () {
+        Route::get('/users', ...)->name('users.index');
+    });
+});
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
+    assert_eq!(names, vec!["api.v1.users.index"]);
+}
+
+#[test]
+fn route_group_does_not_prefix_routes_outside_body() {
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    Route::get('/users')->name('users.index');
+});
+Route::get('/login')->name('login');
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
+    assert_eq!(
+        names,
+        vec!["admin.users.index", "login"],
+        "route outside the group must NOT be prefixed"
+    );
+}
+
+#[test]
+fn route_group_without_prefix_does_not_contribute() {
+    // A group with no `->name(...)` and no array `'as'` — it's a valid
+    // grouping but doesn't affect child route names.
+    let src = r#"<?php
+Route::middleware('auth')->group(function () {
+    Route::get('/dashboard')->name('dashboard');
+});
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
+    assert_eq!(names, vec!["dashboard"]);
+}
+
+#[test]
+fn route_group_sibling_groups_do_not_cross_pollinate() {
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    Route::get('/x')->name('x');
+});
+Route::name('api.')->group(function () {
+    Route::get('/y')->name('y');
+});
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
+    assert_eq!(names, vec!["admin.x", "api.y"]);
 }

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -1322,9 +1322,32 @@ pub fn parse_service_provider_source<'db>(
     use regex::Regex;
 
     lazy_static! {
-        /// Matches $this->app->bind('name', ...) or ->singleton(...)
-        static ref BINDING_RE: Regex = Regex::new(
-            r#"\$this->app->(bind|singleton)\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*(?:function|\[)?[^)]*\\?([A-Za-z0-9_\\]+)(?:::class)?)?\s*\)"#
+        /// Matches `$this->app->bind('name', Class::class)` or
+        /// `$this->app->singleton('name', Class::class)` where the concrete
+        /// is given as a static class reference.
+        ///
+        /// Two earlier shapes — `..., function () { ... })` (closure concrete)
+        /// and `..., $variable` (variable concrete) — are matched separately
+        /// below so they can be classified rather than mis-extracted as a
+        /// class name. The original combined regex back-tracked into closure
+        /// parameter lists (e.g. `function ($app)`) and pulled `"p"` out of
+        /// `$app`, which is the bug being fixed here.
+        static ref BINDING_CLASS_RE: Regex = Regex::new(
+            r#"\$this->app->(bind|singleton)\s*\(\s*['"]([^'"]+)['"]\s*,\s*\\?([A-Za-z0-9_\\]+)::class"#
+        ).unwrap();
+
+        /// Matches `$this->app->bind('name', function ...)` or `fn (...) =>`.
+        /// The concrete in this case is a closure — we record `"Closure"`
+        /// rather than trying to derive a class name.
+        static ref BINDING_CLOSURE_RE: Regex = Regex::new(
+            r#"\$this->app->(bind|singleton)\s*\(\s*['"]([^'"]+)['"]\s*,\s*(?:function\s*\(|fn\s*\()"#
+        ).unwrap();
+
+        /// Matches a bare `$this->app->bind('name')` or `->singleton('name')`
+        /// — no second argument. Falls back to abstract = concrete in the
+        /// handler.
+        static ref BINDING_BARE_RE: Regex = Regex::new(
+            r#"\$this->app->(bind|singleton)\s*\(\s*['"]([^'"]+)['"]\s*\)"#
         ).unwrap();
 
         /// Matches $this->app->alias('concrete', 'alias')
@@ -1425,29 +1448,84 @@ pub fn parse_service_provider_source<'db>(
         }
     }
 
-    // Parse bind/singleton registrations
-    for cap in BINDING_RE.captures_iter(text) {
-        if let (Some(method), Some(name)) = (cap.get(1), cap.get(2)) {
+    // Parse bind/singleton registrations. Three regexes target the three
+    // forms a binding's concrete can take — explicit class, closure, or no
+    // second argument. Each abstract name is registered exactly once, with
+    // the class regex taking precedence over closure, which takes precedence
+    // over bare (no second arg). The earlier combined regex back-tracked
+    // into closure parameter lists and pulled garbage like `"p"` out of
+    // `function ($app)`; the three narrower regexes can't do that.
+    let mut bindings_seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for cap in BINDING_CLASS_RE.captures_iter(text) {
+        if let (Some(method), Some(name), Some(concrete)) = (cap.get(1), cap.get(2), cap.get(3)) {
+            let abstract_name = name.as_str();
+            if !bindings_seen.insert(abstract_name.to_string()) {
+                continue;
+            }
+            let concrete_class = concrete.as_str().trim_start_matches('\\').to_string();
             let binding_type = match method.as_str() {
                 "singleton" => BindingTypeEnum::Singleton,
-                "bind" => BindingTypeEnum::Bind,
                 _ => BindingTypeEnum::Bind,
             };
-
-            let abstract_name = name.as_str();
-            let concrete_class = cap
-                .get(3)
-                .map(|m| m.as_str().trim_start_matches('\\'))
-                .unwrap_or(abstract_name);
-
             let line = text[..name.start()].lines().count() as u32;
-            let file_path = resolve_class_to_file_internal(concrete_class, &root);
-
+            let file_path = resolve_class_to_file_internal(&concrete_class, &root);
             let binding_name = BindingName::new(db, abstract_name.to_string());
             bindings.push(ParsedBindingReg::new(
                 db,
                 binding_name,
-                concrete_class.to_string(),
+                concrete_class,
+                file_path,
+                binding_type,
+                line,
+                priority,
+                path.clone(),
+            ));
+        }
+    }
+
+    for cap in BINDING_CLOSURE_RE.captures_iter(text) {
+        if let (Some(method), Some(name)) = (cap.get(1), cap.get(2)) {
+            let abstract_name = name.as_str();
+            if !bindings_seen.insert(abstract_name.to_string()) {
+                continue;
+            }
+            let binding_type = match method.as_str() {
+                "singleton" => BindingTypeEnum::Singleton,
+                _ => BindingTypeEnum::Bind,
+            };
+            let line = text[..name.start()].lines().count() as u32;
+            let binding_name = BindingName::new(db, abstract_name.to_string());
+            bindings.push(ParsedBindingReg::new(
+                db,
+                binding_name,
+                "Closure".to_string(),
+                None,
+                binding_type,
+                line,
+                priority,
+                path.clone(),
+            ));
+        }
+    }
+
+    for cap in BINDING_BARE_RE.captures_iter(text) {
+        if let (Some(method), Some(name)) = (cap.get(1), cap.get(2)) {
+            let abstract_name = name.as_str();
+            if !bindings_seen.insert(abstract_name.to_string()) {
+                continue;
+            }
+            let binding_type = match method.as_str() {
+                "singleton" => BindingTypeEnum::Singleton,
+                _ => BindingTypeEnum::Bind,
+            };
+            let line = text[..name.start()].lines().count() as u32;
+            let file_path = resolve_class_to_file_internal(abstract_name, &root);
+            let binding_name = BindingName::new(db, abstract_name.to_string());
+            bindings.push(ParsedBindingReg::new(
+                db,
+                binding_name,
+                abstract_name.to_string(),
                 file_path,
                 binding_type,
                 line,

--- a/laravel-lsp/src/tests/class_locator_and_properties.rs
+++ b/laravel-lsp/src/tests/class_locator_and_properties.rs
@@ -1,8 +1,9 @@
 use laravel_lsp::class_locator::find_php_class_file;
 use laravel_lsp::livewire_resolver::extract_blade_variable_at_cursor;
 use laravel_lsp::php_class::{
-    extract_class_properties, extract_class_signature, extract_property_declaration,
-    find_property_declaration_position, find_property_definition_line, read_line_from_file,
+    extract_class_fqn, extract_class_properties, extract_class_signature,
+    extract_property_declaration, find_property_declaration_position,
+    find_property_definition_line, read_line_from_file,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -602,4 +603,86 @@ fn read_line_from_file_returns_none_for_out_of_range_line() {
 fn read_line_from_file_returns_none_for_missing_file() {
     let nonexistent = std::path::PathBuf::from("/nonexistent/file.php");
     assert_eq!(read_line_from_file(&nonexistent, 0), None);
+}
+
+// ============================================================================
+// php_class::extract_class_fqn
+// ============================================================================
+
+#[test]
+fn extract_class_fqn_combines_namespace_and_class() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("Counter.php");
+    fs::write(
+        &path,
+        "<?php\nnamespace App\\Livewire;\n\nuse Livewire\\Component;\n\nclass Counter extends Component\n{\n}\n",
+    )
+    .unwrap();
+    assert_eq!(
+        extract_class_fqn(&path).as_deref(),
+        Some("App\\Livewire\\Counter")
+    );
+}
+
+#[test]
+fn extract_class_fqn_handles_namespaceless_class() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("Plain.php");
+    fs::write(&path, "<?php\nclass Plain\n{\n}\n").unwrap();
+    assert_eq!(extract_class_fqn(&path).as_deref(), Some("Plain"));
+}
+
+#[test]
+fn extract_class_fqn_handles_modifiers_and_interfaces() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("Repo.php");
+    fs::write(
+        &path,
+        "<?php\nnamespace App\\Services;\n\nfinal class UserRepo implements Repo\n{\n}\n",
+    )
+    .unwrap();
+    assert_eq!(
+        extract_class_fqn(&path).as_deref(),
+        Some("App\\Services\\UserRepo")
+    );
+}
+
+#[test]
+fn extract_class_fqn_works_for_interfaces_and_traits() {
+    let dir = TempDir::new().unwrap();
+    let interface_path = dir.path().join("Lookup.php");
+    fs::write(
+        &interface_path,
+        "<?php\nnamespace App\\Contracts;\n\ninterface Lookup {}\n",
+    )
+    .unwrap();
+    assert_eq!(
+        extract_class_fqn(&interface_path).as_deref(),
+        Some("App\\Contracts\\Lookup")
+    );
+
+    let trait_path = dir.path().join("Findable.php");
+    fs::write(
+        &trait_path,
+        "<?php\nnamespace App\\Concerns;\n\ntrait Findable {}\n",
+    )
+    .unwrap();
+    assert_eq!(
+        extract_class_fqn(&trait_path).as_deref(),
+        Some("App\\Concerns\\Findable")
+    );
+}
+
+#[test]
+fn extract_class_fqn_returns_none_for_no_class() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("helpers.php");
+    fs::write(&path, "<?php\nfunction helper() {}\n").unwrap();
+    assert_eq!(extract_class_fqn(&path), None);
+}
+
+#[test]
+fn extract_class_fqn_returns_none_for_missing_file() {
+    let nonexistent = std::path::PathBuf::from("/nonexistent/Class.php");
+    assert_eq!(extract_class_fqn(&nonexistent), None);
 }

--- a/laravel-lsp/src/tests/class_locator_and_properties.rs
+++ b/laravel-lsp/src/tests/class_locator_and_properties.rs
@@ -1,6 +1,9 @@
 use laravel_lsp::class_locator::find_php_class_file;
 use laravel_lsp::livewire_resolver::extract_blade_variable_at_cursor;
-use laravel_lsp::php_class::{extract_class_properties, find_property_declaration_position};
+use laravel_lsp::php_class::{
+    extract_class_properties, extract_property_declaration, find_property_declaration_position,
+    find_property_definition_line,
+};
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
@@ -291,4 +294,210 @@ class ContactForm extends Form {
     let line = lines[pos.0 as usize];
     let col_range = &line[pos.1 as usize..pos.2 as usize];
     assert_eq!(col_range, "$name");
+}
+
+// ============================================================================
+// php_class::find_property_definition_line
+// ============================================================================
+
+#[test]
+fn finds_public_property_definition_line() {
+    let src = "<?php\nclass User {\n    public string $name;\n    public int $age;\n}\n";
+    // `name` is on line 2 (0-based: line 2 because <?php is line 0, blank is 1, no — let me count)
+    // Line 0: `<?php`
+    // Line 1: `class User {`
+    // Line 2: `    public string $name;`
+    let line = find_property_definition_line(src, "name").expect("should find name");
+    assert_eq!(line, 2);
+}
+
+#[test]
+fn finds_phpdoc_property_definition_line() {
+    let src = r#"<?php
+/**
+ * @property string $email
+ * @property int $age
+ */
+class User {}
+"#;
+    let line = find_property_definition_line(src, "email").expect("should find email");
+    // Line 0: <?php
+    // Line 1: /**
+    // Line 2:  * @property string $email
+    assert_eq!(line, 2);
+}
+
+#[test]
+fn finds_property_in_casts_array() {
+    let src = r#"<?php
+class User extends Model {
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+        'is_admin' => 'boolean',
+    ];
+}
+"#;
+    let line = find_property_definition_line(src, "is_admin").expect("should find is_admin");
+    // Line 4: `        'is_admin' => 'boolean',`
+    assert_eq!(line, 4);
+}
+
+#[test]
+fn finds_relationship_method() {
+    let src = r#"<?php
+class User extends Model {
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+}
+"#;
+    let line = find_property_definition_line(src, "posts").expect("should find posts");
+    // Line 2: `    public function posts()`
+    assert_eq!(line, 2);
+}
+
+#[test]
+fn picks_earliest_match_when_multiple_shapes_present() {
+    // A model with the same column in BOTH @property AND $casts. The earlier
+    // occurrence (@property doc block) wins.
+    let src = r#"<?php
+/** @property string $email */
+class User extends Model {
+    protected $casts = [
+        'email' => 'string',
+    ];
+}
+"#;
+    let line = find_property_definition_line(src, "email").expect("should find email");
+    // The @property line (line 1) comes before the $casts entry (line 4).
+    assert_eq!(line, 1);
+}
+
+#[test]
+fn returns_none_when_property_not_declared_anywhere() {
+    let src = "<?php\nclass User { public $name; }\n";
+    assert_eq!(find_property_definition_line(src, "missing"), None);
+}
+
+#[test]
+fn does_not_falsely_match_substring_property_names() {
+    // `name_with_extra` should not match a search for `name`.
+    let src = "<?php\nclass User { public $name_with_extra; }\n";
+    assert_eq!(find_property_definition_line(src, "name"), None);
+}
+
+// ============================================================================
+// php_class::extract_property_declaration
+// ============================================================================
+
+#[test]
+fn extracts_declaration_text_for_typed_property() {
+    let src = "<?php\nclass User {\n    public string $email;\n}\n";
+    let decl = extract_property_declaration(src, "email").expect("should find");
+    assert_eq!(decl.declaration_text, "public string $email;");
+    assert_eq!(decl.line, 2);
+    assert!(decl.description.is_none());
+    assert!(decl.phpdoc_tags.is_empty());
+}
+
+#[test]
+fn extracts_phpdoc_description_above_property() {
+    let src = r#"<?php
+class User {
+    /**
+     * The user's email address.
+     */
+    public string $email;
+}
+"#;
+    let decl = extract_property_declaration(src, "email").expect("should find");
+    assert_eq!(
+        decl.description.as_deref(),
+        Some("The user's email address.")
+    );
+}
+
+#[test]
+fn extracts_phpdoc_tags() {
+    let src = r#"<?php
+class Controller {
+    /**
+     * Authorize a given action for the current user.
+     *
+     * @param mixed $ability
+     * @param mixed $arguments
+     * @return \Illuminate\Auth\Access\Response
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorize($ability, $arguments = []) {}
+}
+"#;
+    let decl = extract_property_declaration(src, "authorize").expect("should find");
+    assert_eq!(
+        decl.description.as_deref(),
+        Some("Authorize a given action for the current user.")
+    );
+    assert!(
+        decl.phpdoc_tags
+            .iter()
+            .any(|t| t == "@param mixed $ability"),
+        "got tags: {:?}",
+        decl.phpdoc_tags
+    );
+    assert!(decl
+        .phpdoc_tags
+        .iter()
+        .any(|t| t == "@return \\Illuminate\\Auth\\Access\\Response"));
+    assert!(decl
+        .phpdoc_tags
+        .iter()
+        .any(|t| t == "@throws \\Illuminate\\Auth\\Access\\AuthorizationException"));
+}
+
+#[test]
+fn description_joins_multiline_summary() {
+    let src = r#"<?php
+class User {
+    /**
+     * The user's email address.
+     * Used for password recovery and notifications.
+     */
+    public string $email;
+}
+"#;
+    let decl = extract_property_declaration(src, "email").expect("should find");
+    let desc = decl.description.unwrap();
+    assert!(desc.contains("The user's email address."));
+    assert!(desc.contains("Used for password recovery"));
+}
+
+#[test]
+fn no_phpdoc_above_returns_none_description() {
+    let src = "<?php\nclass User {\n    public string $email;\n}\n";
+    let decl = extract_property_declaration(src, "email").expect("should find");
+    assert!(decl.description.is_none());
+    assert!(decl.phpdoc_tags.is_empty());
+}
+
+#[test]
+fn ignores_phpdoc_separated_by_other_code() {
+    // A PHPDoc block with code BETWEEN it and the property — should not
+    // associate the docblock with the property.
+    let src = r#"<?php
+class User {
+    /**
+     * This describes something else.
+     */
+    public string $other;
+
+    public string $email;
+}
+"#;
+    let decl = extract_property_declaration(src, "email").expect("should find");
+    assert!(
+        decl.description.is_none(),
+        "got unexpected description: {:?}",
+        decl.description
+    );
 }

--- a/laravel-lsp/src/tests/class_locator_and_properties.rs
+++ b/laravel-lsp/src/tests/class_locator_and_properties.rs
@@ -1,8 +1,8 @@
 use laravel_lsp::class_locator::find_php_class_file;
 use laravel_lsp::livewire_resolver::extract_blade_variable_at_cursor;
 use laravel_lsp::php_class::{
-    extract_class_properties, extract_property_declaration, find_property_declaration_position,
-    find_property_definition_line,
+    extract_class_properties, extract_class_signature, extract_property_declaration,
+    find_property_declaration_position, find_property_definition_line, read_line_from_file,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -500,4 +500,106 @@ class User {
         "got unexpected description: {:?}",
         decl.description
     );
+}
+
+// ============================================================================
+// php_class::extract_class_signature
+// ============================================================================
+
+#[test]
+fn extract_class_signature_returns_class_line() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("Counter.php");
+    fs::write(
+        &path,
+        "<?php\nnamespace App\\Livewire;\n\nuse Livewire\\Component;\n\nclass Counter extends Component\n{\n    public int $count = 0;\n}\n",
+    )
+    .unwrap();
+    let got = extract_class_signature(&path).expect("should find class");
+    assert_eq!(got, "class Counter extends Component");
+}
+
+#[test]
+fn extract_class_signature_handles_final_and_abstract_modifiers() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("Foo.php");
+    fs::write(
+        &path,
+        "<?php\nfinal class Foo extends Bar implements Baz\n{\n}\n",
+    )
+    .unwrap();
+    let got = extract_class_signature(&path).expect("should find class");
+    assert_eq!(got, "final class Foo extends Bar implements Baz");
+}
+
+#[test]
+fn extract_class_signature_ignores_class_keyword_in_strings() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("Foo.php");
+    // The string `'class FakeClass'` must NOT trick the matcher — our
+    // regex anchors at start-of-line. Body braces (`{}`) are intentionally
+    // excluded from the captured signature — same shape intelephense uses.
+    fs::write(
+        &path,
+        "<?php\n$x = 'class FakeClass';\nclass Real extends Bar {}\n",
+    )
+    .unwrap();
+    let got = extract_class_signature(&path).expect("should find class");
+    assert_eq!(got, "class Real extends Bar");
+}
+
+#[test]
+fn extract_class_signature_returns_none_for_files_without_class() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("helpers.php");
+    fs::write(&path, "<?php\nfunction helper() {}\n").unwrap();
+    assert_eq!(extract_class_signature(&path), None);
+}
+
+// ============================================================================
+// php_class::read_line_from_file
+// ============================================================================
+
+#[test]
+fn read_line_from_file_returns_targeted_line() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("routes.php");
+    fs::write(
+        &path,
+        "<?php\nRoute::get('/users', [UserController::class, 'index'])->name('users.index');\nRoute::post('/users', [UserController::class, 'store'])->name('users.store');\n",
+    )
+    .unwrap();
+    assert_eq!(read_line_from_file(&path, 0).as_deref(), Some("<?php"));
+    assert!(read_line_from_file(&path, 1)
+        .unwrap()
+        .contains("Route::get"));
+    assert!(read_line_from_file(&path, 2)
+        .unwrap()
+        .contains("Route::post"));
+}
+
+#[test]
+fn read_line_from_file_preserves_leading_whitespace() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("x.php");
+    fs::write(&path, "first\n    indented line\n").unwrap();
+    assert_eq!(
+        read_line_from_file(&path, 1).as_deref(),
+        Some("    indented line"),
+        "leading whitespace should survive — hover snippets care about indentation context"
+    );
+}
+
+#[test]
+fn read_line_from_file_returns_none_for_out_of_range_line() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("short.php");
+    fs::write(&path, "one\ntwo\n").unwrap();
+    assert_eq!(read_line_from_file(&path, 99), None);
+}
+
+#[test]
+fn read_line_from_file_returns_none_for_missing_file() {
+    let nonexistent = std::path::PathBuf::from("/nonexistent/file.php");
+    assert_eq!(read_line_from_file(&nonexistent, 0), None);
 }

--- a/laravel-lsp/src/translation_lookup.rs
+++ b/laravel-lsp/src/translation_lookup.rs
@@ -1,0 +1,168 @@
+//! Resolve Laravel translation keys to their localized strings.
+//!
+//! Laravel supports three translation shapes:
+//!
+//! - **Dotted keys** (`__('validation.required')`) — resolved through PHP files
+//!   under `lang/{locale}/`. `validation.required` → `lang/en/validation.php`,
+//!   key `required`.
+//!
+//! - **Namespaced dotted keys** (`__('filament-tables::table.label')`) — resolved
+//!   through `lang/vendor/{namespace}/{locale}/{file}.php` (the published
+//!   location for package translations). Vendor packages that haven't been
+//!   published still hold their source translations under
+//!   `vendor/{vendor}/{package}/...` but this resolver only checks the
+//!   published path. Scanning unpublished package translations is a separate
+//!   piece of work tracked elsewhere.
+//!
+//! - **Text keys** (`__('Welcome to our app')`) — resolved through the single
+//!   JSON file `lang/{locale}.json`. The key IS the source string and the
+//!   value is the translated string.
+//!
+//! All three shapes route to the same PHP-array walker from [`config_lookup`]
+//! since Laravel's `.php` translation files share their exact shape with
+//! config files.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::config_lookup;
+
+/// A resolved translation along with the file the value was read from.
+/// The source file is rendered as a display-friendly path in hover output so
+/// users can tell whether a key came from an app file, a published vendor
+/// translation, or the JSON catalogue.
+#[derive(Debug, Clone)]
+pub struct ResolvedTranslation {
+    pub value: String,
+    pub source_file: PathBuf,
+}
+
+/// Resolve a translation key against a project root and locale. Returns both
+/// the translated value and the file it was read from — see
+/// [`ResolvedTranslation`].
+///
+/// For namespaced keys (`package::file.key`), the resolver tries the
+/// published location first (`lang/vendor/<namespace>/...`) and falls back
+/// to the unpublished vendor location when `vendor_map` is provided. See
+/// [`crate::vendor_translations`] for how that map is built.
+pub fn resolve_translation_detailed(
+    root: &Path,
+    key: &str,
+    locale: &str,
+    vendor_map: Option<&HashMap<String, PathBuf>>,
+) -> Option<ResolvedTranslation> {
+    if let Some((namespace, rest)) = split_namespace(key) {
+        if let Some(r) = resolve_namespaced(root, namespace, rest, locale) {
+            return Some(r);
+        }
+        // Published path missed — try the unpublished vendor directory.
+        if let Some(map) = vendor_map {
+            if let Some(dir) = map.get(namespace) {
+                return resolve_namespaced_in_dir(dir, rest, locale);
+            }
+        }
+        return None;
+    }
+    if is_dotted_key(key) {
+        return resolve_dotted(root, key, locale);
+    }
+    resolve_text_key(root, key, locale)
+}
+
+/// Backwards-compatible wrapper that returns only the value, matching the
+/// pre-source-file API. Used by tests that don't care about the source path.
+pub fn resolve_translation(root: &Path, key: &str, locale: &str) -> Option<String> {
+    resolve_translation_detailed(root, key, locale, None).map(|r| r.value)
+}
+
+/// Split a namespaced key (`package::file.key.path`) into its namespace and
+/// the rest. Returns `None` for keys without a `::` separator.
+fn split_namespace(key: &str) -> Option<(&str, &str)> {
+    let idx = key.find("::")?;
+    Some((&key[..idx], &key[idx + 2..]))
+}
+
+/// Distinguish a dotted PHP-file key (`validation.required`) from a text key
+/// (`"Welcome to our app"`). Heuristic: dotted keys contain a `.` and no
+/// whitespace.
+fn is_dotted_key(key: &str) -> bool {
+    key.contains('.') && !key.contains(' ')
+}
+
+/// Resolve a dotted key against `lang/{locale}/{file}.php`.
+fn resolve_dotted(root: &Path, key: &str, locale: &str) -> Option<ResolvedTranslation> {
+    let mut parts = key.split('.');
+    let file = parts.next()?;
+    let key_path: Vec<&str> = parts.collect();
+    if key_path.is_empty() {
+        return None;
+    }
+    let path = root.join("lang").join(locale).join(format!("{}.php", file));
+    read_php_value(&path, &key_path)
+}
+
+/// Resolve a published namespaced key against
+/// `lang/vendor/{namespace}/{locale}/{file}.php`.
+fn resolve_namespaced(
+    root: &Path,
+    namespace: &str,
+    rest: &str,
+    locale: &str,
+) -> Option<ResolvedTranslation> {
+    let mut parts = rest.split('.');
+    let file = parts.next()?;
+    let key_path: Vec<&str> = parts.collect();
+    if key_path.is_empty() {
+        return None;
+    }
+    let path = root
+        .join("lang")
+        .join("vendor")
+        .join(namespace)
+        .join(locale)
+        .join(format!("{}.php", file));
+    read_php_value(&path, &key_path)
+}
+
+/// Resolve a namespaced key against an explicit lang directory — the
+/// fallback used when the published path missed and the namespace was
+/// discovered via [`crate::vendor_translations`].
+fn resolve_namespaced_in_dir(
+    lang_dir: &Path,
+    rest: &str,
+    locale: &str,
+) -> Option<ResolvedTranslation> {
+    let mut parts = rest.split('.');
+    let file = parts.next()?;
+    let key_path: Vec<&str> = parts.collect();
+    if key_path.is_empty() {
+        return None;
+    }
+    let path = lang_dir.join(locale).join(format!("{}.php", file));
+    read_php_value(&path, &key_path)
+}
+
+/// Resolve a text key against `lang/{locale}.json`.
+fn resolve_text_key(root: &Path, key: &str, locale: &str) -> Option<ResolvedTranslation> {
+    let path = root.join("lang").join(format!("{}.json", locale));
+    let content = std::fs::read_to_string(&path).ok()?;
+    let map: serde_json::Map<String, serde_json::Value> = serde_json::from_str(&content).ok()?;
+    let value = map.get(key)?.as_str()?;
+    Some(ResolvedTranslation {
+        value: format!("'{}'", value),
+        source_file: path,
+    })
+}
+
+/// Shared PHP-file read + walk. Returns the bundled value + source path on hit.
+fn read_php_value(path: &Path, key_path: &[&str]) -> Option<ResolvedTranslation> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let value = config_lookup::resolve_in_source(&content, key_path)?;
+    Some(ResolvedTranslation {
+        value,
+        source_file: path.to_path_buf(),
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/translation_lookup/tests.rs
+++ b/laravel-lsp/src/translation_lookup/tests.rs
@@ -1,0 +1,282 @@
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+/// Build a fake Laravel project root with a `lang/` directory ready for tests.
+fn fake_project_with_lang() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let lang = dir.path().join("lang");
+    fs::create_dir_all(lang.join("en")).unwrap();
+    dir
+}
+
+#[test]
+fn resolves_dotted_key_from_php_file() {
+    let project = fake_project_with_lang();
+    let validation = project.path().join("lang/en/validation.php");
+    fs::write(
+        &validation,
+        "<?php\nreturn [\n    'required' => 'The :attribute field is required.',\n];\n",
+    )
+    .unwrap();
+
+    let got = resolve_translation(project.path(), "validation.required", "en");
+    assert_eq!(got.as_deref(), Some("'The :attribute field is required.'"));
+}
+
+#[test]
+fn resolves_nested_dotted_key_from_php_file() {
+    let project = fake_project_with_lang();
+    let auth = project.path().join("lang/en/auth.php");
+    fs::write(
+        &auth,
+        "<?php\nreturn [\n    'failed' => 'These credentials do not match.',\n    'throttle' => [\n        'message' => 'Too many attempts.',\n    ],\n];\n",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_translation(project.path(), "auth.failed", "en").as_deref(),
+        Some("'These credentials do not match.'")
+    );
+    assert_eq!(
+        resolve_translation(project.path(), "auth.throttle.message", "en").as_deref(),
+        Some("'Too many attempts.'")
+    );
+}
+
+#[test]
+fn resolves_text_key_from_json_file() {
+    let project = fake_project_with_lang();
+    let json = project.path().join("lang/en.json");
+    fs::write(
+        &json,
+        r#"{
+    "Welcome to our app": "Welcome to our app",
+    "Sign in": "Sign in"
+}
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolve_translation(project.path(), "Welcome to our app", "en").as_deref(),
+        Some("'Welcome to our app'")
+    );
+}
+
+#[test]
+fn returns_none_for_missing_dotted_key() {
+    let project = fake_project_with_lang();
+    let validation = project.path().join("lang/en/validation.php");
+    fs::write(&validation, "<?php\nreturn ['present' => 'x'];\n").unwrap();
+
+    assert_eq!(
+        resolve_translation(project.path(), "validation.missing", "en"),
+        None
+    );
+}
+
+#[test]
+fn returns_none_for_missing_json_key() {
+    let project = fake_project_with_lang();
+    let json = project.path().join("lang/en.json");
+    fs::write(&json, r#"{"Present": "Present"}"#).unwrap();
+
+    assert_eq!(
+        resolve_translation(project.path(), "Missing entry", "en"),
+        None
+    );
+}
+
+#[test]
+fn returns_none_when_file_does_not_exist() {
+    let project = fake_project_with_lang();
+    // No files written.
+    assert_eq!(
+        resolve_translation(project.path(), "validation.required", "en"),
+        None
+    );
+    assert_eq!(
+        resolve_translation(project.path(), "Free-form text", "en"),
+        None
+    );
+}
+
+#[test]
+fn dotted_key_classifier_distinguishes_shapes() {
+    assert!(is_dotted_key("validation.required"));
+    assert!(is_dotted_key("auth.throttle.message"));
+    // A user-facing sentence with a period — has spaces, so treated as a text key.
+    assert!(!is_dotted_key("Welcome to our app."));
+    // No dot, no spaces — treat as text key (degenerate case).
+    assert!(!is_dotted_key("single"));
+}
+
+#[test]
+fn namespace_splitter_separates_vendor_from_rest() {
+    assert_eq!(
+        split_namespace("filament-tables::table.actions.label"),
+        Some(("filament-tables", "table.actions.label"))
+    );
+    assert_eq!(split_namespace("validation.required"), None);
+    assert_eq!(split_namespace("plain text"), None);
+}
+
+#[test]
+fn resolves_namespaced_translation_from_published_path() {
+    let project = fake_project_with_lang();
+    let vendor_dir = project.path().join("lang/vendor/filament-tables/en");
+    fs::create_dir_all(&vendor_dir).unwrap();
+    let table = vendor_dir.join("table.php");
+    fs::write(
+        &table,
+        "<?php\nreturn [\n    'actions' => [\n        'filter' => [\n            'label' => 'Filter',\n        ],\n    ],\n];\n",
+    )
+    .unwrap();
+
+    let got = resolve_translation(
+        project.path(),
+        "filament-tables::table.actions.filter.label",
+        "en",
+    );
+    assert_eq!(got.as_deref(), Some("'Filter'"));
+}
+
+#[test]
+fn resolves_namespaced_translation_with_source_path() {
+    let project = fake_project_with_lang();
+    let vendor_dir = project.path().join("lang/vendor/livewire/en");
+    fs::create_dir_all(&vendor_dir).unwrap();
+    fs::write(
+        vendor_dir.join("validation.php"),
+        "<?php\nreturn ['required' => 'This field is required.'];\n",
+    )
+    .unwrap();
+
+    let resolved =
+        resolve_translation_detailed(project.path(), "livewire::validation.required", "en", None)
+            .expect("namespaced lookup should hit");
+
+    assert_eq!(resolved.value, "'This field is required.'");
+    assert!(
+        resolved
+            .source_file
+            .ends_with("lang/vendor/livewire/en/validation.php"),
+        "got: {:?}",
+        resolved.source_file
+    );
+}
+
+#[test]
+fn returns_none_for_missing_namespaced_file() {
+    let project = fake_project_with_lang();
+    assert_eq!(
+        resolve_translation(project.path(), "filament-tables::table.actions.label", "en"),
+        None
+    );
+}
+
+#[test]
+fn falls_back_to_unpublished_vendor_dir_when_published_path_missing() {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    let project = fake_project_with_lang();
+    // No published translations at lang/vendor/<ns>. Instead, simulate an
+    // unpublished package at vendor/<ns>/lang/en/<file>.php.
+    let vendor_lang = project.path().join("vendor/acme/billing/resources/lang");
+    let en_dir = vendor_lang.join("en");
+    fs::create_dir_all(&en_dir).unwrap();
+    fs::write(
+        en_dir.join("invoice.php"),
+        "<?php\nreturn ['total' => 'Total'];\n",
+    )
+    .unwrap();
+
+    let mut vendor_map: HashMap<String, PathBuf> = HashMap::new();
+    vendor_map.insert("billing".to_string(), vendor_lang.clone());
+
+    let resolved = resolve_translation_detailed(
+        project.path(),
+        "billing::invoice.total",
+        "en",
+        Some(&vendor_map),
+    )
+    .expect("unpublished vendor fallback should resolve");
+    assert_eq!(resolved.value, "'Total'");
+    assert!(
+        resolved
+            .source_file
+            .ends_with("vendor/acme/billing/resources/lang/en/invoice.php"),
+        "got: {:?}",
+        resolved.source_file
+    );
+}
+
+#[test]
+fn published_path_still_wins_over_vendor_map_when_both_exist() {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    let project = fake_project_with_lang();
+    // Published value
+    let published = project.path().join("lang/vendor/billing/en");
+    fs::create_dir_all(&published).unwrap();
+    fs::write(
+        published.join("invoice.php"),
+        "<?php\nreturn ['total' => 'Published total'];\n",
+    )
+    .unwrap();
+    // Unpublished value with the same key but different string
+    let vendor_lang = project.path().join("vendor/acme/billing/lang");
+    let en_dir = vendor_lang.join("en");
+    fs::create_dir_all(&en_dir).unwrap();
+    fs::write(
+        en_dir.join("invoice.php"),
+        "<?php\nreturn ['total' => 'Vendor total'];\n",
+    )
+    .unwrap();
+
+    let mut vendor_map: HashMap<String, PathBuf> = HashMap::new();
+    vendor_map.insert("billing".to_string(), vendor_lang);
+
+    let resolved = resolve_translation_detailed(
+        project.path(),
+        "billing::invoice.total",
+        "en",
+        Some(&vendor_map),
+    )
+    .expect("should resolve");
+    // Published overrides — the user's choice when they ran
+    // `php artisan vendor:publish` should take precedence.
+    assert_eq!(resolved.value, "'Published total'");
+}
+
+#[test]
+fn dotted_key_without_path_returns_none() {
+    let project = fake_project_with_lang();
+    // A bare file name like "validation" — no key segment after the dot.
+    assert_eq!(
+        resolve_translation(project.path(), "validation", "en"),
+        None
+    );
+}
+
+#[test]
+fn respects_locale_argument() {
+    let project = fake_project_with_lang();
+    fs::create_dir_all(project.path().join("lang/fr")).unwrap();
+    let en = project.path().join("lang/en/validation.php");
+    let fr = project.path().join("lang/fr/validation.php");
+    fs::write(&en, "<?php\nreturn ['required' => 'English'];\n").unwrap();
+    fs::write(&fr, "<?php\nreturn ['required' => 'Français'];\n").unwrap();
+
+    assert_eq!(
+        resolve_translation(project.path(), "validation.required", "en").as_deref(),
+        Some("'English'")
+    );
+    assert_eq!(
+        resolve_translation(project.path(), "validation.required", "fr").as_deref(),
+        Some("'Français'")
+    );
+}

--- a/laravel-lsp/src/vendor_translations.rs
+++ b/laravel-lsp/src/vendor_translations.rs
@@ -1,0 +1,126 @@
+//! Discover translation-namespace registrations across vendor packages.
+//!
+//! Laravel packages register their translations in a `ServiceProvider::boot()`
+//! method via:
+//!
+//! ```php
+//! $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'package-namespace');
+//! ```
+//!
+//! The published location for those translations is `lang/vendor/<namespace>/`
+//! in the host project, which [`crate::translation_lookup`] already handles.
+//! This module fills the gap for translations that **haven't been published** —
+//! it walks `vendor/` for service providers that call `loadTranslationsFrom`,
+//! extracts each `(namespace, directory)` pair, and returns a map the
+//! resolver can fall back to when the published path doesn't exist.
+//!
+//! No on-disk cache yet — the scan runs once at LSP startup and the result
+//! lives in memory. A composer.lock-keyed cache (like
+//! [`crate::config::scan_vendor_for_component_aliases`]) is a worthwhile
+//! follow-up once the scan time becomes a noticeable cost on first hover.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+lazy_static! {
+    /// Matches `$this->loadTranslationsFrom(__DIR__.'/relative/path', 'namespace')`.
+    /// Captures the relative path and the namespace.
+    static ref LOAD_TRANSLATIONS_RE: Regex = Regex::new(
+        r#"\$this->loadTranslationsFrom\s*\(\s*__DIR__\s*\.\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]+)['"]\s*\)"#
+    ).unwrap();
+}
+
+/// Walk `vendor/` for service providers that register translation namespaces.
+/// Returns a map of `namespace → absolute lang directory`.
+///
+/// The scan applies two cheap gates before parsing any file:
+/// - **Filename**: must contain `ServiceProvider`
+/// - **Content substring**: must contain `loadTranslationsFrom`
+///
+/// Roughly the same shape as
+/// [`crate::config::scan_vendor_for_component_aliases`] — these two scans
+/// could share a single vendor-walk pass once we add the persistent cache.
+pub fn scan_vendor_translation_namespaces(root: &Path) -> HashMap<String, PathBuf> {
+    let vendor = root.join("vendor");
+    if !vendor.is_dir() {
+        return HashMap::new();
+    }
+
+    let mut namespaces: HashMap<String, PathBuf> = HashMap::new();
+
+    for entry in walkdir::WalkDir::new(&vendor)
+        .max_depth(10)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("php") {
+            continue;
+        }
+        let filename_matches = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.contains("ServiceProvider"))
+            .unwrap_or(false);
+        if !filename_matches {
+            continue;
+        }
+
+        let Ok(source) = fs::read_to_string(path) else {
+            continue;
+        };
+        if !source.contains("loadTranslationsFrom") {
+            continue;
+        }
+
+        extract_translations_from(&source, path, &mut namespaces);
+    }
+
+    namespaces
+}
+
+/// Apply [`LOAD_TRANSLATIONS_RE`] to the given source. Each match contributes
+/// a `namespace → absolute_lang_dir` entry. The relative path is resolved
+/// against the provider file's directory (the `__DIR__` reference).
+///
+/// First-match-wins on namespace conflict — service-provider boot order is
+/// non-deterministic and we have no good way to rank packages without a full
+/// composer dependency graph.
+fn extract_translations_from(
+    source: &str,
+    provider_path: &Path,
+    namespaces: &mut HashMap<String, PathBuf>,
+) {
+    let provider_dir = match provider_path.parent() {
+        Some(d) => d,
+        None => return,
+    };
+
+    for cap in LOAD_TRANSLATIONS_RE.captures_iter(source) {
+        let (Some(rel), Some(ns)) = (cap.get(1), cap.get(2)) else {
+            continue;
+        };
+        // PHP source: `__DIR__.'/../resources/lang'` — the captured fragment
+        // starts with `/`. Rust's `Path::join` treats any path starting with
+        // `/` as absolute and discards the receiver, so we strip leading `/`
+        // and `./` before joining onto the provider directory.
+        let rel_str = rel
+            .as_str()
+            .trim_start_matches('/')
+            .trim_start_matches("./");
+        let lang_dir = provider_dir.join(rel_str);
+        let resolved = lang_dir.canonicalize().unwrap_or(lang_dir);
+        namespaces
+            .entry(ns.as_str().to_string())
+            .or_insert(resolved);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/vendor_translations/tests.rs
+++ b/laravel-lsp/src/vendor_translations/tests.rs
@@ -1,0 +1,139 @@
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+/// Build a fake vendor tree at `vendor/<vendor>/<package>/` with a service
+/// provider file at the standard location.
+fn fake_vendor_package(project: &Path, vendor: &str, pkg: &str, provider: &str) -> PathBuf {
+    let provider_dir = project.join("vendor").join(vendor).join(pkg).join("src");
+    fs::create_dir_all(&provider_dir).unwrap();
+    let provider_path = provider_dir.join(format!("{}.php", provider));
+    provider_path
+}
+
+#[test]
+fn extracts_single_load_translations_from_registration() {
+    let project = TempDir::new().unwrap();
+    let provider = fake_vendor_package(project.path(), "acme", "billing", "BillingServiceProvider");
+
+    let lang_dir = provider.parent().unwrap().join("../resources/lang");
+    fs::create_dir_all(&lang_dir).unwrap();
+    fs::write(
+        &provider,
+        r#"<?php
+namespace Acme\Billing;
+class BillingServiceProvider {
+    public function boot() {
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'billing');
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    let resolved = map.get("billing").expect("should find billing namespace");
+    assert!(
+        resolved.ends_with("resources/lang"),
+        "expected resolved to end with resources/lang, got: {:?}",
+        resolved
+    );
+}
+
+#[test]
+fn ignores_non_provider_php_files() {
+    // A non-provider file with `loadTranslationsFrom` in a docblock should
+    // be skipped by the filename gate.
+    let project = TempDir::new().unwrap();
+    let non_provider = project.path().join("vendor/acme/billing/src/Helpers.php");
+    fs::create_dir_all(non_provider.parent().unwrap()).unwrap();
+    fs::write(
+        &non_provider,
+        r#"<?php
+namespace Acme\Billing;
+// $this->loadTranslationsFrom(__DIR__.'/../lang', 'billing');
+class Helpers {}
+"#,
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    assert!(map.is_empty(), "non-provider files must be ignored");
+}
+
+#[test]
+fn ignores_providers_without_load_translations_from_call() {
+    let project = TempDir::new().unwrap();
+    let provider = fake_vendor_package(project.path(), "acme", "billing", "BillingServiceProvider");
+    fs::write(
+        &provider,
+        r#"<?php
+class BillingServiceProvider {
+    public function boot() {
+        $this->loadViewsFrom(__DIR__.'/../views', 'billing');
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    assert!(
+        map.is_empty(),
+        "providers without loadTranslationsFrom must contribute nothing"
+    );
+}
+
+#[test]
+fn captures_multiple_namespaces_across_packages() {
+    let project = TempDir::new().unwrap();
+    let p1 = fake_vendor_package(project.path(), "acme", "billing", "BillingServiceProvider");
+    let p2 = fake_vendor_package(project.path(), "acme", "auth", "AuthServiceProvider");
+    fs::write(
+        &p1,
+        "<?php\nclass X { public function boot() { $this->loadTranslationsFrom(__DIR__.'/../lang', 'billing'); } }\n",
+    )
+    .unwrap();
+    fs::write(
+        &p2,
+        "<?php\nclass Y { public function boot() { $this->loadTranslationsFrom(__DIR__.'/../lang', 'auth'); } }\n",
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    assert!(map.contains_key("billing"));
+    assert!(map.contains_key("auth"));
+}
+
+#[test]
+fn returns_empty_when_vendor_dir_missing() {
+    let project = TempDir::new().unwrap();
+    // No vendor/ directory.
+    let map = scan_vendor_translation_namespaces(project.path());
+    assert!(map.is_empty());
+}
+
+#[test]
+fn first_registration_wins_on_namespace_conflict() {
+    // Two packages register the same namespace. First-match-wins.
+    let project = TempDir::new().unwrap();
+    let p1 = fake_vendor_package(project.path(), "first", "pkg", "FirstServiceProvider");
+    let p2 = fake_vendor_package(project.path(), "second", "pkg", "SecondServiceProvider");
+    fs::write(
+        &p1,
+        "<?php\nclass A { public function boot() { $this->loadTranslationsFrom(__DIR__.'/../lang', 'shared'); } }\n",
+    )
+    .unwrap();
+    fs::write(
+        &p2,
+        "<?php\nclass B { public function boot() { $this->loadTranslationsFrom(__DIR__.'/../lang', 'shared'); } }\n",
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    let resolved = map.get("shared").expect("conflict must still resolve");
+    // The path will contain either "first" or "second" depending on walk order —
+    // accept either, but it must be a single deterministic entry.
+    let s = resolved.to_string_lossy();
+    assert!(s.contains("first") || s.contains("second"), "got: {}", s);
+}


### PR DESCRIPTION
Fixes #9.

## Summary

Adds `textDocument/hover` support across the full Laravel pattern surface, plus Blade-variable hover with intelephense-style formatting. **Drafted because we'd like to sit on it and re-test before merging.**

## Patterns covered

All 9 patterns in the issue, plus 2 extras added during manual testing:

- ✅ View — `view('users.profile')`
- ✅ Blade component — `<x-button>` (both anonymous AND class-backed)
- ✅ Livewire — `<livewire:counter>`
- ✅ Route — `route('users.show')` (HTTP verb + URI + Controller@action)
- ✅ Config — `config('app.name')` (resolved value)
- ✅ Env — `env('APP_KEY')` (current value — see masking deviation below)
- ✅ Translation — `__('validation.required')` (incl. `vendor::namespace.key` + unpublished vendor scan)
- ✅ Middleware — `->middleware('auth')` (alias → FQN as header)
- ✅ Binding — `app('cache')` (alias → concrete class as header)
- ✅ **Asset** — `asset()`, `Vite::asset()`, `mix()`, `public_path()`, etc. _(added during manual testing)_
- ✅ **URL** — `url('/path')` _(added during manual testing)_
- ✅ Blade variable — `$user->email`, with intelephense-style class::prop header + declaration + PHPDoc + `@param/@return/@throws` tags

Patterns not yet hovered (silently return None): directives, actions, Pennant features.

## Hover architecture

Single template, single render function. Per-pattern variation lives in *what data we pass*, not *how it renders*:

```rust
pub struct HoverContent<'a> {
    pub header: Option<&'a str>,       // bold class FQN (only when adding info beyond cursor)
    pub detail: Option<&'a str>,       // inline line (route verb/URI/action, etc.)
    pub description: Option<&'a str>,  // PHPDoc summary
    pub code: Option<CodeBlock<'a>>,   // fenced code; `Php` auto-prepends `<?php\n`
    pub tags: &'a [String],            // @param/@return etc. as italic lines
    pub source_link: Option<&'a str>,  // markdown link to the source file:line
    pub trailer: Option<&'a str>,      // *(not found)* etc.
}
pub fn render(content: &HoverContent) -> String { /* one template */ }
```

Each dispatcher arm in `main.rs` builds a `HoverContent` and calls `render`. Adding a new pattern = build a `HoverContent`, no new formatter needed.

## Acceptance criteria (from #9)

- [x] Implement `Backend::hover()` in `laravel-lsp/src/main.rs`
- [x] Declare `hover_provider` capability during `initialize`
- [x] Reuse existing `salsa.get_parsed_patterns()` to find the pattern at the cursor
- [x] Return `MarkupContent` (markdown) with the data for each pattern type
- [x] **Class-backed component detection** — `<x-button>` with `app/View/Components/Button.php` renders the class FQN as header + class signature in code block (same shape as Livewire). Anonymous components fall through to `@props([...])`.
- [x] Tests covering at least 3 pattern types (actual: every pattern + render template + helpers)
- ⚠️ **Env secret masking** — explicitly removed after testing review. The developer wrote the values and can open `.env` directly; masking in the editor is theatre. Documented here as a deliberate deviation from the issue spec.

## Beyond the issue's scope (added during the work)

- **Route group name compositing** — `Route::name('admin.')->group(...)` nested arbitrarily deep now resolves child route names correctly. Fixes both hover AND goto-definition for grouped routes.
- **Binding extractor closure-param bug** — the combined `BINDING_RE` was greedy-backtracking into closure parameter lists and storing `"p"` (last letter of `$app`) as the concrete class for `singleton('migrator', fn($app) => ...)`. Split into three narrower regexes.
- **PHPDoc extraction for Blade variables** — pulls declaration line + leading PHPDoc summary + tags, renders intelephense-style.
- **Vendor translation scanning** — when a `package::key` translation isn't published locally to `lang/vendor/<ns>/`, falls back to scanning vendor providers for `loadTranslationsFrom(...)` registrations.
- **Blade-file origin fallback** — when variable type resolves to `mixed` (loop-variable sentinel), surfaces the `@foreach` / `@props` line that introduced the variable.
- **`<?php` opener in PHP code blocks** — tree-sitter-php's standard grammar requires the opening tag for parsing → without it, code blocks render with no syntax highlighting. `CodeLanguage::Php` prepends `<?php\n` to match what intelephense does.
- **Clickable file:// source links** — bottom-line link is markdown `[path:line](file:///abs#L42)`; Zed renders it as click-to-open. Empirically verified.

## Commits

1. `fix: 🐛 Stop binding extractor backtracking into closure params`
2. `feat: ✨ Extend route_discovery with method/URI/action + group composition`
3. `feat: ✨ Add textDocument/hover for Laravel patterns + Blade variables`
4. `feat: ✨ Make hover source-line a clickable file:// link`
5. `feat: ✨ Add source-code snippets to view, component, livewire, route hovers`
6. `refactor: 🎨 Unify hover formatters and add class-backed component detection`

## Test plan

- [x] 462 tests passing (209 lib + 174 main bin + 79 integration)
- [x] `cargo fmt` clean
- [x] `cargo clippy --lib --bins --tests` silent
- [x] Manual testing in Zed against a real Laravel project (multiple rounds; feedback addressed across the commits)

## Known limitations (follow-up issues)

- **Eloquent DB columns not in `$casts`/`@property`** — class file path shows, but no specific property line. Pulling column info from migrations would close this gap.
- **Full intelephense-parity type inference** — out of scope; intelephense maintains its own type system with PHPDoc/generic propagation. We surface what we can statically; deeper inference is a separate feature.
- **Persistent vendor translation cache** — currently in-memory only, rebuilt on each LSP restart. A composer.lock-keyed disk cache mirroring `scan_vendor_for_component_aliases` is the next step.
- **`loadJsonTranslationsFrom`** — vendor scanner only handles the namespaced PHP form, not JSON text-key translations from packages.