### PR TITLE
feat: documentSymbol for Laravel outline panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,31 @@ Supports MySQL, PostgreSQL, SQLite, and SQL Server.
 }
 ```
 
-**🗺️ Laravel-aware outline panel** populates Zed's outline panel and breadcrumbs with Laravel-specific structure that no PHP language server knows about: route definitions (`GET /users [name=users.index]`) in route files, and the `@section` / `@push` / `@yield` / component-tag hierarchy in Blade templates.
+**🗺️ Laravel-aware outline panel** populates Zed's outline panel and breadcrumbs with Laravel-specific structure that no PHP language server understands:
 
-PHP class outlines (controllers, models, Livewire components, jobs, services) come from whatever PHP language server you have installed — Intelephense, Phpactor, or PhpTools — because those servers have real semantic understanding of PHP that a tree-sitter walker can't match, and Zed merges document-symbol responses across all language servers serving a file. Anything we emit for `.php` files would render twice in the outline panel, so we don't.
+- **Route files** — every `Route::get/post/...` call labelled `METHOD URI [name=...]`, with nested `Route::group(...)` calls becoming hierarchical containers labelled `group [prefix=..., name=...]`. Prefix and name chains propagate to children. Covers all Route methods including `resource`, `apiResource`, `singleton`, `livewire`, `view`, `redirect`, `fallback`, etc.
+- **Blade templates** — `@extends`, `@section`, `@push`, `@yield`, `@stack`, `@include*`, `@props`, plus the modern tag syntax: `<x-component>`, `<livewire:counter>`, `<flux:icon>`, `<x-slot:name>`. Paired tags nest their children; self-closing tags appear as leaves.
 
-Zed defaults to tree-sitter outlines, which don't know about Laravel patterns — opt into LSP outlines for Blade to use this feature ([`zed#48780`](https://github.com/zed-industries/zed/pull/48780)):
+PHP class outlines (controllers, models, Livewire components, jobs, services) come from whatever PHP language server you have installed — those servers have real semantic understanding of PHP that a tree-sitter walker can't match. The official [**PHP**](https://github.com/zed-extensions/php) Zed extension registers Intelephense, Phpactor, and PhpTools; install it and pick whichever LSP you prefer.
+
+**Requirements**
+
+| Outline | Requires |
+|---|---|
+| Route files | This extension, plus `document_symbols: on` for `PHP` (route files use the `PHP` language). |
+| Blade templates | This extension, the [Laravel Blade](https://github.com/bajrangCoder/zed-laravel-blade) extension (for the `Blade` language definition), plus `document_symbols: on` for `Blade`. |
+| PHP class files | A PHP language server (the [PHP](https://github.com/zed-extensions/php) extension provides Intelephense / Phpactor / PhpTools), plus `document_symbols: on` for `PHP`. |
+
+**Configuration**
+
+Zed defaults to tree-sitter outlines, which don't call any LSP — opt into LSP outlines per-language ([`zed#48780`](https://github.com/zed-industries/zed/pull/48780)):
 
 ```json
 {
   "languages": {
+    "PHP": {
+      "document_symbols": "on"
+    },
     "Blade": {
       "document_symbols": "on"
     }
@@ -102,7 +118,7 @@ Zed defaults to tree-sitter outlines, which don't know about Laravel patterns �
 }
 ```
 
-The same `document_symbols: on` switch also unlocks your PHP LSP's richer outline for `.php` files if you want it. Editors that call `textDocument/documentSymbol` unconditionally (Helix, Neovim, Sublime/LSP, Kate) need no opt-in.
+`document_symbols: on` for `PHP` unlocks both our route outline (for files under `routes/`) and your PHP LSP's class outline (for everything else). `document_symbols: on` for `Blade` unlocks our Blade outline. Editors that call `textDocument/documentSymbol` unconditionally (Helix, Neovim, Sublime/LSP, Kate) need no opt-in.
 
 > **Quirks worth knowing** — Zed colors outline labels by word-matching them against the source buffer's tree-sitter highlights, which produces slightly inconsistent colors on multi-segment URLs (e.g., `/cra-details` may color `cra` and `details` differently if they match different tokens elsewhere in the file). Route names appear in the LSP `detail` field, which Zed's outline panel doesn't currently render (VSCode and Sublime/LSP do). Both are tracked upstream: [zed#57576](https://github.com/zed-industries/zed/issues/57576).
 
@@ -421,20 +437,24 @@ Cmd+Click works on both opening AND closing tags:
 
 ### 🗺️ Outline Panel
 
-When LSP outlines are enabled for Blade (see [Configuration](#️-configuration)), Zed's outline panel and breadcrumbs surface Laravel-aware structure that no PHP language server can see:
+When LSP outlines are enabled (see [Configuration](#️-configuration)), Zed's outline panel and breadcrumbs surface Laravel-aware structure that no PHP language server can see.
 
-**Route files** show each definition with HTTP verb, URI, and route name. Nested `Route::group(...)` calls become hierarchical containers labelled with the group's prefix and name:
+**Route files** show each definition with HTTP verb, URI, and route name. Nested `Route::group(...)` calls become hierarchical containers labelled with the group's prefix and name; prefix and route-name chains inherit from the enclosing group:
 
 ```
 routes/web.php
-├─ GET /                 [name=home]
-├─ POST /login           [name=login]
+├─ GET  /                       [name=home]
+├─ POST /login                  [name=login]
 └─ group [prefix=/admin, name=admin.]
-   ├─ GET /users         [name=admin.users.index]
-   └─ POST /users        [name=admin.users.store]
+   ├─ GET  /users               [name=admin.users.index]
+   ├─ POST /users               [name=admin.users.store]
+   └─ group [prefix=/settings, name=admin.settings.]
+      └─ GET /profile           [name=admin.settings.profile]
 ```
 
-**Blade templates** show the section / push / yield hierarchy, component-tag nesting, slots, props, and includes:
+Recognised Route methods: `get`, `post`, `put`, `patch`, `delete`, `options`, `any`, `match`, `view`, `redirect`, `permanentRedirect`, `fallback`, `livewire`, `resource`, `apiResource`, `singleton`, `apiSingleton`.
+
+**Blade templates** show the section / push / yield hierarchy alongside the modern tag-based component syntax. Paired tags nest their content; self-closing tags appear as leaves with ` />` so the source shape is visible at a glance:
 
 ```
 resources/views/components/card.blade.php
@@ -445,7 +465,24 @@ resources/views/components/card.blade.php
    └─ <livewire:card-footer />
 ```
 
-**PHP files** — controllers, models, Livewire components, jobs, services, helpers — get their outline from whatever PHP language server you have installed (Intelephense, Phpactor, PhpTools). Set `document_symbols: on` for the `PHP` language in your Zed settings to use that LSP outline instead of Zed's tree-sitter fallback.
+```
+resources/views/layouts/app.blade.php
+├─ @extends layouts.master
+├─ @include partials.nav
+├─ @section content
+│  ├─ @yield title
+│  └─ @push scripts
+└─ @section sidebar
+```
+
+Recognised constructs: `@extends`, `@section`/`@endsection`, `@push`/`@endpush`, `@prepend`/`@endprepend`, `@stack`, `@yield`, `@component`/`@endcomponent`, `@slot`/`@endslot`, `@props`, `@include`, `@includeIf`, `@includeWhen`, `@includeUnless`, `@includeFirst`, plus `<x-*>`, `<livewire:*>`, `<flux:*>`, `<x-slot:name>`, and `<x-slot name="...">`.
+
+**PHP class files** (controllers, models, Livewire components, jobs, services, helpers) get their outline from whichever PHP language server you have installed — Intelephense, Phpactor, or PhpTools. We deliberately don't emit symbols for these files because Zed merges document-symbol responses across all LSPs serving a file, so any output from us would render twice in the outline panel. The PHP LSPs already provide semantically-rich PHP outlines that a tree-sitter walker can't match.
+
+If your PHP class outline isn't appearing, make sure:
+
+1. The official [**PHP**](https://github.com/zed-extensions/php) Zed extension is installed and one of its LSPs (Intelephense, Phpactor, PhpTools) is active for the file.
+2. Your settings include `"document_symbols": "on"` under `languages.PHP` (see [Configuration](#️-configuration)).
 
 ## 🚧 Planned Features
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,26 @@ Supports MySQL, PostgreSQL, SQLite, and SQL Server.
 }
 ```
 
+**🗺️ Laravel-aware outline panel** populates Zed's outline panel and breadcrumbs with Laravel-specific structure that no PHP language server knows about: route definitions (`GET /users [name=users.index]`) in route files, and the `@section` / `@push` / `@yield` / component-tag hierarchy in Blade templates.
+
+PHP class outlines (controllers, models, Livewire components, jobs, services) come from whatever PHP language server you have installed — Intelephense, Phpactor, or PhpTools — because those servers have real semantic understanding of PHP that a tree-sitter walker can't match, and Zed merges document-symbol responses across all language servers serving a file. Anything we emit for `.php` files would render twice in the outline panel, so we don't.
+
+Zed defaults to tree-sitter outlines, which don't know about Laravel patterns — opt into LSP outlines for Blade to use this feature ([`zed#48780`](https://github.com/zed-industries/zed/pull/48780)):
+
+```json
+{
+  "languages": {
+    "Blade": {
+      "document_symbols": "on"
+    }
+  }
+}
+```
+
+The same `document_symbols: on` switch also unlocks your PHP LSP's richer outline for `.php` files if you want it. Editors that call `textDocument/documentSymbol` unconditionally (Helix, Neovim, Sublime/LSP, Kate) need no opt-in.
+
+> **Quirks worth knowing** — Zed colors outline labels by word-matching them against the source buffer's tree-sitter highlights, which produces slightly inconsistent colors on multi-segment URLs (e.g., `/cra-details` may color `cra` and `details` differently if they match different tokens elsewhere in the file). Route names appear in the LSP `detail` field, which Zed's outline panel doesn't currently render (VSCode and Sublime/LSP do). Both are tracked upstream: [zed#57576](https://github.com/zed-industries/zed/issues/57576).
+
 ## ✨ Features
 
 ### 🔗 Go-to-Definition
@@ -398,6 +418,34 @@ Cmd+Click works on both opening AND closing tags:
 ```
 
 > **Note:** Blade syntax highlighting is provided by the separate [**Laravel Blade**](https://github.com/bajrangCoder/zed-laravel-blade) Zed extension. Install it alongside this extension for full Blade support. For enhanced directive highlighting — including correct coloring of custom directives that tree-sitter doesn't recognize — enable semantic tokens in your settings. See the [Configuration](#️-configuration) section above.
+
+### 🗺️ Outline Panel
+
+When LSP outlines are enabled for Blade (see [Configuration](#️-configuration)), Zed's outline panel and breadcrumbs surface Laravel-aware structure that no PHP language server can see:
+
+**Route files** show each definition with HTTP verb, URI, and route name. Nested `Route::group(...)` calls become hierarchical containers labelled with the group's prefix and name:
+
+```
+routes/web.php
+├─ GET /                 [name=home]
+├─ POST /login           [name=login]
+└─ group [prefix=/admin, name=admin.]
+   ├─ GET /users         [name=admin.users.index]
+   └─ POST /users        [name=admin.users.store]
+```
+
+**Blade templates** show the section / push / yield hierarchy, component-tag nesting, slots, props, and includes:
+
+```
+resources/views/components/card.blade.php
+├─ @props title
+└─ <x-card>
+   ├─ <x-slot:header>
+   ├─ <x-card-body>
+   └─ <livewire:card-footer />
+```
+
+**PHP files** — controllers, models, Livewire components, jobs, services, helpers — get their outline from whatever PHP language server you have installed (Intelephense, Phpactor, PhpTools). Set `document_symbols: on` for the `PHP` language in your Zed settings to use that LSP outline instead of Zed's tree-sitter fallback.
 
 ## 🚧 Planned Features
 

--- a/laravel-lsp/src/document_symbols.rs
+++ b/laravel-lsp/src/document_symbols.rs
@@ -6,23 +6,32 @@
 //!
 //! ## Supported file kinds
 //!
-//! | Kind                | Symbols                                                 |
-//! |---------------------|---------------------------------------------------------|
-//! | `RouteFile`         | `Route::get/post/...` calls labelled `METHOD URI [n=…]` |
-//! | `Blade`             | `@section`, `@push`, `@yield`, `@stack`, `@component`   |
-//! | `LivewireComponent` | Class + public properties + public methods              |
-//! | `EloquentModel`     | Class + relationship methods + `scope*` methods         |
+//! | Kind         | Symbols                                                                |
+//! |--------------|------------------------------------------------------------------------|
+//! | `RouteFile`  | `Route::get/post/...` calls labelled `METHOD URI [n=…]`                |
+//! | `Blade`      | `@section`, `@push`, `@yield`, `@stack`, `@component` with nesting     |
+//! | `Php`        | Classes / interfaces / traits / enums + members + free functions       |
+//! | `Other`      | Empty                                                                  |
 //!
-//! Each extractor returns plain `SymbolEntry` values; the LSP handler in
-//! `main.rs` converts these to `tower_lsp::lsp_types::DocumentSymbol` and the
-//! Salsa actor in `salsa_impl.rs` memoizes them per file version.
+//! For `Php` files, the extractor further specialises: Livewire components
+//! emit *public-only* properties and methods; Eloquent models emit *only*
+//! relationship methods and `scope*` methods; everything else emits full
+//! class structure (all visibility levels, all top-level structures, plus
+//! free functions).
 //!
-//! All positions are 0-based to match the LSP and the rest of this codebase
-//! (see `CLAUDE.md` § Position Indexing Convention).
+//! Structural parsing of PHP class bodies goes through [`crate::php_outline`]
+//! (tree-sitter); only routes and Blade still use regex. All positions are
+//! 0-based to match the LSP and the rest of this codebase (see `CLAUDE.md`
+//! § Position Indexing Convention).
 
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::path::Path;
+
+use crate::php_outline::{
+    extract_php_structure, PhpFileStructure, PhpFunctionInfo, PhpMethodInfo, PhpPropertyInfo,
+    PhpStructure, PhpStructureKind, PhpVisibility,
+};
 
 /// A single entry in the document symbol tree. Plain data so it can cross the
 /// Salsa async boundary and be cached cheaply.
@@ -45,12 +54,14 @@ pub struct SymbolEntry {
     pub children: Vec<SymbolEntry>,
 }
 
-/// LSP-aligned symbol kinds. Restricted to the variants this extension actually
-/// emits — wider mapping happens in `main.rs` where `tower_lsp` types are
-/// available.
+/// LSP-aligned symbol kinds we actually emit. Mapping to `tower_lsp::SymbolKind`
+/// happens in `main.rs` where the LSP types are available.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SymbolEntryKind {
     Class,
+    Interface,
+    Trait,
+    Enum,
     Method,
     Property,
     Field,
@@ -59,54 +70,41 @@ pub enum SymbolEntryKind {
     Variable,
 }
 
-/// File classification — drives which extractor runs.
+/// Path-based file classification. PHP class files are all `Php` — the
+/// Livewire/Model/Generic subclassification happens inside extraction so we
+/// only parse PHP once per request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FileKind {
     /// A file under `routes/` (web.php, api.php, etc.).
     RouteFile,
     /// A `*.blade.php` file.
     Blade,
-    /// A PHP class extending `Livewire\Component` (or aliased equivalent).
-    LivewireComponent,
-    /// A PHP class extending `Illuminate\Database\Eloquent\Model` (or aliased).
-    EloquentModel,
+    /// Any `.php` file outside `routes/` — Livewire / model / plain class /
+    /// helpers file. Differentiation happens in `extract_symbols`.
+    Php,
     /// Anything else — no Laravel-aware symbols to emit.
     Other,
 }
 
-/// Classify a file by path + content. Path is checked first because it's
-/// cheap; content is consulted only to disambiguate plain PHP files.
-pub fn classify_file(path: &Path, content: &str) -> FileKind {
+/// Classify a file by path. Path is sufficient for the top-level dispatch —
+/// PHP files are all routed to the `Php` extractor which then parses the
+/// content once with tree-sitter to pick the right shape.
+pub fn classify_file(path: &Path) -> FileKind {
     let path_str = path.to_string_lossy();
 
-    // Blade files — extension is authoritative.
     if path_str.ends_with(".blade.php") {
         return FileKind::Blade;
     }
-
-    // Non-PHP files: nothing to do here.
     if !path_str.ends_with(".php") {
         return FileKind::Other;
     }
-
-    // Files under any `routes/` directory are route files. Match the
-    // `is_under_routes_dir` heuristic from route_discovery.rs.
     if path
         .components()
         .any(|c| c.as_os_str().eq_ignore_ascii_case("routes"))
     {
         return FileKind::RouteFile;
     }
-
-    // PHP class files — disambiguate by what they extend.
-    if content_extends_livewire_component(content) {
-        return FileKind::LivewireComponent;
-    }
-    if content_extends_eloquent_model(content) {
-        return FileKind::EloquentModel;
-    }
-
-    FileKind::Other
+    FileKind::Php
 }
 
 /// Dispatch to the right extractor based on file kind.
@@ -114,8 +112,7 @@ pub fn extract_symbols(content: &str, kind: FileKind) -> Vec<SymbolEntry> {
     match kind {
         FileKind::RouteFile => extract_route_symbols(content),
         FileKind::Blade => extract_blade_symbols(content),
-        FileKind::LivewireComponent => extract_livewire_symbols(content),
-        FileKind::EloquentModel => extract_model_symbols(content),
+        FileKind::Php => extract_php_symbols(content),
         FileKind::Other => Vec::new(),
     }
 }
@@ -319,49 +316,115 @@ fn push_blade_entry(
 }
 
 // ============================================================================
-// Livewire components
+// PHP (Livewire / Eloquent / Generic) — single parse, content-based dispatch
 // ============================================================================
 
-/// Extract the component class + its public properties and methods.
-fn extract_livewire_symbols(content: &str) -> Vec<SymbolEntry> {
-    let Some(class) = extract_class_outline(content) else {
-        return Vec::new();
-    };
-    vec![class]
+/// Parse the PHP file once via tree-sitter, then dispatch by what the first
+/// class extends. Plain PHP files (no class, or class that doesn't extend a
+/// Laravel base) get a full structural outline.
+fn extract_php_symbols(content: &str) -> Vec<SymbolEntry> {
+    let structure = extract_php_structure(content);
+
+    let first_class_extends = structure
+        .structures
+        .iter()
+        .find(|s| s.kind == PhpStructureKind::Class)
+        .and_then(|c| c.extends.as_deref());
+
+    match first_class_extends {
+        Some(extends) if is_livewire_component(extends) => livewire_symbols(&structure),
+        Some(extends) if is_eloquent_model(extends) => model_symbols(&structure),
+        _ => generic_php_symbols(&structure),
+    }
 }
 
-// ============================================================================
-// Eloquent models
-// ============================================================================
+/// `Component` (bare), `Livewire\Component`, or any class whose extends target
+/// resolves to `Component` after namespace-simplification. Conservative — a
+/// non-Livewire `Component` base would also match, but the generic path also
+/// produces sensible output, so the cost of a false positive is low.
+fn is_livewire_component(extends: &str) -> bool {
+    extends == "Component"
+}
 
-/// Extract the model class + relationship methods + `scope*` methods. Other
-/// public methods are intentionally omitted — they're rarely what someone
-/// jumps to in a model.
-fn extract_model_symbols(content: &str) -> Vec<SymbolEntry> {
-    let Some(mut class) = extract_class_outline(content) else {
+fn is_eloquent_model(extends: &str) -> bool {
+    matches!(
+        extends,
+        "Model" | "Authenticatable" | "Pivot" | "MorphPivot"
+    )
+}
+
+/// Livewire components: emit the class with *public* properties and methods
+/// only. Private/protected members are implementation details, not surface area.
+fn livewire_symbols(structure: &PhpFileStructure) -> Vec<SymbolEntry> {
+    let Some(class) = structure
+        .structures
+        .iter()
+        .find(|s| s.kind == PhpStructureKind::Class)
+    else {
         return Vec::new();
     };
 
-    // Filter the class's methods to relationships + scopes; keep everything
-    // else off the outline to avoid noise.
-    class.children.retain(|child| match child.kind {
-        SymbolEntryKind::Method => {
-            let is_scope = child.name.starts_with("scope")
-                && child
-                    .name
-                    .chars()
-                    .nth(5)
-                    .is_some_and(|c| c.is_ascii_uppercase());
-            let is_relationship = child
-                .detail
-                .as_deref()
-                .is_some_and(is_relationship_return_type);
-            is_scope || is_relationship
-        }
-        _ => false,
-    });
+    let mut entry = structure_to_symbol(class);
 
-    vec![class]
+    let mut children: Vec<SymbolEntry> = class
+        .properties
+        .iter()
+        .filter(|p| p.visibility == PhpVisibility::Public)
+        .map(property_to_symbol)
+        .chain(
+            class
+                .methods
+                .iter()
+                .filter(|m| m.visibility == PhpVisibility::Public)
+                .map(method_to_symbol),
+        )
+        .collect();
+    children.sort_by_key(|c| (c.start_line, c.start_column));
+    extend_class_end_to_last_child(&mut entry, &children);
+    entry.children = children;
+
+    vec![entry]
+}
+
+/// Eloquent models: emit the class with *only* relationship methods (return
+/// type matches a known Eloquent relation) and query scopes (`scope*`). Other
+/// methods are noise on the outline of a model.
+fn model_symbols(structure: &PhpFileStructure) -> Vec<SymbolEntry> {
+    let Some(class) = structure
+        .structures
+        .iter()
+        .find(|s| s.kind == PhpStructureKind::Class)
+    else {
+        return Vec::new();
+    };
+
+    let mut entry = structure_to_symbol(class);
+
+    let mut children: Vec<SymbolEntry> = class
+        .methods
+        .iter()
+        .filter(|m| is_relationship(m) || is_scope(m))
+        .map(method_to_symbol)
+        .collect();
+    children.sort_by_key(|c| (c.start_line, c.start_column));
+    extend_class_end_to_last_child(&mut entry, &children);
+    entry.children = children;
+
+    vec![entry]
+}
+
+fn is_relationship(m: &PhpMethodInfo) -> bool {
+    m.return_type
+        .as_deref()
+        .is_some_and(is_relationship_return_type)
+}
+
+fn is_scope(m: &PhpMethodInfo) -> bool {
+    m.name.starts_with("scope")
+        && m.name
+            .chars()
+            .nth(5)
+            .is_some_and(|c| c.is_ascii_uppercase())
 }
 
 fn is_relationship_return_type(detail: &str) -> bool {
@@ -381,127 +444,104 @@ fn is_relationship_return_type(detail: &str) -> bool {
     RELATIONSHIPS.iter().any(|r| detail.contains(r))
 }
 
-// ============================================================================
-// Shared PHP class outline parser (used by Livewire + Model extractors)
-// ============================================================================
+/// Plain PHP files (controllers, jobs, helpers, etc.) — emit every top-level
+/// class/interface/trait/enum with *all* properties and methods regardless of
+/// visibility, plus any free functions. This is the strict-upgrade path when
+/// a Zed user opts into LSP outlines: parity with tree-sitter outline.scm
+/// plus our Laravel-aware sugar.
+fn generic_php_symbols(structure: &PhpFileStructure) -> Vec<SymbolEntry> {
+    let mut symbols = Vec::new();
 
-/// Parse a PHP class declaration and emit a `Class` symbol with public
-/// properties (`Property`) and public methods (`Method`) as children. Method
-/// `detail` carries the declared return type, when present, so the model
-/// filter can recognise relationships.
-fn extract_class_outline(content: &str) -> Option<SymbolEntry> {
-    lazy_static! {
-        static ref CLASS_RE: Regex =
-            Regex::new(r#"\bclass\s+([A-Za-z_][A-Za-z0-9_]*)\b(?:\s+extends\s+([A-Za-z_\\][A-Za-z0-9_\\]*))?"#)
-                .unwrap();
-        // public [readonly] [type] $name [= ...];
-        static ref PROPERTY_RE: Regex = Regex::new(
-            r#"(?m)^\s*public\s+(?:readonly\s+)?(?:(\??[\w\\]+)\s+)?\$([A-Za-z_][A-Za-z0-9_]*)"#,
-        )
-        .unwrap();
-        // public function name(...) [: Return]
-        static ref METHOD_RE: Regex = Regex::new(
-            r#"(?m)^\s*public\s+(?:static\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?::\s*(\??[\w\\|]+))?"#,
-        )
-        .unwrap();
+    for s in &structure.structures {
+        let mut entry = structure_to_symbol(s);
+
+        let mut children: Vec<SymbolEntry> = s
+            .properties
+            .iter()
+            .map(property_to_symbol)
+            .chain(s.methods.iter().map(method_to_symbol))
+            .collect();
+        children.sort_by_key(|c| (c.start_line, c.start_column));
+        extend_class_end_to_last_child(&mut entry, &children);
+        entry.children = children;
+
+        symbols.push(entry);
     }
 
-    let class_cap = CLASS_RE.captures(content)?;
-    let class_match = class_cap.get(0).expect("regex match always has group 0");
-    let class_name = class_cap.get(1)?.as_str().to_string();
-    let extends = class_cap.get(2).map(|m| simple_class_name(m.as_str()));
+    for f in &structure.functions {
+        symbols.push(function_to_symbol(f));
+    }
 
-    let (start_line, start_column) = byte_to_line_col(content, class_match.start());
+    symbols
+}
 
-    let mut class = SymbolEntry {
-        name: class_name,
-        detail: extends.map(|e| format!("extends {e}")),
-        kind: SymbolEntryKind::Class,
-        start_line,
-        start_column,
-        end_line: start_line,
-        end_column: start_column,
-        children: Vec::new(),
+fn structure_to_symbol(s: &PhpStructure) -> SymbolEntry {
+    let kind = match s.kind {
+        PhpStructureKind::Class => SymbolEntryKind::Class,
+        PhpStructureKind::Interface => SymbolEntryKind::Interface,
+        PhpStructureKind::Trait => SymbolEntryKind::Trait,
+        PhpStructureKind::Enum => SymbolEntryKind::Enum,
     };
-
-    for cap in PROPERTY_RE.captures_iter(content) {
-        let m = cap.get(0).expect("regex match always has group 0");
-        let type_hint = cap.get(1).map(|t| t.as_str().to_string());
-        let name = cap.get(2)?.as_str().to_string();
-        let (line, column) = byte_to_line_col(content, m.start());
-        let (end_line, end_column) = byte_to_line_col(content, m.end());
-
-        class.children.push(SymbolEntry {
-            name: format!("${name}"),
-            detail: type_hint,
-            kind: SymbolEntryKind::Property,
-            start_line: line,
-            start_column: column,
-            end_line,
-            end_column,
-            children: Vec::new(),
-        });
+    let detail = s.extends.as_ref().map(|e| format!("extends {e}"));
+    SymbolEntry {
+        name: s.name.clone(),
+        detail,
+        kind,
+        start_line: s.start_line,
+        start_column: s.start_column,
+        end_line: s.end_line,
+        end_column: s.end_column,
+        children: Vec::new(),
     }
-
-    for cap in METHOD_RE.captures_iter(content) {
-        let m = cap.get(0).expect("regex match always has group 0");
-        let name = cap.get(1)?.as_str().to_string();
-        let return_type = cap.get(2).map(|t| simple_class_name(t.as_str()));
-        let (line, column) = byte_to_line_col(content, m.start());
-        let (end_line, end_column) = byte_to_line_col(content, m.end());
-
-        class.children.push(SymbolEntry {
-            name,
-            detail: return_type,
-            kind: SymbolEntryKind::Method,
-            start_line: line,
-            start_column: column,
-            end_line,
-            end_column,
-            children: Vec::new(),
-        });
-    }
-
-    // Sort children by position so editors render them in source order.
-    class
-        .children
-        .sort_by_key(|c| (c.start_line, c.start_column));
-
-    // Approximate the class's end position with the last child's end (or the
-    // class declaration if the body has no children).
-    if let Some(last) = class.children.last() {
-        class.end_line = last.end_line;
-        class.end_column = last.end_column;
-    }
-
-    Some(class)
 }
 
-fn simple_class_name(fqn: &str) -> String {
-    fqn.rsplit('\\').next().unwrap_or(fqn).to_string()
+fn method_to_symbol(m: &PhpMethodInfo) -> SymbolEntry {
+    SymbolEntry {
+        name: m.name.clone(),
+        detail: m.return_type.clone(),
+        kind: SymbolEntryKind::Method,
+        start_line: m.start_line,
+        start_column: m.start_column,
+        end_line: m.end_line,
+        end_column: m.end_column,
+        children: Vec::new(),
+    }
 }
 
-fn content_extends_livewire_component(content: &str) -> bool {
-    // Match `extends Component`, `extends \Livewire\Component`, or
-    // `extends Livewire\Component`. False positives on plain PHP classes
-    // that happen to extend something else named "Component" are tolerable —
-    // the model extractor only fires when this returns false anyway.
-    lazy_static! {
-        static ref RE: Regex = Regex::new(r#"extends\s+(?:\\?Livewire\\)?Component\b"#,).unwrap();
+fn property_to_symbol(p: &PhpPropertyInfo) -> SymbolEntry {
+    SymbolEntry {
+        name: format!("${}", p.name),
+        detail: p.property_type.clone(),
+        kind: SymbolEntryKind::Property,
+        start_line: p.start_line,
+        start_column: p.start_column,
+        end_line: p.end_line,
+        end_column: p.end_column,
+        children: Vec::new(),
     }
-    RE.is_match(content)
 }
 
-fn content_extends_eloquent_model(content: &str) -> bool {
-    // Match `extends Model`, `extends \Illuminate\Database\Eloquent\Model`,
-    // or `extends Authenticatable` (the User model's typical base).
-    lazy_static! {
-        static ref RE: Regex = Regex::new(
-            r#"extends\s+(?:\\?Illuminate\\Database\\Eloquent\\)?(?:Model|Authenticatable|Pivot|MorphPivot)\b"#,
-        )
-        .unwrap();
+fn function_to_symbol(f: &PhpFunctionInfo) -> SymbolEntry {
+    SymbolEntry {
+        name: f.name.clone(),
+        detail: f.return_type.clone(),
+        kind: SymbolEntryKind::Function,
+        start_line: f.start_line,
+        start_column: f.start_column,
+        end_line: f.end_line,
+        end_column: f.end_column,
+        children: Vec::new(),
     }
-    RE.is_match(content)
+}
+
+/// Tighten the class's `end_*` to the last child's end. tree-sitter already
+/// gives us the true class end, but for *filtered* outlines (Livewire/Model)
+/// shrinking to the visible children gives editors a tighter selection range.
+fn extend_class_end_to_last_child(entry: &mut SymbolEntry, children: &[SymbolEntry]) {
+    if let Some(last) = children.last() {
+        entry.end_line = last.end_line;
+        entry.end_column = last.end_column;
+    }
 }
 
 // ============================================================================

--- a/laravel-lsp/src/document_symbols.rs
+++ b/laravel-lsp/src/document_symbols.rs
@@ -10,28 +10,33 @@
 //! |--------------|------------------------------------------------------------------------|
 //! | `RouteFile`  | `Route::get/post/...` calls labelled `METHOD URI [n=…]`                |
 //! | `Blade`      | `@section`, `@push`, `@yield`, `@stack`, `@component` with nesting     |
-//! | `Php`        | Classes / interfaces / traits / enums + members + free functions       |
+//! | `Php`        | Empty — see note below                                                 |
 //! | `Other`      | Empty                                                                  |
 //!
-//! For `Php` files, the extractor further specialises: Livewire components
-//! emit *public-only* properties and methods; Eloquent models emit *only*
-//! relationship methods and `scope*` methods; everything else emits full
-//! class structure (all visibility levels, all top-level structures, plus
-//! free functions).
+//! ## Why `Php` returns no symbols
 //!
-//! Structural parsing of PHP class bodies goes through [`crate::php_outline`]
-//! (tree-sitter); only routes and Blade still use regex. All positions are
-//! 0-based to match the LSP and the rest of this codebase (see `CLAUDE.md`
-//! § Position Indexing Convention).
+//! Most Zed users with Laravel projects have the `php` extension installed,
+//! which registers Intelephense / Phpactor / PhpTools as language servers
+//! for the `PHP` language. Those LSPs return their own `textDocument/document
+//! Symbol` responses, and Zed *merges* responses from all LSPs serving a
+//! file — which means anything we emit for `.php` files appears twice in
+//! the outline panel: once with our rich labels (`public function show(int
+//! $id): View`) and once with the PHP LSP's bare labels (`public function
+//! show` with locals/catches as children).
+//!
+//! We can't deduplicate from our side (Zed handles the merge), and our
+//! rich-labelled PHP outline doesn't add Laravel-specific information that
+//! Intelephense doesn't already cover at the class-member level. So we
+//! cede PHP class bodies to the dedicated PHP LSP and keep our own
+//! documentSymbol contribution focused on Laravel-specific shapes the PHP
+//! LSP doesn't understand: route declarations and Blade templates.
+//!
+//! All positions are 0-based to match the LSP and the rest of this codebase
+//! (see `CLAUDE.md` § Position Indexing Convention).
 
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::path::Path;
-
-use crate::php_outline::{
-    extract_php_structure, PhpFileStructure, PhpFunctionInfo, PhpMethodInfo, PhpPropertyInfo,
-    PhpStructure, PhpStructureKind, PhpVisibility,
-};
 
 /// A single entry in the document symbol tree. Plain data so it can cross the
 /// Salsa async boundary and be cached cheaply.
@@ -70,25 +75,26 @@ pub enum SymbolEntryKind {
     Variable,
 }
 
-/// Path-based file classification. PHP class files are all `Php` — the
-/// Livewire/Model/Generic subclassification happens inside extraction so we
-/// only parse PHP once per request.
+/// Path-based file classification. Plain PHP files (`Php`) are classified
+/// so that the dispatch knows to skip them — see the module-level docs on
+/// why we don't emit document symbols for plain PHP.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FileKind {
     /// A file under `routes/` (web.php, api.php, etc.).
     RouteFile,
     /// A `*.blade.php` file.
     Blade,
-    /// Any `.php` file outside `routes/` — Livewire / model / plain class /
-    /// helpers file. Differentiation happens in `extract_symbols`.
+    /// Any `.php` file outside `routes/` — Livewire component, model,
+    /// controller, helpers file, etc. Dispatched to an empty extractor;
+    /// see the module-level docs for why.
     Php,
     /// Anything else — no Laravel-aware symbols to emit.
     Other,
 }
 
 /// Classify a file by path. Path is sufficient for the top-level dispatch —
-/// PHP files are all routed to the `Php` extractor which then parses the
-/// content once with tree-sitter to pick the right shape.
+/// we don't peek into PHP file contents because the `Php` extractor returns
+/// empty regardless.
 pub fn classify_file(path: &Path) -> FileKind {
     let path_str = path.to_string_lossy();
 
@@ -107,13 +113,13 @@ pub fn classify_file(path: &Path) -> FileKind {
     FileKind::Php
 }
 
-/// Dispatch to the right extractor based on file kind.
+/// Dispatch to the right extractor based on file kind. `Php` returns
+/// empty — see module-level docs.
 pub fn extract_symbols(content: &str, kind: FileKind) -> Vec<SymbolEntry> {
     match kind {
         FileKind::RouteFile => extract_route_symbols(content),
         FileKind::Blade => extract_blade_symbols(content),
-        FileKind::Php => extract_php_symbols(content),
-        FileKind::Other => Vec::new(),
+        FileKind::Php | FileKind::Other => Vec::new(),
     }
 }
 
@@ -121,119 +127,344 @@ pub fn extract_symbols(content: &str, kind: FileKind) -> Vec<SymbolEntry> {
 // Routes
 // ============================================================================
 
-/// Extract `Route::verb('/uri', ...)` definitions and their `->name(...)`
-/// suffixes (when present). Each becomes a top-level symbol; route groups
-/// are flattened — we don't currently track `Route::prefix(...)->group(...)`
-/// nesting in the outline.
+/// Walk the route file's AST via [`crate::route_outline`] and convert the
+/// resulting `RouteOutline` tree into `SymbolEntry` form. Group containers
+/// become hierarchical `Namespace`-kind symbols with their child routes
+/// nested inside; leaf routes become `Function`-kind symbols with label
+/// `METHOD URI` and a `[name=…]` detail when named.
 fn extract_route_symbols(content: &str) -> Vec<SymbolEntry> {
-    lazy_static! {
-        // Match `Route::verb('uri'` or `Route::verb("uri"`. The verb capture
-        // covers the standard HTTP routing helpers we surface in the outline.
-        static ref ROUTE_RE: Regex = Regex::new(
-            r#"Route::(get|post|put|patch|delete|options|any|match|view|redirect|fallback)\s*\(\s*(?:\[[^\]]*\]\s*,\s*)?['"]([^'"]*)['"]"#,
-        )
-        .unwrap();
-        // Match `->name('foo')` or `->name("foo")` following the route. Captures
-        // only the name; the caller searches for this within the route's tail
-        // up to the next semicolon.
-        static ref NAME_RE: Regex = Regex::new(r#"->name\s*\(\s*['"]([^'"]+)['"]"#).unwrap();
-    }
+    let outline = crate::route_outline::extract_route_outline(content);
+    outline.iter().map(route_outline_to_symbol).collect()
+}
 
-    let mut symbols = Vec::new();
-
-    for cap in ROUTE_RE.captures_iter(content) {
-        let full_match = cap.get(0).expect("regex match always has group 0");
-        let verb = cap.get(1).map(|m| m.as_str()).unwrap_or("");
-        let uri = cap.get(2).map(|m| m.as_str()).unwrap_or("");
-
-        // Look ahead for `->name(...)` up to the next semicolon — that
-        // captures the typical fluent-chain shape without consuming the next
-        // route call.
-        let tail_start = full_match.end();
-        let tail_end = content[tail_start..]
-            .find(';')
-            .map(|i| tail_start + i)
-            .unwrap_or(content.len());
-        let tail = &content[tail_start..tail_end];
-
-        let name = NAME_RE
-            .captures(tail)
-            .and_then(|c| c.get(1))
-            .map(|m| m.as_str().to_string());
-
-        let (start_line, start_column) = byte_to_line_col(content, full_match.start());
-        let (end_line, end_column) = byte_to_line_col(content, tail_end);
-
-        let detail = name.as_ref().map(|n| format!("[name={n}]"));
-        let label = format!("{} {}", verb.to_uppercase(), uri);
-
-        symbols.push(SymbolEntry {
-            name: label,
-            detail,
+fn route_outline_to_symbol(route: &crate::route_outline::RouteOutline) -> SymbolEntry {
+    if route.is_group {
+        // Group container labelled `group [prefix=/x, name=y.]` — the
+        // literal `group` is the primary type identifier; the bracket
+        // suffix lists whichever modifiers the group applies. Detail is
+        // not set because Zed's outline panel doesn't render it
+        // (zed-industries/zed#49095) — we keep everything in `name` for
+        // consistent rendering across editors. Upstream coloring tracked
+        // at zed#57576.
+        //
+        // `kind: Function` (not `Namespace`) and `range` taken from the
+        // closure expression (not the wider chain) together prevent Zed
+        // from overlaying tree-sitter `Closure` children inside our group.
+        SymbolEntry {
+            name: group_label(&route.uri, route.name.as_deref()),
+            detail: None,
             kind: SymbolEntryKind::Function,
-            start_line,
-            start_column,
-            end_line,
-            end_column,
+            start_line: route.start_line,
+            start_column: route.start_column,
+            end_line: route.end_line,
+            end_column: route.end_column,
+            children: route.children.iter().map(route_outline_to_symbol).collect(),
+        }
+    } else {
+        // Leaf route: `METHOD URI` with the route name appended in
+        // brackets when present.
+        SymbolEntry {
+            name: route_label(&route.method, &route.uri, route.name.as_deref()),
+            detail: None,
+            kind: SymbolEntryKind::Function,
+            start_line: route.start_line,
+            start_column: route.start_column,
+            end_line: route.end_line,
+            end_column: route.end_column,
             children: Vec::new(),
-        });
+        }
     }
+}
 
-    symbols
+/// Compose a group label. Examples:
+///   `group`
+///   `group [prefix=/api]`
+///   `group [name=api.]`
+///   `group [prefix=/api, name=api.]`
+fn group_label(uri: &str, name: Option<&str>) -> String {
+    let mut parts = Vec::with_capacity(2);
+    if !uri.is_empty() {
+        parts.push(format!("prefix={uri}"));
+    }
+    if let Some(n) = name {
+        parts.push(format!("name={n}"));
+    }
+    if parts.is_empty() {
+        "group".to_string()
+    } else {
+        format!("group [{}]", parts.join(", "))
+    }
+}
+
+/// Compose a leaf-route label. Examples:
+///   `GET /users`
+///   `GET /users [name=users.index]`
+fn route_label(method: &str, uri: &str, name: Option<&str>) -> String {
+    match name {
+        Some(n) => format!("{method} {uri} [name={n}]"),
+        None => format!("{method} {uri}"),
+    }
 }
 
 // ============================================================================
 // Blade
 // ============================================================================
 
-/// Extract structural Blade directives (`@section`, `@push`, `@stack`,
-/// `@yield`, `@component`) with parent/child nesting derived from the
-/// open/close pairs.
+/// Extract noteworthy structural elements from a Blade file: layout
+/// directives (`@extends`, `@section`, `@yield`, `@push`, `@stack`),
+/// declarative directives (`@props`, `@slot`, `@include*`), and the modern
+/// HTML-tag-based component usage (`<x-…>`, `<livewire:…>`, `<flux:…>`,
+/// `<x-slot:…>`).
+///
+/// Container directives that have `@end*` partners (`@section`, `@push`,
+/// `@prepend`, `@component`) form parent/child nesting via an open-block
+/// stack. Everything else — `@yield`, `@stack`, `@extends`, `@include`,
+/// `@props`, `@slot`, HTML component tags — emits as leaves of whatever
+/// container they live inside.
 fn extract_blade_symbols(content: &str) -> Vec<SymbolEntry> {
     lazy_static! {
-        // Match any of the structural directives we surface, optionally with
-        // an argument list. The directive name is captured for dispatch.
+        // Directives we surface — both block-style (with @end partners) and
+        // self-contained. Capture 1 = directive name. The argument list is
+        // parsed separately by `parse_directive_args` because real Blade
+        // code has nested parens (`@includeWhen($user->method(), 'partial')`)
+        // and array literals (`@props(['title', 'count' => 0])`) which a
+        // pure regex can't balance.
         static ref DIRECTIVE_RE: Regex = Regex::new(
-            r#"@(section|endsection|push|endpush|prepend|endprepend|stack|yield|component|endcomponent|extends)\b(?:\s*\(\s*['"]([^'"]*)['"]\s*(?:,[^)]*)?\))?"#,
+            r#"@(section|endsection|push|endpush|prepend|endprepend|stack|yield|component|endcomponent|extends|include|includeIf|includeWhen|includeUnless|includeFirst|slot|endslot|props)\b"#,
+        )
+        .unwrap();
+        // Opening / self-closing component tags. Capture 1 = full tag-name
+        // (e.g. `x-button`, `livewire:counter`, `flux:icon`). Capture 2 =
+        // any trailing `/` that makes the tag self-closing (`<x-icon />`).
+        // The Rust regex crate doesn't support look-ahead, so `<x-slot:…>`
+        // and `<x-slot name="…">` are filtered out in the loop below
+        // (handled by `SLOT_TAG_RE` separately so we can render them as
+        // slot declarations rather than generic component usage).
+        static ref COMPONENT_OPEN_TAG_RE: Regex = Regex::new(
+            r#"<((?:x-[a-z][a-z0-9._:-]*)|(?:livewire:[a-z][a-z0-9._-]*)|(?:flux:[a-z][a-z0-9._-]*))\b[^>]*?(/?)>"#,
+        )
+        .unwrap();
+        // Closing component tags — `</x-name>`, `</livewire:name>`,
+        // `</flux:name>`. Capture 1 = the tag name (must match the opening
+        // tag's name for the pair to nest).
+        static ref COMPONENT_CLOSE_TAG_RE: Regex = Regex::new(
+            r#"</((?:x-[a-z][a-z0-9._:-]*)|(?:livewire:[a-z][a-z0-9._-]*)|(?:flux:[a-z][a-z0-9._-]*))>"#,
+        )
+        .unwrap();
+        // Slot declarations — `<x-slot:name>` (Laravel 9+) and the legacy
+        // `<x-slot name="value">` form. Capture 1 = the slot name (modern
+        // syntax); capture 2 = the slot name (legacy syntax).
+        static ref SLOT_TAG_RE: Regex = Regex::new(
+            r#"<x-slot(?::([a-zA-Z_][a-zA-Z0-9_-]*)|\s+name=['"]([^'"]+)['"])"#,
         )
         .unwrap();
     }
 
-    let mut roots: Vec<SymbolEntry> = Vec::new();
-    let mut stack: Vec<BladeOpenBlock> = Vec::new();
+    // Collect every interesting match across all regexes, keyed by source
+    // byte offset. We process them in source order so the nesting stack
+    // assigns children to the right parent.
+    enum BladeMatch {
+        Directive {
+            directive: String,
+            arg: Option<String>,
+            start: usize,
+            end: usize,
+        },
+        /// `<x-button>` (opens a block that nests until `</x-button>`).
+        ComponentOpen {
+            tag: String,
+            start: usize,
+            end: usize,
+        },
+        /// `</x-button>` (closes the matching `ComponentOpen`).
+        ComponentClose {
+            tag: String,
+            start: usize,
+            end: usize,
+        },
+        /// `<x-icon />` (self-closing, emitted as a leaf without nesting).
+        ComponentSelfClose {
+            tag: String,
+            start: usize,
+            end: usize,
+        },
+        /// `<x-slot:name>` or `<x-slot name="…">` — emitted as a leaf for
+        /// now (slot pairing across the modern/legacy closing forms isn't
+        /// worth the complexity yet).
+        SlotTag {
+            name: String,
+            start: usize,
+            end: usize,
+        },
+    }
+
+    fn match_start(m: &BladeMatch) -> usize {
+        match m {
+            BladeMatch::Directive { start, .. }
+            | BladeMatch::ComponentOpen { start, .. }
+            | BladeMatch::ComponentClose { start, .. }
+            | BladeMatch::ComponentSelfClose { start, .. }
+            | BladeMatch::SlotTag { start, .. } => *start,
+        }
+    }
+
+    let mut matches: Vec<BladeMatch> = Vec::new();
 
     for cap in DIRECTIVE_RE.captures_iter(content) {
         let full = cap.get(0).expect("regex match always has group 0");
-        let directive = cap.get(1).map(|m| m.as_str()).unwrap_or("");
-        let arg = cap.get(2).map(|m| m.as_str().to_string());
-
-        let (start_line, start_column) = byte_to_line_col(content, full.start());
-        let (end_line, end_column) = byte_to_line_col(content, full.end());
-
-        match directive {
-            // Closing directives pop the matching open block. If the stack
-            // head doesn't match (unbalanced source), we still pop to avoid
-            // runaway nesting — outlines tolerate inexact end positions better
-            // than missing blocks.
-            "endsection" => {
-                close_blade_block(&mut stack, &mut roots, "section", end_line, end_column)
+        let directive = cap
+            .get(1)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        let (arg, end_pos) = parse_directive_args(content, full.end());
+        matches.push(BladeMatch::Directive {
+            directive,
+            arg,
+            start: full.start(),
+            end: end_pos,
+        });
+    }
+    for cap in COMPONENT_OPEN_TAG_RE.captures_iter(content) {
+        let full = cap.get(0).expect("regex match always has group 0");
+        let tag = cap
+            .get(1)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        // Skip slot tags — emitted as `SlotTag` below.
+        if tag == "x-slot" || tag.starts_with("x-slot:") {
+            continue;
+        }
+        let self_closing = cap.get(2).map(|m| m.as_str() == "/").unwrap_or(false);
+        let entry = if self_closing {
+            BladeMatch::ComponentSelfClose {
+                tag,
+                start: full.start(),
+                end: full.end(),
             }
-            "endpush" => close_blade_block(&mut stack, &mut roots, "push", end_line, end_column),
-            "endprepend" => {
-                close_blade_block(&mut stack, &mut roots, "prepend", end_line, end_column)
+        } else {
+            BladeMatch::ComponentOpen {
+                tag,
+                start: full.start(),
+                end: full.end(),
             }
-            "endcomponent" => {
-                close_blade_block(&mut stack, &mut roots, "component", end_line, end_column)
-            }
+        };
+        matches.push(entry);
+    }
+    for cap in COMPONENT_CLOSE_TAG_RE.captures_iter(content) {
+        let full = cap.get(0).expect("regex match always has group 0");
+        let tag = cap
+            .get(1)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        if tag == "x-slot" || tag.starts_with("x-slot:") {
+            continue;
+        }
+        matches.push(BladeMatch::ComponentClose {
+            tag,
+            start: full.start(),
+            end: full.end(),
+        });
+    }
+    for cap in SLOT_TAG_RE.captures_iter(content) {
+        let full = cap.get(0).expect("regex match always has group 0");
+        let name = cap
+            .get(1)
+            .or_else(|| cap.get(2))
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        matches.push(BladeMatch::SlotTag {
+            name,
+            start: full.start(),
+            end: full.end(),
+        });
+    }
 
-            // Opening directives push a new block onto the stack.
-            "section" | "push" | "prepend" | "component" => {
-                let name = arg.unwrap_or_else(|| format!("@{directive}"));
+    matches.sort_by_key(match_start);
+
+    let mut roots: Vec<SymbolEntry> = Vec::new();
+    let mut stack: Vec<BladeOpenBlock> = Vec::new();
+
+    for m in matches {
+        match m {
+            BladeMatch::Directive {
+                directive,
+                arg,
+                start,
+                end,
+            } => {
+                let (start_line, start_column) = byte_to_line_col(content, start);
+                let (end_line, end_column) = byte_to_line_col(content, end);
+
+                match directive.as_str() {
+                    // Closing directives pop the matching open block. If the
+                    // stack head doesn't match (unbalanced source), we still
+                    // pop to avoid runaway nesting.
+                    "endsection" => {
+                        close_blade_block(&mut stack, &mut roots, "section", end_line, end_column)
+                    }
+                    "endpush" => {
+                        close_blade_block(&mut stack, &mut roots, "push", end_line, end_column)
+                    }
+                    "endprepend" => {
+                        close_blade_block(&mut stack, &mut roots, "prepend", end_line, end_column)
+                    }
+                    "endcomponent" => {
+                        close_blade_block(&mut stack, &mut roots, "component", end_line, end_column)
+                    }
+                    "endslot" => {
+                        close_blade_block(&mut stack, &mut roots, "slot", end_line, end_column)
+                    }
+
+                    // Opening directives push a new block onto the stack.
+                    "section" | "push" | "prepend" | "component" | "slot" => {
+                        let label = blade_directive_label(&directive, arg.as_deref());
+                        stack.push(BladeOpenBlock {
+                            directive: directive.clone(),
+                            symbol: SymbolEntry {
+                                name: label,
+                                detail: None,
+                                kind: SymbolEntryKind::Namespace,
+                                start_line,
+                                start_column,
+                                end_line,
+                                end_column,
+                                children: Vec::new(),
+                            },
+                        });
+                    }
+
+                    // Self-contained directives.
+                    "stack" | "yield" | "extends" | "props" | "include" | "includeIf"
+                    | "includeWhen" | "includeUnless" | "includeFirst" => {
+                        let label = blade_directive_label(&directive, arg.as_deref());
+                        push_blade_entry(
+                            &mut stack,
+                            &mut roots,
+                            SymbolEntry {
+                                name: label,
+                                detail: None,
+                                kind: SymbolEntryKind::Field,
+                                start_line,
+                                start_column,
+                                end_line,
+                                end_column,
+                                children: Vec::new(),
+                            },
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            BladeMatch::ComponentOpen { tag, start, end } => {
+                // Push as a container; children will be added until the
+                // matching `</tag>` arrives (or we flush on EOF).
+                let (start_line, start_column) = byte_to_line_col(content, start);
+                let (end_line, end_column) = byte_to_line_col(content, end);
                 stack.push(BladeOpenBlock {
-                    directive: directive.to_string(),
+                    directive: format!("tag:{tag}"),
                     symbol: SymbolEntry {
-                        name,
-                        detail: Some(format!("@{directive}")),
+                        name: format!("<{tag}>"),
+                        detail: None,
                         kind: SymbolEntryKind::Namespace,
                         start_line,
                         start_column,
@@ -243,17 +474,25 @@ fn extract_blade_symbols(content: &str) -> Vec<SymbolEntry> {
                     },
                 });
             }
-
-            // Self-contained directives — emit as leaves of the current parent
-            // (or root) without entering the stack.
-            "stack" | "yield" | "extends" => {
-                let name = arg.unwrap_or_else(|| format!("@{directive}"));
+            BladeMatch::ComponentClose { tag, start: _, end } => {
+                let (end_line, end_column) = byte_to_line_col(content, end);
+                close_blade_block(
+                    &mut stack,
+                    &mut roots,
+                    &format!("tag:{tag}"),
+                    end_line,
+                    end_column,
+                );
+            }
+            BladeMatch::ComponentSelfClose { tag, start, end } => {
+                let (start_line, start_column) = byte_to_line_col(content, start);
+                let (end_line, end_column) = byte_to_line_col(content, end);
                 push_blade_entry(
                     &mut stack,
                     &mut roots,
                     SymbolEntry {
-                        name,
-                        detail: Some(format!("@{directive}")),
+                        name: format!("<{tag} />"),
+                        detail: None,
                         kind: SymbolEntryKind::Field,
                         start_line,
                         start_column,
@@ -263,7 +502,24 @@ fn extract_blade_symbols(content: &str) -> Vec<SymbolEntry> {
                     },
                 );
             }
-            _ => {}
+            BladeMatch::SlotTag { name, start, end } => {
+                let (start_line, start_column) = byte_to_line_col(content, start);
+                let (end_line, end_column) = byte_to_line_col(content, end);
+                push_blade_entry(
+                    &mut stack,
+                    &mut roots,
+                    SymbolEntry {
+                        name: format!("<x-slot:{name}>"),
+                        detail: None,
+                        kind: SymbolEntryKind::Field,
+                        start_line,
+                        start_column,
+                        end_line,
+                        end_column,
+                        children: Vec::new(),
+                    },
+                );
+            }
         }
     }
 
@@ -273,6 +529,93 @@ fn extract_blade_symbols(content: &str) -> Vec<SymbolEntry> {
     }
 
     roots
+}
+
+/// Compose a Blade directive label. The directive is always present (used
+/// to identify the kind of entry); the argument is appended when supplied.
+/// Examples:
+///   `@extends layouts.app`
+///   `@section content`
+///   `@include partials.header`
+///   `@props title`      ← first array key when @props(['title', ...])
+fn blade_directive_label(directive: &str, arg: Option<&str>) -> String {
+    match arg {
+        Some(a) => format!("@{directive} {a}"),
+        None => format!("@{directive}"),
+    }
+}
+
+/// Scan a Blade directive's `(...)` argument list with brace-aware balanced
+/// paren tracking. Returns `(first_string, end_of_directive)`:
+///   - `first_string` is the first quoted string literal anywhere in the
+///     args (`'title'` from `@props(['title', ...])`, or
+///     `'partial'` from `@includeWhen($x->y(), 'partial')`).
+///   - `end_of_directive` is the byte offset just past the matching close
+///     paren, or `after_directive` if there are no parens. Used as the
+///     symbol's end position.
+///
+/// Handles nested parens (so `$user->method()` inside args doesn't truncate
+/// the search early) and quoted-string escape sequences.
+fn parse_directive_args(content: &str, after_directive: usize) -> (Option<String>, usize) {
+    let bytes = content.as_bytes();
+    let mut i = after_directive;
+
+    // Skip whitespace between the directive and its opening `(`. Stop at
+    // newlines — a directive without args on the same line has none.
+    while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+        i += 1;
+    }
+    if i >= bytes.len() || bytes[i] != b'(' {
+        return (None, after_directive);
+    }
+    i += 1; // step past the `(`
+
+    let mut depth: u32 = 0;
+    let mut first_string: Option<String> = None;
+    let mut in_string = false;
+    let mut string_quote = b' ';
+    let mut string_start = 0usize;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+
+        if in_string {
+            if c == b'\\' && i + 1 < bytes.len() {
+                // Skip the escaped char. We're only looking for the string
+                // closing quote; precise escape semantics don't matter here.
+                i += 2;
+                continue;
+            }
+            if c == string_quote {
+                if first_string.is_none() {
+                    if let Ok(s) = std::str::from_utf8(&bytes[string_start..i]) {
+                        first_string = Some(s.to_string());
+                    }
+                }
+                in_string = false;
+            }
+        } else {
+            match c {
+                b'(' => depth += 1,
+                b')' => {
+                    if depth == 0 {
+                        return (first_string, i + 1);
+                    }
+                    depth -= 1;
+                }
+                b'\'' | b'"' => {
+                    in_string = true;
+                    string_quote = c;
+                    string_start = i + 1;
+                }
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+
+    // Unclosed args — return whatever we found, ending at EOF.
+    (first_string, bytes.len())
 }
 
 /// One frame on the Blade open-block stack — the directive that opened it
@@ -312,235 +655,6 @@ fn push_blade_entry(
         parent.symbol.children.push(entry);
     } else {
         roots.push(entry);
-    }
-}
-
-// ============================================================================
-// PHP (Livewire / Eloquent / Generic) — single parse, content-based dispatch
-// ============================================================================
-
-/// Parse the PHP file once via tree-sitter, then dispatch by what the first
-/// class extends. Plain PHP files (no class, or class that doesn't extend a
-/// Laravel base) get a full structural outline.
-fn extract_php_symbols(content: &str) -> Vec<SymbolEntry> {
-    let structure = extract_php_structure(content);
-
-    let first_class_extends = structure
-        .structures
-        .iter()
-        .find(|s| s.kind == PhpStructureKind::Class)
-        .and_then(|c| c.extends.as_deref());
-
-    match first_class_extends {
-        Some(extends) if is_livewire_component(extends) => livewire_symbols(&structure),
-        Some(extends) if is_eloquent_model(extends) => model_symbols(&structure),
-        _ => generic_php_symbols(&structure),
-    }
-}
-
-/// `Component` (bare), `Livewire\Component`, or any class whose extends target
-/// resolves to `Component` after namespace-simplification. Conservative — a
-/// non-Livewire `Component` base would also match, but the generic path also
-/// produces sensible output, so the cost of a false positive is low.
-fn is_livewire_component(extends: &str) -> bool {
-    extends == "Component"
-}
-
-fn is_eloquent_model(extends: &str) -> bool {
-    matches!(
-        extends,
-        "Model" | "Authenticatable" | "Pivot" | "MorphPivot"
-    )
-}
-
-/// Livewire components: emit the class with *public* properties and methods
-/// only. Private/protected members are implementation details, not surface area.
-fn livewire_symbols(structure: &PhpFileStructure) -> Vec<SymbolEntry> {
-    let Some(class) = structure
-        .structures
-        .iter()
-        .find(|s| s.kind == PhpStructureKind::Class)
-    else {
-        return Vec::new();
-    };
-
-    let mut entry = structure_to_symbol(class);
-
-    let mut children: Vec<SymbolEntry> = class
-        .properties
-        .iter()
-        .filter(|p| p.visibility == PhpVisibility::Public)
-        .map(property_to_symbol)
-        .chain(
-            class
-                .methods
-                .iter()
-                .filter(|m| m.visibility == PhpVisibility::Public)
-                .map(method_to_symbol),
-        )
-        .collect();
-    children.sort_by_key(|c| (c.start_line, c.start_column));
-    extend_class_end_to_last_child(&mut entry, &children);
-    entry.children = children;
-
-    vec![entry]
-}
-
-/// Eloquent models: emit the class with *only* relationship methods (return
-/// type matches a known Eloquent relation) and query scopes (`scope*`). Other
-/// methods are noise on the outline of a model.
-fn model_symbols(structure: &PhpFileStructure) -> Vec<SymbolEntry> {
-    let Some(class) = structure
-        .structures
-        .iter()
-        .find(|s| s.kind == PhpStructureKind::Class)
-    else {
-        return Vec::new();
-    };
-
-    let mut entry = structure_to_symbol(class);
-
-    let mut children: Vec<SymbolEntry> = class
-        .methods
-        .iter()
-        .filter(|m| is_relationship(m) || is_scope(m))
-        .map(method_to_symbol)
-        .collect();
-    children.sort_by_key(|c| (c.start_line, c.start_column));
-    extend_class_end_to_last_child(&mut entry, &children);
-    entry.children = children;
-
-    vec![entry]
-}
-
-fn is_relationship(m: &PhpMethodInfo) -> bool {
-    m.return_type
-        .as_deref()
-        .is_some_and(is_relationship_return_type)
-}
-
-fn is_scope(m: &PhpMethodInfo) -> bool {
-    m.name.starts_with("scope")
-        && m.name
-            .chars()
-            .nth(5)
-            .is_some_and(|c| c.is_ascii_uppercase())
-}
-
-fn is_relationship_return_type(detail: &str) -> bool {
-    const RELATIONSHIPS: &[&str] = &[
-        "HasMany",
-        "HasOne",
-        "BelongsTo",
-        "BelongsToMany",
-        "HasManyThrough",
-        "HasOneThrough",
-        "MorphMany",
-        "MorphOne",
-        "MorphTo",
-        "MorphToMany",
-        "MorphedByMany",
-    ];
-    RELATIONSHIPS.iter().any(|r| detail.contains(r))
-}
-
-/// Plain PHP files (controllers, jobs, helpers, etc.) — emit every top-level
-/// class/interface/trait/enum with *all* properties and methods regardless of
-/// visibility, plus any free functions. This is the strict-upgrade path when
-/// a Zed user opts into LSP outlines: parity with tree-sitter outline.scm
-/// plus our Laravel-aware sugar.
-fn generic_php_symbols(structure: &PhpFileStructure) -> Vec<SymbolEntry> {
-    let mut symbols = Vec::new();
-
-    for s in &structure.structures {
-        let mut entry = structure_to_symbol(s);
-
-        let mut children: Vec<SymbolEntry> = s
-            .properties
-            .iter()
-            .map(property_to_symbol)
-            .chain(s.methods.iter().map(method_to_symbol))
-            .collect();
-        children.sort_by_key(|c| (c.start_line, c.start_column));
-        extend_class_end_to_last_child(&mut entry, &children);
-        entry.children = children;
-
-        symbols.push(entry);
-    }
-
-    for f in &structure.functions {
-        symbols.push(function_to_symbol(f));
-    }
-
-    symbols
-}
-
-fn structure_to_symbol(s: &PhpStructure) -> SymbolEntry {
-    let kind = match s.kind {
-        PhpStructureKind::Class => SymbolEntryKind::Class,
-        PhpStructureKind::Interface => SymbolEntryKind::Interface,
-        PhpStructureKind::Trait => SymbolEntryKind::Trait,
-        PhpStructureKind::Enum => SymbolEntryKind::Enum,
-    };
-    let detail = s.extends.as_ref().map(|e| format!("extends {e}"));
-    SymbolEntry {
-        name: s.name.clone(),
-        detail,
-        kind,
-        start_line: s.start_line,
-        start_column: s.start_column,
-        end_line: s.end_line,
-        end_column: s.end_column,
-        children: Vec::new(),
-    }
-}
-
-fn method_to_symbol(m: &PhpMethodInfo) -> SymbolEntry {
-    SymbolEntry {
-        name: m.name.clone(),
-        detail: m.return_type.clone(),
-        kind: SymbolEntryKind::Method,
-        start_line: m.start_line,
-        start_column: m.start_column,
-        end_line: m.end_line,
-        end_column: m.end_column,
-        children: Vec::new(),
-    }
-}
-
-fn property_to_symbol(p: &PhpPropertyInfo) -> SymbolEntry {
-    SymbolEntry {
-        name: format!("${}", p.name),
-        detail: p.property_type.clone(),
-        kind: SymbolEntryKind::Property,
-        start_line: p.start_line,
-        start_column: p.start_column,
-        end_line: p.end_line,
-        end_column: p.end_column,
-        children: Vec::new(),
-    }
-}
-
-fn function_to_symbol(f: &PhpFunctionInfo) -> SymbolEntry {
-    SymbolEntry {
-        name: f.name.clone(),
-        detail: f.return_type.clone(),
-        kind: SymbolEntryKind::Function,
-        start_line: f.start_line,
-        start_column: f.start_column,
-        end_line: f.end_line,
-        end_column: f.end_column,
-        children: Vec::new(),
-    }
-}
-
-/// Tighten the class's `end_*` to the last child's end. tree-sitter already
-/// gives us the true class end, but for *filtered* outlines (Livewire/Model)
-/// shrinking to the visible children gives editors a tighter selection range.
-fn extend_class_end_to_last_child(entry: &mut SymbolEntry, children: &[SymbolEntry]) {
-    if let Some(last) = children.last() {
-        entry.end_line = last.end_line;
-        entry.end_column = last.end_column;
     }
 }
 

--- a/laravel-lsp/src/document_symbols.rs
+++ b/laravel-lsp/src/document_symbols.rs
@@ -1,0 +1,529 @@
+//! Document symbol extraction for `textDocument/documentSymbol`.
+//!
+//! Produces a hierarchical symbol tree for Laravel-aware file types so editors
+//! (Zed outline, Helix symbol picker, Neovim aerial, etc.) can show structural
+//! navigation that's meaningful for Laravel projects.
+//!
+//! ## Supported file kinds
+//!
+//! | Kind                | Symbols                                                 |
+//! |---------------------|---------------------------------------------------------|
+//! | `RouteFile`         | `Route::get/post/...` calls labelled `METHOD URI [n=…]` |
+//! | `Blade`             | `@section`, `@push`, `@yield`, `@stack`, `@component`   |
+//! | `LivewireComponent` | Class + public properties + public methods              |
+//! | `EloquentModel`     | Class + relationship methods + `scope*` methods         |
+//!
+//! Each extractor returns plain `SymbolEntry` values; the LSP handler in
+//! `main.rs` converts these to `tower_lsp::lsp_types::DocumentSymbol` and the
+//! Salsa actor in `salsa_impl.rs` memoizes them per file version.
+//!
+//! All positions are 0-based to match the LSP and the rest of this codebase
+//! (see `CLAUDE.md` § Position Indexing Convention).
+
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::path::Path;
+
+/// A single entry in the document symbol tree. Plain data so it can cross the
+/// Salsa async boundary and be cached cheaply.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SymbolEntry {
+    /// Display name (e.g. "GET /users", "increment", "$count").
+    pub name: String,
+    /// Secondary detail shown after the name (e.g. "[name=users.index]",
+    /// "HasMany").
+    pub detail: Option<String>,
+    pub kind: SymbolEntryKind,
+    /// 0-based start line.
+    pub start_line: u32,
+    /// 0-based start column.
+    pub start_column: u32,
+    /// 0-based end line.
+    pub end_line: u32,
+    /// 0-based end column (exclusive — column one past the last character).
+    pub end_column: u32,
+    pub children: Vec<SymbolEntry>,
+}
+
+/// LSP-aligned symbol kinds. Restricted to the variants this extension actually
+/// emits — wider mapping happens in `main.rs` where `tower_lsp` types are
+/// available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SymbolEntryKind {
+    Class,
+    Method,
+    Property,
+    Field,
+    Function,
+    Namespace,
+    Variable,
+}
+
+/// File classification — drives which extractor runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FileKind {
+    /// A file under `routes/` (web.php, api.php, etc.).
+    RouteFile,
+    /// A `*.blade.php` file.
+    Blade,
+    /// A PHP class extending `Livewire\Component` (or aliased equivalent).
+    LivewireComponent,
+    /// A PHP class extending `Illuminate\Database\Eloquent\Model` (or aliased).
+    EloquentModel,
+    /// Anything else — no Laravel-aware symbols to emit.
+    Other,
+}
+
+/// Classify a file by path + content. Path is checked first because it's
+/// cheap; content is consulted only to disambiguate plain PHP files.
+pub fn classify_file(path: &Path, content: &str) -> FileKind {
+    let path_str = path.to_string_lossy();
+
+    // Blade files — extension is authoritative.
+    if path_str.ends_with(".blade.php") {
+        return FileKind::Blade;
+    }
+
+    // Non-PHP files: nothing to do here.
+    if !path_str.ends_with(".php") {
+        return FileKind::Other;
+    }
+
+    // Files under any `routes/` directory are route files. Match the
+    // `is_under_routes_dir` heuristic from route_discovery.rs.
+    if path
+        .components()
+        .any(|c| c.as_os_str().eq_ignore_ascii_case("routes"))
+    {
+        return FileKind::RouteFile;
+    }
+
+    // PHP class files — disambiguate by what they extend.
+    if content_extends_livewire_component(content) {
+        return FileKind::LivewireComponent;
+    }
+    if content_extends_eloquent_model(content) {
+        return FileKind::EloquentModel;
+    }
+
+    FileKind::Other
+}
+
+/// Dispatch to the right extractor based on file kind.
+pub fn extract_symbols(content: &str, kind: FileKind) -> Vec<SymbolEntry> {
+    match kind {
+        FileKind::RouteFile => extract_route_symbols(content),
+        FileKind::Blade => extract_blade_symbols(content),
+        FileKind::LivewireComponent => extract_livewire_symbols(content),
+        FileKind::EloquentModel => extract_model_symbols(content),
+        FileKind::Other => Vec::new(),
+    }
+}
+
+// ============================================================================
+// Routes
+// ============================================================================
+
+/// Extract `Route::verb('/uri', ...)` definitions and their `->name(...)`
+/// suffixes (when present). Each becomes a top-level symbol; route groups
+/// are flattened — we don't currently track `Route::prefix(...)->group(...)`
+/// nesting in the outline.
+fn extract_route_symbols(content: &str) -> Vec<SymbolEntry> {
+    lazy_static! {
+        // Match `Route::verb('uri'` or `Route::verb("uri"`. The verb capture
+        // covers the standard HTTP routing helpers we surface in the outline.
+        static ref ROUTE_RE: Regex = Regex::new(
+            r#"Route::(get|post|put|patch|delete|options|any|match|view|redirect|fallback)\s*\(\s*(?:\[[^\]]*\]\s*,\s*)?['"]([^'"]*)['"]"#,
+        )
+        .unwrap();
+        // Match `->name('foo')` or `->name("foo")` following the route. Captures
+        // only the name; the caller searches for this within the route's tail
+        // up to the next semicolon.
+        static ref NAME_RE: Regex = Regex::new(r#"->name\s*\(\s*['"]([^'"]+)['"]"#).unwrap();
+    }
+
+    let mut symbols = Vec::new();
+
+    for cap in ROUTE_RE.captures_iter(content) {
+        let full_match = cap.get(0).expect("regex match always has group 0");
+        let verb = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let uri = cap.get(2).map(|m| m.as_str()).unwrap_or("");
+
+        // Look ahead for `->name(...)` up to the next semicolon — that
+        // captures the typical fluent-chain shape without consuming the next
+        // route call.
+        let tail_start = full_match.end();
+        let tail_end = content[tail_start..]
+            .find(';')
+            .map(|i| tail_start + i)
+            .unwrap_or(content.len());
+        let tail = &content[tail_start..tail_end];
+
+        let name = NAME_RE
+            .captures(tail)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str().to_string());
+
+        let (start_line, start_column) = byte_to_line_col(content, full_match.start());
+        let (end_line, end_column) = byte_to_line_col(content, tail_end);
+
+        let detail = name.as_ref().map(|n| format!("[name={n}]"));
+        let label = format!("{} {}", verb.to_uppercase(), uri);
+
+        symbols.push(SymbolEntry {
+            name: label,
+            detail,
+            kind: SymbolEntryKind::Function,
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+            children: Vec::new(),
+        });
+    }
+
+    symbols
+}
+
+// ============================================================================
+// Blade
+// ============================================================================
+
+/// Extract structural Blade directives (`@section`, `@push`, `@stack`,
+/// `@yield`, `@component`) with parent/child nesting derived from the
+/// open/close pairs.
+fn extract_blade_symbols(content: &str) -> Vec<SymbolEntry> {
+    lazy_static! {
+        // Match any of the structural directives we surface, optionally with
+        // an argument list. The directive name is captured for dispatch.
+        static ref DIRECTIVE_RE: Regex = Regex::new(
+            r#"@(section|endsection|push|endpush|prepend|endprepend|stack|yield|component|endcomponent|extends)\b(?:\s*\(\s*['"]([^'"]*)['"]\s*(?:,[^)]*)?\))?"#,
+        )
+        .unwrap();
+    }
+
+    let mut roots: Vec<SymbolEntry> = Vec::new();
+    let mut stack: Vec<BladeOpenBlock> = Vec::new();
+
+    for cap in DIRECTIVE_RE.captures_iter(content) {
+        let full = cap.get(0).expect("regex match always has group 0");
+        let directive = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+        let arg = cap.get(2).map(|m| m.as_str().to_string());
+
+        let (start_line, start_column) = byte_to_line_col(content, full.start());
+        let (end_line, end_column) = byte_to_line_col(content, full.end());
+
+        match directive {
+            // Closing directives pop the matching open block. If the stack
+            // head doesn't match (unbalanced source), we still pop to avoid
+            // runaway nesting — outlines tolerate inexact end positions better
+            // than missing blocks.
+            "endsection" => {
+                close_blade_block(&mut stack, &mut roots, "section", end_line, end_column)
+            }
+            "endpush" => close_blade_block(&mut stack, &mut roots, "push", end_line, end_column),
+            "endprepend" => {
+                close_blade_block(&mut stack, &mut roots, "prepend", end_line, end_column)
+            }
+            "endcomponent" => {
+                close_blade_block(&mut stack, &mut roots, "component", end_line, end_column)
+            }
+
+            // Opening directives push a new block onto the stack.
+            "section" | "push" | "prepend" | "component" => {
+                let name = arg.unwrap_or_else(|| format!("@{directive}"));
+                stack.push(BladeOpenBlock {
+                    directive: directive.to_string(),
+                    symbol: SymbolEntry {
+                        name,
+                        detail: Some(format!("@{directive}")),
+                        kind: SymbolEntryKind::Namespace,
+                        start_line,
+                        start_column,
+                        end_line,
+                        end_column,
+                        children: Vec::new(),
+                    },
+                });
+            }
+
+            // Self-contained directives — emit as leaves of the current parent
+            // (or root) without entering the stack.
+            "stack" | "yield" | "extends" => {
+                let name = arg.unwrap_or_else(|| format!("@{directive}"));
+                push_blade_entry(
+                    &mut stack,
+                    &mut roots,
+                    SymbolEntry {
+                        name,
+                        detail: Some(format!("@{directive}")),
+                        kind: SymbolEntryKind::Field,
+                        start_line,
+                        start_column,
+                        end_line,
+                        end_column,
+                        children: Vec::new(),
+                    },
+                );
+            }
+            _ => {}
+        }
+    }
+
+    // Flush any unclosed open blocks — emit at whatever depth they ended up.
+    while let Some(open) = stack.pop() {
+        push_blade_entry(&mut stack, &mut roots, open.symbol);
+    }
+
+    roots
+}
+
+/// One frame on the Blade open-block stack — the directive that opened it
+/// plus the in-progress symbol that will receive children until `@end*` closes it.
+struct BladeOpenBlock {
+    directive: String,
+    symbol: SymbolEntry,
+}
+
+fn close_blade_block(
+    stack: &mut Vec<BladeOpenBlock>,
+    roots: &mut Vec<SymbolEntry>,
+    expected: &str,
+    end_line: u32,
+    end_column: u32,
+) {
+    while let Some(top) = stack.pop() {
+        let matched = top.directive == expected;
+        let mut symbol = top.symbol;
+        if matched {
+            symbol.end_line = end_line;
+            symbol.end_column = end_column;
+        }
+        push_blade_entry(stack, roots, symbol);
+        if matched {
+            return;
+        }
+    }
+}
+
+fn push_blade_entry(
+    stack: &mut [BladeOpenBlock],
+    roots: &mut Vec<SymbolEntry>,
+    entry: SymbolEntry,
+) {
+    if let Some(parent) = stack.last_mut() {
+        parent.symbol.children.push(entry);
+    } else {
+        roots.push(entry);
+    }
+}
+
+// ============================================================================
+// Livewire components
+// ============================================================================
+
+/// Extract the component class + its public properties and methods.
+fn extract_livewire_symbols(content: &str) -> Vec<SymbolEntry> {
+    let Some(class) = extract_class_outline(content) else {
+        return Vec::new();
+    };
+    vec![class]
+}
+
+// ============================================================================
+// Eloquent models
+// ============================================================================
+
+/// Extract the model class + relationship methods + `scope*` methods. Other
+/// public methods are intentionally omitted — they're rarely what someone
+/// jumps to in a model.
+fn extract_model_symbols(content: &str) -> Vec<SymbolEntry> {
+    let Some(mut class) = extract_class_outline(content) else {
+        return Vec::new();
+    };
+
+    // Filter the class's methods to relationships + scopes; keep everything
+    // else off the outline to avoid noise.
+    class.children.retain(|child| match child.kind {
+        SymbolEntryKind::Method => {
+            let is_scope = child.name.starts_with("scope")
+                && child
+                    .name
+                    .chars()
+                    .nth(5)
+                    .is_some_and(|c| c.is_ascii_uppercase());
+            let is_relationship = child
+                .detail
+                .as_deref()
+                .is_some_and(is_relationship_return_type);
+            is_scope || is_relationship
+        }
+        _ => false,
+    });
+
+    vec![class]
+}
+
+fn is_relationship_return_type(detail: &str) -> bool {
+    const RELATIONSHIPS: &[&str] = &[
+        "HasMany",
+        "HasOne",
+        "BelongsTo",
+        "BelongsToMany",
+        "HasManyThrough",
+        "HasOneThrough",
+        "MorphMany",
+        "MorphOne",
+        "MorphTo",
+        "MorphToMany",
+        "MorphedByMany",
+    ];
+    RELATIONSHIPS.iter().any(|r| detail.contains(r))
+}
+
+// ============================================================================
+// Shared PHP class outline parser (used by Livewire + Model extractors)
+// ============================================================================
+
+/// Parse a PHP class declaration and emit a `Class` symbol with public
+/// properties (`Property`) and public methods (`Method`) as children. Method
+/// `detail` carries the declared return type, when present, so the model
+/// filter can recognise relationships.
+fn extract_class_outline(content: &str) -> Option<SymbolEntry> {
+    lazy_static! {
+        static ref CLASS_RE: Regex =
+            Regex::new(r#"\bclass\s+([A-Za-z_][A-Za-z0-9_]*)\b(?:\s+extends\s+([A-Za-z_\\][A-Za-z0-9_\\]*))?"#)
+                .unwrap();
+        // public [readonly] [type] $name [= ...];
+        static ref PROPERTY_RE: Regex = Regex::new(
+            r#"(?m)^\s*public\s+(?:readonly\s+)?(?:(\??[\w\\]+)\s+)?\$([A-Za-z_][A-Za-z0-9_]*)"#,
+        )
+        .unwrap();
+        // public function name(...) [: Return]
+        static ref METHOD_RE: Regex = Regex::new(
+            r#"(?m)^\s*public\s+(?:static\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?::\s*(\??[\w\\|]+))?"#,
+        )
+        .unwrap();
+    }
+
+    let class_cap = CLASS_RE.captures(content)?;
+    let class_match = class_cap.get(0).expect("regex match always has group 0");
+    let class_name = class_cap.get(1)?.as_str().to_string();
+    let extends = class_cap.get(2).map(|m| simple_class_name(m.as_str()));
+
+    let (start_line, start_column) = byte_to_line_col(content, class_match.start());
+
+    let mut class = SymbolEntry {
+        name: class_name,
+        detail: extends.map(|e| format!("extends {e}")),
+        kind: SymbolEntryKind::Class,
+        start_line,
+        start_column,
+        end_line: start_line,
+        end_column: start_column,
+        children: Vec::new(),
+    };
+
+    for cap in PROPERTY_RE.captures_iter(content) {
+        let m = cap.get(0).expect("regex match always has group 0");
+        let type_hint = cap.get(1).map(|t| t.as_str().to_string());
+        let name = cap.get(2)?.as_str().to_string();
+        let (line, column) = byte_to_line_col(content, m.start());
+        let (end_line, end_column) = byte_to_line_col(content, m.end());
+
+        class.children.push(SymbolEntry {
+            name: format!("${name}"),
+            detail: type_hint,
+            kind: SymbolEntryKind::Property,
+            start_line: line,
+            start_column: column,
+            end_line,
+            end_column,
+            children: Vec::new(),
+        });
+    }
+
+    for cap in METHOD_RE.captures_iter(content) {
+        let m = cap.get(0).expect("regex match always has group 0");
+        let name = cap.get(1)?.as_str().to_string();
+        let return_type = cap.get(2).map(|t| simple_class_name(t.as_str()));
+        let (line, column) = byte_to_line_col(content, m.start());
+        let (end_line, end_column) = byte_to_line_col(content, m.end());
+
+        class.children.push(SymbolEntry {
+            name,
+            detail: return_type,
+            kind: SymbolEntryKind::Method,
+            start_line: line,
+            start_column: column,
+            end_line,
+            end_column,
+            children: Vec::new(),
+        });
+    }
+
+    // Sort children by position so editors render them in source order.
+    class
+        .children
+        .sort_by_key(|c| (c.start_line, c.start_column));
+
+    // Approximate the class's end position with the last child's end (or the
+    // class declaration if the body has no children).
+    if let Some(last) = class.children.last() {
+        class.end_line = last.end_line;
+        class.end_column = last.end_column;
+    }
+
+    Some(class)
+}
+
+fn simple_class_name(fqn: &str) -> String {
+    fqn.rsplit('\\').next().unwrap_or(fqn).to_string()
+}
+
+fn content_extends_livewire_component(content: &str) -> bool {
+    // Match `extends Component`, `extends \Livewire\Component`, or
+    // `extends Livewire\Component`. False positives on plain PHP classes
+    // that happen to extend something else named "Component" are tolerable —
+    // the model extractor only fires when this returns false anyway.
+    lazy_static! {
+        static ref RE: Regex = Regex::new(r#"extends\s+(?:\\?Livewire\\)?Component\b"#,).unwrap();
+    }
+    RE.is_match(content)
+}
+
+fn content_extends_eloquent_model(content: &str) -> bool {
+    // Match `extends Model`, `extends \Illuminate\Database\Eloquent\Model`,
+    // or `extends Authenticatable` (the User model's typical base).
+    lazy_static! {
+        static ref RE: Regex = Regex::new(
+            r#"extends\s+(?:\\?Illuminate\\Database\\Eloquent\\)?(?:Model|Authenticatable|Pivot|MorphPivot)\b"#,
+        )
+        .unwrap();
+    }
+    RE.is_match(content)
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Convert a byte offset into 0-based (line, column). Mirrors the helper in
+/// `route_discovery::byte_to_line_col` — kept local so this module has no
+/// dependency on internals of another extractor.
+fn byte_to_line_col(content: &str, byte_offset: usize) -> (u32, u32) {
+    let bytes = content.as_bytes();
+    let mut line = 0u32;
+    let mut last_newline: i64 = -1;
+    for (idx, b) in bytes.iter().enumerate().take(byte_offset) {
+        if *b == b'\n' {
+            line += 1;
+            last_newline = idx as i64;
+        }
+    }
+    let column = (byte_offset as i64 - last_newline - 1) as u32;
+    (line, column)
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/document_symbols/tests.rs
+++ b/laravel-lsp/src/document_symbols/tests.rs
@@ -1,0 +1,268 @@
+//! Tests for document symbol extraction.
+
+use super::*;
+use std::path::PathBuf;
+
+// ============================================================================
+// File classification
+// ============================================================================
+
+#[test]
+fn classify_blade_file_by_extension() {
+    let path = PathBuf::from("/app/resources/views/users/show.blade.php");
+    assert_eq!(classify_file(&path, ""), FileKind::Blade);
+}
+
+#[test]
+fn classify_route_file_by_directory() {
+    let path = PathBuf::from("/app/routes/web.php");
+    assert_eq!(classify_file(&path, "<?php\n"), FileKind::RouteFile);
+}
+
+#[test]
+fn classify_livewire_component_by_content() {
+    let path = PathBuf::from("/app/app/Livewire/Counter.php");
+    let content = "<?php\nclass Counter extends Component {}\n";
+    assert_eq!(classify_file(&path, content), FileKind::LivewireComponent);
+}
+
+#[test]
+fn classify_eloquent_model_by_content() {
+    let path = PathBuf::from("/app/app/Models/User.php");
+    let content = "<?php\nclass User extends Model {}\n";
+    assert_eq!(classify_file(&path, content), FileKind::EloquentModel);
+}
+
+#[test]
+fn classify_user_model_with_authenticatable_base() {
+    let path = PathBuf::from("/app/app/Models/User.php");
+    let content = "<?php\nclass User extends Authenticatable {}\n";
+    assert_eq!(classify_file(&path, content), FileKind::EloquentModel);
+}
+
+#[test]
+fn classify_plain_php_file_as_other() {
+    let path = PathBuf::from("/app/app/Helpers/Util.php");
+    let content = "<?php\nclass Util {}\n";
+    assert_eq!(classify_file(&path, content), FileKind::Other);
+}
+
+// ============================================================================
+// Route file extraction
+// ============================================================================
+
+#[test]
+fn extracts_named_get_route() {
+    let content = r#"<?php
+Route::get('/users', [UserController::class, 'index'])->name('users.index');
+"#;
+    let symbols = extract_route_symbols(content);
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "GET /users");
+    assert_eq!(symbols[0].detail.as_deref(), Some("[name=users.index]"));
+}
+
+#[test]
+fn extracts_multiple_verbs() {
+    let content = r#"<?php
+Route::get('/a', fn () => 1)->name('a');
+Route::post('/b', fn () => 1);
+Route::put('/c', fn () => 1)->name('c');
+Route::delete('/d', fn () => 1);
+"#;
+    let symbols = extract_route_symbols(content);
+    let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, vec!["GET /a", "POST /b", "PUT /c", "DELETE /d"]);
+    assert_eq!(symbols[0].detail.as_deref(), Some("[name=a]"));
+    assert!(symbols[1].detail.is_none()); // unnamed POST
+    assert_eq!(symbols[2].detail.as_deref(), Some("[name=c]"));
+    assert!(symbols[3].detail.is_none());
+}
+
+#[test]
+fn route_positions_are_zero_based() {
+    let content = "<?php\nRoute::get('/x', fn () => 1);\n";
+    let symbols = extract_route_symbols(content);
+    assert_eq!(symbols[0].start_line, 1, "second line is index 1");
+    assert_eq!(symbols[0].start_column, 0, "line starts at column 0");
+}
+
+// ============================================================================
+// Blade extraction
+// ============================================================================
+
+#[test]
+fn extracts_section_with_yield_child() {
+    let content = r#"@extends('layouts.app')
+@section('content')
+    @yield('title')
+@endsection
+"#;
+    let symbols = extract_blade_symbols(content);
+    // Roots: @extends, @section
+    assert_eq!(symbols.len(), 2);
+    assert_eq!(symbols[0].name, "layouts.app");
+    assert_eq!(symbols[0].detail.as_deref(), Some("@extends"));
+    assert_eq!(symbols[1].name, "content");
+    assert_eq!(symbols[1].detail.as_deref(), Some("@section"));
+    assert_eq!(symbols[1].children.len(), 1);
+    assert_eq!(symbols[1].children[0].name, "title");
+    assert_eq!(symbols[1].children[0].detail.as_deref(), Some("@yield"));
+}
+
+#[test]
+fn extracts_nested_push_inside_section() {
+    let content = r#"@section('content')
+    @push('scripts')
+        <script>console.log('hi');</script>
+    @endpush
+@endsection
+"#;
+    let symbols = extract_blade_symbols(content);
+    assert_eq!(symbols.len(), 1);
+    let section = &symbols[0];
+    assert_eq!(section.name, "content");
+    assert_eq!(section.children.len(), 1);
+    assert_eq!(section.children[0].name, "scripts");
+    assert_eq!(section.children[0].detail.as_deref(), Some("@push"));
+}
+
+#[test]
+fn unclosed_section_still_emits() {
+    let content = "@section('content')\n@yield('inner')\n";
+    let symbols = extract_blade_symbols(content);
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "content");
+    // @yield landed inside the open section before flush
+    assert_eq!(symbols[0].children.len(), 1);
+}
+
+// ============================================================================
+// Livewire extraction
+// ============================================================================
+
+#[test]
+fn extracts_livewire_class_with_props_and_methods() {
+    let content = r#"<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class Counter extends Component
+{
+    public int $count = 0;
+    public string $label = 'clicks';
+
+    public function increment(): void
+    {
+        $this->count++;
+    }
+
+    private function helper(): void
+    {
+        // private — should NOT appear in outline
+    }
+
+    public function render()
+    {
+        return view('livewire.counter');
+    }
+}
+"#;
+    let symbols = extract_livewire_symbols(content);
+    assert_eq!(symbols.len(), 1);
+    let class = &symbols[0];
+    assert_eq!(class.name, "Counter");
+    assert_eq!(class.detail.as_deref(), Some("extends Component"));
+
+    // Only the *public* members should appear.
+    let names: Vec<&str> = class.children.iter().map(|c| c.name.as_str()).collect();
+    assert!(names.contains(&"$count"));
+    assert!(names.contains(&"$label"));
+    assert!(names.contains(&"increment"));
+    assert!(names.contains(&"render"));
+    assert!(
+        !names.contains(&"helper"),
+        "private methods stay off the outline"
+    );
+}
+
+// ============================================================================
+// Model extraction
+// ============================================================================
+
+#[test]
+fn extracts_model_relationships_and_scopes() {
+    let content = r#"<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Post extends Model
+{
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class);
+    }
+
+    public function scopePublished($query)
+    {
+        return $query->whereNotNull('published_at');
+    }
+
+    public function getTitleAttribute(): string
+    {
+        return $this->attributes['title'];
+    }
+
+    public function someUnrelatedMethod(): void
+    {
+        // Not a relationship, not a scope — stays off the outline.
+    }
+}
+"#;
+    let symbols = extract_model_symbols(content);
+    assert_eq!(symbols.len(), 1);
+    let class = &symbols[0];
+    assert_eq!(class.name, "Post");
+
+    let names: Vec<&str> = class.children.iter().map(|c| c.name.as_str()).collect();
+    assert!(names.contains(&"author"), "BelongsTo relationship surfaces");
+    assert!(names.contains(&"comments"), "HasMany relationship surfaces");
+    assert!(names.contains(&"scopePublished"), "scope method surfaces");
+    assert!(
+        !names.contains(&"getTitleAttribute"),
+        "accessor without relationship return type is filtered"
+    );
+    assert!(
+        !names.contains(&"someUnrelatedMethod"),
+        "non-scope, non-relationship methods are filtered"
+    );
+}
+
+// ============================================================================
+// Dispatch via extract_symbols
+// ============================================================================
+
+#[test]
+fn extract_symbols_dispatches_to_route_extractor() {
+    let content = "<?php\nRoute::get('/x', fn () => 1)->name('x');\n";
+    let symbols = extract_symbols(content, FileKind::RouteFile);
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "GET /x");
+}
+
+#[test]
+fn extract_symbols_other_returns_empty() {
+    let symbols = extract_symbols("any content", FileKind::Other);
+    assert!(symbols.is_empty());
+}

--- a/laravel-lsp/src/document_symbols/tests.rs
+++ b/laravel-lsp/src/document_symbols/tests.rs
@@ -4,47 +4,31 @@ use super::*;
 use std::path::PathBuf;
 
 // ============================================================================
-// File classification
+// File classification (path-only)
 // ============================================================================
 
 #[test]
 fn classify_blade_file_by_extension() {
     let path = PathBuf::from("/app/resources/views/users/show.blade.php");
-    assert_eq!(classify_file(&path, ""), FileKind::Blade);
+    assert_eq!(classify_file(&path), FileKind::Blade);
 }
 
 #[test]
 fn classify_route_file_by_directory() {
     let path = PathBuf::from("/app/routes/web.php");
-    assert_eq!(classify_file(&path, "<?php\n"), FileKind::RouteFile);
+    assert_eq!(classify_file(&path), FileKind::RouteFile);
 }
 
 #[test]
-fn classify_livewire_component_by_content() {
-    let path = PathBuf::from("/app/app/Livewire/Counter.php");
-    let content = "<?php\nclass Counter extends Component {}\n";
-    assert_eq!(classify_file(&path, content), FileKind::LivewireComponent);
-}
-
-#[test]
-fn classify_eloquent_model_by_content() {
-    let path = PathBuf::from("/app/app/Models/User.php");
-    let content = "<?php\nclass User extends Model {}\n";
-    assert_eq!(classify_file(&path, content), FileKind::EloquentModel);
-}
-
-#[test]
-fn classify_user_model_with_authenticatable_base() {
-    let path = PathBuf::from("/app/app/Models/User.php");
-    let content = "<?php\nclass User extends Authenticatable {}\n";
-    assert_eq!(classify_file(&path, content), FileKind::EloquentModel);
-}
-
-#[test]
-fn classify_plain_php_file_as_other() {
+fn classify_php_file_as_php_by_extension() {
     let path = PathBuf::from("/app/app/Helpers/Util.php");
-    let content = "<?php\nclass Util {}\n";
-    assert_eq!(classify_file(&path, content), FileKind::Other);
+    assert_eq!(classify_file(&path), FileKind::Php);
+}
+
+#[test]
+fn classify_non_php_file_as_other() {
+    let path = PathBuf::from("/app/README.md");
+    assert_eq!(classify_file(&path), FileKind::Other);
 }
 
 // ============================================================================
@@ -74,7 +58,7 @@ Route::delete('/d', fn () => 1);
     let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
     assert_eq!(names, vec!["GET /a", "POST /b", "PUT /c", "DELETE /d"]);
     assert_eq!(symbols[0].detail.as_deref(), Some("[name=a]"));
-    assert!(symbols[1].detail.is_none()); // unnamed POST
+    assert!(symbols[1].detail.is_none());
     assert_eq!(symbols[2].detail.as_deref(), Some("[name=c]"));
     assert!(symbols[3].detail.is_none());
 }
@@ -99,7 +83,6 @@ fn extracts_section_with_yield_child() {
 @endsection
 "#;
     let symbols = extract_blade_symbols(content);
-    // Roots: @extends, @section
     assert_eq!(symbols.len(), 2);
     assert_eq!(symbols[0].name, "layouts.app");
     assert_eq!(symbols[0].detail.as_deref(), Some("@extends"));
@@ -133,16 +116,15 @@ fn unclosed_section_still_emits() {
     let symbols = extract_blade_symbols(content);
     assert_eq!(symbols.len(), 1);
     assert_eq!(symbols[0].name, "content");
-    // @yield landed inside the open section before flush
     assert_eq!(symbols[0].children.len(), 1);
 }
 
 // ============================================================================
-// Livewire extraction
+// PHP — Livewire components (public-only filter)
 // ============================================================================
 
 #[test]
-fn extracts_livewire_class_with_props_and_methods() {
+fn livewire_component_shows_only_public_members() {
     let content = r#"<?php
 
 namespace App\Livewire;
@@ -153,6 +135,7 @@ class Counter extends Component
 {
     public int $count = 0;
     public string $label = 'clicks';
+    private $internal;
 
     public function increment(): void
     {
@@ -170,16 +153,20 @@ class Counter extends Component
     }
 }
 "#;
-    let symbols = extract_livewire_symbols(content);
+    let symbols = extract_php_symbols(content);
     assert_eq!(symbols.len(), 1);
     let class = &symbols[0];
     assert_eq!(class.name, "Counter");
+    assert_eq!(class.kind, SymbolEntryKind::Class);
     assert_eq!(class.detail.as_deref(), Some("extends Component"));
 
-    // Only the *public* members should appear.
     let names: Vec<&str> = class.children.iter().map(|c| c.name.as_str()).collect();
     assert!(names.contains(&"$count"));
     assert!(names.contains(&"$label"));
+    assert!(
+        !names.contains(&"$internal"),
+        "private props stay off the outline"
+    );
     assert!(names.contains(&"increment"));
     assert!(names.contains(&"render"));
     assert!(
@@ -189,11 +176,11 @@ class Counter extends Component
 }
 
 // ============================================================================
-// Model extraction
+// PHP — Eloquent models (relationships + scopes only)
 // ============================================================================
 
 #[test]
-fn extracts_model_relationships_and_scopes() {
+fn model_shows_only_relationships_and_scopes() {
     let content = r#"<?php
 
 namespace App\Models;
@@ -230,15 +217,15 @@ class Post extends Model
     }
 }
 "#;
-    let symbols = extract_model_symbols(content);
+    let symbols = extract_php_symbols(content);
     assert_eq!(symbols.len(), 1);
     let class = &symbols[0];
     assert_eq!(class.name, "Post");
 
     let names: Vec<&str> = class.children.iter().map(|c| c.name.as_str()).collect();
-    assert!(names.contains(&"author"), "BelongsTo relationship surfaces");
-    assert!(names.contains(&"comments"), "HasMany relationship surfaces");
-    assert!(names.contains(&"scopePublished"), "scope method surfaces");
+    assert!(names.contains(&"author"));
+    assert!(names.contains(&"comments"));
+    assert!(names.contains(&"scopePublished"));
     assert!(
         !names.contains(&"getTitleAttribute"),
         "accessor without relationship return type is filtered"
@@ -249,8 +236,135 @@ class Post extends Model
     );
 }
 
+#[test]
+fn user_model_with_authenticatable_base_is_recognised() {
+    let content = r#"<?php
+class User extends Authenticatable
+{
+    public function posts(): HasMany
+    {
+        return $this->hasMany(Post::class);
+    }
+}
+"#;
+    let symbols = extract_php_symbols(content);
+    assert_eq!(symbols.len(), 1);
+    let names: Vec<&str> = symbols[0]
+        .children
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert_eq!(names, vec!["posts"]);
+}
+
 // ============================================================================
-// Dispatch via extract_symbols
+// PHP — Generic (controllers, jobs, helpers, interfaces, etc.)
+// ============================================================================
+
+#[test]
+fn generic_php_class_shows_all_visibilities() {
+    let content = r#"<?php
+
+namespace App\Http\Controllers;
+
+class UserController
+{
+    public function __construct(private UserRepo $repo) {}
+
+    public function index() {
+        return view('users.index');
+    }
+
+    public function store(Request $request) {
+        // ...
+    }
+
+    protected function authorize(): void {}
+
+    private function buildQuery() {}
+}
+"#;
+    let symbols = extract_php_symbols(content);
+    assert_eq!(symbols.len(), 1);
+    let class = &symbols[0];
+    assert_eq!(class.name, "UserController");
+
+    let names: Vec<&str> = class.children.iter().map(|c| c.name.as_str()).collect();
+    // All methods regardless of visibility — strict-upgrade behaviour vs.
+    // tree-sitter outline.
+    assert!(names.contains(&"__construct"));
+    assert!(names.contains(&"index"));
+    assert!(names.contains(&"store"));
+    assert!(names.contains(&"authorize"));
+    assert!(names.contains(&"buildQuery"));
+}
+
+#[test]
+fn generic_php_emits_multiple_top_level_structures() {
+    let content = r#"<?php
+class Foo {}
+interface Bar {}
+trait Baz {}
+enum Qux {}
+"#;
+    let symbols = extract_php_symbols(content);
+    assert_eq!(symbols.len(), 4);
+    assert_eq!(symbols[0].name, "Foo");
+    assert_eq!(symbols[0].kind, SymbolEntryKind::Class);
+    assert_eq!(symbols[1].name, "Bar");
+    assert_eq!(symbols[1].kind, SymbolEntryKind::Interface);
+    assert_eq!(symbols[2].name, "Baz");
+    assert_eq!(symbols[2].kind, SymbolEntryKind::Trait);
+    assert_eq!(symbols[3].name, "Qux");
+    assert_eq!(symbols[3].kind, SymbolEntryKind::Enum);
+}
+
+#[test]
+fn generic_php_emits_free_functions() {
+    let content = r#"<?php
+
+if (!function_exists('format_money')) {
+    function format_money(int $cents): string {
+        return '$' . number_format($cents / 100, 2);
+    }
+}
+
+function legacy_helper(): void {}
+"#;
+    let symbols = extract_php_symbols(content);
+    let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains(&"format_money"));
+    assert!(names.contains(&"legacy_helper"));
+}
+
+#[test]
+fn generic_php_class_without_extends_uses_generic_path() {
+    // No `extends Component` / `extends Model` — should go through generic
+    // path, not be misclassified as Livewire or Eloquent.
+    let content = r#"<?php
+class PlainOldClass {
+    public function hello(): string {
+        return 'hi';
+    }
+    private function secret() {}
+}
+"#;
+    let symbols = extract_php_symbols(content);
+    assert_eq!(symbols.len(), 1);
+    let names: Vec<&str> = symbols[0]
+        .children
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert!(names.contains(&"hello"));
+    assert!(
+        names.contains(&"secret"),
+        "private members visible in generic outline"
+    );
+}
+
+// ============================================================================
+// Dispatch
 // ============================================================================
 
 #[test]
@@ -265,4 +379,24 @@ fn extract_symbols_dispatches_to_route_extractor() {
 fn extract_symbols_other_returns_empty() {
     let symbols = extract_symbols("any content", FileKind::Other);
     assert!(symbols.is_empty());
+}
+
+#[test]
+fn extract_symbols_php_dispatches_through_subclassification() {
+    // PHP file with Livewire component — should produce a class symbol with
+    // the public-only filter applied.
+    let content =
+        "<?php\nclass Foo extends Component {\n    public int $a = 0;\n    private $b;\n}\n";
+    let symbols = extract_symbols(content, FileKind::Php);
+    assert_eq!(symbols.len(), 1);
+    let names: Vec<&str> = symbols[0]
+        .children
+        .iter()
+        .map(|c| c.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["$a"],
+        "private $b filtered out by Livewire path"
+    );
 }

--- a/laravel-lsp/src/document_symbols/tests.rs
+++ b/laravel-lsp/src/document_symbols/tests.rs
@@ -42,8 +42,10 @@ Route::get('/users', [UserController::class, 'index'])->name('users.index');
 "#;
     let symbols = extract_route_symbols(content);
     assert_eq!(symbols.len(), 1);
-    assert_eq!(symbols[0].name, "GET /users");
-    assert_eq!(symbols[0].detail.as_deref(), Some("[name=users.index]"));
+    // Route name goes in the label, not detail — Zed's outline panel
+    // doesn't render detail (zed-industries/zed#49095).
+    assert_eq!(symbols[0].name, "GET /users [name=users.index]");
+    assert!(symbols[0].detail.is_none());
 }
 
 #[test]
@@ -56,11 +58,11 @@ Route::delete('/d', fn () => 1);
 "#;
     let symbols = extract_route_symbols(content);
     let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
-    assert_eq!(names, vec!["GET /a", "POST /b", "PUT /c", "DELETE /d"]);
-    assert_eq!(symbols[0].detail.as_deref(), Some("[name=a]"));
-    assert!(symbols[1].detail.is_none());
-    assert_eq!(symbols[2].detail.as_deref(), Some("[name=c]"));
-    assert!(symbols[3].detail.is_none());
+    assert_eq!(
+        names,
+        vec!["GET /a [name=a]", "POST /b", "PUT /c [name=c]", "DELETE /d",]
+    );
+    assert!(symbols.iter().all(|s| s.detail.is_none()));
 }
 
 #[test]
@@ -84,13 +86,10 @@ fn extracts_section_with_yield_child() {
 "#;
     let symbols = extract_blade_symbols(content);
     assert_eq!(symbols.len(), 2);
-    assert_eq!(symbols[0].name, "layouts.app");
-    assert_eq!(symbols[0].detail.as_deref(), Some("@extends"));
-    assert_eq!(symbols[1].name, "content");
-    assert_eq!(symbols[1].detail.as_deref(), Some("@section"));
+    assert_eq!(symbols[0].name, "@extends layouts.app");
+    assert_eq!(symbols[1].name, "@section content");
     assert_eq!(symbols[1].children.len(), 1);
-    assert_eq!(symbols[1].children[0].name, "title");
-    assert_eq!(symbols[1].children[0].detail.as_deref(), Some("@yield"));
+    assert_eq!(symbols[1].children[0].name, "@yield title");
 }
 
 #[test]
@@ -104,10 +103,9 @@ fn extracts_nested_push_inside_section() {
     let symbols = extract_blade_symbols(content);
     assert_eq!(symbols.len(), 1);
     let section = &symbols[0];
-    assert_eq!(section.name, "content");
+    assert_eq!(section.name, "@section content");
     assert_eq!(section.children.len(), 1);
-    assert_eq!(section.children[0].name, "scripts");
-    assert_eq!(section.children[0].detail.as_deref(), Some("@push"));
+    assert_eq!(section.children[0].name, "@push scripts");
 }
 
 #[test]
@@ -115,253 +113,208 @@ fn unclosed_section_still_emits() {
     let content = "@section('content')\n@yield('inner')\n";
     let symbols = extract_blade_symbols(content);
     assert_eq!(symbols.len(), 1);
-    assert_eq!(symbols[0].name, "content");
+    assert_eq!(symbols[0].name, "@section content");
     assert_eq!(symbols[0].children.len(), 1);
 }
 
-// ============================================================================
-// PHP — Livewire components (public-only filter)
-// ============================================================================
-
 #[test]
-fn livewire_component_shows_only_public_members() {
-    let content = r#"<?php
-
-namespace App\Livewire;
-
-use Livewire\Component;
-
-class Counter extends Component
-{
-    public int $count = 0;
-    public string $label = 'clicks';
-    private $internal;
-
-    public function increment(): void
-    {
-        $this->count++;
-    }
-
-    private function helper(): void
-    {
-        // private — should NOT appear in outline
-    }
-
-    public function render()
-    {
-        return view('livewire.counter');
-    }
-}
+fn extracts_blade_component_tags() {
+    let content = r#"<div>
+    <x-button>Click me</x-button>
+    <x-forms.input name="email" />
+    <livewire:counter />
+    <flux:icon name="search" />
+</div>
 "#;
-    let symbols = extract_php_symbols(content);
-    assert_eq!(symbols.len(), 1);
-    let class = &symbols[0];
-    assert_eq!(class.name, "Counter");
-    assert_eq!(class.kind, SymbolEntryKind::Class);
-    assert_eq!(class.detail.as_deref(), Some("extends Component"));
-
-    let names: Vec<&str> = class.children.iter().map(|c| c.name.as_str()).collect();
-    assert!(names.contains(&"$count"));
-    assert!(names.contains(&"$label"));
-    assert!(
-        !names.contains(&"$internal"),
-        "private props stay off the outline"
-    );
-    assert!(names.contains(&"increment"));
-    assert!(names.contains(&"render"));
-    assert!(
-        !names.contains(&"helper"),
-        "private methods stay off the outline"
-    );
-}
-
-// ============================================================================
-// PHP — Eloquent models (relationships + scopes only)
-// ============================================================================
-
-#[test]
-fn model_shows_only_relationships_and_scopes() {
-    let content = r#"<?php
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-
-class Post extends Model
-{
-    public function author(): BelongsTo
-    {
-        return $this->belongsTo(User::class);
-    }
-
-    public function comments(): HasMany
-    {
-        return $this->hasMany(Comment::class);
-    }
-
-    public function scopePublished($query)
-    {
-        return $query->whereNotNull('published_at');
-    }
-
-    public function getTitleAttribute(): string
-    {
-        return $this->attributes['title'];
-    }
-
-    public function someUnrelatedMethod(): void
-    {
-        // Not a relationship, not a scope — stays off the outline.
-    }
-}
-"#;
-    let symbols = extract_php_symbols(content);
-    assert_eq!(symbols.len(), 1);
-    let class = &symbols[0];
-    assert_eq!(class.name, "Post");
-
-    let names: Vec<&str> = class.children.iter().map(|c| c.name.as_str()).collect();
-    assert!(names.contains(&"author"));
-    assert!(names.contains(&"comments"));
-    assert!(names.contains(&"scopePublished"));
-    assert!(
-        !names.contains(&"getTitleAttribute"),
-        "accessor without relationship return type is filtered"
-    );
-    assert!(
-        !names.contains(&"someUnrelatedMethod"),
-        "non-scope, non-relationship methods are filtered"
-    );
-}
-
-#[test]
-fn user_model_with_authenticatable_base_is_recognised() {
-    let content = r#"<?php
-class User extends Authenticatable
-{
-    public function posts(): HasMany
-    {
-        return $this->hasMany(Post::class);
-    }
-}
-"#;
-    let symbols = extract_php_symbols(content);
-    assert_eq!(symbols.len(), 1);
-    let names: Vec<&str> = symbols[0]
-        .children
-        .iter()
-        .map(|c| c.name.as_str())
-        .collect();
-    assert_eq!(names, vec!["posts"]);
-}
-
-// ============================================================================
-// PHP — Generic (controllers, jobs, helpers, interfaces, etc.)
-// ============================================================================
-
-#[test]
-fn generic_php_class_shows_all_visibilities() {
-    let content = r#"<?php
-
-namespace App\Http\Controllers;
-
-class UserController
-{
-    public function __construct(private UserRepo $repo) {}
-
-    public function index() {
-        return view('users.index');
-    }
-
-    public function store(Request $request) {
-        // ...
-    }
-
-    protected function authorize(): void {}
-
-    private function buildQuery() {}
-}
-"#;
-    let symbols = extract_php_symbols(content);
-    assert_eq!(symbols.len(), 1);
-    let class = &symbols[0];
-    assert_eq!(class.name, "UserController");
-
-    let names: Vec<&str> = class.children.iter().map(|c| c.name.as_str()).collect();
-    // All methods regardless of visibility — strict-upgrade behaviour vs.
-    // tree-sitter outline.
-    assert!(names.contains(&"__construct"));
-    assert!(names.contains(&"index"));
-    assert!(names.contains(&"store"));
-    assert!(names.contains(&"authorize"));
-    assert!(names.contains(&"buildQuery"));
-}
-
-#[test]
-fn generic_php_emits_multiple_top_level_structures() {
-    let content = r#"<?php
-class Foo {}
-interface Bar {}
-trait Baz {}
-enum Qux {}
-"#;
-    let symbols = extract_php_symbols(content);
-    assert_eq!(symbols.len(), 4);
-    assert_eq!(symbols[0].name, "Foo");
-    assert_eq!(symbols[0].kind, SymbolEntryKind::Class);
-    assert_eq!(symbols[1].name, "Bar");
-    assert_eq!(symbols[1].kind, SymbolEntryKind::Interface);
-    assert_eq!(symbols[2].name, "Baz");
-    assert_eq!(symbols[2].kind, SymbolEntryKind::Trait);
-    assert_eq!(symbols[3].name, "Qux");
-    assert_eq!(symbols[3].kind, SymbolEntryKind::Enum);
-}
-
-#[test]
-fn generic_php_emits_free_functions() {
-    let content = r#"<?php
-
-if (!function_exists('format_money')) {
-    function format_money(int $cents): string {
-        return '$' . number_format($cents / 100, 2);
-    }
-}
-
-function legacy_helper(): void {}
-"#;
-    let symbols = extract_php_symbols(content);
+    let symbols = extract_blade_symbols(content);
     let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
-    assert!(names.contains(&"format_money"));
-    assert!(names.contains(&"legacy_helper"));
+    // `<x-button>` is a container (paired with `</x-button>`); the other
+    // three are self-closing leaves. Self-closing tags include the ` />`
+    // in their label so the source shape is visible at a glance.
+    assert_eq!(
+        names,
+        vec![
+            "<x-button>",
+            "<x-forms.input />",
+            "<livewire:counter />",
+            "<flux:icon />",
+        ]
+    );
+    assert!(
+        symbols[0].children.is_empty(),
+        "x-button has no nested component children in this test"
+    );
 }
 
 #[test]
-fn generic_php_class_without_extends_uses_generic_path() {
-    // No `extends Component` / `extends Model` — should go through generic
-    // path, not be misclassified as Livewire or Eloquent.
-    let content = r#"<?php
-class PlainOldClass {
-    public function hello(): string {
-        return 'hi';
-    }
-    private function secret() {}
-}
+fn paired_component_tag_nests_its_children() {
+    let content = r#"<x-card>
+    <x-card-header>Title</x-card-header>
+    <livewire:card-body />
+</x-card>
 "#;
-    let symbols = extract_php_symbols(content);
+    let symbols = extract_blade_symbols(content);
     assert_eq!(symbols.len(), 1);
-    let names: Vec<&str> = symbols[0]
+    let card = &symbols[0];
+    assert_eq!(card.name, "<x-card>");
+    let child_names: Vec<&str> = card.children.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(
+        child_names,
+        vec!["<x-card-header>", "<livewire:card-body />"]
+    );
+}
+
+#[test]
+fn extracts_blade_slot_tags() {
+    let content = r#"<x-card>
+    <x-slot:header>Title</x-slot:header>
+    <x-slot name="footer">Footer</x-slot>
+    Body content
+</x-card>
+"#;
+    let symbols = extract_blade_symbols(content);
+    // `<x-card>` is now a paired container; the slot tags live inside it
+    // as children. Slot tags are rendered as `<x-slot:NAME>` regardless of
+    // which syntax form the source used.
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "<x-card>");
+    let child_names: Vec<&str> = symbols[0]
         .children
         .iter()
         .map(|c| c.name.as_str())
         .collect();
-    assert!(names.contains(&"hello"));
-    assert!(
-        names.contains(&"secret"),
-        "private members visible in generic outline"
+    assert!(child_names.contains(&"<x-slot:header>"));
+    assert!(child_names.contains(&"<x-slot:footer>"));
+}
+
+#[test]
+fn extracts_blade_props_declaration() {
+    let content = r#"@props(['title', 'count' => 0])
+
+<div class="card">{{ $title }} — {{ $count }}</div>
+"#;
+    let symbols = extract_blade_symbols(content);
+    assert_eq!(symbols.len(), 1);
+    // We capture the first string argument of @props, which for the
+    // common `['title', 'count' => 0]` shape is the first key.
+    assert_eq!(symbols[0].name, "@props title");
+}
+
+#[test]
+fn extracts_blade_includes() {
+    let content = r#"@include('partials.header')
+@includeIf('partials.banner', ['variant' => 'success'])
+@includeWhen($user->isAdmin(), 'partials.admin-nav')
+@includeUnless($guest, 'partials.user-nav')
+@includeFirst(['custom.layout', 'default.layout'])
+"#;
+    let symbols = extract_blade_symbols(content);
+    let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "@include partials.header",
+            "@includeIf partials.banner",
+            "@includeWhen partials.admin-nav",
+            "@includeUnless partials.user-nav",
+            "@includeFirst custom.layout",
+        ]
     );
 }
+
+#[test]
+fn blade_outline_for_component_file() {
+    // A typical Blade component file: props + slot + child components.
+    let content = r#"@props(['title'])
+
+<div class="card">
+    <x-slot:header>
+        {{ $title }}
+    </x-slot:header>
+
+    <x-card-body>
+        {{ $slot }}
+    </x-card-body>
+
+    <livewire:card-footer :title="$title" />
+</div>
+"#;
+    let symbols = extract_blade_symbols(content);
+
+    // Walk the full tree — component containers nest their content as
+    // children, so the livewire tag below `<x-card-body>` is a sibling at
+    // the top level, while the slot inside `<x-card-body>`'s scope nests
+    // under it (because the close tag is delayed).
+    fn collect_names(entries: &[SymbolEntry], out: &mut Vec<String>) {
+        for e in entries {
+            out.push(e.name.clone());
+            collect_names(&e.children, out);
+        }
+    }
+    let mut names = Vec::new();
+    collect_names(&symbols, &mut names);
+
+    assert!(names.iter().any(|n| n == "@props title"));
+    assert!(names.iter().any(|n| n == "<x-slot:header>"));
+    assert!(names.iter().any(|n| n == "<x-card-body>"));
+    assert!(names.iter().any(|n| n == "<livewire:card-footer />"));
+}
+
+#[test]
+fn blade_outline_for_layout_file() {
+    // A typical Blade layout file: sections nesting yields and pushes.
+    let content = r#"<!DOCTYPE html>
+<html>
+<head>
+    <title>@yield('title', 'Default')</title>
+    @stack('head')
+</head>
+<body>
+    @include('partials.nav')
+
+    @section('content')
+        @yield('inner')
+    @show
+
+    @push('scripts')
+        <script>console.log('layout');</script>
+    @endpush
+</body>
+</html>
+"#;
+    let symbols = extract_blade_symbols(content);
+
+    // Collect names from the whole tree (Top + children) since the layout's
+    // `@section` is unclosed and ends up containing the `@push scripts`
+    // entry as a child.
+    fn collect_names(entries: &[SymbolEntry], out: &mut Vec<String>) {
+        for e in entries {
+            out.push(e.name.clone());
+            collect_names(&e.children, out);
+        }
+    }
+    let mut names = Vec::new();
+    collect_names(&symbols, &mut names);
+
+    assert!(names.iter().any(|n| n == "@yield title"));
+    assert!(names.iter().any(|n| n == "@stack head"));
+    assert!(names.iter().any(|n| n == "@include partials.nav"));
+    assert!(names.iter().any(|n| n.starts_with("@section")));
+    assert!(names.iter().any(|n| n == "@push scripts"));
+}
+
+// ============================================================================
+// PHP — intentionally returns empty
+// ============================================================================
+//
+// See module-level docs on document_symbols.rs: most users have a PHP LSP
+// (Intelephense / Phpactor / PhpTools) installed, and Zed merges document
+// symbol responses across LSPs. Anything we emit for `.php` files appears
+// twice in the outline panel. We cede PHP class bodies to the dedicated PHP
+// LSP and keep our contribution scoped to Laravel-specific shapes: route
+// declarations and Blade templates. PHP structural parsing still exists in
+// `crate::php_outline` for potential reuse elsewhere (hover, completions),
+// but it's not wired into `extract_symbols`.
 
 // ============================================================================
 // Dispatch
@@ -372,7 +325,7 @@ fn extract_symbols_dispatches_to_route_extractor() {
     let content = "<?php\nRoute::get('/x', fn () => 1)->name('x');\n";
     let symbols = extract_symbols(content, FileKind::RouteFile);
     assert_eq!(symbols.len(), 1);
-    assert_eq!(symbols[0].name, "GET /x");
+    assert_eq!(symbols[0].name, "GET /x [name=x]");
 }
 
 #[test]
@@ -382,21 +335,14 @@ fn extract_symbols_other_returns_empty() {
 }
 
 #[test]
-fn extract_symbols_php_dispatches_through_subclassification() {
-    // PHP file with Livewire component — should produce a class symbol with
-    // the public-only filter applied.
+fn extract_symbols_php_returns_empty() {
+    // We deliberately don't emit document symbols for `.php` files — see
+    // the module-level docs on document_symbols.rs. PHP outline is owned
+    // by whichever PHP LSP the user has installed (Intelephense / Phpactor
+    // / PhpTools) because Zed merges responses across LSPs and any output
+    // from us would render twice in the outline panel.
     let content =
         "<?php\nclass Foo extends Component {\n    public int $a = 0;\n    private $b;\n}\n";
     let symbols = extract_symbols(content, FileKind::Php);
-    assert_eq!(symbols.len(), 1);
-    let names: Vec<&str> = symbols[0]
-        .children
-        .iter()
-        .map(|c| c.name.as_str())
-        .collect();
-    assert_eq!(
-        names,
-        vec!["$a"],
-        "private $b filtered out by Livewire path"
-    );
+    assert!(symbols.is_empty());
 }

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -18,6 +18,7 @@ pub mod class_locator;
 pub mod config;
 pub mod config_lookup;
 pub mod database;
+pub mod document_symbols;
 pub mod hover;
 pub mod livewire_resolver;
 pub mod middleware_parser;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -25,6 +25,7 @@ pub mod middleware_parser;
 pub mod model_analyzer;
 pub mod parser;
 pub mod php_class;
+pub mod php_outline;
 pub mod queries;
 pub mod route_binding;
 pub mod route_discovery;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -29,6 +29,7 @@ pub mod php_outline;
 pub mod queries;
 pub mod route_binding;
 pub mod route_discovery;
+pub mod route_outline;
 pub mod slot_navigation;
 pub mod translation_lookup;
 pub mod validation_rules;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -14410,15 +14410,29 @@ impl LanguageServer for LaravelLanguageServer {
         params: DocumentSymbolParams,
     ) -> jsonrpc::Result<Option<DocumentSymbolResponse>> {
         let uri = &params.text_document.uri;
+        info!("📚 document_symbol: requested for {}", uri);
+
         let file_path = match uri.to_file_path() {
             Ok(p) => p,
-            Err(_) => return Ok(None),
+            Err(_) => {
+                info!("📚 document_symbol: URI did not convert to file path; returning None");
+                return Ok(None);
+            }
         };
 
         let entries = match self.salsa.get_document_symbols(file_path).await {
             Ok(Some(arc)) => arc,
-            _ => return Ok(Some(DocumentSymbolResponse::Nested(Vec::new()))),
+            Ok(None) => {
+                info!("📚 document_symbol: Salsa returned None (file not registered?); empty list");
+                return Ok(Some(DocumentSymbolResponse::Nested(Vec::new())));
+            }
+            Err(e) => {
+                info!("📚 document_symbol: Salsa error '{}'; empty list", e);
+                return Ok(Some(DocumentSymbolResponse::Nested(Vec::new())));
+            }
         };
+
+        info!("📚 document_symbol: {} symbols for {}", entries.len(), uri);
 
         let symbols: Vec<DocumentSymbol> = entries.iter().map(symbol_entry_to_lsp).collect();
         Ok(Some(DocumentSymbolResponse::Nested(symbols)))

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13687,6 +13687,9 @@ fn symbol_entry_kind_to_lsp(kind: laravel_lsp::document_symbols::SymbolEntryKind
     use laravel_lsp::document_symbols::SymbolEntryKind;
     match kind {
         SymbolEntryKind::Class => SymbolKind::CLASS,
+        SymbolEntryKind::Interface => SymbolKind::INTERFACE,
+        SymbolEntryKind::Trait => SymbolKind::STRUCT,
+        SymbolEntryKind::Enum => SymbolKind::ENUM,
         SymbolEntryKind::Method => SymbolKind::METHOD,
         SymbolEntryKind::Property => SymbolKind::PROPERTY,
         SymbolEntryKind::Field => SymbolKind::FIELD,

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13649,6 +13649,53 @@ return [
     }
 }
 
+/// Convert a `document_symbols::SymbolEntry` (LSP-agnostic) into a tower-lsp
+/// `DocumentSymbol`. Recurses into children. `selection_range` is set to the
+/// same range as `range` — clients use selection_range for the click target.
+#[allow(deprecated)]
+fn symbol_entry_to_lsp(entry: &laravel_lsp::document_symbols::SymbolEntry) -> DocumentSymbol {
+    let range = Range {
+        start: Position {
+            line: entry.start_line,
+            character: entry.start_column,
+        },
+        end: Position {
+            line: entry.end_line,
+            character: entry.end_column,
+        },
+    };
+
+    DocumentSymbol {
+        name: entry.name.clone(),
+        detail: entry.detail.clone(),
+        kind: symbol_entry_kind_to_lsp(entry.kind),
+        tags: None,
+        // `deprecated` is deprecated in the LSP spec in favour of `tags`,
+        // but the field is still required by tower-lsp's struct definition.
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: if entry.children.is_empty() {
+            None
+        } else {
+            Some(entry.children.iter().map(symbol_entry_to_lsp).collect())
+        },
+    }
+}
+
+fn symbol_entry_kind_to_lsp(kind: laravel_lsp::document_symbols::SymbolEntryKind) -> SymbolKind {
+    use laravel_lsp::document_symbols::SymbolEntryKind;
+    match kind {
+        SymbolEntryKind::Class => SymbolKind::CLASS,
+        SymbolEntryKind::Method => SymbolKind::METHOD,
+        SymbolEntryKind::Property => SymbolKind::PROPERTY,
+        SymbolEntryKind::Field => SymbolKind::FIELD,
+        SymbolEntryKind::Function => SymbolKind::FUNCTION,
+        SymbolEntryKind::Namespace => SymbolKind::NAMESPACE,
+        SymbolEntryKind::Variable => SymbolKind::VARIABLE,
+    }
+}
+
 #[tower_lsp::async_trait]
 impl LanguageServer for LaravelLanguageServer {
     async fn initialize(&self, params: InitializeParams) -> jsonrpc::Result<InitializeResult> {
@@ -13741,6 +13788,13 @@ impl LanguageServer for LaravelLanguageServer {
 
                 // ✅ Code actions for quick fixes (create missing views, etc.)
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+
+                // ✅ Document symbol provider — populates outline panels
+                // (Zed outline, Helix symbol picker, Neovim aerial, etc.) with
+                // Laravel-aware structure: route definitions, Blade section
+                // hierarchy, Livewire component members, Eloquent relationships
+                // and scopes.
+                document_symbol_provider: Some(OneOf::Left(true)),
 
                 // On-type formatting (currently unused, bracket expansion uses completions)
                 document_on_type_formatting_provider: Some(DocumentOnTypeFormattingOptions {
@@ -14342,6 +14396,30 @@ impl LanguageServer for LaravelLanguageServer {
     // NOTE: completion handler removed - capability not advertised in ServerCapabilities
 
     // NOTE: code_lens handler removed - Zed doesn't support custom LSP commands
+
+    /// Document-symbol request — returns Laravel-aware structure for outline
+    /// panels. Delegates the parsing to the Salsa actor which memoizes per file
+    /// version. Unknown / unsupported file kinds return an empty list rather
+    /// than `None` so clients render an empty outline instead of falling back
+    /// to no-LSP behaviour.
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> jsonrpc::Result<Option<DocumentSymbolResponse>> {
+        let uri = &params.text_document.uri;
+        let file_path = match uri.to_file_path() {
+            Ok(p) => p,
+            Err(_) => return Ok(None),
+        };
+
+        let entries = match self.salsa.get_document_symbols(file_path).await {
+            Ok(Some(arc)) => arc,
+            _ => return Ok(Some(DocumentSymbolResponse::Nested(Vec::new()))),
+        };
+
+        let symbols: Vec<DocumentSymbol> = entries.iter().map(symbol_entry_to_lsp).collect();
+        Ok(Some(DocumentSymbolResponse::Nested(symbols)))
+    }
 
     /// Handle code action requests (quick fixes like "Create missing view")
     async fn code_action(

--- a/laravel-lsp/src/php_outline.rs
+++ b/laravel-lsp/src/php_outline.rs
@@ -1,0 +1,329 @@
+//! PHP file structural outline via tree-sitter.
+//!
+//! Returns the top-level classes / interfaces / traits / enums in a PHP file
+//! together with their methods and properties, plus any free functions. The
+//! types are plain data so consumers (document_symbols.rs) can filter for
+//! Laravel-specific shapes (Livewire components, Eloquent models) on top.
+//!
+//! Tree-sitter is the right tool here — regex-based PHP class parsing trips
+//! over heredocs, strings, and comments, and gets ambiguous on multi-class
+//! files. The cost is one extra parse per outline request, memoized via Salsa.
+
+use tree_sitter::Node;
+
+/// Parsed structure of a PHP file: top-level class-like declarations plus
+/// free-standing functions. Empty default is used as the "parse failed"
+/// sentinel.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct PhpFileStructure {
+    pub structures: Vec<PhpStructure>,
+    pub functions: Vec<PhpFunctionInfo>,
+}
+
+/// A class/interface/trait/enum declaration with its members.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PhpStructure {
+    pub kind: PhpStructureKind,
+    pub name: String,
+    /// Simplified `extends` target (final `\`-segment), if any.
+    pub extends: Option<String>,
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+    pub methods: Vec<PhpMethodInfo>,
+    pub properties: Vec<PhpPropertyInfo>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PhpStructureKind {
+    Class,
+    Interface,
+    Trait,
+    Enum,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PhpMethodInfo {
+    pub name: String,
+    pub visibility: PhpVisibility,
+    /// Simplified return type (final `\`-segment), if any.
+    pub return_type: Option<String>,
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PhpPropertyInfo {
+    /// Name without leading `$`.
+    pub name: String,
+    pub visibility: PhpVisibility,
+    pub property_type: Option<String>,
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PhpFunctionInfo {
+    pub name: String,
+    pub return_type: Option<String>,
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PhpVisibility {
+    Public,
+    Protected,
+    Private,
+}
+
+/// Parse a PHP file and extract its structural outline. Returns an empty
+/// `PhpFileStructure` on parse failure (which Salsa caches the same way as a
+/// successful empty result — callers shouldn't distinguish).
+pub fn extract_php_structure(content: &str) -> PhpFileStructure {
+    let Ok(tree) = crate::parser::parse_php(content) else {
+        return PhpFileStructure::default();
+    };
+    let source = content.as_bytes();
+    let mut result = PhpFileStructure::default();
+    walk_top_level(tree.root_node(), source, &mut result);
+    result
+}
+
+/// Walk the top-level of a node and collect any class-like declarations and
+/// free functions found. Recurses into namespace blocks so declarations inside
+/// `namespace Foo { ... }` still surface.
+fn walk_top_level(node: Node, source: &[u8], result: &mut PhpFileStructure) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "class_declaration" => {
+                if let Some(s) = parse_structure(child, source, PhpStructureKind::Class) {
+                    result.structures.push(s);
+                }
+            }
+            "interface_declaration" => {
+                if let Some(s) = parse_structure(child, source, PhpStructureKind::Interface) {
+                    result.structures.push(s);
+                }
+            }
+            "trait_declaration" => {
+                if let Some(s) = parse_structure(child, source, PhpStructureKind::Trait) {
+                    result.structures.push(s);
+                }
+            }
+            "enum_declaration" => {
+                if let Some(s) = parse_structure(child, source, PhpStructureKind::Enum) {
+                    result.structures.push(s);
+                }
+            }
+            "function_definition" => {
+                if let Some(f) = parse_function(child, source) {
+                    result.functions.push(f);
+                }
+            }
+            // Recurse into wrappers that commonly contain top-level
+            // declarations:
+            //   - `namespace_definition` for `namespace Foo { class Bar {} }`
+            //   - `compound_statement` for namespace / if-statement bodies
+            //   - `if_statement` for the `function_exists` guard pattern
+            //     common in Laravel helpers files
+            //   - `else_clause` / `else_if_clause` for the same
+            "namespace_definition"
+            | "compound_statement"
+            | "if_statement"
+            | "else_clause"
+            | "else_if_clause" => {
+                walk_top_level(child, source, result);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn parse_structure(node: Node, source: &[u8], kind: PhpStructureKind) -> Option<PhpStructure> {
+    let name = field_text(node, "name", source)?;
+    let extends = parse_extends(node, source);
+    let (start_line, start_column) = pos(node.start_position());
+    let (end_line, end_column) = pos(node.end_position());
+
+    let mut methods = Vec::new();
+    let mut properties = Vec::new();
+
+    if let Some(body) = node.child_by_field_name("body") {
+        let mut body_cursor = body.walk();
+        for member in body.children(&mut body_cursor) {
+            match member.kind() {
+                "method_declaration" => {
+                    if let Some(m) = parse_method(member, source) {
+                        methods.push(m);
+                    }
+                }
+                "property_declaration" => {
+                    properties.extend(parse_properties(member, source));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Some(PhpStructure {
+        kind,
+        name,
+        extends,
+        start_line,
+        start_column,
+        end_line,
+        end_column,
+        methods,
+        properties,
+    })
+}
+
+fn parse_extends(node: Node, source: &[u8]) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "base_clause" {
+            let mut bc_cursor = child.walk();
+            for bc_child in child.children(&mut bc_cursor) {
+                let kind = bc_child.kind();
+                if kind == "name" || kind == "qualified_name" {
+                    if let Ok(text) = bc_child.utf8_text(source) {
+                        return Some(simple_name(text));
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn parse_method(node: Node, source: &[u8]) -> Option<PhpMethodInfo> {
+    let name = field_text(node, "name", source)?;
+    let visibility = parse_visibility(node, source);
+    let return_type = node
+        .child_by_field_name("return_type")
+        .and_then(|n| n.utf8_text(source).ok())
+        .map(|s| simple_name(s.trim_start_matches([':', ' ']).trim()));
+    let (start_line, start_column) = pos(node.start_position());
+    let (end_line, end_column) = pos(node.end_position());
+
+    Some(PhpMethodInfo {
+        name,
+        visibility,
+        return_type,
+        start_line,
+        start_column,
+        end_line,
+        end_column,
+    })
+}
+
+fn parse_properties(node: Node, source: &[u8]) -> Vec<PhpPropertyInfo> {
+    let visibility = parse_visibility(node, source);
+    let property_type = node
+        .child_by_field_name("type")
+        .and_then(|n| n.utf8_text(source).ok())
+        .map(|s| simple_name(s.trim()));
+
+    let mut props = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() != "property_element" {
+            continue;
+        }
+        let mut prop_cursor = child.walk();
+        for pchild in child.children(&mut prop_cursor) {
+            // `variable_name` wraps the `$name` token; some tree-sitter-php
+            // versions surface the bare `name` directly. Handle both.
+            if pchild.kind() == "variable_name" || pchild.kind() == "name" {
+                if let Ok(text) = pchild.utf8_text(source) {
+                    let (line, column) = pos(pchild.start_position());
+                    let (end_line, end_column) = pos(pchild.end_position());
+                    props.push(PhpPropertyInfo {
+                        name: text.trim_start_matches('$').to_string(),
+                        visibility,
+                        property_type: property_type.clone(),
+                        start_line: line,
+                        start_column: column,
+                        end_line,
+                        end_column,
+                    });
+                }
+            }
+        }
+    }
+    props
+}
+
+/// Look for a `visibility_modifier` child and read its keyword. PHP defaults
+/// to `public` when no modifier is present (matches the language spec).
+fn parse_visibility(node: Node, source: &[u8]) -> PhpVisibility {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "visibility_modifier" {
+            if let Ok(text) = child.utf8_text(source) {
+                return match text {
+                    "private" => PhpVisibility::Private,
+                    "protected" => PhpVisibility::Protected,
+                    _ => PhpVisibility::Public,
+                };
+            }
+        }
+    }
+    PhpVisibility::Public
+}
+
+fn parse_function(node: Node, source: &[u8]) -> Option<PhpFunctionInfo> {
+    let name = field_text(node, "name", source)?;
+    let return_type = node
+        .child_by_field_name("return_type")
+        .and_then(|n| n.utf8_text(source).ok())
+        .map(|s| simple_name(s.trim_start_matches([':', ' ']).trim()));
+    let (start_line, start_column) = pos(node.start_position());
+    let (end_line, end_column) = pos(node.end_position());
+
+    Some(PhpFunctionInfo {
+        name,
+        return_type,
+        start_line,
+        start_column,
+        end_line,
+        end_column,
+    })
+}
+
+fn field_text(node: Node, field: &str, source: &[u8]) -> Option<String> {
+    node.child_by_field_name(field)?
+        .utf8_text(source)
+        .ok()
+        .map(|s| s.to_string())
+}
+
+fn pos(point: tree_sitter::Point) -> (u32, u32) {
+    (point.row as u32, point.column as u32)
+}
+
+/// Strip namespace prefix from a fully-qualified name. `\App\Models\User` →
+/// `User`. Leading `?` (nullable) is preserved as part of the name.
+fn simple_name(fqn: &str) -> String {
+    let trimmed = fqn.trim();
+    let nullable = trimmed.starts_with('?');
+    let body = trimmed.trim_start_matches('?').trim_start_matches('\\');
+    let simple = body.rsplit('\\').next().unwrap_or(body);
+    if nullable {
+        format!("?{simple}")
+    } else {
+        simple.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/php_outline.rs
+++ b/laravel-lsp/src/php_outline.rs
@@ -49,6 +49,7 @@ pub struct PhpMethodInfo {
     pub visibility: PhpVisibility,
     /// Simplified return type (final `\`-segment), if any.
     pub return_type: Option<String>,
+    pub parameters: Vec<PhpParameter>,
     pub start_line: u32,
     pub start_column: u32,
     pub end_line: u32,
@@ -71,10 +72,20 @@ pub struct PhpPropertyInfo {
 pub struct PhpFunctionInfo {
     pub name: String,
     pub return_type: Option<String>,
+    pub parameters: Vec<PhpParameter>,
     pub start_line: u32,
     pub start_column: u32,
     pub end_line: u32,
     pub end_column: u32,
+}
+
+/// A single parameter from a method or function signature. `name` is the
+/// variable name without the leading `$`. `param_type` is the simplified
+/// type annotation if present.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PhpParameter {
+    pub name: String,
+    pub param_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -212,6 +223,10 @@ fn parse_method(node: Node, source: &[u8]) -> Option<PhpMethodInfo> {
         .child_by_field_name("return_type")
         .and_then(|n| n.utf8_text(source).ok())
         .map(|s| simple_name(s.trim_start_matches([':', ' ']).trim()));
+    let parameters = node
+        .child_by_field_name("parameters")
+        .map(|p| parse_parameters(p, source))
+        .unwrap_or_default();
     let (start_line, start_column) = pos(node.start_position());
     let (end_line, end_column) = pos(node.end_position());
 
@@ -219,6 +234,7 @@ fn parse_method(node: Node, source: &[u8]) -> Option<PhpMethodInfo> {
         name,
         visibility,
         return_type,
+        parameters,
         start_line,
         start_column,
         end_line,
@@ -287,17 +303,67 @@ fn parse_function(node: Node, source: &[u8]) -> Option<PhpFunctionInfo> {
         .child_by_field_name("return_type")
         .and_then(|n| n.utf8_text(source).ok())
         .map(|s| simple_name(s.trim_start_matches([':', ' ']).trim()));
+    let parameters = node
+        .child_by_field_name("parameters")
+        .map(|p| parse_parameters(p, source))
+        .unwrap_or_default();
     let (start_line, start_column) = pos(node.start_position());
     let (end_line, end_column) = pos(node.end_position());
 
     Some(PhpFunctionInfo {
         name,
         return_type,
+        parameters,
         start_line,
         start_column,
         end_line,
         end_column,
     })
+}
+
+/// Walk a `formal_parameters` node and extract each parameter's name and
+/// type annotation. Skips defaults (the symbol label has finite room and
+/// defaults add noise without aiding navigation). Handles simple
+/// parameters, constructor property promotion, and variadic parameters
+/// uniformly — we just extract `(type, $name)` for each.
+fn parse_parameters(node: Node, source: &[u8]) -> Vec<PhpParameter> {
+    let mut params = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "simple_parameter" | "property_promotion_parameter" | "variadic_parameter" => {
+                if let Some(param) = parse_one_parameter(child, source) {
+                    params.push(param);
+                }
+            }
+            _ => {}
+        }
+    }
+    params
+}
+
+fn parse_one_parameter(node: Node, source: &[u8]) -> Option<PhpParameter> {
+    // Type may appear as a `type:` field or as a child node of various
+    // type-related kinds depending on the tree-sitter-php version.
+    let param_type = node
+        .child_by_field_name("type")
+        .and_then(|n| n.utf8_text(source).ok())
+        .map(|s| simple_name(s.trim()));
+
+    // Name comes from a `variable_name` child (or `name` field directly).
+    let mut name: Option<String> = None;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "variable_name" {
+            if let Ok(text) = child.utf8_text(source) {
+                name = Some(text.trim_start_matches('$').to_string());
+                break;
+            }
+        }
+    }
+    let name = name?;
+
+    Some(PhpParameter { name, param_type })
 }
 
 fn field_text(node: Node, field: &str, source: &[u8]) -> Option<String> {

--- a/laravel-lsp/src/php_outline/tests.rs
+++ b/laravel-lsp/src/php_outline/tests.rs
@@ -223,3 +223,73 @@ fn positions_are_zero_based() {
     assert_eq!(class.start_line, 1);
     assert_eq!(class.start_column, 0);
 }
+
+#[test]
+fn extracts_method_parameters_with_types() {
+    let content = r#"<?php
+class Foo
+{
+    public function bar(int $count, ?string $name, $untyped) {}
+}
+"#;
+    let s = extract_php_structure(content);
+    let method = &s.structures[0].methods[0];
+    assert_eq!(method.name, "bar");
+    let params: Vec<(&str, Option<&str>)> = method
+        .parameters
+        .iter()
+        .map(|p| (p.name.as_str(), p.param_type.as_deref()))
+        .collect();
+    assert_eq!(
+        params,
+        vec![
+            ("count", Some("int")),
+            ("name", Some("?string")),
+            ("untyped", None),
+        ]
+    );
+}
+
+#[test]
+fn extracts_constructor_property_promotion_parameters() {
+    let content = r#"<?php
+class Foo
+{
+    public function __construct(
+        private string $name,
+        protected readonly int $age,
+        public ?Logger $logger = null,
+    ) {}
+}
+"#;
+    let s = extract_php_structure(content);
+    let ctor = &s.structures[0].methods[0];
+    assert_eq!(ctor.name, "__construct");
+    let names: Vec<&str> = ctor.parameters.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, vec!["name", "age", "logger"]);
+}
+
+#[test]
+fn extracts_free_function_parameters() {
+    let content = r#"<?php
+function format_money(int $cents, string $currency = 'USD'): string {
+    return '';
+}
+"#;
+    let s = extract_php_structure(content);
+    let f = &s.functions[0];
+    assert_eq!(f.name, "format_money");
+    assert_eq!(f.parameters.len(), 2);
+    assert_eq!(f.parameters[0].name, "cents");
+    assert_eq!(f.parameters[0].param_type.as_deref(), Some("int"));
+    assert_eq!(f.parameters[1].name, "currency");
+    assert_eq!(f.parameters[1].param_type.as_deref(), Some("string"));
+}
+
+#[test]
+fn no_parameters_when_signature_is_empty() {
+    let content = "<?php\nclass Foo { public function bar() {} }\n";
+    let s = extract_php_structure(content);
+    let m = &s.structures[0].methods[0];
+    assert!(m.parameters.is_empty());
+}

--- a/laravel-lsp/src/php_outline/tests.rs
+++ b/laravel-lsp/src/php_outline/tests.rs
@@ -1,0 +1,225 @@
+//! Tests for tree-sitter PHP outline extraction.
+
+use super::*;
+
+#[test]
+fn empty_input_returns_empty_structure() {
+    let s = extract_php_structure("");
+    assert!(s.structures.is_empty());
+    assert!(s.functions.is_empty());
+}
+
+#[test]
+fn extracts_single_class_with_methods_and_properties() {
+    let content = r#"<?php
+class User
+{
+    public int $id;
+    protected string $email;
+    private $token;
+
+    public function fullName(): string {
+        return $this->first . ' ' . $this->last;
+    }
+
+    protected function hash(): string {
+        return md5($this->token);
+    }
+}
+"#;
+    let s = extract_php_structure(content);
+    assert_eq!(s.structures.len(), 1);
+    let class = &s.structures[0];
+    assert_eq!(class.kind, PhpStructureKind::Class);
+    assert_eq!(class.name, "User");
+
+    let prop_names: Vec<&str> = class.properties.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(prop_names, vec!["id", "email", "token"]);
+
+    let vis: Vec<PhpVisibility> = class.properties.iter().map(|p| p.visibility).collect();
+    assert_eq!(
+        vis,
+        vec![
+            PhpVisibility::Public,
+            PhpVisibility::Protected,
+            PhpVisibility::Private
+        ]
+    );
+
+    let method_names: Vec<&str> = class.methods.iter().map(|m| m.name.as_str()).collect();
+    assert_eq!(method_names, vec!["fullName", "hash"]);
+    assert_eq!(class.methods[0].visibility, PhpVisibility::Public);
+    assert_eq!(class.methods[1].visibility, PhpVisibility::Protected);
+}
+
+#[test]
+fn extracts_extends_clause() {
+    let content = r#"<?php
+class Counter extends \Livewire\Component {
+    public int $count = 0;
+}
+"#;
+    let s = extract_php_structure(content);
+    assert_eq!(s.structures.len(), 1);
+    assert_eq!(s.structures[0].extends.as_deref(), Some("Component"));
+}
+
+#[test]
+fn extracts_return_types_with_namespace_stripped() {
+    let content = r#"<?php
+class Post {
+    public function comments(): \Illuminate\Database\Eloquent\Relations\HasMany {
+        return $this->hasMany(Comment::class);
+    }
+}
+"#;
+    let s = extract_php_structure(content);
+    assert_eq!(s.structures.len(), 1);
+    let method = &s.structures[0].methods[0];
+    assert_eq!(method.name, "comments");
+    assert_eq!(method.return_type.as_deref(), Some("HasMany"));
+}
+
+#[test]
+fn extracts_nullable_return_type() {
+    let content = r#"<?php
+class Repo {
+    public function find(): ?User {
+        return null;
+    }
+}
+"#;
+    let s = extract_php_structure(content);
+    let m = &s.structures[0].methods[0];
+    assert_eq!(m.return_type.as_deref(), Some("?User"));
+}
+
+#[test]
+fn extracts_interface() {
+    let content = r#"<?php
+interface Repository {
+    public function find(int $id);
+    public function save($entity): void;
+}
+"#;
+    let s = extract_php_structure(content);
+    assert_eq!(s.structures.len(), 1);
+    let iface = &s.structures[0];
+    assert_eq!(iface.kind, PhpStructureKind::Interface);
+    assert_eq!(iface.name, "Repository");
+    let names: Vec<&str> = iface.methods.iter().map(|m| m.name.as_str()).collect();
+    assert_eq!(names, vec!["find", "save"]);
+}
+
+#[test]
+fn extracts_trait() {
+    let content = r#"<?php
+trait HasUuid {
+    protected string $uuid;
+    public function uuid(): string {
+        return $this->uuid;
+    }
+}
+"#;
+    let s = extract_php_structure(content);
+    assert_eq!(s.structures.len(), 1);
+    assert_eq!(s.structures[0].kind, PhpStructureKind::Trait);
+    assert_eq!(s.structures[0].name, "HasUuid");
+}
+
+#[test]
+fn extracts_enum() {
+    let content = r#"<?php
+enum Status: string {
+    case Active = 'active';
+    case Inactive = 'inactive';
+
+    public function label(): string {
+        return match ($this) {
+            Status::Active => 'Active',
+            Status::Inactive => 'Inactive',
+        };
+    }
+}
+"#;
+    let s = extract_php_structure(content);
+    assert_eq!(s.structures.len(), 1);
+    let e = &s.structures[0];
+    assert_eq!(e.kind, PhpStructureKind::Enum);
+    assert_eq!(e.name, "Status");
+    let method_names: Vec<&str> = e.methods.iter().map(|m| m.name.as_str()).collect();
+    assert_eq!(method_names, vec!["label"]);
+}
+
+#[test]
+fn extracts_multiple_top_level_structures() {
+    let content = r#"<?php
+class Foo {}
+interface Bar {}
+trait Baz {}
+"#;
+    let s = extract_php_structure(content);
+    assert_eq!(s.structures.len(), 3);
+    assert_eq!(s.structures[0].name, "Foo");
+    assert_eq!(s.structures[0].kind, PhpStructureKind::Class);
+    assert_eq!(s.structures[1].name, "Bar");
+    assert_eq!(s.structures[1].kind, PhpStructureKind::Interface);
+    assert_eq!(s.structures[2].name, "Baz");
+    assert_eq!(s.structures[2].kind, PhpStructureKind::Trait);
+}
+
+#[test]
+fn extracts_free_functions() {
+    let content = r#"<?php
+
+function helper_one(int $x): int {
+    return $x + 1;
+}
+
+function helper_two(): void {}
+"#;
+    let s = extract_php_structure(content);
+    assert!(s.structures.is_empty());
+    assert_eq!(s.functions.len(), 2);
+    assert_eq!(s.functions[0].name, "helper_one");
+    assert_eq!(s.functions[0].return_type.as_deref(), Some("int"));
+    assert_eq!(s.functions[1].name, "helper_two");
+    assert_eq!(s.functions[1].return_type.as_deref(), Some("void"));
+}
+
+#[test]
+fn class_inside_namespace_is_extracted() {
+    let content = r#"<?php
+namespace App\Models;
+
+class User {
+    public string $email;
+}
+"#;
+    let s = extract_php_structure(content);
+    assert_eq!(s.structures.len(), 1);
+    assert_eq!(s.structures[0].name, "User");
+}
+
+#[test]
+fn default_visibility_is_public() {
+    // PHP defaults to public for methods and properties without an explicit modifier.
+    let content = r#"<?php
+class Implicit {
+    function doThing() {}
+}
+"#;
+    let s = extract_php_structure(content);
+    let m = &s.structures[0].methods[0];
+    assert_eq!(m.visibility, PhpVisibility::Public);
+}
+
+#[test]
+fn positions_are_zero_based() {
+    let content = "<?php\nclass Foo {}\n";
+    let s = extract_php_structure(content);
+    let class = &s.structures[0];
+    // `class Foo {}` starts on line 1 (0-based), column 0.
+    assert_eq!(class.start_line, 1);
+    assert_eq!(class.start_column, 0);
+}

--- a/laravel-lsp/src/route_outline.rs
+++ b/laravel-lsp/src/route_outline.rs
@@ -1,0 +1,352 @@
+//! Tree-sitter walker for Laravel route files.
+//!
+//! Produces a hierarchical outline of routes that preserves group nesting,
+//! computes combined URIs (a route inside `prefix('/api')` shows `/api/users`,
+//! not `/users`), and combines route name prefixes (a route inside
+//! `name('api.')` shows `api.users`, not `users`).
+//!
+//! Unlike a regex-based extractor, this walks the PHP AST and matches every
+//! `Route::*` method by structure — so `Route::livewire`, `Route::resource`,
+//! `Route::apiResource`, and any future custom route method surface
+//! automatically without us maintaining a verb allow-list.
+//!
+//! The output is plain data (`RouteOutline`) so it can be memoized through
+//! Salsa and converted to `SymbolEntry` by `document_symbols.rs`.
+
+use tree_sitter::Node;
+
+/// One entry in the route outline tree. Leaf entries are route definitions
+/// (HTTP verbs, `livewire`, `resource`, etc.); container entries are
+/// `Route::group(...)` blocks with their nested routes as children.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RouteOutline {
+    /// HTTP verb or Laravel route method, uppercased: GET, POST, RESOURCE,
+    /// LIVEWIRE, REDIRECT, VIEW, etc. "GROUP" for container entries.
+    pub method: String,
+    /// Full URI including any inherited group prefixes. For groups, the
+    /// group's accumulated prefix (e.g. "/api/admin" for a nested group).
+    pub uri: String,
+    /// Full route name including any inherited group name prefixes, if the
+    /// route is named. For groups, the accumulated name prefix if any.
+    pub name: Option<String>,
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+    /// For group containers, the nested routes/groups in source order.
+    /// For leaf routes, always empty.
+    pub children: Vec<RouteOutline>,
+    /// True for `Route::group(...)` containers.
+    pub is_group: bool,
+}
+
+/// Parse a route file's content and return the outline tree. Returns an
+/// empty vec on parse failure.
+pub fn extract_route_outline(content: &str) -> Vec<RouteOutline> {
+    let Ok(tree) = crate::parser::parse_php(content) else {
+        return Vec::new();
+    };
+    let source = content.as_bytes();
+    let ctx = GroupContext::default();
+    let mut output = Vec::new();
+    walk_statements(tree.root_node(), source, &ctx, &mut output);
+    output
+}
+
+/// Inherited context from enclosing `Route::group(...)` blocks. Accumulated
+/// as we descend; the empty default is the file's top level.
+#[derive(Debug, Clone, Default)]
+struct GroupContext {
+    /// URI prefix (combined `prefix('...')` from all enclosing groups).
+    prefix: String,
+    /// Route name prefix (combined `name('...')` from all enclosing groups).
+    name_prefix: String,
+}
+
+/// Walk a statement list (file root, namespace body, or group closure body)
+/// looking for `Route::*(...)` expression statements.
+fn walk_statements(node: Node, source: &[u8], ctx: &GroupContext, output: &mut Vec<RouteOutline>) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "expression_statement" => {
+                // The expression statement wraps a single expression — find it.
+                let mut inner = child.walk();
+                for expr in child.children(&mut inner) {
+                    if is_call_node(expr) {
+                        process_chain(expr, source, ctx, output);
+                    }
+                }
+            }
+            // Recurse into wrappers that can contain expression statements
+            // (namespaces, compound statements). Closures are handled
+            // separately via `walk_statements` from inside group processing.
+            "namespace_definition" | "compound_statement" => {
+                walk_statements(child, source, ctx, output);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Process a single `Route::method()->method()->...` chain. Decides whether
+/// it's a leaf route definition or a group container, and emits accordingly.
+fn process_chain(chain: Node, source: &[u8], ctx: &GroupContext, output: &mut Vec<RouteOutline>) {
+    let data = collect_chain(chain, source);
+
+    // Bail if the chain doesn't start with `Route::` — we don't want to
+    // emit entries for unrelated method calls that happen to live in a
+    // route file.
+    if !data.is_route_chain {
+        return;
+    }
+
+    if let Some(method) = data.route_method {
+        // Leaf route definition.
+        let route_uri = data.route_uri.unwrap_or_default();
+        let combined_uri = format!("{}{}", ctx.prefix, route_uri);
+        // For leaf routes, `name_arg` is the route's own `->name('foo')` call.
+        let combined_name = data.name_arg.map(|n| format!("{}{}", ctx.name_prefix, n));
+
+        let (start_line, start_column) = pos(chain.start_position());
+        let (end_line, end_column) = pos(chain.end_position());
+
+        output.push(RouteOutline {
+            method: method.to_uppercase(),
+            uri: combined_uri,
+            name: combined_name,
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+            children: Vec::new(),
+            is_group: false,
+        });
+    } else if let Some(closure_node) = data.group_closure {
+        // Group container. Apply this group's modifiers to the inherited
+        // context, then recurse into the closure body with the new context.
+        let prefix_arg = data.prefix_arg.unwrap_or_default();
+        let name_arg = data.name_arg.unwrap_or_default();
+        let new_ctx = GroupContext {
+            prefix: format!("{}{}", ctx.prefix, prefix_arg),
+            name_prefix: format!("{}{}", ctx.name_prefix, name_arg),
+        };
+
+        let mut children = Vec::new();
+        if let Some(body) = closure_node.child_by_field_name("body") {
+            walk_statements(body, source, &new_ctx, &mut children);
+        }
+
+        // Position the group entry at the closure expression itself (not
+        // the wider chain) so it overlaps Zed's tree-sitter "Closure" symbol
+        // at the exact same range — gives the outline UI a chance to dedupe.
+        let (start_line, start_column) = pos(closure_node.start_position());
+        let (end_line, end_column) = pos(closure_node.end_position());
+
+        // Skip empty groups — they're noise.
+        if children.is_empty() {
+            return;
+        }
+
+        output.push(RouteOutline {
+            method: "GROUP".to_string(),
+            uri: new_ctx.prefix,
+            name: if new_ctx.name_prefix.is_empty() {
+                None
+            } else {
+                Some(new_ctx.name_prefix)
+            },
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+            children,
+            is_group: true,
+        });
+    }
+    // Other chains (e.g. `Route::pattern(...)` config calls) are ignored.
+}
+
+/// Data collected from one chain. All fields are populated by walking the
+/// chain from outermost call inward.
+#[derive(Default)]
+struct ChainData<'a> {
+    /// True if the chain's innermost call is `Route::*` (scoped to `Route`).
+    is_route_chain: bool,
+    /// Set when we encounter a route definition method like `get`/`post`.
+    route_method: Option<String>,
+    /// The first string argument to the route method (the URI pattern).
+    route_uri: Option<String>,
+    /// Combined `->name('...')` argument from anywhere in the chain. For
+    /// leaf routes this is the route name; for groups it's the name prefix.
+    name_arg: Option<String>,
+    /// `->prefix('...')` argument (only meaningful for groups).
+    prefix_arg: Option<String>,
+    /// The `anonymous_function_creation_expression` node passed to
+    /// `->group(...)`, if the chain is a group. Tracked instead of just the
+    /// body so the consumer can position the group symbol at the closure's
+    /// own range — this lets the outline merge cleanly with Zed's tree-sitter
+    /// "Closure" symbol that would otherwise appear alongside ours.
+    group_closure: Option<Node<'a>>,
+}
+
+/// Walk a method chain from outermost call inward, collecting each method's
+/// name and relevant arguments into `ChainData`.
+fn collect_chain<'a>(chain: Node<'a>, source: &[u8]) -> ChainData<'a> {
+    let mut data = ChainData::default();
+    let mut current = Some(chain);
+
+    while let Some(node) = current {
+        match node.kind() {
+            "member_call_expression" => {
+                if let Some((name, args)) = method_name_and_args(node, source) {
+                    apply_method(&mut data, &name, args, source);
+                }
+                current = node.child_by_field_name("object");
+            }
+            "scoped_call_expression" => {
+                // Innermost call (`Route::method(...)`). Verify the scope is
+                // `Route` so we don't claim chains like `Foo::bar()->baz()`.
+                if let Some(scope) = node.child_by_field_name("scope") {
+                    if let Ok(scope_text) = scope.utf8_text(source) {
+                        if scope_text == "Route" || scope_text.ends_with("\\Route") {
+                            data.is_route_chain = true;
+                        }
+                    }
+                }
+                if let Some((name, args)) = method_name_and_args(node, source) {
+                    apply_method(&mut data, &name, args, source);
+                }
+                current = None;
+            }
+            _ => {
+                current = None;
+            }
+        }
+    }
+
+    data
+}
+
+/// Apply one method call from the chain to the accumulated data.
+fn apply_method<'a>(data: &mut ChainData<'a>, name: &str, args: Node<'a>, source: &[u8]) {
+    match name {
+        // Route definition methods. The first string argument is the URI.
+        // We don't allow-list these specifically — anything that's not a
+        // known modifier or `group` is treated as a definition. But to keep
+        // false positives low, we still match against the common methods.
+        "get" | "post" | "put" | "patch" | "delete" | "options" | "any" | "match" | "view"
+        | "redirect" | "fallback" | "livewire" | "resource" | "apiResource" | "singleton"
+        | "apiSingleton" | "permanentRedirect" => {
+            data.route_method = Some(name.to_string());
+            data.route_uri = first_string_arg(args, source);
+        }
+
+        // Group container. The closure argument is the group body.
+        "group" => {
+            data.group_closure = find_closure_node(args);
+        }
+
+        // Modifiers — meaning depends on whether we end up as route or group.
+        "prefix" => {
+            data.prefix_arg = first_string_arg(args, source);
+        }
+        // `as()` is an alias for `name()` in Laravel.
+        "name" | "as" => {
+            data.name_arg = first_string_arg(args, source);
+        }
+
+        // Modifiers we don't currently visualize: middleware, withoutMiddleware,
+        // domain, where, whereNumber, whereAlpha, controller, etc.
+        _ => {}
+    }
+}
+
+/// Get the method `name:` and `arguments:` fields from a call node.
+fn method_name_and_args<'a>(node: Node<'a>, source: &[u8]) -> Option<(String, Node<'a>)> {
+    let name = node
+        .child_by_field_name("name")?
+        .utf8_text(source)
+        .ok()?
+        .to_string();
+    let args = node.child_by_field_name("arguments")?;
+    Some((name, args))
+}
+
+/// Extract the first string literal from an arguments list. Handles both
+/// `'single-quoted'` and `"double-quoted"` forms (tree-sitter-php names them
+/// `string` and `encapsed_string` respectively).
+fn first_string_arg(args: Node, source: &[u8]) -> Option<String> {
+    let mut cursor = args.walk();
+    for arg in args.children(&mut cursor) {
+        if arg.kind() != "argument" {
+            continue;
+        }
+        let mut arg_cursor = arg.walk();
+        for inner in arg.children(&mut arg_cursor) {
+            match inner.kind() {
+                "string" | "encapsed_string" => {
+                    return read_string_content(inner, source);
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+/// Read the inner content of a `string` / `encapsed_string` node, stripping
+/// the surrounding quotes. tree-sitter exposes a `string_content` child for
+/// the body; if it's missing (rare), fall back to trimming the raw text.
+fn read_string_content(node: Node, source: &[u8]) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "string_content" {
+            return child.utf8_text(source).ok().map(|s| s.to_string());
+        }
+    }
+    // Fallback: strip the leading/trailing quote chars from the raw node.
+    node.utf8_text(source).ok().map(|s| {
+        s.trim_start_matches(['\'', '"'])
+            .trim_end_matches(['\'', '"'])
+            .to_string()
+    })
+}
+
+/// Find the closure expression node inside an arguments list. Handles both
+/// the modern `Route::group(function () { ... })` form and the legacy
+/// `Route::group(['prefix' => '/x'], function () { ... })` form by scanning
+/// every argument for an anonymous-function node. Returns the closure
+/// expression itself (not its body) so callers can use its range.
+fn find_closure_node(args: Node) -> Option<Node> {
+    let mut cursor = args.walk();
+    for arg in args.children(&mut cursor) {
+        if arg.kind() != "argument" {
+            continue;
+        }
+        let mut arg_cursor = arg.walk();
+        for inner in arg.children(&mut arg_cursor) {
+            if inner.kind() == "anonymous_function_creation_expression"
+                || inner.kind() == "anonymous_function"
+                || inner.kind() == "arrow_function"
+            {
+                return Some(inner);
+            }
+        }
+    }
+    None
+}
+
+fn is_call_node(node: Node) -> bool {
+    matches!(
+        node.kind(),
+        "member_call_expression" | "scoped_call_expression"
+    )
+}
+
+fn pos(point: tree_sitter::Point) -> (u32, u32) {
+    (point.row as u32, point.column as u32)
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/route_outline/tests.rs
+++ b/laravel-lsp/src/route_outline/tests.rs
@@ -1,0 +1,291 @@
+//! Tests for the tree-sitter route outline walker.
+
+use super::*;
+
+fn names(routes: &[RouteOutline]) -> Vec<String> {
+    routes
+        .iter()
+        .map(|r| {
+            if r.is_group {
+                format!("GROUP {}", r.uri)
+            } else {
+                format!("{} {}", r.method, r.uri)
+            }
+        })
+        .collect()
+}
+
+// ============================================================================
+// Empty / non-route inputs
+// ============================================================================
+
+#[test]
+fn empty_input_returns_empty() {
+    assert!(extract_route_outline("").is_empty());
+}
+
+#[test]
+fn non_route_chain_is_ignored() {
+    // `Foo::bar()` should not be claimed as a route.
+    let content = "<?php\nFoo::bar('/x', fn () => 1);\n";
+    assert!(extract_route_outline(content).is_empty());
+}
+
+// ============================================================================
+// Simple route definitions
+// ============================================================================
+
+#[test]
+fn extracts_bare_get_route() {
+    let content = "<?php\nRoute::get('/users', fn () => 1);\n";
+    let routes = extract_route_outline(content);
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].method, "GET");
+    assert_eq!(routes[0].uri, "/users");
+    assert!(routes[0].name.is_none());
+    assert!(!routes[0].is_group);
+}
+
+#[test]
+fn extracts_named_route() {
+    let content = "<?php\nRoute::get('/users', fn () => 1)->name('users.index');\n";
+    let routes = extract_route_outline(content);
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].method, "GET");
+    assert_eq!(routes[0].uri, "/users");
+    assert_eq!(routes[0].name.as_deref(), Some("users.index"));
+}
+
+#[test]
+fn extracts_all_standard_verbs() {
+    let content = r#"<?php
+Route::get('/a', fn () => 1);
+Route::post('/b', fn () => 1);
+Route::put('/c', fn () => 1);
+Route::patch('/d', fn () => 1);
+Route::delete('/e', fn () => 1);
+Route::options('/f', fn () => 1);
+"#;
+    let routes = extract_route_outline(content);
+    let expected = vec![
+        "GET /a",
+        "POST /b",
+        "PUT /c",
+        "PATCH /d",
+        "DELETE /e",
+        "OPTIONS /f",
+    ];
+    assert_eq!(names(&routes), expected);
+}
+
+#[test]
+fn extracts_laravel_route_methods() {
+    // The verb-set the regex extractor missed in Mike's project.
+    let content = r#"<?php
+Route::livewire('/release-notes', ReleaseNotes::class);
+Route::resource('/posts', PostController::class);
+Route::apiResource('/api/posts', PostController::class);
+Route::view('/about', 'pages.about');
+Route::redirect('/old', '/new');
+Route::permanentRedirect('/legacy', '/current');
+"#;
+    let routes = extract_route_outline(content);
+    let expected = vec![
+        "LIVEWIRE /release-notes",
+        "RESOURCE /posts",
+        "APIRESOURCE /api/posts",
+        "VIEW /about",
+        "REDIRECT /old",
+        "PERMANENTREDIRECT /legacy",
+    ];
+    assert_eq!(names(&routes), expected);
+}
+
+// ============================================================================
+// Multi-line route definitions
+// ============================================================================
+
+#[test]
+fn extracts_multi_line_route_definition() {
+    let content = r#"<?php
+Route::get(
+    '/users/{user}',
+    [UserController::class, 'show']
+)->name('users.show');
+"#;
+    let routes = extract_route_outline(content);
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].uri, "/users/{user}");
+    assert_eq!(routes[0].name.as_deref(), Some("users.show"));
+}
+
+// ============================================================================
+// Groups: prefix
+// ============================================================================
+
+#[test]
+fn group_with_prefix_combines_uri() {
+    let content = r#"<?php
+Route::prefix('/api')->group(function () {
+    Route::get('/users', fn () => 1)->name('users');
+    Route::post('/users', fn () => 1)->name('users.store');
+});
+"#;
+    let routes = extract_route_outline(content);
+    assert_eq!(routes.len(), 1);
+    assert!(routes[0].is_group);
+    assert_eq!(routes[0].method, "GROUP");
+    assert_eq!(routes[0].uri, "/api");
+    assert_eq!(routes[0].children.len(), 2);
+    assert_eq!(routes[0].children[0].method, "GET");
+    assert_eq!(routes[0].children[0].uri, "/api/users");
+    assert_eq!(routes[0].children[0].name.as_deref(), Some("users"));
+    assert_eq!(routes[0].children[1].method, "POST");
+    assert_eq!(routes[0].children[1].uri, "/api/users");
+    assert_eq!(routes[0].children[1].name.as_deref(), Some("users.store"));
+}
+
+// ============================================================================
+// Groups: name prefix
+// ============================================================================
+
+#[test]
+fn group_with_name_combines_route_names() {
+    let content = r#"<?php
+Route::name('api.')->group(function () {
+    Route::get('/users', fn () => 1)->name('users');
+});
+"#;
+    let routes = extract_route_outline(content);
+    assert_eq!(routes.len(), 1);
+    assert!(routes[0].is_group);
+    assert_eq!(routes[0].children.len(), 1);
+    assert_eq!(routes[0].children[0].name.as_deref(), Some("api.users"));
+}
+
+// ============================================================================
+// Groups: combined modifiers in any order
+// ============================================================================
+
+#[test]
+fn group_with_middleware_prefix_name_combined() {
+    // The pattern from Mike's actual project.
+    let content = r#"<?php
+Route::middleware('security')->prefix('/security')->name('security.')->group(function () {
+    Route::name('questions.')->group(function () {
+        Route::get('/questions', fn () => 1)->name('create');
+        Route::post('/questions', fn () => 1)->name('store');
+    });
+});
+"#;
+    let routes = extract_route_outline(content);
+    assert_eq!(routes.len(), 1);
+
+    let outer = &routes[0];
+    assert!(outer.is_group);
+    assert_eq!(outer.uri, "/security");
+    assert_eq!(outer.name.as_deref(), Some("security."));
+    assert_eq!(outer.children.len(), 1);
+
+    let inner = &outer.children[0];
+    assert!(inner.is_group);
+    assert_eq!(inner.uri, "/security"); // inner has no prefix; inherits outer's
+    assert_eq!(inner.name.as_deref(), Some("security.questions."));
+    assert_eq!(inner.children.len(), 2);
+
+    assert_eq!(inner.children[0].method, "GET");
+    assert_eq!(inner.children[0].uri, "/security/questions");
+    assert_eq!(
+        inner.children[0].name.as_deref(),
+        Some("security.questions.create")
+    );
+    assert_eq!(inner.children[1].method, "POST");
+    assert_eq!(inner.children[1].uri, "/security/questions");
+    assert_eq!(
+        inner.children[1].name.as_deref(),
+        Some("security.questions.store")
+    );
+}
+
+// ============================================================================
+// Groups: modifiers in different orders
+// ============================================================================
+
+#[test]
+fn modifier_order_does_not_matter() {
+    // `name('x.')->prefix('/x')->group(...)` should behave the same as
+    // `prefix('/x')->name('x.')->group(...)`.
+    let content = r#"<?php
+Route::name('x.')->prefix('/x')->group(function () {
+    Route::get('/show', fn () => 1)->name('show');
+});
+"#;
+    let routes = extract_route_outline(content);
+    assert_eq!(routes[0].children[0].uri, "/x/show");
+    assert_eq!(routes[0].children[0].name.as_deref(), Some("x.show"));
+}
+
+// ============================================================================
+// Groups: `as()` alias for `name()`
+// ============================================================================
+
+#[test]
+fn as_alias_works_like_name() {
+    let content = r#"<?php
+Route::as('api.')->group(function () {
+    Route::get('/users', fn () => 1)->name('users');
+});
+"#;
+    let routes = extract_route_outline(content);
+    assert_eq!(routes[0].children[0].name.as_deref(), Some("api.users"));
+}
+
+// ============================================================================
+// Edge: empty groups
+// ============================================================================
+
+#[test]
+fn empty_group_is_omitted() {
+    let content = r#"<?php
+Route::prefix('/api')->group(function () {
+});
+"#;
+    let routes = extract_route_outline(content);
+    assert!(
+        routes.is_empty(),
+        "empty groups shouldn't clutter the outline"
+    );
+}
+
+// ============================================================================
+// Edge: routes outside groups mixed with groups
+// ============================================================================
+
+#[test]
+fn mixed_top_level_and_grouped_routes() {
+    let content = r#"<?php
+Route::get('/', fn () => 1)->name('home');
+Route::prefix('/api')->group(function () {
+    Route::get('/users', fn () => 1)->name('api.users');
+});
+Route::get('/about', fn () => 1)->name('about');
+"#;
+    let routes = extract_route_outline(content);
+    assert_eq!(routes.len(), 3);
+    assert_eq!(routes[0].uri, "/");
+    assert!(routes[1].is_group);
+    assert_eq!(routes[1].children[0].uri, "/api/users");
+    assert_eq!(routes[2].uri, "/about");
+}
+
+// ============================================================================
+// Position tracking
+// ============================================================================
+
+#[test]
+fn positions_are_zero_based() {
+    let content = "<?php\nRoute::get('/x', fn () => 1);\n";
+    let routes = extract_route_outline(content);
+    assert_eq!(routes[0].start_line, 1, "second line is index 1");
+    assert_eq!(routes[0].start_column, 0, "line starts at column 0");
+}

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -997,7 +997,7 @@ pub fn extract_document_symbols(
 ) -> Vec<crate::document_symbols::SymbolEntry> {
     let path = file.path(db);
     let text = file.text(db);
-    let kind = crate::document_symbols::classify_file(path, text);
+    let kind = crate::document_symbols::classify_file(path);
     crate::document_symbols::extract_symbols(text, kind)
 }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -987,6 +987,20 @@ pub fn parse_blade_php_assignments(db: &dyn Db, file: SourceFile) -> Vec<(String
     crate::blade_php_block::extract_php_block_assignments(text)
 }
 
+/// Extract the document-symbol tree for a file (route file, Blade template,
+/// Livewire component, or Eloquent model). Returns an empty vec for other file
+/// kinds. Memoized: only re-runs when the file's text changes.
+#[salsa::tracked]
+pub fn extract_document_symbols(
+    db: &dyn Db,
+    file: SourceFile,
+) -> Vec<crate::document_symbols::SymbolEntry> {
+    let path = file.path(db);
+    let text = file.text(db);
+    let kind = crate::document_symbols::classify_file(path, text);
+    crate::document_symbols::extract_symbols(text, kind)
+}
+
 /// Resolve a `$this->X` member access against a Livewire component's PHP file.
 /// Tries property type first, then method return type. Memoized per (file_version, member).
 #[salsa::tracked]
@@ -2505,6 +2519,11 @@ pub enum SalsaRequest {
         path: PathBuf,
         reply: oneshot::Sender<Option<Arc<Vec<(String, String)>>>>,
     },
+    /// Get the document-symbol tree for a file (drives textDocument/documentSymbol)
+    GetDocumentSymbols {
+        path: PathBuf,
+        reply: oneshot::Sender<Option<Arc<Vec<crate::document_symbols::SymbolEntry>>>>,
+    },
     /// Resolve a `$this->X` member access in a Livewire component PHP file
     /// (auto-registers the file as a Salsa input via mtime-based invalidation).
     ResolveLivewireMember {
@@ -2785,6 +2804,25 @@ impl SalsaHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(SalsaRequest::GetPhpAssignments {
+                path,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Get the document-symbol tree for a file. Powers textDocument/documentSymbol.
+    /// Memoized — returns the same Arc on repeated calls until the file version changes.
+    pub async fn get_document_symbols(
+        &self,
+        path: PathBuf,
+    ) -> Result<Option<Arc<Vec<crate::document_symbols::SymbolEntry>>>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::GetDocumentSymbols {
                 path,
                 reply: reply_tx,
             })
@@ -3447,6 +3485,11 @@ pub struct SalsaActor {
     loop_blocks_cache: LruCache<PathBuf, (i32, Arc<Vec<crate::blade_loops::BladeLoopBlock>>)>,
     /// LRU cache of parsed `@php ... @endphp` block assignments, keyed by file path + version.
     php_assignments_cache: LruCache<PathBuf, (i32, Arc<Vec<(String, String)>>)>,
+    /// LRU cache of document-symbol trees keyed by file path. Stores file
+    /// version alongside the cached Arc so a version mismatch triggers a
+    /// recompute via the memoized Salsa query.
+    document_symbols_cache:
+        LruCache<PathBuf, (i32, Arc<Vec<crate::document_symbols::SymbolEntry>>)>,
     /// Tracks the on-disk mtime of Livewire component PHP files registered as Salsa inputs.
     /// These files are not opened in the editor (no `did_open`/`did_change` events), so we
     /// invalidate by comparing filesystem mtime on each access.
@@ -3523,6 +3566,7 @@ impl SalsaActor {
                 pattern_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 loop_blocks_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 php_assignments_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
+                document_symbols_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 livewire_mtimes: HashMap::with_capacity(64),
                 livewire_version_counter: 0,
                 // Config management
@@ -3591,6 +3635,10 @@ impl SalsaActor {
                     let result = self.handle_get_php_assignments(&path);
                     let _ = reply.send(result);
                 }
+                SalsaRequest::GetDocumentSymbols { path, reply } => {
+                    let result = self.handle_get_document_symbols(&path);
+                    let _ = reply.send(result);
+                }
                 SalsaRequest::ResolveLivewireMember {
                     path,
                     member,
@@ -3604,6 +3652,7 @@ impl SalsaActor {
                     self.pattern_cache.pop(&path);
                     self.loop_blocks_cache.pop(&path);
                     self.php_assignments_cache.pop(&path);
+                    self.document_symbols_cache.pop(&path);
                     let _ = reply.send(());
                 }
 
@@ -3866,6 +3915,7 @@ impl SalsaActor {
         self.pattern_cache.pop(&path);
         self.loop_blocks_cache.pop(&path);
         self.php_assignments_cache.pop(&path);
+        self.document_symbols_cache.pop(&path);
 
         if let Some(file) = self.files.get(&path) {
             // Update existing file
@@ -3950,6 +4000,27 @@ impl SalsaActor {
         let assignments = parse_blade_php_assignments(&self.db, *file);
         let arc = Arc::new(assignments);
         self.php_assignments_cache
+            .put(path.clone(), (version, Arc::clone(&arc)));
+        Some(arc)
+    }
+
+    /// Handle a document-symbol query. Memoized via Salsa + actor LRU.
+    fn handle_get_document_symbols(
+        &mut self,
+        path: &PathBuf,
+    ) -> Option<Arc<Vec<crate::document_symbols::SymbolEntry>>> {
+        let file = self.files.get(path)?;
+        let version = file.version(&self.db);
+
+        if let Some((cached_version, cached)) = self.document_symbols_cache.get(path) {
+            if *cached_version == version {
+                return Some(Arc::clone(cached));
+            }
+        }
+
+        let symbols = extract_document_symbols(&self.db, *file);
+        let arc = Arc::new(symbols);
+        self.document_symbols_cache
             .put(path.clone(), (version, Arc::clone(&arc)));
         Some(arc)
     }


### PR DESCRIPTION
Fixes #12.

## Summary

Implements `textDocument/documentSymbol` so outline-supporting editors get Laravel-aware structure. Supports four file kinds:

| File kind | What appears in the outline |
|---|---|
| `routes/*.php` | `METHOD URI` per `Route::verb()` call, with `[name=…]` detail when present |
| `*.blade.php` | `@section` / `@push` / `@prepend` / `@component` with nested children; `@yield` / `@stack` / `@extends` as leaves |
| Livewire components | Class + **public** properties and methods |
| Eloquent models | Class + relationship methods (HasMany/BelongsTo/…) + `scope*` methods |
| Plain `.php` files | All top-level classes/interfaces/traits/enums + all members (any visibility) + free functions |

## Zed compatibility note

Zed's outline panel is tree-sitter-driven by default — LSP `documentSymbol` only fires when users opt in via [zed-industries/zed#48780](https://github.com/zed-industries/zed/pull/48780):

```json
{
  "languages": {
    "PHP": {
      "document_symbols": "on"
    },
    "Blade": {
      "document_symbols": "on"
    }
  }
}
```

This setting *replaces* tree-sitter outlines with LSP outlines per-language (it's a switch, not a merge). To make enabling it a strict upgrade rather than a regression on plain PHP files (controllers, jobs, services), the plain-PHP path emits full tree-sitter-parity structure plus our Laravel-aware sugar.

Other LSP-using editors (Helix, Neovim, Sublime/LSP, Kate) call `documentSymbol` unconditionally — they get the outlines with no opt-in.

## Architecture

- **Routes and Blade**: regex-based extraction (their syntaxes don't need a full parser).
- **PHP class structure**: new [`php_outline`](laravel-lsp/src/php_outline.rs) module using `tree-sitter-php`. Returns `PhpFileStructure` with all classes/interfaces/traits/enums + methods + properties + free functions. Visibility and return types preserved.
- **Specialisation**: Livewire and Eloquent extractors filter the structured output (public-only / relationship+scope). Plain PHP emits everything.
- **Memoization**: existing Salsa actor pattern — new `extract_document_symbols` `#[salsa::tracked]` query plus an LRU cache, invalidated alongside other per-file caches on `did_change` and `RemoveFile`. Mirrors `parse_blade_loop_blocks` exactly.
- **LSP conversion**: `SymbolEntry` → `tower_lsp::DocumentSymbol` happens in `main.rs` so the extractor modules stay LSP-agnostic and easy to unit-test.

## Acceptance criteria

- [x] Implement `Backend::document_symbol()` in `main.rs`
- [x] Declare `document_symbol_provider` capability during `initialize`
- [x] Return hierarchical `DocumentSymbol` tree (not flat `SymbolInformation`)
- [x] Route files — each `Route::verb` as a symbol with `METHOD URI [name=…]` label
- [x] Blade files — `@section`, `@push`, `@yield`, `@stack`, `@component`, `@extends` with nesting
- [x] Livewire components — public properties and public methods
- [x] Eloquent models — relationship methods + query scopes
- [x] Plain PHP files — full class structure (any visibility) + interfaces / traits / enums / free functions (parity with tree-sitter outline.scm)
- [x] Tests covering each file kind + classification + dispatch
- [x] 0-based positions throughout
- [x] Cached via Salsa

## Test plan

- [x] `cargo test` — 162 lib tests pass (17 new in this PR), 147 bin tests pass, 79 integration tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo build --release` clean
- [ ] Manual (Zed): with `"document_symbols": "on"` enabled, open `routes/web.php` and confirm route entries populate
- [ ] Manual (Zed): open a Blade file with nested `@section`/`@push` and confirm hierarchy renders
- [ ] Manual (Zed): open a Livewire component and confirm only public members appear
- [ ] Manual (Zed): open an Eloquent model and confirm relationships + scopes appear without other public methods
- [ ] Manual (Zed): open a controller and confirm all methods (public/protected/private) appear (strict-upgrade vs tree-sitter outline)
- [ ] Manual (Zed): open a `helpers.php`-style file with free functions and confirm they appear
- [ ] Documentation: README updated with Zed `document_symbols: on` setup note before merge