### PR TITLE
feat: Eloquent query builder chain completion (#11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ laravel-lsp-binary
 # Environment files
 .env
 .env.local
+MEMORY.md

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,1 @@
+- [Session 2026-05-27: Issue #11 chain completion](../../../.claude/projects/-Users-mike-Developer-zed-laravel/memory/session_chain_completion_2026-05-27.md) — Multi-phase Eloquent builder completion work, draft PR#21, 12 commits

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,1 +1,0 @@
-- [Session 2026-05-27: Issue #11 chain completion](../../../.claude/projects/-Users-mike-Developer-zed-laravel/memory/session_chain_completion_2026-05-27.md) — Multi-phase Eloquent builder completion work, draft PR#21, 12 commits

--- a/laravel-lsp/build.rs
+++ b/laravel-lsp/build.rs
@@ -39,7 +39,7 @@ fn main() {
 /// expose them through `env!()` for inclusion in the startup banner.
 fn emit_build_metadata() {
     let git_hash = std::process::Command::new("git")
-        .args(["rev-parse", "--short=12", "HEAD"])
+        .args(["rev-parse", "--short=5", "HEAD"])
         .output()
         .ok()
         .and_then(|out| {

--- a/laravel-lsp/build.rs
+++ b/laravel-lsp/build.rs
@@ -10,6 +10,12 @@ fn main() {
     // Tell Cargo to re-run this build script if it changes
     println!("cargo:rerun-if-changed=build.rs");
 
+    // Emit build-time metadata so the LSP startup banner can identify
+    // which binary is actually running. Useful when "did Zed pick up
+    // the new build?" comes up — the user matches the short hash to
+    // a known commit.
+    emit_build_metadata();
+
     // Get the output directory where Cargo puts build artifacts
     // OUT_DIR is set by Cargo and points to target/debug/build/<package>/out
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
@@ -27,6 +33,40 @@ fn main() {
 
     // Compile the Blade grammar's C code
     compile_blade_grammar(&grammar_dir);
+}
+
+/// Capture the current git short-hash + dirty-state at build time and
+/// expose them through `env!()` for inclusion in the startup banner.
+fn emit_build_metadata() {
+    let git_hash = std::process::Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let dirty = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .map(|out| !out.stdout.is_empty())
+        .unwrap_or(false);
+
+    let suffix = if dirty { "-dirty" } else { "" };
+    println!("cargo:rustc-env=LARAVEL_LSP_GIT_HASH={git_hash}{suffix}");
+
+    // Best-effort re-run triggers. Cargo can't depend on "is the
+    // working tree dirty," but `.git/HEAD` and `.git/index` cover
+    // commits and `git add`. Out-of-band edits won't bust the cache
+    // — full clean builds will pick them up.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
 }
 
 /// Downloads the tree-sitter-blade grammar from GitHub and extracts it

--- a/laravel-lsp/src/blade_embedded_php.rs
+++ b/laravel-lsp/src/blade_embedded_php.rs
@@ -35,6 +35,13 @@ pub struct BladePhpRegion {
     pub content: String,
     pub row: u32,
     pub column: u32,
+    /// Byte offset of the **content** in the outer Blade file — the first
+    /// byte of `content` lives at `source[byte_offset]`. Used by features
+    /// (e.g. chain extraction) that need to translate snippet-local byte
+    /// ranges back to outer-file coordinates: a token at snippet byte `N`
+    /// (after the `<?php ` wrapper) lives at outer byte
+    /// `byte_offset + (N - PHP_WRAPPER_PREFIX_LEN)`.
+    pub byte_offset: usize,
 }
 
 /// Extract every PHP region from a Blade source. Returns regions in source
@@ -53,6 +60,7 @@ pub fn extract_php_regions(source: &str) -> Vec<BladePhpRegion> {
                     content: echo.php_content.to_string(),
                     row: echo.row as u32,
                     column: echo.column as u32,
+                    byte_offset: echo.byte_start,
                 });
             }
         }
@@ -60,11 +68,26 @@ pub fn extract_php_regions(source: &str) -> Vec<BladePhpRegion> {
 
     // `@php ... @endphp` blocks. The Blade grammar's representation here is
     // uneven across tree-sitter-blade versions, so we lean on regex to get
-    // byte-accurate body positions. The body's first character sits on the
-    // line AFTER the `@php` directive (when written as a block); inline
-    // `@php(...)` form is captured too.
+    // byte-accurate body positions.
     regions.extend(extract_php_block_regions(source));
 
+    // `@php(...)` inline form. Needs a balanced-paren walker because the
+    // body may contain its own parens (`@php($x = route('home', ['a']))`).
+    // Regex can't do this; the walker is small and self-contained.
+    regions.extend(extract_php_inline_regions(source));
+
+    // Dedupe by byte_offset: tree-sitter-blade's `_raw` rule (which fires
+    // for `@php ... @endphp` blocks) also produces a `php_only` node, so
+    // the tree-sitter pass above AND the regex pass below both capture the
+    // same block region. Without dedup, downstream consumers re-process
+    // the same content twice — historically harmless for routes/views but
+    // problematic for chain extraction, where duplicate chains pollute the
+    // position index. Keep the first occurrence (typically the tree-sitter
+    // one, which has the same content but is captured earlier here).
+    regions.sort_by_key(|r| (r.byte_offset, r.content.len()));
+    regions.dedup_by(|a, b| a.byte_offset == b.byte_offset);
+
+    // Stable sort by row/column for the public ordering contract.
     regions.sort_by_key(|r| (r.row, r.column));
     regions
 }
@@ -118,9 +141,107 @@ fn extract_php_block_regions(source: &str) -> Vec<BladePhpRegion> {
             content: body_match.as_str().to_string(),
             row,
             column: col,
+            byte_offset: body_match.start(),
         });
     }
     regions
+}
+
+/// Find `@php(expression)` inline regions. Walks balanced parentheses so
+/// inner parens (`@php($x = route('home', ['a']))`) are matched correctly.
+/// String content is paren-skipped so embedded `(` / `)` inside `'...'` or
+/// `"..."` don't throw off the counter. Escapes inside strings are honoured.
+///
+/// Returns the PHP body (the expression between `@php(` and the matching
+/// `)`), along with its row/column/byte_offset in the Blade source.
+fn extract_php_inline_regions(source: &str) -> Vec<BladePhpRegion> {
+    let bytes = source.as_bytes();
+    let needle = b"@php(";
+    let mut regions = Vec::new();
+    let mut search_from = 0usize;
+
+    while let Some(rel) = find_subslice(bytes, needle, search_from) {
+        let body_start = rel + needle.len();
+        let Some(body_end) = match_balanced_paren_close(bytes, body_start) else {
+            // Unmatched paren — skip this `@php(` and keep searching.
+            search_from = body_start;
+            continue;
+        };
+        // Skip if body is empty — nothing to parse.
+        if body_end > body_start {
+            let content = source[body_start..body_end].to_string();
+            let (row, col) = byte_offset_to_row_col(source, body_start);
+            regions.push(BladePhpRegion {
+                content,
+                row,
+                column: col,
+                byte_offset: body_start,
+            });
+        }
+        // Continue scanning after the closing `)` so nested `@php(` calls
+        // (rare but legal) are still found.
+        search_from = body_end + 1;
+    }
+
+    regions
+}
+
+/// Find the first occurrence of `needle` in `haystack` starting at `from`.
+/// Returns the byte offset of the first byte of the match.
+fn find_subslice(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
+    if from >= haystack.len() {
+        return None;
+    }
+    haystack[from..]
+        .windows(needle.len())
+        .position(|w| w == needle)
+        .map(|p| p + from)
+}
+
+/// Walk forward from `start` (the byte AFTER an opening `(`) looking for the
+/// matching `)` at depth zero. Single/double quoted strings are treated as
+/// opaque blocks — parens inside them don't affect depth, and backslash
+/// escapes inside double-quoted strings advance past the next byte.
+fn match_balanced_paren_close(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut depth: i32 = 1;
+    let mut i = start;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            b'\'' => {
+                // Single-quoted string: only `\'` and `\\` are escapes in PHP.
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'\'' {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                }
+            }
+            b'"' => {
+                // Double-quoted string: more escape sequences, but for paren
+                // matching we only care about skipping the string contents.
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'"' {
+                    if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                        continue;
+                    }
+                    i += 1;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Convert a UTF-8 byte offset into a `(row, column)` tuple, both 0-based.

--- a/laravel-lsp/src/blade_embedded_php/tests.rs
+++ b/laravel-lsp/src/blade_embedded_php/tests.rs
@@ -98,3 +98,70 @@ fn adjust_inner_position_handles_token_at_prefix_boundary() {
     let (_, col) = adjust_inner_position(0, 0, 3, 12);
     assert_eq!(col, 12);
 }
+
+// ---- byte_offset & cross-shape coverage probes -------------------------
+
+#[test]
+fn echo_region_records_byte_offset() {
+    let src = "x{{ route('home') }}y";
+    let regions = extract_php_regions(src);
+    assert_eq!(regions.len(), 1);
+    let region = &regions[0];
+    // The content is " route('home') " (with surrounding spaces inside the
+    // braces). The byte_offset points at the first byte of that content in
+    // the outer source.
+    let extracted_byte = region.byte_offset;
+    let extracted = &src[extracted_byte..extracted_byte + region.content.len()];
+    assert_eq!(
+        extracted, region.content,
+        "byte_offset doesn't point at the content slice"
+    );
+}
+
+#[test]
+fn php_block_region_records_byte_offset() {
+    let src = "x\n@php\n  $url = route('home');\n@endphp\ny";
+    let regions = extract_php_regions(src);
+    let block = regions
+        .iter()
+        .find(|r| r.content.contains("route('home')"))
+        .expect("@php block");
+    let extracted = &src[block.byte_offset..block.byte_offset + block.content.len()];
+    assert_eq!(extracted, block.content);
+}
+
+#[test]
+fn native_php_tag_is_captured() {
+    // <?php ... ?> inside a Blade file. The Blade grammar's _php rule has
+    // a `php_only` alias for the content, which the existing query
+    // `(php_statement (php_only) @echo_php_content)` should match.
+    let src = "<?php $x = route('home'); ?>";
+    let regions = extract_php_regions(src);
+    let captured: Vec<_> = regions
+        .iter()
+        .filter(|r| r.content.contains("route('home')"))
+        .collect();
+    assert!(
+        !captured.is_empty(),
+        "<?php ... ?> region not captured. regions: {:?}",
+        regions
+    );
+}
+
+#[test]
+fn php_inline_short_form_is_captured() {
+    // @php($x = route('home')) — the inline form. The doc comment notes
+    // this was historically skipped; this test pins whether Phase 3.5's
+    // expanded extractor catches it.
+    let src = "@php($x = route('home'))";
+    let regions = extract_php_regions(src);
+    let captured: Vec<_> = regions
+        .iter()
+        .filter(|r| r.content.contains("route('home')"))
+        .collect();
+    assert!(
+        !captured.is_empty(),
+        "@php(...) inline region not captured. regions: {:?}",
+        regions
+    );
+}

--- a/laravel-lsp/src/class_locator.rs
+++ b/laravel-lsp/src/class_locator.rs
@@ -29,6 +29,14 @@ use walkdir::WalkDir;
 /// found. Does not parse the file to verify the class name inside — relies on
 /// Laravel's strong convention that file basename matches class name.
 pub fn find_php_class_file(class_name: &str, root: &Path) -> Option<PathBuf> {
+    // Try the namespace-aware path mapping first — `App\Models\User`
+    // should land at `app/Models/User.php`, not at the first `User.php`
+    // we happen to walk into (which could be `app/Nova/User.php` or
+    // similar). Falls back to a basename walk under app/ if the FQCN
+    // doesn't map to an existing file.
+    if let Some(path) = find_php_class_file_by_fqcn(class_name, root, false) {
+        return Some(path);
+    }
     find_php_class_file_impl(class_name, root, false)
 }
 
@@ -42,13 +50,95 @@ pub fn find_php_class_file(class_name: &str, root: &Path) -> Option<PathBuf> {
 /// (≤10 levels) and the result is cached behind ModelMetadata anyway.
 /// app/-side definitions still win — they're checked first.
 pub fn find_php_class_file_in_app_or_vendor(class_name: &str, root: &Path) -> Option<PathBuf> {
-    // Check app/src first — a project-local class always shadows a vendor
-    // class of the same basename. Only fall back to vendor when nothing
-    // matched in app/.
+    // Try FQCN-aware lookup across app/ AND vendor/ first. If neither
+    // PSR-4-shaped path exists, fall through to a basename walk —
+    // again preferring app/ over vendor/ since project classes shadow
+    // vendor classes with matching basenames.
+    if let Some(path) = find_php_class_file_by_fqcn(class_name, root, false) {
+        return Some(path);
+    }
+    if let Some(path) = find_php_class_file_by_fqcn(class_name, root, true) {
+        return Some(path);
+    }
     if let Some(path) = find_php_class_file_impl(class_name, root, false) {
         return Some(path);
     }
     find_php_class_file_impl(class_name, root, true)
+}
+
+/// Map a fully-qualified class name to its source file path using
+/// Laravel/Composer conventions:
+///
+/// - `App\Models\User` → `app/Models/User.php` (or `src/Models/User.php`
+///   for projects that use `src/` for app code)
+/// - `Laravel\Passport\Token` → `vendor/laravel/passport/src/Token.php`
+///   (lowercased vendor + package, then `src/`, then remaining
+///   namespace segments as path components)
+/// - `Spatie\Permission\Models\Role` →
+///   `vendor/spatie/permission/src/Models/Role.php`
+///
+/// `search_vendor`: when `true`, only consider the vendor/ mapping;
+/// when `false`, only consider the App/ mapping. Callers chain both
+/// modes to cover the realistic search space.
+///
+/// Returns `None` if no candidate path exists on disk. The caller then
+/// falls back to a basename walk so we still resolve unconventional
+/// PSR-4 layouts.
+fn find_php_class_file_by_fqcn(
+    fqcn: &str,
+    project_root: &Path,
+    search_vendor: bool,
+) -> Option<PathBuf> {
+    let segments: Vec<&str> = fqcn.split('\\').filter(|s| !s.is_empty()).collect();
+    if segments.is_empty() {
+        return None;
+    }
+    let class_name = *segments.last().unwrap();
+    let ns_segments = &segments[..segments.len() - 1];
+
+    if !search_vendor {
+        // App\Models\User → app/Models/User.php (and src/ alternative for
+        // projects that use src/ for app code).
+        if ns_segments.first().map(|s| s.to_ascii_lowercase()) == Some("app".to_string()) {
+            let rest = &ns_segments[1..];
+            for app_dir in ["app", "src"] {
+                let mut path = project_root.join(app_dir);
+                for seg in rest {
+                    path = path.join(seg);
+                }
+                path = path.join(format!("{class_name}.php"));
+                if path.exists() {
+                    return Some(path);
+                }
+            }
+        }
+        return None;
+    }
+
+    // Vendor convention: lowercase first two segments → package
+    // directory; remaining segments are paths under `src/` (or under
+    // the package root if `src/` doesn't exist for this package).
+    if ns_segments.len() < 2 {
+        return None;
+    }
+    let vendor = ns_segments[0].to_ascii_lowercase();
+    let pkg = ns_segments[1].to_ascii_lowercase();
+    let rest = &ns_segments[2..];
+
+    for src_segment in ["src", ""] {
+        let mut path = project_root.join("vendor").join(&vendor).join(&pkg);
+        if !src_segment.is_empty() {
+            path = path.join(src_segment);
+        }
+        for seg in rest {
+            path = path.join(seg);
+        }
+        path = path.join(format!("{class_name}.php"));
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
 }
 
 fn find_php_class_file_impl(class_name: &str, root: &Path, search_vendor: bool) -> Option<PathBuf> {
@@ -95,4 +185,102 @@ fn find_php_class_file_impl(class_name: &str, root: &Path, search_vendor: bool) 
 /// some projects also use `src/` for libraries living alongside the app.
 fn search_roots(root: &Path) -> Vec<PathBuf> {
     vec![root.join("app"), root.join("src")]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Spin up a Laravel-shaped tempdir with the given (path, body)
+    /// pairs. Paths are relative to the project root.
+    fn project_with_files(files: &[(&str, &str)]) -> (TempDir, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        for (relpath, body) in files {
+            let full = dir.path().join(relpath);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            std::fs::write(&full, body).unwrap();
+        }
+        let root = dir.path().to_path_buf();
+        (dir, root)
+    }
+
+    #[test]
+    fn fqcn_aware_lookup_prefers_namespace_shape_match() {
+        // Mike's crossbible-vapor case: TWO files named Version.php live
+        // in the project. The FQCN `App\Models\Version` should map to
+        // `app/Models/Version.php`, NOT to `app/Nova/Filters/Version.php`
+        // even though the latter is also a Version.php with the same
+        // basename.
+        let (_dir, root) = project_with_files(&[
+            (
+                "app/Models/Version.php",
+                "<?php\nnamespace App\\Models;\nclass Version {}",
+            ),
+            (
+                "app/Nova/Filters/Version.php",
+                "<?php\nnamespace App\\Nova\\Filters;\nclass Version {}",
+            ),
+        ]);
+        let path =
+            find_php_class_file("App\\Models\\Version", &root).expect("should find the model");
+        assert!(
+            path.ends_with("app/Models/Version.php"),
+            "should pick the namespace-matching file; got: {path:?}"
+        );
+    }
+
+    #[test]
+    fn fqcn_aware_lookup_falls_back_to_basename_when_no_shape_match() {
+        // If only one Version.php exists in the project (no PSR-4 match
+        // possible), the basename walk still finds it.
+        let (_dir, root) =
+            project_with_files(&[("app/SomeOtherPlace/Version.php", "<?php\nclass Version {}")]);
+        let path = find_php_class_file("App\\Models\\Version", &root).expect("fallback walk");
+        assert!(path.ends_with("app/SomeOtherPlace/Version.php"));
+    }
+
+    #[test]
+    fn fqcn_lookup_routes_vendor_classes_to_psr4_path() {
+        // `Laravel\Passport\Token` should resolve to the standard
+        // Composer PSR-4 path. Note: only `find_php_class_file_in_app_or_vendor`
+        // searches vendor — `find_php_class_file` stays app-side only.
+        let (_dir, root) = project_with_files(&[(
+            "vendor/laravel/passport/src/Token.php",
+            "<?php\nnamespace Laravel\\Passport;\nclass Token {}",
+        )]);
+        let path = find_php_class_file_in_app_or_vendor("Laravel\\Passport\\Token", &root)
+            .expect("vendor PSR-4 lookup");
+        assert!(path.ends_with("vendor/laravel/passport/src/Token.php"));
+    }
+
+    #[test]
+    fn fqcn_lookup_app_class_shadows_vendor_match() {
+        // Both an app/-side and a vendor/-side file with the same FQCN
+        // exist? App wins (matches PSR-4 autoload behavior).
+        let (_dir, root) = project_with_files(&[
+            (
+                "app/Models/Token.php",
+                "<?php\nnamespace App\\Models;\nclass Token {}",
+            ),
+            (
+                "vendor/laravel/passport/src/Token.php",
+                "<?php\nnamespace Laravel\\Passport;\nclass Token {}",
+            ),
+        ]);
+        let path = find_php_class_file_in_app_or_vendor("App\\Models\\Token", &root).unwrap();
+        assert!(
+            path.ends_with("app/Models/Token.php"),
+            "App\\Models\\Token should resolve to the project file; got {path:?}"
+        );
+    }
+
+    #[test]
+    fn bare_class_name_with_no_namespace_still_uses_basename_walk() {
+        // `Foo` (no namespace) doesn't have a PSR-4 shape — should fall
+        // through to basename walking.
+        let (_dir, root) = project_with_files(&[("app/Services/Foo.php", "<?php\nclass Foo {}")]);
+        let path = find_php_class_file("Foo", &root).expect("bare-name walk");
+        assert!(path.ends_with("app/Services/Foo.php"));
+    }
 }

--- a/laravel-lsp/src/class_locator.rs
+++ b/laravel-lsp/src/class_locator.rs
@@ -29,14 +29,34 @@ use walkdir::WalkDir;
 /// found. Does not parse the file to verify the class name inside — relies on
 /// Laravel's strong convention that file basename matches class name.
 pub fn find_php_class_file(class_name: &str, root: &Path) -> Option<PathBuf> {
-    // Try the namespace-aware path mapping first — `App\Models\User`
-    // should land at `app/Models/User.php`, not at the first `User.php`
-    // we happen to walk into (which could be `app/Nova/User.php` or
-    // similar). Falls back to a basename walk under app/ if the FQCN
-    // doesn't map to an existing file.
+    // Composer autoload is the authoritative source for any FQCN with
+    // a declared PSR-4 prefix. If it resolves the class — whether to
+    // an app-side or vendor-side path — trust it. A vendor FQCN like
+    // `CrossBibleInc\BibleModels\Models\Book` MUST route to vendor;
+    // falling back to a basename walk under `app/` for such an FQCN
+    // would land on the first same-named file (e.g.
+    // `app/Nova/Filters/Book.php`), which is the wrong class.
+    let autoload = crate::composer_autoload::ComposerAutoload::for_project(root);
+    if let Some(path) = autoload.resolve(class_name) {
+        return Some(path);
+    }
+
+    // Composer doesn't know the FQCN. Try the heuristic mappings for
+    // projects without an installed.json (or for namespaces the user
+    // hasn't declared in composer.json). Cheap App and vendor PSR-4
+    // shape checks, no walking.
     if let Some(path) = find_php_class_file_by_fqcn(class_name, root, false) {
         return Some(path);
     }
+    if let Some(path) = find_php_class_file_by_fqcn(class_name, root, true) {
+        return Some(path);
+    }
+
+    // Last resort: basename walk under `app/` (and `src/`). Vendor is
+    // intentionally not walked here — it's huge and the Composer
+    // step above already handles all conventionally-installed
+    // packages. Inheritance walking, which can legitimately need to
+    // scan vendor by basename, calls `find_php_class_file_in_app_or_vendor`.
     find_php_class_file_impl(class_name, root, false)
 }
 
@@ -50,65 +70,53 @@ pub fn find_php_class_file(class_name: &str, root: &Path) -> Option<PathBuf> {
 /// (≤10 levels) and the result is cached behind ModelMetadata anyway.
 /// app/-side definitions still win — they're checked first.
 pub fn find_php_class_file_in_app_or_vendor(class_name: &str, root: &Path) -> Option<PathBuf> {
-    // Try FQCN-aware lookup across app/ AND vendor/ first. If neither
-    // PSR-4-shaped path exists, fall through to a basename walk —
-    // again preferring app/ over vendor/ since project classes shadow
-    // vendor classes with matching basenames.
+    // Composer first (same reasoning as `find_php_class_file`). For
+    // the inheritance walker this is normally enough — parent classes
+    // declared in any installed package land via PSR-4.
+    let autoload = crate::composer_autoload::ComposerAutoload::for_project(root);
+    if let Some(path) = autoload.resolve(class_name) {
+        return Some(path);
+    }
+
+    // Heuristic fallbacks for projects without installed.json.
     if let Some(path) = find_php_class_file_by_fqcn(class_name, root, false) {
         return Some(path);
     }
     if let Some(path) = find_php_class_file_by_fqcn(class_name, root, true) {
         return Some(path);
     }
+
+    // Last resort: basename walk app/, then vendor/. The vendor walk
+    // is reserved for this app-or-vendor entry point because the
+    // inheritance walker is bounded in depth and cached.
     if let Some(path) = find_php_class_file_impl(class_name, root, false) {
         return Some(path);
     }
     find_php_class_file_impl(class_name, root, true)
 }
 
-/// Map a fully-qualified class name to its source file path.
+/// Heuristic FQCN → file path mapping for projects without an
+/// `installed.json` (or where the user hasn't declared an autoload
+/// entry in `composer.json`). Used as a *fallback* below the
+/// Composer autoload step in the public lookup functions.
 ///
-/// Resolution order:
+/// Mappings:
+/// - `App\Models\User` → `app/Models/User.php` (or `src/Models/User.php`
+///   for projects that use `src/` for app code)
+/// - `Laravel\Passport\Token` → `vendor/laravel/passport/src/Token.php`
+///   (lowercased vendor + package, then `src/`, then remaining
+///   namespace segments). Misses for hyphenated package dirs —
+///   Composer autoload (the step above) handles those correctly.
 ///
-/// 1. **Real Composer PSR-4 data** ([`crate::composer_autoload::ComposerAutoload`])
-///    — reads the project's `composer.json` + `vendor/composer/installed.json`
-///    and uses the actual declared PSR-4 prefix → directory mappings.
-///    This handles packages whose directory name is hyphenated even
-///    though the namespace isn't (e.g. `CrossBibleInc\BibleModels\` →
-///    `vendor/crossbibleinc/bible-models/src/`).
-/// 2. **Conventional heuristic fallback** — for projects without an
-///    `installed.json` (rare), the original mapping kicks in:
-///    - `App\Models\User` → `app/Models/User.php` (or `src/Models/User.php`)
-///    - `Laravel\Passport\Token` → `vendor/laravel/passport/src/Token.php`
-///      (lowercased vendor + package, then `src/`)
+/// `search_vendor`: `true` consults the vendor heuristic only;
+/// `false` the App heuristic only. Callers chain both.
 ///
-/// `search_vendor`: when `true`, only consider the vendor/ mapping;
-/// when `false`, only consider the App/ mapping. Callers chain both
-/// modes to cover the realistic search space. The Composer step
-/// honors this split too — it segregates project-rooted and
-/// vendor-rooted entries.
-///
-/// Returns `None` if neither strategy finds a file on disk. The caller
-/// then falls back to a basename walk so we still resolve
-/// unconventional PSR-4 layouts.
+/// Returns `None` if no candidate path exists on disk.
 fn find_php_class_file_by_fqcn(
     fqcn: &str,
     project_root: &Path,
     search_vendor: bool,
 ) -> Option<PathBuf> {
-    // Try the real Composer PSR-4 map first. Filter results by
-    // whether the resolved path is under vendor/ so the caller's
-    // app-vs-vendor segregation still holds.
-    let autoload = crate::composer_autoload::ComposerAutoload::for_project(project_root);
-    if let Some(path) = autoload.resolve(fqcn) {
-        let is_vendor = path.starts_with(project_root.join("vendor"));
-        if is_vendor == search_vendor {
-            return Some(path);
-        }
-        // Path exists but on the wrong side of the app/vendor split
-        // for this call. Fall through to the heuristic — the OTHER
-        // call (with the flipped flag) will pick up the Composer hit.
-    }
     let segments: Vec<&str> = fqcn.split('\\').filter(|s| !s.is_empty()).collect();
     if segments.is_empty() {
         return None;
@@ -292,6 +300,46 @@ mod tests {
         assert!(
             path.ends_with("app/Models/Token.php"),
             "App\\Models\\Token should resolve to the project file; got {path:?}"
+        );
+    }
+
+    #[test]
+    fn find_php_class_file_routes_vendor_fqcn_via_composer_autoload() {
+        // Phase 5.12: the dotted-walker hands `find_php_class_file` a
+        // vendor FQCN (Phase 5.11 made related_model store FQCNs).
+        // Composer autoload knows the real PSR-4 mapping, including for
+        // hyphenated package dirs. We must trust it even when the
+        // lookup is "app-side" — falling back to a basename walk under
+        // app/ for a vendor FQCN finds a same-named app file (e.g.
+        // app/Nova/Filters/Book.php), which is the wrong class.
+        let installed = r#"{
+            "packages": [
+                {
+                    "name": "crossbibleinc/bible-models",
+                    "autoload": {
+                        "psr-4": { "CrossBibleInc\\BibleModels\\": "src/" }
+                    },
+                    "install-path": "../crossbibleinc/bible-models"
+                }
+            ]
+        }"#;
+        let (_dir, root) = project_with_files(&[
+            ("vendor/composer/installed.json", installed),
+            (
+                "vendor/crossbibleinc/bible-models/src/Models/Book.php",
+                "<?php\nnamespace CrossBibleInc\\BibleModels\\Models;\nclass Book {}",
+            ),
+            (
+                // Same-basename app file — must NOT be picked.
+                "app/Nova/Filters/Book.php",
+                "<?php\nnamespace App\\Nova\\Filters;\nclass Book {}",
+            ),
+        ]);
+        let path = find_php_class_file("CrossBibleInc\\BibleModels\\Models\\Book", &root)
+            .expect("Composer autoload should route the vendor FQCN");
+        assert!(
+            path.ends_with("vendor/crossbibleinc/bible-models/src/Models/Book.php"),
+            "vendor FQCN must resolve to the vendor file via Composer autoload; got {path:?}"
         );
     }
 

--- a/laravel-lsp/src/class_locator.rs
+++ b/laravel-lsp/src/class_locator.rs
@@ -66,29 +66,49 @@ pub fn find_php_class_file_in_app_or_vendor(class_name: &str, root: &Path) -> Op
     find_php_class_file_impl(class_name, root, true)
 }
 
-/// Map a fully-qualified class name to its source file path using
-/// Laravel/Composer conventions:
+/// Map a fully-qualified class name to its source file path.
 ///
-/// - `App\Models\User` → `app/Models/User.php` (or `src/Models/User.php`
-///   for projects that use `src/` for app code)
-/// - `Laravel\Passport\Token` → `vendor/laravel/passport/src/Token.php`
-///   (lowercased vendor + package, then `src/`, then remaining
-///   namespace segments as path components)
-/// - `Spatie\Permission\Models\Role` →
-///   `vendor/spatie/permission/src/Models/Role.php`
+/// Resolution order:
+///
+/// 1. **Real Composer PSR-4 data** ([`crate::composer_autoload::ComposerAutoload`])
+///    — reads the project's `composer.json` + `vendor/composer/installed.json`
+///    and uses the actual declared PSR-4 prefix → directory mappings.
+///    This handles packages whose directory name is hyphenated even
+///    though the namespace isn't (e.g. `CrossBibleInc\BibleModels\` →
+///    `vendor/crossbibleinc/bible-models/src/`).
+/// 2. **Conventional heuristic fallback** — for projects without an
+///    `installed.json` (rare), the original mapping kicks in:
+///    - `App\Models\User` → `app/Models/User.php` (or `src/Models/User.php`)
+///    - `Laravel\Passport\Token` → `vendor/laravel/passport/src/Token.php`
+///      (lowercased vendor + package, then `src/`)
 ///
 /// `search_vendor`: when `true`, only consider the vendor/ mapping;
 /// when `false`, only consider the App/ mapping. Callers chain both
-/// modes to cover the realistic search space.
+/// modes to cover the realistic search space. The Composer step
+/// honors this split too — it segregates project-rooted and
+/// vendor-rooted entries.
 ///
-/// Returns `None` if no candidate path exists on disk. The caller then
-/// falls back to a basename walk so we still resolve unconventional
-/// PSR-4 layouts.
+/// Returns `None` if neither strategy finds a file on disk. The caller
+/// then falls back to a basename walk so we still resolve
+/// unconventional PSR-4 layouts.
 fn find_php_class_file_by_fqcn(
     fqcn: &str,
     project_root: &Path,
     search_vendor: bool,
 ) -> Option<PathBuf> {
+    // Try the real Composer PSR-4 map first. Filter results by
+    // whether the resolved path is under vendor/ so the caller's
+    // app-vs-vendor segregation still holds.
+    let autoload = crate::composer_autoload::ComposerAutoload::for_project(project_root);
+    if let Some(path) = autoload.resolve(fqcn) {
+        let is_vendor = path.starts_with(project_root.join("vendor"));
+        if is_vendor == search_vendor {
+            return Some(path);
+        }
+        // Path exists but on the wrong side of the app/vendor split
+        // for this call. Fall through to the heuristic — the OTHER
+        // call (with the flipped flag) will pick up the Composer hit.
+    }
     let segments: Vec<&str> = fqcn.split('\\').filter(|s| !s.is_empty()).collect();
     if segments.is_empty() {
         return None;

--- a/laravel-lsp/src/class_locator.rs
+++ b/laravel-lsp/src/class_locator.rs
@@ -29,19 +29,54 @@ use walkdir::WalkDir;
 /// found. Does not parse the file to verify the class name inside — relies on
 /// Laravel's strong convention that file basename matches class name.
 pub fn find_php_class_file(class_name: &str, root: &Path) -> Option<PathBuf> {
+    find_php_class_file_impl(class_name, root, false)
+}
+
+/// Same as [`find_php_class_file`] but ALSO searches `vendor/` so the
+/// inheritance walker can pick up parent classes shipped by Laravel
+/// packages (e.g. `OAuthAccessToken extends Laravel\Passport\Token`
+/// — Token lives in `vendor/laravel/passport/src/Token.php`).
+///
+/// Slower than the app-only variant because vendor trees are huge. Use
+/// it only for inheritance walking, where the search depth is bounded
+/// (≤10 levels) and the result is cached behind ModelMetadata anyway.
+/// app/-side definitions still win — they're checked first.
+pub fn find_php_class_file_in_app_or_vendor(class_name: &str, root: &Path) -> Option<PathBuf> {
+    // Check app/src first — a project-local class always shadows a vendor
+    // class of the same basename. Only fall back to vendor when nothing
+    // matched in app/.
+    if let Some(path) = find_php_class_file_impl(class_name, root, false) {
+        return Some(path);
+    }
+    find_php_class_file_impl(class_name, root, true)
+}
+
+fn find_php_class_file_impl(class_name: &str, root: &Path, search_vendor: bool) -> Option<PathBuf> {
     if class_name.is_empty() {
         return None;
     }
     let simple_name = class_name.rsplit('\\').next().unwrap_or(class_name);
     let target_filename = format!("{}.php", simple_name);
 
-    for app_root in search_roots(root) {
+    let roots: Vec<PathBuf> = if search_vendor {
+        vec![root.join("vendor")]
+    } else {
+        search_roots(root)
+    };
+
+    for app_root in roots {
         if !app_root.is_dir() {
             continue;
         }
         let walker = WalkDir::new(&app_root).into_iter().filter_entry(|e| {
             let name = e.file_name().to_string_lossy();
-            !matches!(name.as_ref(), "vendor" | "node_modules" | ".git")
+            // When searching vendor itself, allow descent INTO vendor —
+            // only skip nested vendor/.git/.node_modules dirs.
+            if search_vendor {
+                !matches!(name.as_ref(), "node_modules" | ".git")
+            } else {
+                !matches!(name.as_ref(), "vendor" | "node_modules" | ".git")
+            }
         });
         for entry in walker.filter_map(|e| e.ok()) {
             if !entry.file_type().is_file() {

--- a/laravel-lsp/src/composer_autoload.rs
+++ b/laravel-lsp/src/composer_autoload.rs
@@ -1,0 +1,215 @@
+//! Real PSR-4 class resolution from Composer's autoload data.
+//!
+//! The previous heuristic mapped FQCN → file path by lowercasing namespace
+//! segments (e.g. `Laravel\Passport\Token` → `vendor/laravel/passport/...`).
+//! That works for packages whose directory name exactly matches the
+//! lowercased namespace, but breaks for hyphenated packages:
+//!
+//! - Namespace `CrossBibleInc\BibleModels\` → package dir `crossbibleinc/bible-models`
+//! - Namespace `Symfony\Component\HttpFoundation\` → `symfony/http-foundation`
+//!
+//! Composer normalizes package names with hyphens by convention, but the
+//! namespace itself is camelCase. There's no reliable way to derive one
+//! from the other — Composer reads it from each package's `composer.json`.
+//!
+//! This module loads the canonical autoload data once per project:
+//!
+//! - `<project>/composer.json` — the project's own `autoload` + `autoload-dev`
+//!   (typically `App\\` → `app/`, `Database\\Factories\\` → `database/factories/`)
+//! - `<project>/vendor/composer/installed.json` — every installed package's
+//!   `autoload.psr-4` plus its `install-path` (so we know where to look)
+//!
+//! Resolution: walk the prefix map, find the longest matching PSR-4 prefix
+//! for the FQCN, compute the relative path, append `.php`. If the resulting
+//! file exists on disk, return it.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+/// Cached autoload data for one Laravel project. The PSR-4 prefix list is
+/// sorted longest-first so a more specific prefix wins over a less specific
+/// one (e.g. `App\Models\` over `App\`).
+#[derive(Debug)]
+pub struct ComposerAutoload {
+    /// (psr4_prefix_no_trailing_backslash, absolute_source_roots)
+    prefixes: Vec<(String, Vec<PathBuf>)>,
+}
+
+impl ComposerAutoload {
+    /// Resolve `Acme\Foo\Bar` to its absolute file path if a PSR-4 mapping
+    /// matches and the file exists. Returns `None` for FQCNs with no
+    /// matching prefix or whose computed path doesn't exist on disk.
+    ///
+    /// FQCNs may have a leading `\` (fully qualified) — stripped before
+    /// lookup. The match must end on a namespace separator boundary so
+    /// `App\Models` doesn't accidentally match a prefix `App\Mo`.
+    pub fn resolve(&self, fqcn: &str) -> Option<PathBuf> {
+        let normalized = fqcn.trim_start_matches('\\');
+        for (prefix, source_roots) in &self.prefixes {
+            // `prefix` here is the PSR-4 key with the trailing `\\` stripped.
+            // For boundary safety, the FQCN must either equal the prefix
+            // (impossible — would mean class without namespace) or start
+            // with `<prefix>\` followed by at least one segment.
+            if !normalized.starts_with(prefix.as_str()) {
+                continue;
+            }
+            let after_prefix = &normalized[prefix.len()..];
+            if !after_prefix.starts_with('\\') || after_prefix.len() < 2 {
+                continue;
+            }
+            // Strip the boundary `\` and split the remainder into segments
+            // so we can join them as path components.
+            let rest = &after_prefix[1..];
+            let mut rel_path = PathBuf::new();
+            for seg in rest.split('\\') {
+                rel_path.push(seg);
+            }
+            // PSR-4 always appends `.php` to the leaf component.
+            rel_path.set_extension("php");
+            for source_root in source_roots {
+                let candidate = source_root.join(&rel_path);
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+        None
+    }
+
+    /// Parse autoload data fresh from disk. Doesn't touch the cache —
+    /// callers should normally use [`for_project`] instead.
+    pub fn load(project_root: &Path) -> Self {
+        let mut prefixes: Vec<(String, Vec<PathBuf>)> = Vec::new();
+
+        // Project's own autoload (e.g. App\ → app/, Database\Factories\ → ...).
+        let project_composer = project_root.join("composer.json");
+        if let Ok(text) = std::fs::read_to_string(&project_composer) {
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
+                Self::collect_psr4(value.get("autoload"), project_root, &mut prefixes);
+                Self::collect_psr4(value.get("autoload-dev"), project_root, &mut prefixes);
+            }
+        }
+
+        // Installed packages — Composer writes this on `composer install`
+        // / `composer update`. Each entry has its own PSR-4 mappings and an
+        // `install-path` relative to vendor/composer/.
+        let installed_path = project_root
+            .join("vendor")
+            .join("composer")
+            .join("installed.json");
+        if let Ok(text) = std::fs::read_to_string(&installed_path) {
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
+                // installed.json shape varies: Composer 2 uses { "packages": [...] },
+                // Composer 1 was a bare array. Handle both for robustness.
+                let packages = value
+                    .get("packages")
+                    .and_then(|v| v.as_array())
+                    .or_else(|| value.as_array());
+                if let Some(pkgs) = packages {
+                    let vendor_composer = project_root.join("vendor").join("composer");
+                    for pkg in pkgs {
+                        let install_path = match pkg.get("install-path").and_then(|v| v.as_str()) {
+                            Some(p) => p,
+                            None => continue,
+                        };
+                        let pkg_root = vendor_composer.join(install_path);
+                        let pkg_root = pkg_root.canonicalize().unwrap_or(pkg_root);
+                        Self::collect_psr4(pkg.get("autoload"), &pkg_root, &mut prefixes);
+                    }
+                }
+            }
+        }
+
+        // Longest prefix first so `App\Models\` beats `App\` when both
+        // would otherwise match an FQCN like `App\Models\User`.
+        prefixes.sort_by_key(|entry| std::cmp::Reverse(entry.0.len()));
+
+        Self { prefixes }
+    }
+
+    /// Pull PSR-4 entries out of an `autoload` (or `autoload-dev`) JSON
+    /// blob and append them to the accumulator. Handles both PSR-4 value
+    /// shapes: a single path string, or an array of paths.
+    fn collect_psr4(
+        autoload: Option<&serde_json::Value>,
+        base_dir: &Path,
+        out: &mut Vec<(String, Vec<PathBuf>)>,
+    ) {
+        let Some(autoload) = autoload else { return };
+        let Some(psr4) = autoload.get("psr-4").and_then(|v| v.as_object()) else {
+            return;
+        };
+        for (prefix, paths_value) in psr4 {
+            // Strip trailing `\` so we can match by string-prefix and then
+            // verify the boundary character ourselves.
+            let key = prefix.trim_end_matches('\\').to_string();
+            let mut absolute_paths = Vec::new();
+            match paths_value {
+                serde_json::Value::String(s) => {
+                    absolute_paths.push(base_dir.join(s));
+                }
+                serde_json::Value::Array(arr) => {
+                    for p in arr {
+                        if let Some(s) = p.as_str() {
+                            absolute_paths.push(base_dir.join(s));
+                        }
+                    }
+                }
+                _ => {}
+            }
+            if !absolute_paths.is_empty() {
+                out.push((key, absolute_paths));
+            }
+        }
+    }
+
+    /// Return the cached autoload for `project_root`, loading it lazily on
+    /// first call. Cache key is the canonical project root path; cache
+    /// outlives the LSP session.
+    ///
+    /// The autoload is loaded into a process-wide cache rather than per-LSP
+    /// instance because Composer rarely changes during an editing session
+    /// — when it does (e.g. `composer require ...`), the user typically
+    /// restarts the editor or reloads the extension anyway.
+    pub fn for_project(project_root: &Path) -> &'static ComposerAutoload {
+        static CACHE: OnceLock<Mutex<HashMap<PathBuf, &'static ComposerAutoload>>> =
+            OnceLock::new();
+        let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+
+        let key = project_root
+            .canonicalize()
+            .unwrap_or_else(|_| project_root.to_path_buf());
+
+        // Fast path: already cached.
+        {
+            let map = cache.lock().expect("composer_autoload cache poisoned");
+            if let Some(found) = map.get(&key) {
+                return found;
+            }
+        }
+
+        // Build fresh and intern. `Box::leak` is safe here because the
+        // cache lives for the entire process lifetime — leaks bounded by
+        // the number of distinct projects ever opened.
+        let loaded = Box::leak(Box::new(ComposerAutoload::load(project_root)));
+        let mut map = cache.lock().expect("composer_autoload cache poisoned");
+        // Race-safe: if another thread already inserted while we built,
+        // drop ours and use theirs. (We can't free the leak, but a
+        // duplicate static autoload is harmless.)
+        if let Some(existing) = map.get(&key) {
+            return existing;
+        }
+        map.insert(key.clone(), loaded);
+        loaded
+    }
+
+    /// Direct accessor for tests — count of registered PSR-4 prefixes.
+    #[cfg(test)]
+    pub fn prefix_count(&self) -> usize {
+        self.prefixes.len()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/composer_autoload/tests.rs
+++ b/laravel-lsp/src/composer_autoload/tests.rs
@@ -1,0 +1,189 @@
+use super::*;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// Build a Laravel-shaped tempdir with the given (path, body) pairs.
+fn project_with_files(files: &[(&str, &str)]) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().unwrap();
+    for (relpath, body) in files {
+        let full = dir.path().join(relpath);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(&full, body).unwrap();
+    }
+    let root = dir.path().to_path_buf();
+    (dir, root)
+}
+
+#[test]
+fn resolves_app_classes_via_project_composer_json() {
+    // composer.json maps `App\` → `app/`, so App\Models\User must land
+    // at app/Models/User.php — same answer as the FQCN heuristic, but
+    // now we got there by reading the source of truth.
+    let composer = r#"{
+        "autoload": {
+            "psr-4": {
+                "App\\": "app/"
+            }
+        }
+    }"#;
+    let (_dir, root) = project_with_files(&[
+        ("composer.json", composer),
+        ("app/Models/User.php", "<?php class User {}"),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let resolved = autoload
+        .resolve("App\\Models\\User")
+        .expect("App PSR-4 hit");
+    assert!(
+        resolved.ends_with("app/Models/User.php"),
+        "got {resolved:?}"
+    );
+}
+
+#[test]
+fn resolves_hyphenated_vendor_packages_from_installed_json() {
+    // This is the exact crossbible-vapor failure case: the package dir
+    // is `bible-models` (with hyphen) but the namespace is
+    // `CrossBibleInc\BibleModels\` (no hyphen). The lowercased-namespace
+    // heuristic computes `biblemodels` and misses. The real PSR-4 map
+    // tells us the truth.
+    let installed = r#"{
+        "packages": [
+            {
+                "name": "crossbibleinc/bible-models",
+                "autoload": {
+                    "psr-4": { "CrossBibleInc\\BibleModels\\": "src/" }
+                },
+                "install-path": "../crossbibleinc/bible-models"
+            }
+        ]
+    }"#;
+    let (_dir, root) = project_with_files(&[
+        ("vendor/composer/installed.json", installed),
+        (
+            "vendor/crossbibleinc/bible-models/src/Models/Version.php",
+            "<?php\nnamespace CrossBibleInc\\BibleModels\\Models;\nclass Version {}",
+        ),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let resolved = autoload
+        .resolve("CrossBibleInc\\BibleModels\\Models\\Version")
+        .expect("hyphenated vendor package should resolve");
+    assert!(
+        resolved.ends_with("vendor/crossbibleinc/bible-models/src/Models/Version.php"),
+        "got {resolved:?}"
+    );
+}
+
+#[test]
+fn longest_prefix_wins_when_multiple_match() {
+    // If both `App\` → app/ and `App\Models\` → custom/models/ are
+    // declared, the more specific prefix must win for `App\Models\User`.
+    let composer = r#"{
+        "autoload": {
+            "psr-4": {
+                "App\\": "app/",
+                "App\\Models\\": "custom/models/"
+            }
+        }
+    }"#;
+    let (_dir, root) = project_with_files(&[
+        ("composer.json", composer),
+        ("custom/models/User.php", "<?php class User {}"),
+        ("app/Models/User.php", "<?php class User {}"),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let resolved = autoload.resolve("App\\Models\\User").expect("resolve");
+    assert!(
+        resolved.ends_with("custom/models/User.php"),
+        "longest prefix should win; got {resolved:?}"
+    );
+}
+
+#[test]
+fn psr4_value_can_be_array_of_paths() {
+    // Some packages declare PSR-4 paths as an array — Composer tries
+    // each in order. We try them all and return the first that exists.
+    let composer = r#"{
+        "autoload": {
+            "psr-4": {
+                "App\\": ["app/", "src/"]
+            }
+        }
+    }"#;
+    let (_dir, root) = project_with_files(&[
+        ("composer.json", composer),
+        ("src/Models/User.php", "<?php class User {}"),
+        // Note: NO app/Models/User.php — must fall through to src/.
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let resolved = autoload.resolve("App\\Models\\User").expect("resolve");
+    assert!(
+        resolved.ends_with("src/Models/User.php"),
+        "got {resolved:?}"
+    );
+}
+
+#[test]
+fn returns_none_for_fqcn_with_no_matching_prefix() {
+    // Class lives in a namespace nobody declared autoload for —
+    // resolution must return None so the caller can fall back to other
+    // strategies (basename walk, etc.).
+    let composer = r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#;
+    let (_dir, root) = project_with_files(&[("composer.json", composer)]);
+    let autoload = ComposerAutoload::load(&root);
+    assert!(autoload.resolve("Unrelated\\Vendor\\Something").is_none());
+}
+
+#[test]
+fn returns_none_when_psr4_matches_but_file_doesnt_exist() {
+    // PSR-4 says "this is where it should be", but the file isn't there
+    // (deleted, renamed, never created). We don't lie — return None.
+    let composer = r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#;
+    let (_dir, root) = project_with_files(&[("composer.json", composer)]);
+    let autoload = ComposerAutoload::load(&root);
+    assert!(autoload.resolve("App\\Models\\Missing").is_none());
+}
+
+#[test]
+fn autoload_dev_is_included() {
+    // Database\Factories\ lives in autoload-dev, not autoload. Tests
+    // and seeders need to resolve from there.
+    let composer = r#"{
+        "autoload-dev": {
+            "psr-4": { "Database\\Factories\\": "database/factories/" }
+        }
+    }"#;
+    let (_dir, root) = project_with_files(&[
+        ("composer.json", composer),
+        (
+            "database/factories/UserFactory.php",
+            "<?php\nnamespace Database\\Factories;\nclass UserFactory {}",
+        ),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let resolved = autoload
+        .resolve("Database\\Factories\\UserFactory")
+        .expect("autoload-dev should be honored");
+    assert!(
+        resolved.ends_with("database/factories/UserFactory.php"),
+        "got {resolved:?}"
+    );
+}
+
+#[test]
+fn leading_backslash_in_fqcn_is_tolerated() {
+    // PHP allows `\App\Models\User` (fully qualified marker). We treat
+    // it identically to the version without the leading slash.
+    let composer = r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#;
+    let (_dir, root) = project_with_files(&[
+        ("composer.json", composer),
+        ("app/Models/User.php", "<?php class User {}"),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let resolved = autoload.resolve("\\App\\Models\\User").expect("resolve");
+    assert!(
+        resolved.ends_with("app/Models/User.php"),
+        "got {resolved:?}"
+    );
+}

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -731,6 +731,34 @@ impl DatabaseSchemaProvider {
         };
         let _ = used_fallback_host; // documented in info! above
 
+        // Diagnostic identity probe — when SHOW TABLES returns 0 rows but
+        // the user knows the DB has tables, the connection probably landed
+        // on the wrong MySQL instance (e.g., Homebrew MySQL on 127.0.0.1:3306
+        // intercepting before Sail). Log the server identity so the user can
+        // see what they're actually connected to.
+        if let Ok(row) = sqlx::query(
+            "SELECT DATABASE() AS db, @@hostname AS hostname, USER() AS user, @@version AS version",
+        )
+        .fetch_one(&pool)
+        .await
+        {
+            let db_name: String = row.try_get("db").unwrap_or_default();
+            let hostname: String = row.try_get("hostname").unwrap_or_default();
+            let user: String = row.try_get("user").unwrap_or_default();
+            let version: String = row.try_get("version").unwrap_or_default();
+            info!(
+                "MySQL connected: db={:?} server_hostname={:?} user={:?} version={:?}",
+                db_name, hostname, user, version
+            );
+        }
+        if let Ok(rows) = sqlx::query("SHOW DATABASES").fetch_all(&pool).await {
+            let dbs: Vec<String> = rows
+                .into_iter()
+                .filter_map(|r| r.try_get::<String, _>(0).ok())
+                .collect();
+            info!("MySQL: visible databases = {:?}", dbs);
+        }
+
         // Get tables
         let tables: Vec<String> = sqlx::query("SHOW TABLES")
             .fetch_all(&pool)

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -54,6 +54,30 @@ where
     None
 }
 
+/// Build the `user[:password]` userinfo segment of a `driver://userinfo@…`
+/// connection URL.
+///
+/// When the password is empty, returns just `user` (no trailing `:`).
+/// This matters: `mysql://root:@host/db` (with the `:`) tells sqlx
+/// "empty password specified" and sqlx will send the auth handshake
+/// including an empty password — MySQL responds with `using password: YES`
+/// and may reject the connection (especially against `auth_socket` plugin
+/// setups, or `root@localhost` configurations that require socket auth).
+/// `mysql://root@host/db` (without the `:`) tells sqlx "no password" and
+/// the handshake skips the password packet entirely — accepted by more
+/// permissive MySQL configs.
+///
+/// Special-character escaping is the caller's concern — Laravel's
+/// `.env` values don't typically need URL-encoding in production
+/// credentials, and adding it here would risk double-encoding.
+fn userinfo(user: &str, password: &str) -> String {
+    if password.is_empty() {
+        user.to_string()
+    } else {
+        format!("{user}:{password}")
+    }
+}
+
 /// Mask the password in a database URL for safe logging. Matches the
 /// standard shape `driver://user:pass@host:...` and replaces the password
 /// segment with `***`. If no password is present (or the URL doesn't match
@@ -1118,8 +1142,10 @@ impl DatabaseSchemaProvider {
             out.push(ConnCandidate {
                 label: format!("unix_socket={socket}"),
                 url: format!(
-                    "mysql://{}:{}@localhost/{}?socket={}",
-                    config.username, config.password, config.database, socket
+                    "mysql://{}@localhost/{}?socket={}",
+                    userinfo(&config.username, &config.password),
+                    config.database,
+                    socket
                 ),
                 success_note: Some(
                     "Configured via unix_socket — bypasses TCP entirely.".to_string(),
@@ -1134,8 +1160,11 @@ impl DatabaseSchemaProvider {
             out.push(ConnCandidate {
                 label: format!("tcp {}:{}", host, config.port),
                 url: format!(
-                    "mysql://{}:{}@{}:{}/{}",
-                    config.username, config.password, host, config.port, config.database
+                    "mysql://{}@{}:{}/{}",
+                    userinfo(&config.username, &config.password),
+                    host,
+                    config.port,
+                    config.database
                 ),
                 success_note: if is_sail_fallback {
                     Some(
@@ -1166,12 +1195,14 @@ impl DatabaseSchemaProvider {
         }
 
         if let Some(socket) = &config.unix_socket {
-            // libpq-style socket connection: `postgres://user:pass@/db?host=/path`.
+            // libpq-style socket connection: `postgres://user[:pass]@/db?host=/path`.
             out.push(ConnCandidate {
                 label: format!("unix_socket={socket}"),
                 url: format!(
-                    "postgres://{}:{}@/{}?host={}",
-                    config.username, config.password, config.database, socket
+                    "postgres://{}@/{}?host={}",
+                    userinfo(&config.username, &config.password),
+                    config.database,
+                    socket
                 ),
                 success_note: Some("Configured via unix_socket.".to_string()),
             });
@@ -1182,8 +1213,11 @@ impl DatabaseSchemaProvider {
             out.push(ConnCandidate {
                 label: format!("tcp {}:{}", host, config.port),
                 url: format!(
-                    "postgres://{}:{}@{}:{}/{}",
-                    config.username, config.password, host, config.port, config.database
+                    "postgres://{}@{}:{}/{}",
+                    userinfo(&config.username, &config.password),
+                    host,
+                    config.port,
+                    config.database
                 ),
                 success_note: if is_sail_fallback {
                     Some("Sail / Docker Compose fallback to 127.0.0.1.".to_string())

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -806,7 +806,15 @@ impl DatabaseSchemaProvider {
         }
     }
 
-    /// Resolve an environment variable from .env file
+    /// Resolve an environment variable from .env file.
+    ///
+    /// The regex uses `[ \t]*` (horizontal whitespace only) around `=`,
+    /// NOT `\s*` — `\s` matches newlines in Rust's regex crate, which
+    /// meant the value for an empty `KEY=` would consume the newline and
+    /// then capture the *next line's content* up to its newline. That
+    /// turned a blank `DB_PASSWORD=` into "SESSION_DRIVER=database" (or
+    /// whatever line followed), which was sent as the literal password
+    /// to MySQL and rejected as bad credentials.
     fn resolve_env(&self, key: &str) -> Option<String> {
         let env_path = self.project_root.join(".env");
         let content = match std::fs::read_to_string(&env_path) {
@@ -817,8 +825,13 @@ impl DatabaseSchemaProvider {
             }
         };
 
-        // Pattern: KEY=value or KEY="value" or KEY='value'
-        let pattern = format!(r#"(?m)^{}\s*=\s*['"]?([^'"\n]*)['"]?"#, regex::escape(key));
+        // Pattern: KEY=value or KEY="value" or KEY='value', all on one
+        // line. `[ \t]*` stays horizontal so a blank value (`KEY=\n`)
+        // captures the empty string, not the next line.
+        let pattern = format!(
+            r#"(?m)^{}[ \t]*=[ \t]*['"]?([^'"\n]*)['"]?"#,
+            regex::escape(key)
+        );
         let regex = match Regex::new(&pattern) {
             Ok(r) => r,
             Err(e) => {
@@ -858,6 +871,15 @@ impl DatabaseSchemaProvider {
         let primary_label = candidates.first().map(|c| c.label.clone());
 
         for cand in &candidates {
+            // Log the exact URL shape we're handing to sqlx (with the
+            // password masked). This makes "is the new binary loaded?"
+            // and "did the empty-password URL change actually take
+            // effect?" trivially answerable from the LSP log.
+            info!(
+                "MySQL: trying candidate '{}' with url={}",
+                cand.label,
+                mask_url_password(&cand.url)
+            );
             match MySqlPoolOptions::new()
                 .max_connections(1)
                 .acquire_timeout(Duration::from_secs(5))

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -176,6 +176,17 @@ impl DatabaseSchemaProvider {
         }
     }
 
+    /// Test helper: seed the schema cache directly so tests can exercise
+    /// completion paths against a known schema without a live MySQL /
+    /// Postgres. The cache is the same one `get_schema` reads, so calls
+    /// to `get_tables` / `get_columns_with_types` will see this data
+    /// immediately. Gated to test builds — no production caller should
+    /// be poking the cache manually.
+    #[cfg(test)]
+    pub async fn set_test_schema(&self, schema: DatabaseSchema) {
+        *self.schema_cache.write().await = Some(schema);
+    }
+
     /// Get the last connection error, if any
     pub async fn get_last_error(&self) -> Option<DatabaseConnectionError> {
         self.last_error.read().await.clone()

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -54,6 +54,136 @@ where
     None
 }
 
+/// Turn a raw sqlx-mysql error string into an actionable toast message.
+///
+/// sqlx surfaces MySQL errors as `... error returned from database: NNNN
+/// (SQLSTATE): server-message ...`. We match on the well-known error
+/// codes that have specific remediations and produce a focused message;
+/// anything else falls through to the generic "check your .env" guidance.
+///
+/// Why pattern-match the string instead of using `sqlx::Error::Database`
+/// fields? The error has already been formatted by the time it reaches
+/// this layer (it's a `String`, not a `sqlx::Error`). Re-plumbing the
+/// typed error all the way up would touch every candidate iteration
+/// site; substring matching is plenty robust for a fixed set of MySQL
+/// error codes whose wire format is part of the MySQL protocol.
+fn classify_mysql_error(raw_error: &str, db_name: &str, candidates_str: &str) -> String {
+    // 1049 (42000): Unknown database — connection + auth succeeded,
+    // the named database doesn't exist on this server. Frame the
+    // remediation in Laravel terms — once the database exists, the
+    // user runs `artisan migrate` to populate it. We deliberately
+    // don't dictate HOW to create the database (`CREATE DATABASE`,
+    // `mysql -e`, a GUI tool, Sail helper, etc.); that's outside
+    // Laravel and varies by setup.
+    if raw_error.contains("1049 (42000)") || raw_error.contains("Unknown database") {
+        return format!(
+            "MySQL accepted the connection and credentials, but database \
+             '{db_name}' doesn't exist on this server. Create the database \
+             with your usual tool, then run `php artisan migrate` (or \
+             `./vendor/bin/sail artisan migrate` for Sail projects) to set \
+             up the schema. Or set DB_DATABASE in .env to a database that \
+             already exists. (Tried: [{candidates_str}])"
+        );
+    }
+    // 1045 (28000): Access denied for user — host reachable, credentials
+    // wrong. Specific enough to call out instead of suggesting host issues.
+    if raw_error.contains("1045 (28000)") || raw_error.contains("Access denied for user") {
+        return format!(
+            "MySQL is reachable but rejected the credentials. Check \
+             DB_USERNAME and DB_PASSWORD in .env. The user may need a \
+             password, may not exist on this server, or may be restricted \
+             to socket-only auth. (Tried: [{candidates_str}]) Error: {raw_error}"
+        );
+    }
+    // 2003 / "Can't connect" / TCP refused — server unreachable.
+    if raw_error.contains("2003") || raw_error.contains("Connection refused") {
+        return format!(
+            "Couldn't reach the MySQL server at [{candidates_str}]. Check \
+             DB_HOST / DB_PORT in .env. If using Sail/Docker Compose, ensure \
+             the container is running and the port is mapped to your host \
+             (run `./vendor/bin/sail up -d`). Error: {raw_error}"
+        );
+    }
+    // 1044 (42000): Access denied for user to database — user exists but
+    // doesn't have privileges on the requested database. This is a DB
+    // admin task, not Laravel-fixable, so the guidance is generic.
+    if raw_error.contains("1044 (42000)") {
+        return format!(
+            "MySQL accepted the connection but the user has no privileges \
+             on database '{db_name}'. Either grant the user access to this \
+             database, or set DB_USERNAME / DB_PASSWORD in .env to a user \
+             that has access. Error: {raw_error}"
+        );
+    }
+    // 1146 (42S02): Base table or view not found — schema exists but
+    // the specific table doesn't. Migrations are the Laravel answer.
+    if raw_error.contains("1146 (42S02)") || raw_error.contains("doesn't exist") {
+        return format!(
+            "MySQL is connected and the database '{db_name}' exists, but a \
+             required table is missing. Run `php artisan migrate` (or \
+             `./vendor/bin/sail artisan migrate` for Sail projects) to \
+             apply pending migrations. Error: {raw_error}"
+        );
+    }
+    // Generic fallback — keeps the original guidance for unknown error
+    // codes. Better to over-explain than to miss something.
+    format!(
+        "MySQL connection failed. Tried candidates: [{candidates_str}]. \
+         Last error: {raw_error}. Check DB_URL / DB_HOST / DB_PORT / \
+         DB_DATABASE / DB_USERNAME / DB_PASSWORD / DB_SOCKET in .env. \
+         If using Sail/Docker Compose, ensure the container is running \
+         and the port is mapped to your host (run `./vendor/bin/sail up -d`)."
+    )
+}
+
+/// Postgres equivalent of [`classify_mysql_error`]. SQLSTATE codes:
+/// - `3D000` invalid_catalog_name → database doesn't exist
+/// - `28P01` invalid_password → wrong credentials
+/// - `28000` invalid_authorization_specification → role/host issue
+fn classify_postgres_error(raw_error: &str, db_name: &str, candidates_str: &str) -> String {
+    // 3D000 invalid_catalog_name → database doesn't exist. Same Laravel
+    // framing as MySQL: create the database, then run `artisan migrate`.
+    if raw_error.contains("3D000") {
+        return format!(
+            "PostgreSQL accepted the connection and credentials, but \
+             database '{db_name}' doesn't exist. Create the database with \
+             your usual tool, then run `php artisan migrate` (or \
+             `./vendor/bin/sail artisan migrate` for Sail projects) to set \
+             up the schema. Or set DB_DATABASE in .env to a database that \
+             already exists. (Tried: [{candidates_str}])"
+        );
+    }
+    if raw_error.contains("28P01") || raw_error.contains("password authentication failed") {
+        return format!(
+            "PostgreSQL rejected the credentials. Check DB_USERNAME / \
+             DB_PASSWORD in .env. (Tried: [{candidates_str}]) Error: {raw_error}"
+        );
+    }
+    if raw_error.contains("Connection refused") || raw_error.contains("could not connect") {
+        return format!(
+            "Couldn't reach the PostgreSQL server at [{candidates_str}]. Check \
+             DB_HOST / DB_PORT in .env. If using Sail/Docker Compose, ensure \
+             the container is running. Error: {raw_error}"
+        );
+    }
+    // 42P01 undefined_table → schema exists but the table doesn't. Run
+    // migrations.
+    if raw_error.contains("42P01") {
+        return format!(
+            "PostgreSQL is connected and the database '{db_name}' exists, \
+             but a required table is missing. Run `php artisan migrate` (or \
+             `./vendor/bin/sail artisan migrate` for Sail projects) to apply \
+             pending migrations. Error: {raw_error}"
+        );
+    }
+    format!(
+        "PostgreSQL connection failed. Tried candidates: [{candidates_str}]. \
+         Last error: {raw_error}. Check DB_URL / DB_HOST / DB_PORT / \
+         DB_DATABASE / DB_USERNAME / DB_PASSWORD / DB_SOCKET in .env. \
+         If using Sail/Docker Compose, ensure the container is running."
+    )
+}
+
 /// Build the `user[:password]` userinfo segment of a `driver://userinfo@…`
 /// connection URL.
 ///
@@ -916,18 +1046,13 @@ impl DatabaseSchemaProvider {
         let pool = match pool_opt {
             Some(p) => p,
             None => {
-                let msg = format!(
-                    "MySQL connection failed. Tried candidates: [{}]. Last error: {}. \
-                     Check DB_URL / DB_HOST / DB_PORT / DB_DATABASE / DB_USERNAME / DB_PASSWORD / \
-                     DB_SOCKET in .env. If using Sail/Docker Compose, ensure the container is \
-                     running and the port is mapped to your host (run `./vendor/bin/sail up -d`).",
-                    candidates
-                        .iter()
-                        .map(|c| c.label.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                    last_err.unwrap_or_else(|| "(no error captured)".to_string())
-                );
+                let candidates_str = candidates
+                    .iter()
+                    .map(|c| c.label.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let raw_err = last_err.unwrap_or_else(|| "(no error captured)".to_string());
+                let msg = classify_mysql_error(&raw_err, &config.database, &candidates_str);
                 warn!("{}", msg);
                 self.set_error("mysql", &msg).await;
                 return None;
@@ -1292,18 +1417,13 @@ impl DatabaseSchemaProvider {
         let pool = match pool_opt {
             Some(p) => p,
             None => {
-                let msg = format!(
-                    "PostgreSQL connection failed. Tried candidates: [{}]. Last error: {}. \
-                     Check DB_URL / DB_HOST / DB_PORT / DB_DATABASE / DB_USERNAME / DB_PASSWORD / \
-                     DB_SOCKET in .env. If using Sail/Docker Compose, ensure the container is \
-                     running.",
-                    candidates
-                        .iter()
-                        .map(|c| c.label.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                    last_err.unwrap_or_else(|| "(no error captured)".to_string())
-                );
+                let candidates_str = candidates
+                    .iter()
+                    .map(|c| c.label.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let raw_err = last_err.unwrap_or_else(|| "(no error captured)".to_string());
+                let msg = classify_postgres_error(&raw_err, &config.database, &candidates_str);
                 warn!("{}", msg);
                 self.set_error("pgsql", &msg).await;
                 return None;

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -865,25 +865,124 @@ impl DatabaseSchemaProvider {
         }
         match sqlx::query("SHOW DATABASES").fetch_all(&pool).await {
             Ok(rows) => {
+                let row_count = rows.len();
+                // Try by column name first (`Database` is the standard for
+                // SHOW DATABASES output) then fall back to positional index.
+                // The two-tier helps when sqlx and the server disagree on
+                // the column type or name.
                 let dbs: Vec<String> = rows
                     .into_iter()
-                    .filter_map(|r| r.try_get::<String, _>(0).ok())
+                    .filter_map(|r| {
+                        r.try_get::<String, _>("Database")
+                            .or_else(|_| r.try_get::<String, _>(0))
+                            .ok()
+                    })
                     .collect();
-                info!("MySQL probe — visible databases = {:?}", dbs);
+                info!(
+                    "MySQL probe — SHOW DATABASES returned {} rows, parsed {}: {:?}",
+                    row_count,
+                    dbs.len(),
+                    dbs
+                );
             }
             Err(e) => {
                 warn!("MySQL probe (SHOW DATABASES) failed: {}", e);
             }
         }
 
-        // Get tables
-        let tables: Vec<String> = sqlx::query("SHOW TABLES")
+        // What grants does the connected user actually have? If the LSP user
+        // turns out to be different from the app's user (e.g., wildcard vs
+        // host-specific user shadowing), this output makes it obvious.
+        match sqlx::query("SHOW GRANTS FOR CURRENT_USER()")
             .fetch_all(&pool)
             .await
-            .ok()?
+        {
+            Ok(rows) => {
+                let grants: Vec<String> = rows
+                    .into_iter()
+                    .filter_map(|r| r.try_get::<String, _>(0).ok())
+                    .collect();
+                info!(
+                    "MySQL probe — SHOW GRANTS for current user ({} grants): {:?}",
+                    grants.len(),
+                    grants
+                );
+            }
+            Err(e) => {
+                warn!("MySQL probe (SHOW GRANTS) failed: {}", e);
+            }
+        }
+
+        // information_schema cross-check probe — bypasses SHOW commands
+        // entirely. If this returns a non-zero count but SHOW TABLES below
+        // returns zero, we know the problem is specific to SHOW (driver
+        // quirk, connection state, etc.) and not actual visibility.
+        match sqlx::query(&format!(
+            "SELECT COUNT(*) AS n FROM information_schema.tables WHERE table_schema = '{}'",
+            config.database.replace('\'', "''")
+        ))
+        .fetch_one(&pool)
+        .await
+        {
+            Ok(row) => {
+                let n: i64 = row.try_get("n").unwrap_or(-1);
+                info!(
+                    "MySQL probe — information_schema.tables count for {:?} = {}",
+                    config.database, n
+                );
+            }
+            Err(e) => {
+                warn!("MySQL probe (information_schema count) failed: {}", e);
+            }
+        }
+        // Also try listing them via information_schema, so we can compare
+        // shape against SHOW TABLES below.
+        match sqlx::query(&format!(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = '{}' LIMIT 5",
+            config.database.replace('\'', "''")
+        ))
+        .fetch_all(&pool)
+        .await
+        {
+            Ok(rows) => {
+                let names: Vec<String> = rows
+                    .into_iter()
+                    .filter_map(|r| {
+                        r.try_get::<String, _>("table_name")
+                            .or_else(|_| r.try_get::<String, _>(0))
+                            .ok()
+                    })
+                    .collect();
+                info!(
+                    "MySQL probe — first 5 tables via information_schema = {:?}",
+                    names
+                );
+            }
+            Err(e) => {
+                warn!("MySQL probe (information_schema sample) failed: {}", e);
+            }
+        }
+
+        // Get tables. Log row count + parsed count separately so we can
+        // tell "MySQL returned 0 rows" (privilege issue / empty DB) from
+        // "we failed to parse the column" (sqlx / driver weirdness).
+        let table_rows = match sqlx::query("SHOW TABLES").fetch_all(&pool).await {
+            Ok(rows) => rows,
+            Err(e) => {
+                warn!("MySQL: SHOW TABLES failed: {}", e);
+                return None;
+            }
+        };
+        let row_count = table_rows.len();
+        let tables: Vec<String> = table_rows
             .into_iter()
             .filter_map(|row| row.try_get::<String, _>(0).ok())
             .collect();
+        info!(
+            "MySQL: SHOW TABLES returned {} rows, parsed {} table names",
+            row_count,
+            tables.len()
+        );
 
         // Get columns for each table (with types)
         let mut columns = HashMap::new();

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -11,6 +11,48 @@ use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
+/// Mask the password in a database URL for safe logging. Matches the
+/// standard shape `driver://user:pass@host:...` and replaces the password
+/// segment with `***`. If no password is present (or the URL doesn't match
+/// the expected shape), returns the input unchanged.
+///
+/// This is best-effort — failing gracefully is safer than failing hard,
+/// since logging shouldn't crash the LSP.
+fn mask_url_password(url: &str) -> String {
+    // Find the `://` separator, then the `@` that ends the credentials.
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string();
+    };
+    let creds_start = scheme_end + 3;
+    let Some(at_offset) = url[creds_start..].find('@') else {
+        return url.to_string();
+    };
+    let creds_end = creds_start + at_offset;
+    let creds = &url[creds_start..creds_end];
+    // Credentials are `user[:password]`. Only mask if there's a `:`.
+    let Some(colon_offset) = creds.find(':') else {
+        return url.to_string();
+    };
+    let user_end = creds_start + colon_offset;
+    let mut masked = String::with_capacity(url.len());
+    masked.push_str(&url[..user_end + 1]); // up to and including the `:`
+    masked.push_str("***");
+    masked.push_str(&url[creds_end..]); // from `@` onwards
+    masked
+}
+
+/// One thing the connector should attempt: a URL to connect with, a short
+/// human-readable label for logs, and an optional explanatory note shown
+/// when this candidate is the one that finally succeeded (after earlier
+/// ones failed). The label MUST mask any sensitive bits — the full URL is
+/// in `url` for the driver, never logged directly.
+#[derive(Debug, Clone)]
+struct ConnCandidate {
+    label: String,
+    url: String,
+    success_note: Option<String>,
+}
+
 /// Cached database schema with expiration
 #[derive(Debug, Clone)]
 pub struct DatabaseSchema {
@@ -31,7 +73,11 @@ impl DatabaseSchema {
     }
 }
 
-/// Database connection configuration
+/// Database connection configuration. Mirrors the keys Laravel's default
+/// `config/database.php` exposes for the active connection driver. The
+/// LSP reads each key with the same `env(NAME, DEFAULT)` fallback chain
+/// Laravel itself uses, so even projects that haven't populated `.env`
+/// at all (relying purely on config defaults) connect correctly.
 #[derive(Debug, Clone)]
 pub struct DatabaseConfig {
     pub driver: String,
@@ -40,6 +86,18 @@ pub struct DatabaseConfig {
     pub database: String,
     pub username: String,
     pub password: String,
+    /// A full database URL like `mysql://user:pass@host:port/db`. When
+    /// present, it takes precedence over the individual host/port/etc.
+    /// fields. Laravel's `DB_URL` env var maps here.
+    pub url: Option<String>,
+    /// Unix socket path (e.g., `/tmp/mysql.sock`, `/var/run/mysqld/mysqld.sock`).
+    /// Common on Mac local dev where MySQL/Postgres expose a socket alongside
+    /// TCP. When set, drivers should prefer socket over TCP.
+    pub unix_socket: Option<String>,
+    /// Connection charset (MySQL/Postgres). Defaults to `utf8mb4` for MySQL.
+    pub charset: Option<String>,
+    /// Connection collation (MySQL). Defaults to `utf8mb4_unicode_ci`.
+    pub collation: Option<String>,
 }
 
 /// Database connection error information
@@ -378,7 +436,10 @@ impl DatabaseSchemaProvider {
         let block = connection_block.unwrap_or_default();
         info!("🗄️  Found connection block ({} chars)", block.len());
 
-        // Step 3: Parse settings from the connection block
+        // Step 3: Parse settings from the connection block. Each call honors
+        // Laravel's `env(NAME, DEFAULT)` chain: if the env var is set we use
+        // it, otherwise the default in `config/database.php`, otherwise the
+        // hard-coded fallback below.
         let host = self.parse_env_setting(&block, "host", "127.0.0.1");
         let port_str =
             self.parse_env_setting(&block, "port", &self.default_port(&driver).to_string());
@@ -386,6 +447,13 @@ impl DatabaseSchemaProvider {
         let database = self.parse_env_setting(&block, "database", "laravel");
         let username = self.parse_env_setting(&block, "username", "root");
         let password = self.parse_env_setting(&block, "password", "");
+
+        // Optional / less common settings. Empty / unset → None so the
+        // connection logic can skip them rather than send empty strings.
+        let url = self.parse_optional_setting(&block, "url");
+        let unix_socket = self.parse_optional_setting(&block, "unix_socket");
+        let charset = self.parse_optional_setting(&block, "charset");
+        let collation = self.parse_optional_setting(&block, "collation");
 
         info!("🗄️  Parsed database config:");
         info!("🗄️    driver: {}", driver);
@@ -401,6 +469,20 @@ impl DatabaseSchemaProvider {
                 "(set)"
             }
         );
+        if let Some(u) = &url {
+            // Mask the password in the URL when logging — common shape is
+            // `driver://user:pass@host:port/db`. Best-effort, fail-open.
+            info!("🗄️    url: {}", mask_url_password(u));
+        }
+        if let Some(s) = &unix_socket {
+            info!("🗄️    unix_socket: {}", s);
+        }
+        if let Some(c) = &charset {
+            info!("🗄️    charset: {}", c);
+        }
+        if let Some(c) = &collation {
+            info!("🗄️    collation: {}", c);
+        }
 
         // For SQLite, check if file exists
         if driver == "sqlite" {
@@ -423,6 +505,10 @@ impl DatabaseSchemaProvider {
             database,
             username,
             password,
+            url,
+            unix_socket,
+            charset,
+            collation,
         })
     }
 
@@ -457,6 +543,20 @@ impl DatabaseSchemaProvider {
             Some(remaining[..end_pos].to_string())
         } else {
             None
+        }
+    }
+
+    /// Parse an optional setting from the connection block. Same env() chain
+    /// as [`Self::parse_env_setting`] but returns `None` when the resolved
+    /// value is empty (no env, empty default, or empty string literal). Use
+    /// for settings that shouldn't be passed to the driver when missing —
+    /// e.g., empty `unix_socket` should NOT trigger socket-mode.
+    fn parse_optional_setting(&self, block: &str, key: &str) -> Option<String> {
+        let value = self.parse_env_setting(block, key, "");
+        if value.is_empty() {
+            None
+        } else {
+            Some(value)
         }
     }
 
@@ -659,56 +759,56 @@ impl DatabaseSchemaProvider {
         result
     }
 
-    /// Fetch schema from MySQL/MariaDB
+    /// Fetch schema from MySQL/MariaDB. Tries connection candidates in
+    /// priority order:
+    /// 1. **`DB_URL`** — managed cloud providers (Heroku, Render, AWS)
+    ///    deliver a full connection string. When set, this overrides
+    ///    everything else, exactly as Laravel's `ConfigurationUrlParser`
+    ///    does.
+    /// 2. **`unix_socket`** — common on Mac local dev (Homebrew MySQL),
+    ///    where the daemon exposes both TCP and a `.sock` file.
+    /// 3. **TCP** with the configured host, plus a `127.0.0.1` fallback
+    ///    for Sail / Docker Compose setups where the configured host is a
+    ///    container service name unresolvable from outside Docker.
     async fn fetch_mysql_schema(&self, config: &DatabaseConfig) -> Option<DatabaseSchema> {
         use sqlx::mysql::MySqlPoolOptions;
         use sqlx::Row;
 
-        // Sail / Docker Compose use service hostnames like `mysql`, `pgsql`,
-        // `redis` etc. that only resolve inside the Docker network. The LSP
-        // runs outside Docker (it's a local binary), so `mysql` fails DNS.
-        // Sail's default `docker-compose.yml` maps the container's 3306 to
-        // the host's 3306, so `127.0.0.1:3306` reaches the same database.
-        // Try the configured host first; if that fails AND the host looks
-        // like a Docker service name (no dots, not localhost), retry with
-        // `127.0.0.1`. Most Sail projects Just Work after this fallback.
-        let host_candidates = Self::host_candidates(&config.host);
-
+        let candidates = self.build_mysql_candidates(config);
         let mut last_err: Option<String> = None;
         let mut pool_opt = None;
-        let mut used_fallback_host: Option<&str> = None;
-        for host in &host_candidates {
-            let url = format!(
-                "mysql://{}:{}@{}:{}/{}",
-                config.username, config.password, host, config.port, config.database
-            );
+        let primary_label = candidates.first().map(|c| c.label.clone());
+
+        for cand in &candidates {
             match MySqlPoolOptions::new()
                 .max_connections(1)
                 .acquire_timeout(Duration::from_secs(5))
-                .connect(&url)
+                .connect(&cand.url)
                 .await
             {
                 Ok(p) => {
-                    if host != &config.host {
+                    if Some(&cand.label) != primary_label.as_ref() {
                         info!(
-                            "MySQL: connected via fallback host '{}' (configured host '{}' didn't resolve). \
-                             Looks like a Sail / Docker Compose setup — the LSP runs outside Docker, so \
-                             the service hostname doesn't work, but the mapped host port does.",
-                            host, config.host
+                            "MySQL: connected via fallback '{}' (primary '{}' failed). \
+                             {}",
+                            cand.label,
+                            primary_label.as_deref().unwrap_or("?"),
+                            cand.success_note.as_deref().unwrap_or("")
                         );
-                        used_fallback_host = Some(host);
+                    } else {
+                        info!("MySQL: connected via {}", cand.label);
                     }
                     pool_opt = Some(p);
                     break;
                 }
                 Err(e) => {
-                    if host_candidates.len() > 1 && host == &config.host {
+                    if candidates.len() > 1 && Some(&cand.label) == primary_label.as_ref() {
                         info!(
-                            "MySQL: primary host '{}' didn't connect ({}). Trying fallback...",
-                            host, e
+                            "MySQL: primary candidate '{}' didn't connect ({}). Trying fallback...",
+                            cand.label, e
                         );
                     }
-                    last_err = Some(format!("host='{host}': {e}"));
+                    last_err = Some(format!("{}: {}", cand.label, e));
                 }
             }
         }
@@ -717,11 +817,15 @@ impl DatabaseSchemaProvider {
             Some(p) => p,
             None => {
                 let msg = format!(
-                    "MySQL connection failed. Tried hosts: [{}]. Last error: {}. \
-                     Check DB_HOST / DB_PORT / DB_DATABASE / DB_USERNAME / DB_PASSWORD in .env. \
-                     If using Sail/Docker Compose, ensure the container is running and the \
-                     port is mapped to your host (run `./vendor/bin/sail up -d`).",
-                    host_candidates.join(", "),
+                    "MySQL connection failed. Tried candidates: [{}]. Last error: {}. \
+                     Check DB_URL / DB_HOST / DB_PORT / DB_DATABASE / DB_USERNAME / DB_PASSWORD / \
+                     DB_SOCKET in .env. If using Sail/Docker Compose, ensure the container is \
+                     running and the port is mapped to your host (run `./vendor/bin/sail up -d`).",
+                    candidates
+                        .iter()
+                        .map(|c| c.label.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", "),
                     last_err.unwrap_or_else(|| "(no error captured)".to_string())
                 );
                 warn!("{}", msg);
@@ -729,7 +833,6 @@ impl DatabaseSchemaProvider {
                 return None;
             }
         };
-        let _ = used_fallback_host; // documented in info! above
 
         // Diagnostic identity probe — when SHOW TABLES returns 0 rows but
         // the user knows the DB has tables, the connection probably landed
@@ -820,39 +923,150 @@ impl DatabaseSchemaProvider {
         candidates
     }
 
-    /// Fetch schema from PostgreSQL
+    /// Build the ordered list of MySQL connection candidates. Priority:
+    /// 1. `DB_URL` (full connection string, used by managed cloud providers)
+    /// 2. `unix_socket` (local dev, e.g. Homebrew MySQL exposing `.sock`)
+    /// 3. TCP via configured host + 127.0.0.1 Sail/Docker fallback
+    ///
+    /// All sources of credentials/database come from `config` — the URL/socket
+    /// don't carry their own credentials; we splice them in.
+    fn build_mysql_candidates(&self, config: &DatabaseConfig) -> Vec<ConnCandidate> {
+        let mut out = Vec::new();
+
+        if let Some(url) = &config.url {
+            // Pass DB_URL through verbatim — managed providers (Heroku, Render,
+            // AWS RDS proxy, etc.) bake credentials AND host into the URL and
+            // expect the driver to honor it as-is.
+            out.push(ConnCandidate {
+                label: "DB_URL".to_string(),
+                url: url.clone(),
+                success_note: Some(
+                    "Configured via DB_URL (typical for managed cloud providers).".to_string(),
+                ),
+            });
+        }
+
+        if let Some(socket) = &config.unix_socket {
+            // sqlx-mysql honors the `socket` query parameter — point host at
+            // `localhost` (ignored when socket is present, but required for
+            // URL syntax) and tack the socket on. Real-world socket paths
+            // (`/tmp/mysql.sock`, `/var/run/mysqld/mysqld.sock`) have no
+            // characters that need URL-encoding, so we splice raw.
+            out.push(ConnCandidate {
+                label: format!("unix_socket={socket}"),
+                url: format!(
+                    "mysql://{}:{}@localhost/{}?socket={}",
+                    config.username, config.password, config.database, socket
+                ),
+                success_note: Some(
+                    "Configured via unix_socket — bypasses TCP entirely.".to_string(),
+                ),
+            });
+        }
+
+        // TCP candidates. Always added — these are the fallback path when
+        // neither URL nor socket are configured, OR when those fail.
+        for host in Self::host_candidates(&config.host) {
+            let is_sail_fallback = host == "127.0.0.1" && host != config.host;
+            out.push(ConnCandidate {
+                label: format!("tcp {}:{}", host, config.port),
+                url: format!(
+                    "mysql://{}:{}@{}:{}/{}",
+                    config.username, config.password, host, config.port, config.database
+                ),
+                success_note: if is_sail_fallback {
+                    Some(
+                        "Looks like a Sail / Docker Compose setup — the LSP runs outside Docker, \
+                         so the service hostname doesn't work, but the mapped host port does."
+                            .to_string(),
+                    )
+                } else {
+                    None
+                },
+            });
+        }
+
+        out
+    }
+
+    /// Build the ordered list of PostgreSQL connection candidates. Same
+    /// priority as MySQL: DB_URL → unix_socket → TCP with host fallback.
+    fn build_postgres_candidates(&self, config: &DatabaseConfig) -> Vec<ConnCandidate> {
+        let mut out = Vec::new();
+
+        if let Some(url) = &config.url {
+            out.push(ConnCandidate {
+                label: "DB_URL".to_string(),
+                url: url.clone(),
+                success_note: Some("Configured via DB_URL.".to_string()),
+            });
+        }
+
+        if let Some(socket) = &config.unix_socket {
+            // libpq-style socket connection: `postgres://user:pass@/db?host=/path`.
+            out.push(ConnCandidate {
+                label: format!("unix_socket={socket}"),
+                url: format!(
+                    "postgres://{}:{}@/{}?host={}",
+                    config.username, config.password, config.database, socket
+                ),
+                success_note: Some("Configured via unix_socket.".to_string()),
+            });
+        }
+
+        for host in Self::host_candidates(&config.host) {
+            let is_sail_fallback = host == "127.0.0.1" && host != config.host;
+            out.push(ConnCandidate {
+                label: format!("tcp {}:{}", host, config.port),
+                url: format!(
+                    "postgres://{}:{}@{}:{}/{}",
+                    config.username, config.password, host, config.port, config.database
+                ),
+                success_note: if is_sail_fallback {
+                    Some("Sail / Docker Compose fallback to 127.0.0.1.".to_string())
+                } else {
+                    None
+                },
+            });
+        }
+
+        out
+    }
+
+    /// Fetch schema from PostgreSQL. Same candidate priority as
+    /// `fetch_mysql_schema`: DB_URL → unix_socket → TCP with Sail fallback.
     async fn fetch_postgres_schema(&self, config: &DatabaseConfig) -> Option<DatabaseSchema> {
         use sqlx::postgres::PgPoolOptions;
         use sqlx::Row;
 
-        // Same Sail/Docker fallback story as MySQL — see `fetch_mysql_schema`
-        // for the rationale.
-        let host_candidates = Self::host_candidates(&config.host);
+        let candidates = self.build_postgres_candidates(config);
         let mut last_err: Option<String> = None;
         let mut pool_opt = None;
-        for host in &host_candidates {
-            let url = format!(
-                "postgres://{}:{}@{}:{}/{}",
-                config.username, config.password, host, config.port, config.database
-            );
+        let primary_label = candidates.first().map(|c| c.label.clone());
+
+        for cand in &candidates {
             match PgPoolOptions::new()
                 .max_connections(1)
                 .acquire_timeout(Duration::from_secs(5))
-                .connect(&url)
+                .connect(&cand.url)
                 .await
             {
                 Ok(p) => {
-                    if host != &config.host {
+                    if Some(&cand.label) != primary_label.as_ref() {
                         info!(
-                            "PostgreSQL: connected via fallback host '{}' (configured host '{}' didn't resolve).",
-                            host, config.host
+                            "PostgreSQL: connected via fallback '{}' (primary '{}' failed). {}",
+                            cand.label,
+                            primary_label.as_deref().unwrap_or("?"),
+                            cand.success_note.as_deref().unwrap_or("")
                         );
+                    } else {
+                        info!("PostgreSQL: connected via {}", cand.label);
                     }
                     pool_opt = Some(p);
                     break;
                 }
                 Err(e) => {
-                    last_err = Some(format!("host='{host}': {e}"));
+                    last_err = Some(format!("{}: {}", cand.label, e));
                 }
             }
         }
@@ -861,10 +1075,15 @@ impl DatabaseSchemaProvider {
             Some(p) => p,
             None => {
                 let msg = format!(
-                    "PostgreSQL connection failed. Tried hosts: [{}]. Last error: {}. \
-                     Check DB_HOST / DB_PORT / DB_DATABASE / DB_USERNAME / DB_PASSWORD in .env. \
-                     If using Sail/Docker Compose, ensure the container is running.",
-                    host_candidates.join(", "),
+                    "PostgreSQL connection failed. Tried candidates: [{}]. Last error: {}. \
+                     Check DB_URL / DB_HOST / DB_PORT / DB_DATABASE / DB_USERNAME / DB_PASSWORD / \
+                     DB_SOCKET in .env. If using Sail/Docker Compose, ensure the container is \
+                     running.",
+                    candidates
+                        .iter()
+                        .map(|c| c.label.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", "),
                     last_err.unwrap_or_else(|| "(no error captured)".to_string())
                 );
                 warn!("{}", msg);

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -664,25 +664,72 @@ impl DatabaseSchemaProvider {
         use sqlx::mysql::MySqlPoolOptions;
         use sqlx::Row;
 
-        let url = format!(
-            "mysql://{}:{}@{}:{}/{}",
-            config.username, config.password, config.host, config.port, config.database
-        );
+        // Sail / Docker Compose use service hostnames like `mysql`, `pgsql`,
+        // `redis` etc. that only resolve inside the Docker network. The LSP
+        // runs outside Docker (it's a local binary), so `mysql` fails DNS.
+        // Sail's default `docker-compose.yml` maps the container's 3306 to
+        // the host's 3306, so `127.0.0.1:3306` reaches the same database.
+        // Try the configured host first; if that fails AND the host looks
+        // like a Docker service name (no dots, not localhost), retry with
+        // `127.0.0.1`. Most Sail projects Just Work after this fallback.
+        let host_candidates = Self::host_candidates(&config.host);
 
-        let pool = match MySqlPoolOptions::new()
-            .max_connections(1)
-            .acquire_timeout(Duration::from_secs(5))
-            .connect(&url)
-            .await
-        {
-            Ok(p) => p,
-            Err(e) => {
-                let msg = format!("MySQL connection failed: {}. Check DB_HOST, DB_PORT, DB_DATABASE, DB_USERNAME, DB_PASSWORD in .env", e);
+        let mut last_err: Option<String> = None;
+        let mut pool_opt = None;
+        let mut used_fallback_host: Option<&str> = None;
+        for host in &host_candidates {
+            let url = format!(
+                "mysql://{}:{}@{}:{}/{}",
+                config.username, config.password, host, config.port, config.database
+            );
+            match MySqlPoolOptions::new()
+                .max_connections(1)
+                .acquire_timeout(Duration::from_secs(5))
+                .connect(&url)
+                .await
+            {
+                Ok(p) => {
+                    if host != &config.host {
+                        info!(
+                            "MySQL: connected via fallback host '{}' (configured host '{}' didn't resolve). \
+                             Looks like a Sail / Docker Compose setup — the LSP runs outside Docker, so \
+                             the service hostname doesn't work, but the mapped host port does.",
+                            host, config.host
+                        );
+                        used_fallback_host = Some(host);
+                    }
+                    pool_opt = Some(p);
+                    break;
+                }
+                Err(e) => {
+                    if host_candidates.len() > 1 && host == &config.host {
+                        info!(
+                            "MySQL: primary host '{}' didn't connect ({}). Trying fallback...",
+                            host, e
+                        );
+                    }
+                    last_err = Some(format!("host='{host}': {e}"));
+                }
+            }
+        }
+
+        let pool = match pool_opt {
+            Some(p) => p,
+            None => {
+                let msg = format!(
+                    "MySQL connection failed. Tried hosts: [{}]. Last error: {}. \
+                     Check DB_HOST / DB_PORT / DB_DATABASE / DB_USERNAME / DB_PASSWORD in .env. \
+                     If using Sail/Docker Compose, ensure the container is running and the \
+                     port is mapped to your host (run `./vendor/bin/sail up -d`).",
+                    host_candidates.join(", "),
+                    last_err.unwrap_or_else(|| "(no error captured)".to_string())
+                );
                 warn!("{}", msg);
                 self.set_error("mysql", &msg).await;
                 return None;
             }
         };
+        let _ = used_fallback_host; // documented in info! above
 
         // Get tables
         let tables: Vec<String> = sqlx::query("SHOW TABLES")
@@ -728,25 +775,70 @@ impl DatabaseSchemaProvider {
         })
     }
 
+    /// Build the ordered list of host candidates to try. The primary
+    /// (configured) host is always first; if it looks like a Docker Compose
+    /// service name (no dots, not `localhost`) we add `127.0.0.1` as a
+    /// fallback so Sail / Docker Compose setups work without the LSP needing
+    /// to be inside the Docker network.
+    fn host_candidates(primary: &str) -> Vec<String> {
+        let mut candidates = vec![primary.to_string()];
+        if !primary.is_empty()
+            && !primary.contains('.')
+            && !primary.eq_ignore_ascii_case("localhost")
+            && primary != "127.0.0.1"
+        {
+            candidates.push("127.0.0.1".to_string());
+        }
+        candidates
+    }
+
     /// Fetch schema from PostgreSQL
     async fn fetch_postgres_schema(&self, config: &DatabaseConfig) -> Option<DatabaseSchema> {
         use sqlx::postgres::PgPoolOptions;
         use sqlx::Row;
 
-        let url = format!(
-            "postgres://{}:{}@{}:{}/{}",
-            config.username, config.password, config.host, config.port, config.database
-        );
+        // Same Sail/Docker fallback story as MySQL — see `fetch_mysql_schema`
+        // for the rationale.
+        let host_candidates = Self::host_candidates(&config.host);
+        let mut last_err: Option<String> = None;
+        let mut pool_opt = None;
+        for host in &host_candidates {
+            let url = format!(
+                "postgres://{}:{}@{}:{}/{}",
+                config.username, config.password, host, config.port, config.database
+            );
+            match PgPoolOptions::new()
+                .max_connections(1)
+                .acquire_timeout(Duration::from_secs(5))
+                .connect(&url)
+                .await
+            {
+                Ok(p) => {
+                    if host != &config.host {
+                        info!(
+                            "PostgreSQL: connected via fallback host '{}' (configured host '{}' didn't resolve).",
+                            host, config.host
+                        );
+                    }
+                    pool_opt = Some(p);
+                    break;
+                }
+                Err(e) => {
+                    last_err = Some(format!("host='{host}': {e}"));
+                }
+            }
+        }
 
-        let pool = match PgPoolOptions::new()
-            .max_connections(1)
-            .acquire_timeout(Duration::from_secs(5))
-            .connect(&url)
-            .await
-        {
-            Ok(p) => p,
-            Err(e) => {
-                let msg = format!("PostgreSQL connection failed: {}. Check DB_HOST, DB_PORT, DB_DATABASE, DB_USERNAME, DB_PASSWORD in .env", e);
+        let pool = match pool_opt {
+            Some(p) => p,
+            None => {
+                let msg = format!(
+                    "PostgreSQL connection failed. Tried hosts: [{}]. Last error: {}. \
+                     Check DB_HOST / DB_PORT / DB_DATABASE / DB_USERNAME / DB_PASSWORD in .env. \
+                     If using Sail/Docker Compose, ensure the container is running.",
+                    host_candidates.join(", "),
+                    last_err.unwrap_or_else(|| "(no error captured)".to_string())
+                );
                 warn!("{}", msg);
                 self.set_error("pgsql", &msg).await;
                 return None;

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -11,6 +11,49 @@ use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
+/// Read a string column from a sqlx Row, falling back to a `Vec<u8>` +
+/// lossy UTF-8 decode if the direct `String` decoder rejects the value.
+///
+/// This exists because sqlx-mysql sometimes returns result columns with
+/// binary collation (especially from `SHOW DATABASES`, `SHOW TABLES`,
+/// `SHOW COLUMNS`, and `information_schema.*` against MySQL 8.0). The
+/// `String` decoder bails on those, but the bytes are valid UTF-8 — we
+/// just need to take the manual path. `from_utf8_lossy` is total, so any
+/// stray invalid bytes become U+FFFD rather than a parse error.
+///
+/// Usage: `read_string(&row, "column_name")` or `read_string(&row, 0)`
+/// (by-name overload via the `Idx` trait).
+fn read_string<I>(row: &sqlx::mysql::MySqlRow, index: I) -> Option<String>
+where
+    I: sqlx::ColumnIndex<sqlx::mysql::MySqlRow> + Copy,
+{
+    use sqlx::Row;
+    if let Ok(s) = row.try_get::<String, _>(index) {
+        return Some(s);
+    }
+    if let Ok(bytes) = row.try_get::<Vec<u8>, _>(index) {
+        return Some(String::from_utf8_lossy(&bytes).into_owned());
+    }
+    None
+}
+
+/// Same as [`read_string`] but for PostgreSQL rows. Postgres doesn't have
+/// the same binary-collation issue MySQL does, but symmetry is easier to
+/// maintain across the two drivers.
+fn read_string_pg<I>(row: &sqlx::postgres::PgRow, index: I) -> Option<String>
+where
+    I: sqlx::ColumnIndex<sqlx::postgres::PgRow> + Copy,
+{
+    use sqlx::Row;
+    if let Ok(s) = row.try_get::<String, _>(index) {
+        return Some(s);
+    }
+    if let Ok(bytes) = row.try_get::<Vec<u8>, _>(index) {
+        return Some(String::from_utf8_lossy(&bytes).into_owned());
+    }
+    None
+}
+
 /// Mask the password in a database URL for safe logging. Matches the
 /// standard shape `driver://user:pass@host:...` and replaces the password
 /// segment with `***`. If no password is present (or the URL doesn't match
@@ -850,10 +893,14 @@ impl DatabaseSchemaProvider {
         .await
         {
             Ok(row) => {
-                let db_name: String = row.try_get("db").unwrap_or_default();
-                let hostname: String = row.try_get("hostname").unwrap_or_default();
-                let user: String = row.try_get("user").unwrap_or_default();
-                let version: String = row.try_get("version").unwrap_or_default();
+                // Use read_string everywhere so binary-collation columns
+                // from MySQL 8.0's SHOW/information_schema responses decode
+                // cleanly. Without this, every "string" column came back as
+                // empty and silently dropped — the bug we just isolated.
+                let db_name = read_string(&row, "db").unwrap_or_default();
+                let hostname = read_string(&row, "hostname").unwrap_or_default();
+                let user = read_string(&row, "user").unwrap_or_default();
+                let version = read_string(&row, "version").unwrap_or_default();
                 info!(
                     "MySQL probe — db={:?} server_hostname={:?} user={:?} version={:?}",
                     db_name, hostname, user, version
@@ -872,11 +919,7 @@ impl DatabaseSchemaProvider {
                 // the column type or name.
                 let dbs: Vec<String> = rows
                     .into_iter()
-                    .filter_map(|r| {
-                        r.try_get::<String, _>("Database")
-                            .or_else(|_| r.try_get::<String, _>(0))
-                            .ok()
-                    })
+                    .filter_map(|r| read_string(&r, "Database").or_else(|| read_string(&r, 0)))
                     .collect();
                 info!(
                     "MySQL probe — SHOW DATABASES returned {} rows, parsed {}: {:?}",
@@ -900,7 +943,7 @@ impl DatabaseSchemaProvider {
             Ok(rows) => {
                 let grants: Vec<String> = rows
                     .into_iter()
-                    .filter_map(|r| r.try_get::<String, _>(0).ok())
+                    .filter_map(|r| read_string(&r, 0))
                     .collect();
                 info!(
                     "MySQL probe — SHOW GRANTS for current user ({} grants): {:?}",
@@ -947,11 +990,7 @@ impl DatabaseSchemaProvider {
             Ok(rows) => {
                 let names: Vec<String> = rows
                     .into_iter()
-                    .filter_map(|r| {
-                        r.try_get::<String, _>("table_name")
-                            .or_else(|_| r.try_get::<String, _>(0))
-                            .ok()
-                    })
+                    .filter_map(|r| read_string(&r, "table_name").or_else(|| read_string(&r, 0)))
                     .collect();
                 info!(
                     "MySQL probe — first 5 tables via information_schema = {:?}",
@@ -976,7 +1015,7 @@ impl DatabaseSchemaProvider {
         let row_count = table_rows.len();
         let tables: Vec<String> = table_rows
             .into_iter()
-            .filter_map(|row| row.try_get::<String, _>(0).ok())
+            .filter_map(|row| read_string(&row, 0))
             .collect();
         info!(
             "MySQL: SHOW TABLES returned {} rows, parsed {} table names",
@@ -997,8 +1036,8 @@ impl DatabaseSchemaProvider {
             let mut col_types = Vec::new();
 
             for row in rows {
-                if let Ok(field) = row.try_get::<String, _>("Field") {
-                    let sql_type = row.try_get::<String, _>("Type").unwrap_or_default();
+                if let Some(field) = read_string(&row, "Field") {
+                    let sql_type = read_string(&row, "Type").unwrap_or_default();
                     let php_type = Self::map_sql_type_to_php(&sql_type);
                     col_names.push(field.clone());
                     col_types.push((field, php_type));
@@ -1150,7 +1189,6 @@ impl DatabaseSchemaProvider {
     /// `fetch_mysql_schema`: DB_URL → unix_socket → TCP with Sail fallback.
     async fn fetch_postgres_schema(&self, config: &DatabaseConfig) -> Option<DatabaseSchema> {
         use sqlx::postgres::PgPoolOptions;
-        use sqlx::Row;
 
         let candidates = self.build_postgres_candidates(config);
         let mut last_err: Option<String> = None;
@@ -1213,7 +1251,7 @@ impl DatabaseSchemaProvider {
         .await
         .ok()?
         .into_iter()
-        .filter_map(|row| row.try_get::<String, _>("table_name").ok())
+        .filter_map(|row| read_string_pg(&row, "table_name"))
         .collect();
 
         // Get columns for each table (with types)
@@ -1232,8 +1270,8 @@ impl DatabaseSchemaProvider {
             let mut col_types = Vec::new();
 
             for row in rows {
-                if let Ok(col_name) = row.try_get::<String, _>("column_name") {
-                    let sql_type = row.try_get::<String, _>("data_type").unwrap_or_default();
+                if let Some(col_name) = read_string_pg(&row, "column_name") {
+                    let sql_type = read_string_pg(&row, "data_type").unwrap_or_default();
                     let php_type = Self::map_sql_type_to_php(&sql_type);
                     col_names.push(col_name.clone());
                     col_types.push((col_name, php_type));

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -839,27 +839,41 @@ impl DatabaseSchemaProvider {
         // on the wrong MySQL instance (e.g., Homebrew MySQL on 127.0.0.1:3306
         // intercepting before Sail). Log the server identity so the user can
         // see what they're actually connected to.
-        if let Ok(row) = sqlx::query(
+        //
+        // Use match (not if-let) so any error from these probe queries gets
+        // surfaced — silent failure here is what prevented the previous
+        // diagnostic round from telling us anything.
+        match sqlx::query(
             "SELECT DATABASE() AS db, @@hostname AS hostname, USER() AS user, @@version AS version",
         )
         .fetch_one(&pool)
         .await
         {
-            let db_name: String = row.try_get("db").unwrap_or_default();
-            let hostname: String = row.try_get("hostname").unwrap_or_default();
-            let user: String = row.try_get("user").unwrap_or_default();
-            let version: String = row.try_get("version").unwrap_or_default();
-            info!(
-                "MySQL connected: db={:?} server_hostname={:?} user={:?} version={:?}",
-                db_name, hostname, user, version
-            );
+            Ok(row) => {
+                let db_name: String = row.try_get("db").unwrap_or_default();
+                let hostname: String = row.try_get("hostname").unwrap_or_default();
+                let user: String = row.try_get("user").unwrap_or_default();
+                let version: String = row.try_get("version").unwrap_or_default();
+                info!(
+                    "MySQL probe — db={:?} server_hostname={:?} user={:?} version={:?}",
+                    db_name, hostname, user, version
+                );
+            }
+            Err(e) => {
+                warn!("MySQL probe (identity query) failed: {}", e);
+            }
         }
-        if let Ok(rows) = sqlx::query("SHOW DATABASES").fetch_all(&pool).await {
-            let dbs: Vec<String> = rows
-                .into_iter()
-                .filter_map(|r| r.try_get::<String, _>(0).ok())
-                .collect();
-            info!("MySQL: visible databases = {:?}", dbs);
+        match sqlx::query("SHOW DATABASES").fetch_all(&pool).await {
+            Ok(rows) => {
+                let dbs: Vec<String> = rows
+                    .into_iter()
+                    .filter_map(|r| r.try_get::<String, _>(0).ok())
+                    .collect();
+                info!("MySQL probe — visible databases = {:?}", dbs);
+            }
+            Err(e) => {
+                warn!("MySQL probe (SHOW DATABASES) failed: {}", e);
+            }
         }
 
         // Get tables

--- a/laravel-lsp/src/database/tests.rs
+++ b/laravel-lsp/src/database/tests.rs
@@ -320,6 +320,113 @@ fn postgres_candidates_socket_uses_libpq_style_url() {
     );
 }
 
+// ---- classify_mysql_error: actionable per-error-code toasts (Phase 5.8b) ---
+
+#[test]
+fn classify_mysql_unknown_database_recommends_artisan_migrate() {
+    use super::classify_mysql_error;
+    let raw = "tcp 127.0.0.1:3306: error returned from database: 1049 (42000): Unknown database 'tru_data'";
+    let msg = classify_mysql_error(raw, "tru_data", "tcp 127.0.0.1:3306");
+    assert!(
+        msg.contains("php artisan migrate"),
+        "remediation should be in Laravel terms (artisan migrate), not SQL; got: {msg}"
+    );
+    assert!(
+        msg.contains("sail artisan migrate"),
+        "should mention the Sail variant of the artisan command; got: {msg}"
+    );
+    assert!(
+        msg.contains("accepted the connection"),
+        "should tell user that auth worked; got: {msg}"
+    );
+    assert!(
+        !msg.contains("CREATE DATABASE"),
+        "should NOT include raw SQL commands; got: {msg}"
+    );
+    assert!(
+        !msg.contains("Check DB_URL / DB_HOST"),
+        "should NOT show the generic 'check everything' message; got: {msg}"
+    );
+}
+
+#[test]
+fn classify_mysql_missing_table_recommends_artisan_migrate() {
+    use super::classify_mysql_error;
+    let raw =
+        "tcp 127.0.0.1:3306: error returned from database: 1146 (42S02): Table 'tru_data.users' doesn't exist";
+    let msg = classify_mysql_error(raw, "tru_data", "tcp 127.0.0.1:3306");
+    assert!(
+        msg.contains("php artisan migrate"),
+        "missing-table case should also point at artisan migrate; got: {msg}"
+    );
+    assert!(
+        msg.contains("table is missing"),
+        "should call out that the table specifically is missing; got: {msg}"
+    );
+}
+
+#[test]
+fn classify_mysql_access_denied_calls_out_credentials() {
+    use super::classify_mysql_error;
+    let raw = "tcp 127.0.0.1:3306: error returned from database: 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)";
+    let msg = classify_mysql_error(raw, "tru_data", "tcp 127.0.0.1:3306");
+    assert!(
+        msg.contains("DB_USERNAME"),
+        "should call out DB_USERNAME/PASSWORD; got: {msg}"
+    );
+    assert!(
+        msg.contains("rejected the credentials"),
+        "should say MySQL is reachable but rejected creds; got: {msg}"
+    );
+}
+
+#[test]
+fn classify_mysql_connection_refused_blames_host() {
+    use super::classify_mysql_error;
+    let raw = "tcp 127.0.0.1:3306: 2003 Can't connect to MySQL server (Connection refused)";
+    let msg = classify_mysql_error(raw, "tru_data", "tcp 127.0.0.1:3306");
+    assert!(
+        msg.contains("Couldn't reach the MySQL server"),
+        "got: {msg}"
+    );
+    assert!(msg.contains("DB_HOST / DB_PORT"), "got: {msg}");
+}
+
+#[test]
+fn classify_mysql_unknown_error_falls_through_to_generic() {
+    use super::classify_mysql_error;
+    let raw = "tcp 127.0.0.1:3306: some weird sqlx-side error we've never seen";
+    let msg = classify_mysql_error(raw, "tru_data", "tcp 127.0.0.1:3306");
+    assert!(msg.contains("MySQL connection failed"), "got: {msg}");
+    assert!(
+        msg.contains("Check DB_URL / DB_HOST"),
+        "generic message should keep the full .env checklist; got: {msg}"
+    );
+}
+
+#[test]
+fn classify_postgres_unknown_database_recommends_artisan_migrate() {
+    use super::classify_postgres_error;
+    let raw = "tcp 127.0.0.1:5432: error returned from database: code: \"3D000\" message: \"database \\\"foo\\\" does not exist\"";
+    let msg = classify_postgres_error(raw, "foo", "tcp 127.0.0.1:5432");
+    assert!(
+        msg.contains("php artisan migrate"),
+        "Postgres unknown-database should also use Laravel framing; got: {msg}"
+    );
+    assert!(!msg.contains("CREATE DATABASE"), "no raw SQL; got: {msg}");
+}
+
+#[test]
+fn classify_postgres_missing_table_recommends_artisan_migrate() {
+    use super::classify_postgres_error;
+    let raw = "tcp 127.0.0.1:5432: error returned from database: code: \"42P01\" message: \"relation \\\"users\\\" does not exist\"";
+    let msg = classify_postgres_error(raw, "foo", "tcp 127.0.0.1:5432");
+    assert!(
+        msg.contains("php artisan migrate"),
+        "Postgres missing-table should point at migrations; got: {msg}"
+    );
+}
+
 // ---- userinfo / empty-password URL shape (Phase 5.4) --------------------
 
 #[test]

--- a/laravel-lsp/src/database/tests.rs
+++ b/laravel-lsp/src/database/tests.rs
@@ -383,6 +383,87 @@ fn mysql_candidates_non_empty_password_keeps_colon() {
     );
 }
 
+// ---- resolve_env: empty value should NOT swallow next line (Phase 5.5) ----
+
+#[test]
+fn resolve_env_empty_value_returns_none_not_next_line() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    // The exact shape that broke in Mike's tru-data project: an empty
+    // DB_PASSWORD followed by other entries. The old regex `\s*=\s*` let
+    // the `\s*` after `=` consume the newline and matched the next line
+    // as the value.
+    std::fs::write(
+        dir.path().join(".env"),
+        "DB_PASSWORD=\nSESSION_DRIVER=database\nDB_CONNECTION=mysql\n",
+    )
+    .unwrap();
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let result = provider.resolve_env("DB_PASSWORD");
+    assert_eq!(
+        result, None,
+        "empty value should produce None (filtered by .filter(!is_empty)), \
+         not the next line's content"
+    );
+}
+
+#[test]
+fn resolve_env_normal_value_works() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    std::fs::write(
+        dir.path().join(".env"),
+        "DB_PASSWORD=secret\nDB_USERNAME=sail\n",
+    )
+    .unwrap();
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    assert_eq!(
+        provider.resolve_env("DB_PASSWORD"),
+        Some("secret".to_string())
+    );
+    assert_eq!(
+        provider.resolve_env("DB_USERNAME"),
+        Some("sail".to_string())
+    );
+}
+
+#[test]
+fn resolve_env_quoted_value_strips_quotes() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    std::fs::write(
+        dir.path().join(".env"),
+        "DB_PASSWORD=\"s3cr3t!\"\nOTHER='single quoted'\n",
+    )
+    .unwrap();
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    assert_eq!(
+        provider.resolve_env("DB_PASSWORD"),
+        Some("s3cr3t!".to_string())
+    );
+    assert_eq!(
+        provider.resolve_env("OTHER"),
+        Some("single quoted".to_string())
+    );
+}
+
+#[test]
+fn resolve_env_handles_trailing_whitespace_on_key() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    // Some editors / templates pad with spaces around `=`. Still single-line.
+    std::fs::write(
+        dir.path().join(".env"),
+        "DB_PASSWORD = padded\nDB_HOST=127.0.0.1\n",
+    )
+    .unwrap();
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    assert_eq!(
+        provider.resolve_env("DB_PASSWORD"),
+        Some("padded".to_string())
+    );
+}
+
 #[test]
 fn postgres_candidates_empty_password_url_has_no_colon() {
     let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));

--- a/laravel-lsp/src/database/tests.rs
+++ b/laravel-lsp/src/database/tests.rs
@@ -175,3 +175,147 @@ fn host_candidates_empty_no_fallback() {
         vec!["".to_string()]
     );
 }
+
+// ---- mask_url_password ----
+
+#[test]
+fn mask_url_password_with_credentials() {
+    use super::mask_url_password;
+    assert_eq!(
+        mask_url_password("mysql://sail:secret@127.0.0.1:3306/db"),
+        "mysql://sail:***@127.0.0.1:3306/db"
+    );
+    assert_eq!(
+        mask_url_password("postgres://user:p@ssw0rd@host/db"),
+        // Only the first `@` after creds is treated as the host separator —
+        // best-effort. Any `@` in the password trips this, but it's a
+        // diagnostic helper, not security-critical.
+        "postgres://user:***@ssw0rd@host/db"
+    );
+}
+
+#[test]
+fn mask_url_password_no_password_no_change() {
+    use super::mask_url_password;
+    // No `:` in creds → no password to mask.
+    assert_eq!(
+        mask_url_password("mysql://sail@127.0.0.1/db"),
+        "mysql://sail@127.0.0.1/db"
+    );
+}
+
+#[test]
+fn mask_url_password_no_scheme_returns_input() {
+    use super::mask_url_password;
+    assert_eq!(mask_url_password("not a url"), "not a url");
+}
+
+// ---- build_*_candidates (DB_URL / unix_socket / TCP priority) ----
+
+fn make_config_with(url: Option<&str>, socket: Option<&str>, host: &str) -> super::DatabaseConfig {
+    super::DatabaseConfig {
+        driver: "mysql".to_string(),
+        host: host.to_string(),
+        port: 3306,
+        database: "testdb".to_string(),
+        username: "u".to_string(),
+        password: "p".to_string(),
+        url: url.map(|s| s.to_string()),
+        unix_socket: socket.map(|s| s.to_string()),
+        charset: None,
+        collation: None,
+    }
+}
+
+#[test]
+fn mysql_candidates_db_url_takes_precedence() {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let cfg = make_config_with(Some("mysql://heroku:abc@db.heroku.com/x"), None, "mysql");
+    let candidates = provider.build_mysql_candidates(&cfg);
+
+    // DB_URL must come first.
+    assert_eq!(candidates[0].label, "DB_URL");
+    assert_eq!(candidates[0].url, "mysql://heroku:abc@db.heroku.com/x");
+
+    // TCP fallbacks should still be there in case DB_URL fails.
+    assert!(candidates.iter().any(|c| c.label.starts_with("tcp ")));
+}
+
+#[test]
+fn mysql_candidates_unix_socket_inserted_before_tcp() {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let cfg = make_config_with(None, Some("/tmp/mysql.sock"), "localhost");
+    let candidates = provider.build_mysql_candidates(&cfg);
+
+    // Socket comes before TCP.
+    assert!(candidates[0].label.contains("unix_socket"));
+    assert_eq!(candidates[0].label, "unix_socket=/tmp/mysql.sock");
+    assert!(candidates[0].url.contains("socket=/tmp/mysql.sock"));
+    assert!(candidates[1].label.starts_with("tcp "));
+}
+
+#[test]
+fn mysql_candidates_sail_host_adds_loopback_fallback() {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let cfg = make_config_with(None, None, "mysql");
+    let candidates = provider.build_mysql_candidates(&cfg);
+
+    // Two TCP candidates: configured host + 127.0.0.1 fallback.
+    let tcp: Vec<&str> = candidates
+        .iter()
+        .filter(|c| c.label.starts_with("tcp "))
+        .map(|c| c.label.as_str())
+        .collect();
+    assert_eq!(tcp, vec!["tcp mysql:3306", "tcp 127.0.0.1:3306"]);
+    // The fallback candidate carries the Sail explanation note.
+    let fallback = candidates
+        .iter()
+        .find(|c| c.label == "tcp 127.0.0.1:3306")
+        .unwrap();
+    assert!(
+        fallback
+            .success_note
+            .as_deref()
+            .unwrap_or("")
+            .contains("Sail"),
+        "expected Sail success_note on the loopback fallback"
+    );
+}
+
+#[test]
+fn mysql_candidates_localhost_host_no_extra_fallback() {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let cfg = make_config_with(None, None, "localhost");
+    let candidates = provider.build_mysql_candidates(&cfg);
+
+    let tcp_count = candidates
+        .iter()
+        .filter(|c| c.label.starts_with("tcp "))
+        .count();
+    assert_eq!(
+        tcp_count, 1,
+        "localhost host shouldn't add a 127.0.0.1 fallback"
+    );
+}
+
+#[test]
+fn postgres_candidates_socket_uses_libpq_style_url() {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let mut cfg = make_config_with(None, Some("/tmp/.s.PGSQL.5432"), "localhost");
+    cfg.driver = "pgsql".to_string();
+    cfg.port = 5432;
+    let candidates = provider.build_postgres_candidates(&cfg);
+
+    let socket = candidates
+        .iter()
+        .find(|c| c.label.starts_with("unix_socket"))
+        .expect("expected socket candidate");
+    // Postgres socket convention puts the host in a `host=` query param,
+    // not a `socket=` one (that's libpq syntax). Pin that here so we
+    // don't regress.
+    assert!(
+        socket.url.contains("?host=/tmp/.s.PGSQL.5432"),
+        "got URL: {}",
+        socket.url
+    );
+}

--- a/laravel-lsp/src/database/tests.rs
+++ b/laravel-lsp/src/database/tests.rs
@@ -319,3 +319,87 @@ fn postgres_candidates_socket_uses_libpq_style_url() {
         socket.url
     );
 }
+
+// ---- userinfo / empty-password URL shape (Phase 5.4) --------------------
+
+#[test]
+fn userinfo_with_password_uses_colon() {
+    use super::userinfo;
+    assert_eq!(userinfo("sail", "password"), "sail:password");
+}
+
+#[test]
+fn userinfo_with_empty_password_omits_colon() {
+    use super::userinfo;
+    // `user:` would tell sqlx "empty password supplied" and MySQL responds
+    // with `using password: YES`. `user` (no colon) tells sqlx "no
+    // password" and the handshake omits the password packet — accepted by
+    // permissive setups like passwordless `root@localhost`.
+    assert_eq!(userinfo("root", ""), "root");
+}
+
+#[test]
+fn mysql_candidates_empty_password_url_has_no_colon() {
+    // The full smoke test: with DB_PASSWORD empty, the resulting connection
+    // URL should be `mysql://user@host/...` (no `:` before `@`), not
+    // `mysql://user:@host/...`. This makes sqlx skip sending the password
+    // packet, which lets passwordless MySQL setups accept the connection.
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let mut cfg = make_config_with(None, None, "127.0.0.1");
+    cfg.username = "root".to_string();
+    cfg.password = "".to_string();
+    let candidates = provider.build_mysql_candidates(&cfg);
+    let tcp = candidates
+        .iter()
+        .find(|c| c.label.starts_with("tcp "))
+        .expect("tcp candidate");
+    assert!(
+        tcp.url.starts_with("mysql://root@"),
+        "empty password should produce `user@host`, not `user:@host`; got: {}",
+        tcp.url
+    );
+    assert!(
+        !tcp.url.contains(":@"),
+        "URL must not contain `:@` (empty-password specifier); got: {}",
+        tcp.url
+    );
+}
+
+#[test]
+fn mysql_candidates_non_empty_password_keeps_colon() {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let mut cfg = make_config_with(None, None, "127.0.0.1");
+    cfg.username = "sail".to_string();
+    cfg.password = "secret".to_string();
+    let candidates = provider.build_mysql_candidates(&cfg);
+    let tcp = candidates
+        .iter()
+        .find(|c| c.label.starts_with("tcp "))
+        .expect("tcp candidate");
+    assert!(
+        tcp.url.starts_with("mysql://sail:secret@"),
+        "non-empty password should use the user:pass@ shape; got: {}",
+        tcp.url
+    );
+}
+
+#[test]
+fn postgres_candidates_empty_password_url_has_no_colon() {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let mut cfg = make_config_with(None, None, "127.0.0.1");
+    cfg.driver = "pgsql".to_string();
+    cfg.port = 5432;
+    cfg.username = "postgres".to_string();
+    cfg.password = "".to_string();
+    let candidates = provider.build_postgres_candidates(&cfg);
+    let tcp = candidates
+        .iter()
+        .find(|c| c.label.starts_with("tcp "))
+        .expect("tcp candidate");
+    assert!(
+        tcp.url.starts_with("postgres://postgres@"),
+        "got: {}",
+        tcp.url
+    );
+    assert!(!tcp.url.contains(":@"), "got: {}", tcp.url);
+}

--- a/laravel-lsp/src/database/tests.rs
+++ b/laravel-lsp/src/database/tests.rs
@@ -112,3 +112,66 @@ fn test_map_sql_type_to_php() {
         "string"
     );
 }
+
+// ---- host_candidates (Sail / Docker Compose fallback) ----
+
+#[test]
+fn host_candidates_docker_service_name_adds_localhost_fallback() {
+    // The canonical Sail case — DB_HOST=mysql (the container name).
+    assert_eq!(
+        DatabaseSchemaProvider::host_candidates("mysql"),
+        vec!["mysql".to_string(), "127.0.0.1".to_string()]
+    );
+}
+
+#[test]
+fn host_candidates_postgres_service_name_too() {
+    assert_eq!(
+        DatabaseSchemaProvider::host_candidates("pgsql"),
+        vec!["pgsql".to_string(), "127.0.0.1".to_string()]
+    );
+}
+
+#[test]
+fn host_candidates_localhost_no_fallback() {
+    // Already localhost — no point retrying with itself.
+    assert_eq!(
+        DatabaseSchemaProvider::host_candidates("localhost"),
+        vec!["localhost".to_string()]
+    );
+    assert_eq!(
+        DatabaseSchemaProvider::host_candidates("Localhost"),
+        vec!["Localhost".to_string()]
+    );
+}
+
+#[test]
+fn host_candidates_ip_no_fallback() {
+    // Already an IP — no service-name heuristic.
+    assert_eq!(
+        DatabaseSchemaProvider::host_candidates("127.0.0.1"),
+        vec!["127.0.0.1".to_string()]
+    );
+    assert_eq!(
+        DatabaseSchemaProvider::host_candidates("10.0.5.4"),
+        vec!["10.0.5.4".to_string()]
+    );
+}
+
+#[test]
+fn host_candidates_fqdn_no_fallback() {
+    // Dotted hostname is a real DNS name; don't second-guess it.
+    assert_eq!(
+        DatabaseSchemaProvider::host_candidates("db.internal.example.com"),
+        vec!["db.internal.example.com".to_string()]
+    );
+}
+
+#[test]
+fn host_candidates_empty_no_fallback() {
+    // Defensive — don't add `127.0.0.1` when the input is junk.
+    assert_eq!(
+        DatabaseSchemaProvider::host_candidates(""),
+        vec!["".to_string()]
+    );
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -17,6 +17,7 @@ pub mod blade_props;
 pub mod cache_manager;
 pub mod class_locator;
 pub mod component_declaration_locator;
+pub mod composer_autoload;
 pub mod config;
 pub mod config_key_locator;
 pub mod config_lookup;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -40,6 +40,7 @@ pub mod pattern_indexer;
 pub mod php_class;
 pub mod php_outline;
 pub mod queries;
+pub mod query_chain;
 pub mod references;
 pub mod rename;
 pub mod route_binding;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2788,6 +2788,11 @@ impl LaravelLanguageServer {
             (BuilderMode::BaseBuilder, ArgKind::Column) => {
                 eloquent_completion::columns_raw(&ctx, db).await
             }
+            // `DB::table('|')` — table-name completion. Mode is always
+            // BaseBuilder by the time the receiver is recognised, but we
+            // don't gate on it: even if a future receiver shape produced
+            // Table args in another mode, tables are tables.
+            (_, ArgKind::Table) => eloquent_completion::tables(db).await,
             // Other (mode, expecting) combinations land in Phases 4-6.
             _ => Vec::new(),
         };

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2796,22 +2796,34 @@ impl LaravelLanguageServer {
             }
         };
 
-        // Mid-typing the file often has an unterminated quote at the cursor.
-        // Tree-sitter recovers poorly in that case (the `string` node swallows
-        // everything to the next quote anywhere downstream, producing nonsense
-        // spans). We can't trust Salsa's cached chains for this exact moment,
-        // and the in-memory cached version may be stale relative to the live
-        // documents map too. So: inject a matching close quote at the cursor
-        // if needed, then re-parse + re-extract chains from the fixed-up
-        // content. Per-completion cost is one tree-sitter parse on a small
-        // file (~1-5ms) — well within Mike's 200ms debounce.
-        let fixed_content = fixup_for_completion(content, byte_offset);
-        let parse_source: &str = fixed_content.as_deref().unwrap_or(content);
-        if fixed_content.is_some() {
-            info!(
-                "🔗 chain completion: injected close quote at byte {} to balance unterminated string",
-                byte_offset
-            );
+        // Mid-typing the file often has an unterminated quote at the cursor,
+        // OR has just had a `(` typed with no string arg yet (auto-pair
+        // hasn't synced to the LSP yet, or the editor doesn't auto-pair).
+        // Tree-sitter recovers poorly from either shape, and Salsa's
+        // cached chains can be stale relative to the live documents map.
+        // So: `fixup_for_completion` returns a `CompletionPrep` carrying
+        //   - `fixed_content`: source with a close quote OR `''` injected
+        //     at the cursor so the call parses as a well-formed string-arg
+        //     call expression
+        //   - `quote_for_insertion`: Some('\'') when WE synthesised the
+        //     quotes (cursor was after `(`, no quotes in source), so items
+        //     need to wrap their value with quotes; None when the source
+        //     already had the open quote (insert bare).
+        // Per-completion cost: one tree-sitter parse on the small file,
+        // well within the 200ms debounce.
+        let prep = fixup_for_completion(content, byte_offset);
+        let parse_source: &str = prep
+            .as_ref()
+            .map(|p| p.fixed_content.as_str())
+            .unwrap_or(content);
+        let wrap_with_quote: Option<char> = prep.as_ref().and_then(|p| p.quote_for_insertion);
+        if let Some(p) = prep.as_ref() {
+            if p.fixed_content != content {
+                info!(
+                    "🔗 chain completion: applied fixup at byte {} (wrap_with_quote={:?})",
+                    byte_offset, wrap_with_quote
+                );
+            }
         }
 
         let tree = match laravel_lsp::parser::parse_php(parse_source) {
@@ -2937,13 +2949,13 @@ impl LaravelLanguageServer {
 
         let items = match (ctx.mode, ctx.expecting) {
             (BuilderMode::BaseBuilder, ArgKind::Column) => {
-                eloquent_completion::columns_raw(&ctx, db).await
+                eloquent_completion::columns_raw(&ctx, db, wrap_with_quote).await
             }
-            // `DB::table('|')` — table-name completion. Mode is always
-            // BaseBuilder by the time the receiver is recognised, but we
-            // don't gate on it: even if a future receiver shape produced
-            // Table args in another mode, tables are tables.
-            (_, ArgKind::Table) => eloquent_completion::tables(db).await,
+            // `DB::table('|')` (or `DB::table(|`) — table-name completion.
+            // Mode is always BaseBuilder by the time the receiver is
+            // recognised, but we don't gate on it: even if a future receiver
+            // shape produced Table args in another mode, tables are tables.
+            (_, ArgKind::Table) => eloquent_completion::tables(db, wrap_with_quote).await,
             // Other (mode, expecting) combinations land in Phases 4-6.
             _ => Vec::new(),
         };

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2992,11 +2992,16 @@ impl LaravelLanguageServer {
         Some(items)
     }
 
-    /// Send a one-time `window/showMessage` informing the user that table
-    /// and column autocomplete requires a working DB connection. Shares the
+    /// Send a one-time notification informing the user that table and
+    /// column autocomplete requires a working DB connection. Shares the
     /// `database_diagnostic_shown` flag with the existing exists:/unique:
     /// diagnostic path, so the user only sees ONE notification per LSP
     /// session no matter how they hit the unreachable DB.
+    ///
+    /// Uses `window/showMessageRequest` (with a Dismiss action) rather than
+    /// `window/showMessage` because the latter auto-dismisses after a few
+    /// seconds — the user may not even see it if they're typing. With an
+    /// action button, the notification stays until they explicitly click it.
     async fn maybe_notify_db_unreachable(&self, error_message: &str) {
         let mut shown = self.database_diagnostic_shown.write().await;
         if *shown {
@@ -3011,8 +3016,20 @@ impl LaravelLanguageServer {
              (DB_HOST / DB_PORT / credentials) and reload the window to \
              enable. Error: {error_message}"
         );
-        self.client
-            .show_message(tower_lsp::lsp_types::MessageType::INFO, message)
+        let actions = vec![tower_lsp::lsp_types::MessageActionItem {
+            title: "Dismiss".to_string(),
+            properties: Default::default(),
+        }];
+        // We don't care about the response — the only action is "Dismiss".
+        // The point of using show_message_request is that the notification
+        // persists until the user clicks.
+        let _ = self
+            .client
+            .show_message_request(
+                tower_lsp::lsp_types::MessageType::WARNING,
+                message,
+                Some(actions),
+            )
             .await;
     }
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -215,11 +215,20 @@ struct FilePathCompletion {
 
 /// A model property for autocomplete (used by $model->)
 struct ModelPropertyCompletion {
-    /// The property name (e.g., "id", "email", "first_name")
+    /// The property name (e.g., "id", "email", "first_name"). For the
+    /// method-call form of a relationship, the name includes the
+    /// trailing `()` (e.g., "posts()") so completion inserts the
+    /// callable shape.
     name: String,
     /// The PHP type (e.g., "int", "string", "Carbon", "Collection<Post>")
     php_type: String,
-    /// Source of the property (database, cast, accessor, relationship)
+    /// Source of the property. Known values:
+    /// - `database` / `cast` / `accessor`: model attribute shapes
+    /// - `relationship`: relation accessed as a property (lazy-loaded
+    ///   result — Collection or related Model)
+    /// - `relationship_query`: relation called as a method (returns the
+    ///   Relation/Builder, chainable via `->where(...)`)
+    /// - `class` / `blade-loop`: generic public-property scans
     source: String,
 }
 
@@ -10693,15 +10702,41 @@ impl LaravelLanguageServer {
             }
         }
 
-        // 4. Add relationships
+        // 4. Add relationships — TWO entries per relation so the user
+        //    can pick the right shape:
+        //
+        //    a) `posts`   → kind=PROPERTY, returns the lazy-loaded
+        //       Collection/Model. Type label `Collection<Post>` /
+        //       `?Post`. This is what `$model->posts` evaluates to.
+        //    b) `posts()` → kind=METHOD, returns the Relation/Builder.
+        //       Type label `HasMany<Post>`, etc. This is the query
+        //       hook (`$model->posts()->where('published', true)`).
+        //
+        //    The two share `seen_names` against the bare method name —
+        //    we register the property form first, then unconditionally
+        //    push the method form. The method form's `name` carries
+        //    the trailing `()` so the completion handler picks it up
+        //    as the method shape without an extra flag on the struct.
         for rel in &metadata.relationships {
+            let result_type =
+                relationship_to_php_type(&rel.relationship_type, rel.related_model.as_deref());
+            let relation_type = format!(
+                "{}<{}>",
+                rel.relationship_type,
+                rel.related_model.as_deref().unwrap_or("Model"),
+            );
             if seen_names.insert(rel.method_name.clone()) {
-                let php_type =
-                    relationship_to_php_type(&rel.relationship_type, rel.related_model.as_deref());
+                // Property form: lazy-loaded result.
                 properties.push(ModelPropertyCompletion {
                     name: rel.method_name.clone(),
-                    php_type,
+                    php_type: result_type,
                     source: "relationship".to_string(),
+                });
+                // Query hook: relation builder, chain `->where(...)` etc.
+                properties.push(ModelPropertyCompletion {
+                    name: format!("{}()", rel.method_name),
+                    php_type: relation_type,
+                    source: "relationship_query".to_string(),
                 });
             }
         }
@@ -15344,13 +15379,13 @@ impl LanguageServer for LaravelLanguageServer {
             //
             // If the client doesn't support work-done-progress, `begin`
             // returns None and the rest of the flow just skips reports.
-            // Title carries the build hash so the status bar reads
-            // `Laravel (bf280) — Starting indexer…`. Matches the startup
-            // banner: when "is the new binary loaded?" comes up, the
-            // status bar answers without anyone opening the log panel.
+            // Status bar stays brand-clean — `🚀 Laravel — Starting
+            // indexer…`. The build hash lives in the startup banner
+            // (LSP logs) only; it's a developer-debug detail, not
+            // something to clutter the editor chrome with.
             let mut progress = laravel_lsp::indexing_progress::IndexingProgress::begin(
                 client,
-                format!("🚀 Laravel ({})", env!("LARAVEL_LSP_GIT_HASH")),
+                "🚀 Laravel",
                 "Starting indexer…",
             )
             .await;
@@ -17435,14 +17470,31 @@ impl LanguageServer for LaravelLanguageServer {
                     // Get model properties
                     let properties = self.get_class_properties(&class_name).await;
 
-                    // Build completion items, filtering by prefix
+                    // Build completion items, filtering by prefix. The
+                    // `relationship_query` shape (`posts()`) is matched
+                    // by the bare prefix the user typed — they type
+                    // "post" and we want both `posts` and `posts()` to
+                    // surface — so we strip the trailing `()` before
+                    // comparing.
                     let prefix_lower = typed_prefix.to_lowercase();
                     let items: Vec<CompletionItem> = properties
                         .into_iter()
-                        .filter(|p| p.name.to_lowercase().starts_with(&prefix_lower))
+                        .filter(|p| {
+                            p.name
+                                .trim_end_matches("()")
+                                .to_lowercase()
+                                .starts_with(&prefix_lower)
+                        })
                         .map(|p| {
+                            // Relationship shapes:
+                            //   `relationship`       → kind=PROPERTY
+                            //       (`$model->posts` returns Collection)
+                            //   `relationship_query` → kind=METHOD
+                            //       (`$model->posts()` returns the
+                            //       Relation, chainable via ->where)
                             let kind = match p.source.as_str() {
-                                "relationship" => CompletionItemKind::METHOD,
+                                "relationship" => CompletionItemKind::PROPERTY,
+                                "relationship_query" => CompletionItemKind::METHOD,
                                 "accessor" => CompletionItemKind::PROPERTY,
                                 _ => CompletionItemKind::FIELD,
                             };

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3003,7 +3003,11 @@ impl LaravelLanguageServer {
         // a known table — same shape as a `DB::table('x')->where('|')`
         // chain. Bonus: no casts/accessors get applied (Base = schema
         // only), which is correct for what `->toBase()` returns.
-        let ctx = match (ctx.mode, ctx.effective_table.as_ref(), ctx.effective_model.clone()) {
+        let ctx = match (
+            ctx.mode,
+            ctx.effective_table.as_ref(),
+            ctx.effective_model.clone(),
+        ) {
             (BuilderMode::BaseBuilder, None, Some(model)) => {
                 let root_clone = self.initialized_root.read().await.clone();
                 match root_clone {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -226,7 +226,7 @@ struct ModelPropertyCompletion {
     /// - `database` / `cast` / `accessor`: model attribute shapes
     /// - `relationship`: relation accessed as a property (lazy-loaded
     ///   result — Collection or related Model)
-    /// - `relationship_query`: relation called as a method (returns the
+    /// - `relationship query`: relation called as a method (returns the
     ///   Relation/Builder, chainable via `->where(...)`)
     /// - `class` / `blade-loop`: generic public-property scans
     source: String,
@@ -10736,7 +10736,7 @@ impl LaravelLanguageServer {
                 properties.push(ModelPropertyCompletion {
                     name: format!("{}()", rel.method_name),
                     php_type: relation_type,
-                    source: "relationship_query".to_string(),
+                    source: "relationship query".to_string(),
                 });
             }
         }
@@ -17471,7 +17471,7 @@ impl LanguageServer for LaravelLanguageServer {
                     let properties = self.get_class_properties(&class_name).await;
 
                     // Build completion items, filtering by prefix. The
-                    // `relationship_query` shape (`posts()`) is matched
+                    // `relationship query` shape (`posts()`) is matched
                     // by the bare prefix the user typed — they type
                     // "post" and we want both `posts` and `posts()` to
                     // surface — so we strip the trailing `()` before
@@ -17489,12 +17489,12 @@ impl LanguageServer for LaravelLanguageServer {
                             // Relationship shapes:
                             //   `relationship`       → kind=PROPERTY
                             //       (`$model->posts` returns Collection)
-                            //   `relationship_query` → kind=METHOD
+                            //   `relationship query` → kind=METHOD
                             //       (`$model->posts()` returns the
                             //       Relation, chainable via ->where)
                             let kind = match p.source.as_str() {
                                 "relationship" => CompletionItemKind::PROPERTY,
-                                "relationship_query" => CompletionItemKind::METHOD,
+                                "relationship query" => CompletionItemKind::METHOD,
                                 "accessor" => CompletionItemKind::PROPERTY,
                                 _ => CompletionItemKind::FIELD,
                             };

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2943,8 +2943,8 @@ impl LaravelLanguageServer {
             }
         };
         info!(
-            "🔗 chain completion: cursor in chain — mode={:?} expecting={:?} table={:?} model={:?}",
-            ctx.mode, ctx.expecting, ctx.effective_table, ctx.effective_model
+            "🔗 chain completion: cursor in chain — mode={:?} expecting={:?} table={:?} model={:?} closure_hop={:?}",
+            ctx.mode, ctx.expecting, ctx.effective_table, ctx.effective_model, ctx.closure_relation_hop
         );
 
         let db_guard = self.database_schema.read().await;
@@ -2954,6 +2954,45 @@ impl LaravelLanguageServer {
                 info!("🔗 chain completion: database_schema not initialised yet");
                 return None;
             }
+        };
+
+        // Phase 8: if the cursor is inside a relation closure
+        // (`whereHas('rel', fn ($q) => $q->where('|'))` or
+        // `with(['rel' => fn ($q) => …])`), resolve one relation hop on
+        // the parent model BEFORE dispatching. effective_model flips
+        // from parent → related; the rest of the dispatch runs as if
+        // the cursor were inside a direct chain on the related model.
+        let ctx = if let Some(rel) = ctx.closure_relation_hop.clone() {
+            let root_clone = self.initialized_root.read().await.clone();
+            let Some(root) = root_clone else {
+                info!(
+                    "🔗 chain completion: closure-scope hop needs project root, not yet initialised"
+                );
+                return None;
+            };
+            let Some(parent_class) = ctx.effective_model.clone() else {
+                info!("🔗 chain completion: closure_relation_hop set but no parent model");
+                return None;
+            };
+            match eloquent_completion::resolve_related_model(&parent_class, &rel, &root).await {
+                Some(related) => {
+                    info!("🔗 closure-scope: resolved {parent_class}::{rel} → {related}");
+                    laravel_lsp::query_chain::ChainContext {
+                        effective_model: Some(related),
+                        closure_relation_hop: None,
+                        ..ctx
+                    }
+                }
+                None => {
+                    info!(
+                        "🔗 chain completion: couldn't resolve {parent_class}::{rel} \
+                         for closure-scope hop (relation missing or no related_model)"
+                    );
+                    return None;
+                }
+            }
+        } else {
+            ctx
         };
 
         let items = match (ctx.mode, ctx.expecting) {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -10532,18 +10532,6 @@ impl LaravelLanguageServer {
         result
     }
 
-    /// Heuristic check: does `content` define a class that extends Laravel's
-    /// `Model`? Used by `get_class_properties` to decide whether to run the
-    /// Eloquent-rich flow (DB schema, casts, relationships) or fall back to
-    /// the generic public-property scan that works for any PHP class.
-    fn content_extends_model(content: &str) -> bool {
-        let pattern = r"class\s+\w+\s+extends\s+\\?(?:Illuminate\\Database\\Eloquent\\)?Model\b";
-        regex::Regex::new(pattern)
-            .ok()
-            .map(|re| re.is_match(content))
-            .unwrap_or(false)
-    }
-
     /// Locate any PHP class file under `app/` (or `src/`) and return its
     /// `public Type $foo` declarations. Used as the generic fallback when a
     /// class isn't an Eloquent model — Livewire Forms, Livewire components,
@@ -10573,31 +10561,6 @@ impl LaravelLanguageServer {
         props
     }
 
-    /// Find the model file path for a given class name
-    /// Searches in app/Models/ directory
-    fn find_model_file(
-        &self,
-        root: &std::path::Path,
-        class_name: &str,
-    ) -> Option<std::path::PathBuf> {
-        // Try app/Models/ClassName.php first (Laravel 8+)
-        let model_path = root
-            .join("app")
-            .join("Models")
-            .join(format!("{}.php", class_name));
-        if model_path.exists() {
-            return Some(model_path);
-        }
-
-        // Try app/ClassName.php (older Laravel)
-        let old_model_path = root.join("app").join(format!("{}.php", class_name));
-        if old_model_path.exists() {
-            return Some(old_model_path);
-        }
-
-        None
-    }
-
     /// Get all properties for a class. Returns Eloquent-rich data (DB columns,
     /// casts, accessors, relationships) when the class lives in a standard
     /// model location AND extends `Model`; otherwise falls back to a generic
@@ -10619,15 +10582,16 @@ impl LaravelLanguageServer {
             None => return Vec::new(),
         };
 
-        // Try the model paths first (`app/Models/X.php`, `app/X.php`). When the
-        // file is there AND it actually extends `Model`, run the full Eloquent
-        // resolution. Anything else (Livewire Forms, DTOs, etc.) falls through
-        // to the generic public-property scan below.
-        let model_path = self.find_model_file(&root, class_name);
+        // Locate the class file via Composer autoload (PSR-4 aware, handles
+        // hyphenated vendor packages). If the class's `extends` chain
+        // reaches Eloquent's `Model` — possibly through several intermediate
+        // base classes — surface the full Eloquent property set. Otherwise
+        // fall back to the generic public-property scan, which works for
+        // Livewire Forms, DTOs, value objects, etc.
+        let model_path = laravel_lsp::class_locator::find_php_class_file(class_name, &root);
         let appears_to_be_model = model_path
             .as_deref()
-            .and_then(|p| std::fs::read_to_string(p).ok())
-            .map(|content| Self::content_extends_model(&content))
+            .map(|p| ModelMetadata::extends_eloquent_model(p, &root))
             .unwrap_or(false);
 
         if !appears_to_be_model {
@@ -10639,13 +10603,15 @@ impl LaravelLanguageServer {
             None => return Vec::new(),
         };
 
-        // Read and parse the model file
-        let content = match std::fs::read_to_string(&model_path) {
-            Ok(c) => c,
-            Err(_) => return Vec::new(),
+        // Walk inheritance so children pick up the parent's `$table`,
+        // casts, accessors, and relationships — same machinery the chain
+        // path uses (Phase 5.6+). Without this, an empty subclass like
+        // `App\Models\Version extends BaseModel` would surface no
+        // properties even when the vendor parent declares them.
+        let metadata = match ModelMetadata::from_file_with_inheritance(&model_path, &root) {
+            Some(m) => m,
+            None => return Vec::new(),
         };
-
-        let metadata = ModelMetadata::from_content(&content);
 
         // Determine the table name (either from $table property or by convention)
         let table_name = metadata.table_name.clone().unwrap_or_else(|| {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2775,14 +2775,35 @@ impl LaravelLanguageServer {
         let file_path = uri.to_file_path().ok()?;
         let patterns = self.salsa.get_patterns(file_path).await.ok().flatten()?;
         if patterns.chains.is_empty() {
+            debug!("🔗 chain completion: no chains cached for this file");
             return None;
         }
+        debug!("🔗 chain completion: {} chains in file", patterns.chains.len());
 
         let byte_offset = position_to_byte_offset(content, position.line, position.character)?;
-        let ctx = detect_chain_context_at(&patterns.chains, byte_offset)?;
+        let ctx = match detect_chain_context_at(&patterns.chains, byte_offset) {
+            Some(c) => c,
+            None => {
+                debug!(
+                    "🔗 chain completion: cursor at byte {} matched no chain link arg",
+                    byte_offset
+                );
+                return None;
+            }
+        };
+        info!(
+            "🔗 chain completion: cursor in chain — mode={:?} expecting={:?} table={:?} model={:?}",
+            ctx.mode, ctx.expecting, ctx.effective_table, ctx.effective_model
+        );
 
         let db_guard = self.database_schema.read().await;
-        let db = db_guard.as_ref()?;
+        let db = match db_guard.as_ref() {
+            Some(db) => db,
+            None => {
+                info!("🔗 chain completion: database_schema not initialised yet");
+                return None;
+            }
+        };
 
         let items = match (ctx.mode, ctx.expecting) {
             (BuilderMode::BaseBuilder, ArgKind::Column) => {
@@ -2796,6 +2817,18 @@ impl LaravelLanguageServer {
             // Other (mode, expecting) combinations land in Phases 4-6.
             _ => Vec::new(),
         };
+
+        if items.is_empty() {
+            info!(
+                "🔗 chain completion: matched {:?} but produced 0 items — \
+                 likely DB unreachable or table/columns not in introspected schema. \
+                 Check the database WARN above; .env DB_HOST may not resolve \
+                 outside of Docker/Sail.",
+                ctx.expecting
+            );
+        } else {
+            info!("🔗 chain completion: returning {} items", items.len());
+        }
 
         Some(items)
     }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -5048,17 +5048,52 @@ impl LaravelLanguageServer {
 
         // Log config status but always store provider
         // Errors will be handled when completions are requested
-        if let Some(config) = provider.get_database_config().await {
+        let has_config = if let Some(config) = provider.get_database_config().await {
             info!(
                 "   🗄️  Database config found: {} @ {}:{}",
                 config.driver, config.host, config.port
             );
+            true
         } else {
             debug!("warn:  Database config not found - will show diagnostic on first use");
-        }
+            false
+        };
 
         // Always store provider - errors handled when completions requested
         *self.database_schema.write().await = Some(provider);
+
+        // Pre-warm the schema cache in the background. The cold fetch costs
+        // ~50ms for SHOW TABLES + ~4ms per table for SHOW COLUMNS — on a
+        // 600-table schema that's ~2.5s. Doing it here, in parallel with
+        // vendor/app provider rescans and pattern cache warming, means the
+        // user's first `DB::table('|')` completion hits a warm cache and
+        // returns instantly. Skipped when there's no config (nothing to
+        // introspect and the toast would be noise).
+        if has_config {
+            let db = self.database_schema.clone();
+            tokio::spawn(async move {
+                let start = std::time::Instant::now();
+                info!("🔥 Pre-warming database schema cache...");
+                let schema = {
+                    let guard = db.read().await;
+                    match guard.as_ref() {
+                        Some(provider) => provider.get_schema().await,
+                        None => None,
+                    }
+                };
+                match schema {
+                    Some(s) => info!(
+                        "🔥 Database schema cache warmed: {} tables in {:?}",
+                        s.tables.len(),
+                        start.elapsed()
+                    ),
+                    None => info!(
+                        "🔥 Database schema pre-warm failed ({:?}) — will retry on first completion",
+                        start.elapsed()
+                    ),
+                }
+            });
+        }
     }
 
     /// Check if a file exists with async I/O and TTL caching

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2908,6 +2908,15 @@ impl LaravelLanguageServer {
                                     "Closure{{body={}..{}}}",
                                     body_byte_range.0, body_byte_range.1
                                 ),
+                                laravel_lsp::query_chain::ChainArg::Array {
+                                    elements,
+                                    span_byte_range,
+                                } => format!(
+                                    "Array{{{}..{},n={}}}",
+                                    span_byte_range.0,
+                                    span_byte_range.1,
+                                    elements.len()
+                                ),
                                 laravel_lsp::query_chain::ChainArg::Other => "Other".to_string(),
                             })
                             .collect();

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -17076,8 +17076,16 @@ impl LanguageServer for LaravelLanguageServer {
                 .await
             {
                 if !items.is_empty() {
+                    // `is_incomplete: true` hints the client that this list
+                    // depends on cursor state (which chain link the cursor
+                    // is in, what arg position, etc.) and may change as the
+                    // user types or deletes. Some clients (notably Zed) use
+                    // this to refetch more aggressively — including after a
+                    // delete/backspace that wouldn't otherwise re-trigger
+                    // completion. Cost is nil: schema is cached, the helper
+                    // short-circuits when no chain contains the cursor.
                     return Ok(Some(CompletionResponse::List(CompletionList {
-                        is_incomplete: false,
+                        is_incomplete: true,
                         items,
                     })));
                 }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2768,8 +2768,8 @@ impl LaravelLanguageServer {
         uri: &tower_lsp::lsp_types::Url,
     ) -> Option<Vec<CompletionItem>> {
         use laravel_lsp::query_chain::{
-            detect_chain_context_at, eloquent_completion, position_to_byte_offset, ArgKind,
-            BuilderMode,
+            detect_chain_context_at_diagnostic, eloquent_completion, position_to_byte_offset,
+            ArgKind, BuilderMode, ChainResolveFailure,
         };
 
         // Diagnostic marker — fires unconditionally for every completion request
@@ -2821,13 +2821,85 @@ impl LaravelLanguageServer {
                 return None;
             }
         };
-        let ctx = match detect_chain_context_at(&patterns.chains, byte_offset) {
-            Some(c) => c,
-            None => {
+        let ctx = match detect_chain_context_at_diagnostic(&patterns.chains, byte_offset) {
+            Ok(c) => c,
+            Err(ChainResolveFailure::NoChainAtCursor { chains }) => {
+                // Dump every chain's span so we can see why none contained
+                // the cursor. Most likely culprits: byte offset translated
+                // wrong (UTF-16 vs UTF-8?), file content out of sync between
+                // documents cache and Salsa, chain extractor producing
+                // wrong spans.
+                let spans: Vec<String> = chains
+                    .iter()
+                    .map(|c| {
+                        let method_summary: String = c
+                            .links
+                            .iter()
+                            .map(|l| l.method.as_str())
+                            .collect::<Vec<_>>()
+                            .join("->");
+                        format!(
+                            "{}-{} (recv={:?} :: {})",
+                            c.span_byte_range.0,
+                            c.span_byte_range.1,
+                            c.receiver,
+                            method_summary
+                        )
+                    })
+                    .collect();
                 info!(
-                    "🔗 chain completion: cursor at byte {} matched no chain link arg \
-                     (cursor isn't inside a string arg of a chain we recognise)",
-                    byte_offset
+                    "🔗 chain completion: cursor at byte {} doesn't fall inside any chain span. \
+                     Chains: [{}]",
+                    byte_offset,
+                    spans.join(", ")
+                );
+                return None;
+            }
+            Err(ChainResolveFailure::InChain { chain }) => {
+                let arg_summary: Vec<String> = chain
+                    .links
+                    .iter()
+                    .map(|l| {
+                        let arg_spans: Vec<String> = l
+                            .args
+                            .iter()
+                            .map(|a| match a {
+                                laravel_lsp::query_chain::ChainArg::StringLit {
+                                    quote,
+                                    span_byte_range,
+                                    value,
+                                } => format!(
+                                    "Str{{{:?},{}..{},val={:?}}}",
+                                    quote, span_byte_range.0, span_byte_range.1, value
+                                ),
+                                laravel_lsp::query_chain::ChainArg::Closure {
+                                    body_byte_range,
+                                    ..
+                                } => format!(
+                                    "Closure{{body={}..{}}}",
+                                    body_byte_range.0, body_byte_range.1
+                                ),
+                                laravel_lsp::query_chain::ChainArg::Other => "Other".to_string(),
+                            })
+                            .collect();
+                        format!(
+                            "{}@{}-{}[arg={:?}, args=[{}]]",
+                            l.method,
+                            l.span_byte_range.0,
+                            l.span_byte_range.1,
+                            l.arg,
+                            arg_spans.join(", ")
+                        )
+                    })
+                    .collect();
+                info!(
+                    "🔗 chain completion: cursor at byte {} is INSIDE chain {}..{} (recv={:?}) but \
+                     not inside a recognised string arg. Links: [{}]",
+                    byte_offset,
+                    chain.span_byte_range.0,
+                    chain.span_byte_range.1,
+                    chain.receiver,
+                    arg_summary.join(", ")
                 );
                 return None;
             }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2951,12 +2951,34 @@ impl LaravelLanguageServer {
             (BuilderMode::BaseBuilder, ArgKind::Column) => {
                 eloquent_completion::columns_raw(&ctx, db, wrap_with_quote).await
             }
+            // `User::where('|')` and friends — Eloquent static-receiver
+            // column completion. Resolves the model class FQCN to a model
+            // file (async I/O), reads `ModelMetadata` for `$table` + casts,
+            // and returns DB columns with cast-aware PHP types in detail.
+            // Needs the project root for class-file lookup — cloned out of
+            // the shared lock so we don't hold it across the model parse.
+            (BuilderMode::EloquentBuilder, ArgKind::Column) => {
+                let root = self.initialized_root.read().await.clone();
+                match root {
+                    Some(root) => {
+                        eloquent_completion::columns_for_builder(&ctx, db, wrap_with_quote, &root)
+                            .await
+                    }
+                    None => {
+                        info!(
+                            "🔗 chain completion: project root not yet initialised — \
+                             can't resolve Eloquent model class"
+                        );
+                        Vec::new()
+                    }
+                }
+            }
             // `DB::table('|')` (or `DB::table(|`) — table-name completion.
             // Mode is always BaseBuilder by the time the receiver is
             // recognised, but we don't gate on it: even if a future receiver
             // shape produced Table args in another mode, tables are tables.
             (_, ArgKind::Table) => eloquent_completion::tables(db, wrap_with_quote).await,
-            // Other (mode, expecting) combinations land in Phases 4-6.
+            // Other (mode, expecting) combinations land in Phases 5-9.
             _ => Vec::new(),
         };
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2995,6 +2995,46 @@ impl LaravelLanguageServer {
             ctx
         };
 
+        // Phase 6 post-toBase normalization: `User::where(...)->toBase()`
+        // flips the chain mode to BaseBuilder, but we still know which
+        // model was on the other side. effective_table stays None until
+        // we resolve it from the model. Doing this BEFORE dispatch means
+        // the `(BaseBuilder, Column)` arm runs columns_raw cleanly with
+        // a known table — same shape as a `DB::table('x')->where('|')`
+        // chain. Bonus: no casts/accessors get applied (Base = schema
+        // only), which is correct for what `->toBase()` returns.
+        let ctx = match (ctx.mode, ctx.effective_table.as_ref(), ctx.effective_model.clone()) {
+            (BuilderMode::BaseBuilder, None, Some(model)) => {
+                let root_clone = self.initialized_root.read().await.clone();
+                match root_clone {
+                    Some(root) => {
+                        match eloquent_completion::resolve_table_for_model(&model, &root).await {
+                            Some(table) => {
+                                info!(
+                                    "🔗 post-toBase: resolved model {:?} → table {:?}",
+                                    model, table
+                                );
+                                laravel_lsp::query_chain::ChainContext {
+                                    effective_table: Some(table),
+                                    ..ctx
+                                }
+                            }
+                            None => {
+                                info!(
+                                    "🔗 post-toBase: couldn't resolve table for model {:?} \
+                                     (file missing or no `$table` and snake_pluralize failed)",
+                                    model
+                                );
+                                ctx
+                            }
+                        }
+                    }
+                    None => ctx,
+                }
+            }
+            _ => ctx,
+        };
+
         let items = match (ctx.mode, ctx.expecting) {
             (BuilderMode::BaseBuilder, ArgKind::Column) => {
                 eloquent_completion::columns_raw(&ctx, db, wrap_with_quote).await
@@ -3049,12 +3089,53 @@ impl LaravelLanguageServer {
             // would teach the user something untrue. Stay quiet.
             (BuilderMode::BaseBuilder, ArgKind::Relation)
             | (BuilderMode::BaseBuilder, ArgKind::ClosureCarrier) => Vec::new(),
+            // Phase 6: `User::all()->where('|')` / `->get()->where('|')` etc.
+            // — Collection mode. Result is a hydrated Collection<Model>; its
+            // `where()` filters in memory against model property access,
+            // which means accessors are valid args too (they're not in
+            // the DB but they ARE on the model instance). `columns_for_collection`
+            // returns DB columns + accessors, ranked so DB columns appear first.
+            (BuilderMode::EloquentCollection, ArgKind::Column) => {
+                let root = self.initialized_root.read().await.clone();
+                match root {
+                    Some(root) => {
+                        eloquent_completion::columns_for_collection(
+                            &ctx,
+                            db,
+                            wrap_with_quote,
+                            &root,
+                        )
+                        .await
+                    }
+                    None => {
+                        info!(
+                            "🔗 chain completion: project root not yet initialised — \
+                             can't resolve Collection-mode columns"
+                        );
+                        Vec::new()
+                    }
+                }
+            }
+            // Collection's `load('|')` / `loadMissing('|')` work just like
+            // Builder's `with('|')` — they take relation names. ClosureCarrier
+            // also applies (Collection still supports keyed-array constraints
+            // through some helpers).
+            (BuilderMode::EloquentCollection, ArgKind::Relation)
+            | (BuilderMode::EloquentCollection, ArgKind::ClosureCarrier) => {
+                let root = self.initialized_root.read().await.clone();
+                match root {
+                    Some(root) => {
+                        eloquent_completion::relations(&ctx, wrap_with_quote, &root).await
+                    }
+                    None => Vec::new(),
+                }
+            }
             // `DB::table('|')` (or `DB::table(|`) — table-name completion.
             // Mode is always BaseBuilder by the time the receiver is
             // recognised, but we don't gate on it: even if a future receiver
             // shape produced Table args in another mode, tables are tables.
             (_, ArgKind::Table) => eloquent_completion::tables(db, wrap_with_quote).await,
-            // Other (mode, expecting) combinations land in Phases 6-9.
+            // Other (mode, expecting) combinations land in Phases 7-9.
             _ => Vec::new(),
         };
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2751,6 +2751,50 @@ use laravel_lsp::livewire_resolver::{
 };
 
 impl LaravelLanguageServer {
+    /// Eloquent / DB query builder chain completion entry point.
+    ///
+    /// Resolves the cursor to a `ChainContext`, dispatches on
+    /// `(BuilderMode, ArgKind)` to the appropriate completion-items helper,
+    /// and returns the items (or `None` if no chain covers the cursor / the
+    /// chain receiver is unresolved at this phase).
+    ///
+    /// Phase 3 implements `(BaseBuilder, Column)` only — Eloquent receivers
+    /// short-circuit in [`laravel_lsp::query_chain::detect_chain_context_at`]
+    /// because model resolution is async I/O and lands in later phases.
+    async fn try_query_chain_completion(
+        &self,
+        content: &str,
+        position: tower_lsp::lsp_types::Position,
+        uri: &tower_lsp::lsp_types::Url,
+    ) -> Option<Vec<CompletionItem>> {
+        use laravel_lsp::query_chain::{
+            detect_chain_context_at, eloquent_completion, position_to_byte_offset, ArgKind,
+            BuilderMode,
+        };
+
+        let file_path = uri.to_file_path().ok()?;
+        let patterns = self.salsa.get_patterns(file_path).await.ok().flatten()?;
+        if patterns.chains.is_empty() {
+            return None;
+        }
+
+        let byte_offset = position_to_byte_offset(content, position.line, position.character)?;
+        let ctx = detect_chain_context_at(&patterns.chains, byte_offset)?;
+
+        let db_guard = self.database_schema.read().await;
+        let db = db_guard.as_ref()?;
+
+        let items = match (ctx.mode, ctx.expecting) {
+            (BuilderMode::BaseBuilder, ArgKind::Column) => {
+                eloquent_completion::columns_raw(&ctx, db).await
+            }
+            // Other (mode, expecting) combinations land in Phases 4-6.
+            _ => Vec::new(),
+        };
+
+        Some(items)
+    }
+
     fn new(client: Client) -> Self {
         Self {
             client,
@@ -16748,6 +16792,24 @@ impl LanguageServer for LaravelLanguageServer {
 
         // In PHP/Blade files, check for various contexts
         if is_php_or_blade {
+            // Eloquent / DB query builder chain completion. No line-local
+            // pre-filter: chains can span multiple lines (the `->` may live
+            // on a different line than the cursor), and the helper itself
+            // short-circuits fast (single Arc::clone + emptiness check) when
+            // the file has no chains. Files with chains pay an O(chains)
+            // walk which is in the tens.
+            if let Some(items) = self
+                .try_query_chain_completion(&content, position, uri)
+                .await
+            {
+                if !items.is_empty() {
+                    return Ok(Some(CompletionResponse::List(CompletionList {
+                        is_incomplete: false,
+                        items,
+                    })));
+                }
+            }
+
             // Check for variable name context in Blade files (typing $user, $u, etc.)
             // This must come BEFORE model property context to avoid conflicts
             if uri.path().ends_with(".blade.php") {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -15344,9 +15344,13 @@ impl LanguageServer for LaravelLanguageServer {
             //
             // If the client doesn't support work-done-progress, `begin`
             // returns None and the rest of the flow just skips reports.
+            // Title carries the build hash so the status bar reads
+            // `Laravel (bf280) — Starting indexer…`. Matches the startup
+            // banner: when "is the new binary loaded?" comes up, the
+            // status bar answers without anyone opening the log panel.
             let mut progress = laravel_lsp::indexing_progress::IndexingProgress::begin(
                 client,
-                "Laravel",
+                format!("Laravel ({})", env!("LARAVEL_LSP_GIT_HASH")),
                 "Starting indexer…",
             )
             .await;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2772,20 +2772,61 @@ impl LaravelLanguageServer {
             BuilderMode,
         };
 
-        let file_path = uri.to_file_path().ok()?;
-        let patterns = self.salsa.get_patterns(file_path).await.ok().flatten()?;
+        // Diagnostic marker — fires unconditionally for every completion request
+        // in a .php/.blade.php file. If this line doesn't appear in the LSP
+        // log, the new binary isn't being run.
+        info!(
+            "🔗 chain completion: ENTERED ({}:{}:{})",
+            uri.path(),
+            position.line,
+            position.character
+        );
+
+        let file_path = match uri.to_file_path() {
+            Ok(p) => p,
+            Err(_) => {
+                info!("🔗 chain completion: uri.to_file_path() failed for {}", uri);
+                return None;
+            }
+        };
+        let patterns = match self.salsa.get_patterns(file_path).await {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                info!("🔗 chain completion: salsa.get_patterns returned None");
+                return None;
+            }
+            Err(e) => {
+                info!("🔗 chain completion: salsa.get_patterns failed: {}", e);
+                return None;
+            }
+        };
         if patterns.chains.is_empty() {
-            debug!("🔗 chain completion: no chains cached for this file");
+            info!(
+                "🔗 chain completion: 0 chains cached for this file — file may have \
+                 been parsed by an older binary (the disk cache survives builds). \
+                 Try editing the file (add a space, save) to force re-extraction."
+            );
             return None;
         }
-        debug!("🔗 chain completion: {} chains in file", patterns.chains.len());
+        info!("🔗 chain completion: {} chains in file", patterns.chains.len());
 
-        let byte_offset = position_to_byte_offset(content, position.line, position.character)?;
+        let byte_offset = match position_to_byte_offset(content, position.line, position.character)
+        {
+            Some(b) => b,
+            None => {
+                info!(
+                    "🔗 chain completion: position {}:{} out of file bounds",
+                    position.line, position.character
+                );
+                return None;
+            }
+        };
         let ctx = match detect_chain_context_at(&patterns.chains, byte_offset) {
             Some(c) => c,
             None => {
-                debug!(
-                    "🔗 chain completion: cursor at byte {} matched no chain link arg",
+                info!(
+                    "🔗 chain completion: cursor at byte {} matched no chain link arg \
+                     (cursor isn't inside a string arg of a chain we recognise)",
                     byte_offset
                 );
                 return None;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2973,12 +2973,40 @@ impl LaravelLanguageServer {
                     }
                 }
             }
+            // `User::with('|')` / `User::whereHas('|', closure)` /
+            // `User::load('|')` etc. — Eloquent relation-name completion.
+            // ArgKind::ClosureCarrier wins over ArgKind::Relation in the
+            // method classifier, so we accept both — for the first string
+            // arg they mean the same thing (a relationship method name on
+            // the current model). Inside the closure body the cursor would
+            // resolve to a *different* chain anyway (Phase 8 closure scope).
+            (BuilderMode::EloquentBuilder, ArgKind::Relation)
+            | (BuilderMode::EloquentBuilder, ArgKind::ClosureCarrier) => {
+                let root = self.initialized_root.read().await.clone();
+                match root {
+                    Some(root) => {
+                        eloquent_completion::relations(&ctx, wrap_with_quote, &root).await
+                    }
+                    None => {
+                        info!(
+                            "🔗 chain completion: project root not yet initialised — \
+                             can't resolve relations"
+                        );
+                        Vec::new()
+                    }
+                }
+            }
+            // Load-bearing: `DB::table('users')->with('|')` is user error —
+            // Query Builder has no relation methods, so listing relations
+            // would teach the user something untrue. Stay quiet.
+            (BuilderMode::BaseBuilder, ArgKind::Relation)
+            | (BuilderMode::BaseBuilder, ArgKind::ClosureCarrier) => Vec::new(),
             // `DB::table('|')` (or `DB::table(|`) — table-name completion.
             // Mode is always BaseBuilder by the time the receiver is
             // recognised, but we don't gate on it: even if a future receiver
             // shape produced Table args in another mode, tables are tables.
             (_, ArgKind::Table) => eloquent_completion::tables(db, wrap_with_quote).await,
-            // Other (mode, expecting) combinations land in Phases 5-9.
+            // Other (mode, expecting) combinations land in Phases 6-9.
             _ => Vec::new(),
         };
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2768,9 +2768,11 @@ impl LaravelLanguageServer {
         uri: &tower_lsp::lsp_types::Url,
     ) -> Option<Vec<CompletionItem>> {
         use laravel_lsp::query_chain::{
-            detect_chain_context_at_diagnostic, eloquent_completion, position_to_byte_offset,
-            ArgKind, BuilderMode, ChainResolveFailure,
+            detect_chain_context_at_diagnostic, eloquent_completion, extract_chains,
+            fixup_for_completion, position_to_byte_offset, ArgKind, BuilderChain, BuilderMode,
+            ChainResolveFailure,
         };
+        use std::sync::Arc;
 
         // Diagnostic marker — fires unconditionally for every completion request
         // in a .php/.blade.php file. If this line doesn't appear in the LSP
@@ -2781,34 +2783,6 @@ impl LaravelLanguageServer {
             position.line,
             position.character
         );
-
-        let file_path = match uri.to_file_path() {
-            Ok(p) => p,
-            Err(_) => {
-                info!("🔗 chain completion: uri.to_file_path() failed for {}", uri);
-                return None;
-            }
-        };
-        let patterns = match self.salsa.get_patterns(file_path).await {
-            Ok(Some(p)) => p,
-            Ok(None) => {
-                info!("🔗 chain completion: salsa.get_patterns returned None");
-                return None;
-            }
-            Err(e) => {
-                info!("🔗 chain completion: salsa.get_patterns failed: {}", e);
-                return None;
-            }
-        };
-        if patterns.chains.is_empty() {
-            info!(
-                "🔗 chain completion: 0 chains cached for this file — file may have \
-                 been parsed by an older binary (the disk cache survives builds). \
-                 Try editing the file (add a space, save) to force re-extraction."
-            );
-            return None;
-        }
-        info!("🔗 chain completion: {} chains in file", patterns.chains.len());
 
         let byte_offset = match position_to_byte_offset(content, position.line, position.character)
         {
@@ -2821,7 +2795,53 @@ impl LaravelLanguageServer {
                 return None;
             }
         };
-        let ctx = match detect_chain_context_at_diagnostic(&patterns.chains, byte_offset) {
+
+        // Mid-typing the file often has an unterminated quote at the cursor.
+        // Tree-sitter recovers poorly in that case (the `string` node swallows
+        // everything to the next quote anywhere downstream, producing nonsense
+        // spans). We can't trust Salsa's cached chains for this exact moment,
+        // and the in-memory cached version may be stale relative to the live
+        // documents map too. So: inject a matching close quote at the cursor
+        // if needed, then re-parse + re-extract chains from the fixed-up
+        // content. Per-completion cost is one tree-sitter parse on a small
+        // file (~1-5ms) — well within Mike's 200ms debounce.
+        let fixed_content = fixup_for_completion(content, byte_offset);
+        let parse_source: &str = fixed_content.as_deref().unwrap_or(content);
+        if fixed_content.is_some() {
+            info!(
+                "🔗 chain completion: injected close quote at byte {} to balance unterminated string",
+                byte_offset
+            );
+        }
+
+        let tree = match laravel_lsp::parser::parse_php(parse_source) {
+            Ok(t) => t,
+            Err(e) => {
+                info!(
+                    "🔗 chain completion: parse_php failed on fixed-up content: {}",
+                    e
+                );
+                return None;
+            }
+        };
+        let chains: Vec<Arc<BuilderChain>> = extract_chains(&tree, parse_source)
+            .into_iter()
+            .map(Arc::new)
+            .collect();
+
+        if chains.is_empty() {
+            info!("🔗 chain completion: 0 chains in (fixed-up) file at completion time");
+            return None;
+        }
+        info!(
+            "🔗 chain completion: {} chains in (fixed-up) file",
+            chains.len()
+        );
+
+        // file_path is still needed downstream for diagnostics. Resolve once.
+        let _file_path = uri.to_file_path().ok();
+
+        let ctx = match detect_chain_context_at_diagnostic(&chains, byte_offset) {
             Ok(c) => c,
             Err(ChainResolveFailure::NoChainAtCursor { chains }) => {
                 // Dump every chain's span so we can see why none contained
@@ -2840,10 +2860,7 @@ impl LaravelLanguageServer {
                             .join("->");
                         format!(
                             "{}-{} (recv={:?} :: {})",
-                            c.span_byte_range.0,
-                            c.span_byte_range.1,
-                            c.receiver,
-                            method_summary
+                            c.span_byte_range.0, c.span_byte_range.1, c.receiver, method_summary
                         )
                     })
                     .collect();

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -9108,8 +9108,11 @@ impl LaravelLanguageServer {
         context: &ValidationParamContext,
         content: &str,
         cursor_line: usize,
-        uri: &Url,
-        position: Position,
+        // `uri` and `position` were used by the inline DB-error diagnostic
+        // we removed in Phase 5.3; the toast doesn't need them. Kept in
+        // the signature so callers don't have to change.
+        _uri: &Url,
+        _position: Position,
     ) -> Vec<CompletionItem> {
         use laravel_lsp::validation_rules::{LaravelRulesParser, ParamType};
 
@@ -9240,39 +9243,13 @@ impl LaravelLanguageServer {
                     if tables.is_empty() {
                         if let Some(error) = provider.get_last_error().await {
                             info!("   ❌ Database connection error: {}", error.message);
-
-                            // Check if we've already shown this diagnostic
-                            let mut shown = self.database_diagnostic_shown.write().await;
-                            if !*shown {
-                                *shown = true;
-
-                                // Publish diagnostic at the validation rule position
-                                let diagnostic = Diagnostic {
-                                    range: Range {
-                                        start: position,
-                                        end: Position {
-                                            line: position.line,
-                                            character: position.character + context.rule_name.len() as u32 + 1, // +1 for colon
-                                        },
-                                    },
-                                    severity: Some(DiagnosticSeverity::INFORMATION),
-                                    code: None,
-                                    source: Some("laravel".to_string()),
-                                    message: format!(
-                                        "Database connection failed: {}\n\nConfigure these in .env for exists:/unique: autocomplete:\n- DB_CONNECTION\n- DB_HOST\n- DB_DATABASE\n- DB_USERNAME\n- DB_PASSWORD",
-                                        error.message
-                                    ),
-                                    related_information: None,
-                                    tags: None,
-                                    code_description: None,
-                                    data: None,
-                                };
-
-                                self.client
-                                    .publish_diagnostics(uri.clone(), vec![diagnostic], None)
-                                    .await;
-                            }
-
+                            // Surface the unreachable-DB notification via the
+                            // single persistent toast. The previous inline
+                            // diagnostic at the rule position used the same
+                            // one-shot flag as the toast, so whichever fired
+                            // first hid the other. One channel = one signal,
+                            // and toast persists until the user dismisses it.
+                            self.maybe_notify_db_unreachable(&error.message).await;
                             // Return empty - no completions available
                             return Vec::new();
                         }
@@ -9434,36 +9411,14 @@ impl LaravelLanguageServer {
                     }
                 } else {
                     debug!("warn:  Database schema provider not initialized");
-
-                    // Publish diagnostic at the validation rule position
-                    let mut shown = self.database_diagnostic_shown.write().await;
-                    if !*shown {
-                        *shown = true;
-
-                        let diagnostic = Diagnostic {
-                            range: Range {
-                                start: position,
-                                end: Position {
-                                    line: position.line,
-                                    character: position.character + context.rule_name.len() as u32 + 1, // +1 for colon
-                                },
-                            },
-                            severity: Some(DiagnosticSeverity::INFORMATION),
-                            code: None,
-                            source: Some("laravel".to_string()),
-                            message: "Database not configured. Set DB_CONNECTION, DB_HOST, DB_DATABASE, DB_USERNAME, DB_PASSWORD in .env for exists:/unique: autocomplete.".to_string(),
-                            related_information: None,
-                            tags: None,
-                            code_description: None,
-                            data: None,
-                        };
-
-                        self.client
-                            .publish_diagnostics(uri.clone(), vec![diagnostic], None)
-                            .await;
-                    }
-
-                    // Return empty - no completions available
+                    // Same persistent-toast channel as the unreachable-DB
+                    // path above. "Provider not initialised" means no .env
+                    // (or no detection of one); say so explicitly.
+                    self.maybe_notify_db_unreachable(
+                        "Database not configured. Set DB_CONNECTION, DB_HOST, \
+                         DB_DATABASE, DB_USERNAME, DB_PASSWORD in .env.",
+                    )
+                    .await;
                     Vec::new()
                 }
             }
@@ -12737,46 +12692,6 @@ return [
         })
     }
 
-    /// Check if database connection has failed and return an Info diagnostic if so
-    /// This diagnostic is shown once per session when exists:/unique: validation rules are used
-    /// but the database cannot be connected
-    async fn get_database_error_diagnostic(&self) -> Option<Diagnostic> {
-        // Check if we've already shown this diagnostic
-        let mut shown = self.database_diagnostic_shown.write().await;
-        if *shown {
-            return None;
-        }
-
-        // Check if database schema provider exists and has an error
-        let schema_guard = self.database_schema.read().await;
-        if let Some(ref provider) = *schema_guard {
-            if let Some(error) = provider.get_last_error().await {
-                // Mark as shown so we don't show it again
-                *shown = true;
-
-                return Some(Diagnostic {
-                    range: Range {
-                        start: Position { line: 0, character: 0 },
-                        end: Position { line: 0, character: 0 },
-                    },
-                    severity: Some(DiagnosticSeverity::INFORMATION),
-                    code: None,
-                    source: Some("laravel".to_string()),
-                    message: format!(
-                        "Database connection failed: {}\nConfigure database settings in .env for exists:/unique: validation autocomplete.",
-                        error.message
-                    ),
-                    related_information: None,
-                    tags: None,
-                    code_description: None,
-                    data: None,
-                });
-            }
-        }
-
-        None
-    }
-
     /// Clone server for spawning async tasks
     fn clone_for_spawn(&self) -> Self {
         LaravelLanguageServer {
@@ -12824,10 +12739,15 @@ return [
             diagnostics.push(vendor_diag);
         }
 
-        // Check for database connection error diagnostic (shows once per session)
-        if let Some(db_diag) = self.get_database_error_diagnostic().await {
-            diagnostics.push(db_diag);
-        }
+        // Database-unreachable notifications go through the persistent
+        // toast (`maybe_notify_db_unreachable`) — driven from the chain
+        // completion handler when an LSP-completing path actually needs
+        // the DB and finds it unavailable. We deliberately don't publish
+        // a diagnostic from here: a 0:0 diagnostic on whatever file
+        // happened to be open is awkward, and emitting both a diagnostic
+        // AND a toast meant whichever fired first stole the
+        // `database_diagnostic_shown` flag and suppressed the other.
+        // Toast wins; diagnostic is gone.
 
         // Get the Laravel config (checks memory cache first, then Salsa)
         let t_config = std::time::Instant::now();

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -6874,12 +6874,25 @@ impl LaravelLanguageServer {
     /// 1. Variable access: `$user->` where we need to resolve $user's type
     /// 2. Static chain: `User::find(1)->` or `User::where(...)->first()->` where we extract the class
     ///
+    /// `file_content` is consulted to resolve bare class names against the
+    /// file's `use` statements. Without that step, `Version::first()->` in
+    /// a file with `use App\Models\Version;` ends up as the bare hint
+    /// `"Version"`, which then basename-matches the first `Version.php` on
+    /// disk — frequently the wrong file when a Nova filter or Livewire
+    /// component shares the name. With the use-statement step, the hint
+    /// becomes `App\Models\Version` and Composer autoload routes the
+    /// lookup correctly.
+    ///
     /// Examples:
     /// - `$user->` returns Some(("$user", ""))
     /// - `$user->na` returns Some(("$user", "na"))
-    /// - `User::find(1)->` returns Some(("User", ""))
-    /// - `User::find(1)->ema` returns Some(("User", "ema"))
-    fn get_model_property_context(line_text: &str, character: u32) -> Option<(String, String)> {
+    /// - `User::find(1)->` with `use App\Models\User;` returns Some(("App\\Models\\User", ""))
+    /// - `User::find(1)->ema` ditto plus prefix "ema"
+    fn get_model_property_context(
+        line_text: &str,
+        character: u32,
+        file_content: &str,
+    ) -> Option<(String, String)> {
         let cursor = character as usize;
         if cursor > line_text.len() {
             return None;
@@ -6901,8 +6914,10 @@ impl LaravelLanguageServer {
         // Get the part before `->`
         let before_arrow = &before_cursor[..arrow_pos];
 
-        // Try to extract the class/variable that the arrow is on
-        let class_hint = Self::extract_model_class_hint(before_arrow)?;
+        // Try to extract the class/variable that the arrow is on, then
+        // resolve bare class names through the file's use aliases +
+        // namespace so downstream lookup gets a FQCN.
+        let class_hint = Self::extract_model_class_hint(before_arrow, file_content)?;
 
         Some((class_hint, typed_prefix))
     }
@@ -6911,13 +6926,23 @@ impl LaravelLanguageServer {
     ///
     /// Handles:
     /// - `$variable` -> returns "$variable" (caller will resolve type)
-    /// - `User::find(1)` -> returns "User"
-    /// - `User::where(...)->first()` -> returns "User"
+    /// - `User::find(1)` -> returns the FQCN (`App\Models\User`) if the
+    ///   file imports it via `use`, else the bare name
+    /// - `User::where(...)->first()` -> ditto
     /// - `$this` -> returns "$this" (for use inside a model)
-    fn extract_model_class_hint(before_arrow: &str) -> Option<String> {
+    ///
+    /// `file_content` is scanned for `use` statements + the file's own
+    /// namespace so that a bare class reference becomes a FQCN. This
+    /// is what makes Composer-autoload-driven file lookup reliable
+    /// downstream — without it, a same-basename collision (e.g. a Nova
+    /// filter named like a model) wins by accident.
+    fn extract_model_class_hint(before_arrow: &str, file_content: &str) -> Option<String> {
+        use laravel_lsp::model_analyzer::ModelMetadata;
         let trimmed = before_arrow.trim_end();
 
-        // Case 1: Ends with a variable like $user or $this
+        // Case 1: Ends with a variable like $user or $this — return as-is,
+        // the caller resolves $var's type separately (typed param +
+        // docblock scan).
         if let Some(var_match) = regex::Regex::new(r"\$([a-zA-Z_][a-zA-Z0-9_]*)$")
             .ok()
             .and_then(|re| re.find(trimmed))
@@ -6925,32 +6950,28 @@ impl LaravelLanguageServer {
             return Some(var_match.as_str().to_string());
         }
 
-        // Case 2: Ends with a method call on a static class like User::find(1) or User::where(...)->first()
-        // Look for the class name at the start of a static chain
-        // Pattern: ClassName::method(...) or ClassName::method(...)->other(...)
-        if let Some(caps) = regex::Regex::new(r"([A-Z][a-zA-Z0-9_]*)::(?:find|findOrFail|first|firstOrFail|where|query|all|get|create|make|findOr|sole|firstOr|firstWhere|findMany)\s*\(")
-            .ok()
-            .and_then(|re| re.captures(trimmed))
-        {
-            if let Some(class) = caps.get(1) {
-                return Some(class.as_str().to_string());
-            }
-        }
+        // Case 2: Static call on a class — `User::find(...)`,
+        // `User::where(...)->first()`, etc. Extract the leading class
+        // name from the first `Foo::method(` we find.
+        let static_chain_re = regex::Regex::new(
+            r"([A-Z][a-zA-Z0-9_]*)::(?:find|findOrFail|first|firstOrFail|where|query|all|get|create|make|findOr|sole|firstOr|firstWhere|findMany)\s*\(",
+        )
+        .ok()?;
+        let bare = static_chain_re
+            .captures(trimmed)
+            .and_then(|c| c.get(1).map(|m| m.as_str().to_string()))?;
 
-        // Case 3: Ends with a method call like ->first(), ->find(), etc. - try to find class earlier in chain
-        if trimmed.ends_with(')') {
-            // Look backwards for a class name in a static call pattern
-            if let Some(caps) = regex::Regex::new(r"([A-Z][a-zA-Z0-9_]*)::(?:find|findOrFail|first|firstOrFail|where|query|all|get|create|make)\s*\(")
-                .ok()
-                .and_then(|re| re.captures(trimmed))
-            {
-                if let Some(class) = caps.get(1) {
-                    return Some(class.as_str().to_string());
-                }
-            }
-        }
-
-        None
+        // Resolve the bare class name through the file's `use` statements
+        // and namespace, yielding a FQCN. `resolve_to_fqcn` falls through
+        // to the bare name if no use alias matches and no namespace is
+        // declared — so we always return something usable.
+        let aliases = ModelMetadata::extract_use_aliases_from_php(file_content);
+        let namespace = ModelMetadata::extract_namespace(file_content);
+        Some(ModelMetadata::resolve_to_fqcn(
+            &bare,
+            namespace.as_deref(),
+            &aliases,
+        ))
     }
 
     /// Resolve a variable name to its model class type by analyzing the file content
@@ -10593,6 +10614,9 @@ impl LaravelLanguageServer {
             .as_deref()
             .map(|p| ModelMetadata::extends_eloquent_model(p, &root))
             .unwrap_or(false);
+        info!(
+            "   📦 get_class_properties: class={class_name:?} file={model_path:?} is_eloquent={appears_to_be_model}"
+        );
 
         if !appears_to_be_model {
             return Self::extract_generic_class_properties(&root, class_name);
@@ -17379,10 +17403,10 @@ impl LanguageServer for LaravelLanguageServer {
 
             // Check for model property context ($user-> or User::find()->)
             if let Some((class_hint, typed_prefix)) =
-                Self::get_model_property_context(line_text, position.character)
+                Self::get_model_property_context(line_text, position.character, &content)
             {
-                debug!(
-                    "   Model property context, class hint: '{}', typed prefix: '{}'",
+                info!(
+                    "   📦 Model property context, class hint: '{}', typed prefix: '{}'",
                     class_hint, typed_prefix
                 );
 
@@ -17402,7 +17426,7 @@ impl LanguageServer for LaravelLanguageServer {
                 };
 
                 if let Some(class_name) = model_class {
-                    debug!("   Resolved model class: {}", class_name);
+                    info!("   📦 Resolved model class: {}", class_name);
 
                     // Get model properties
                     let properties = self.get_class_properties(&class_name).await;
@@ -17440,8 +17464,8 @@ impl LanguageServer for LaravelLanguageServer {
                         })
                         .collect();
 
-                    debug!(
-                        "   Returning {} model property completion items",
+                    info!(
+                        "   📦 Returning {} model property completion items",
                         items.len()
                     );
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3194,7 +3194,7 @@ impl LaravelLanguageServer {
         drop(shown);
 
         let message = format!(
-            "Laravel LSP: Database is unreachable, so table and column \
+            "Laravel: Database is unreachable, so table and column \
              autocompletion is disabled. Fix DB connectivity in .env \
              (DB_HOST / DB_PORT / credentials) and reload the window to \
              enable. Error: {error_message}"
@@ -3385,7 +3385,7 @@ impl LaravelLanguageServer {
         {
             debug!("Failed to register config files with Salsa: {}", e);
         } else {
-            info!("Laravel LSP: Config files registered with Salsa for incremental caching");
+            info!("Laravel: Config files registered with Salsa for incremental caching");
         }
     }
 
@@ -3458,7 +3458,7 @@ impl LaravelLanguageServer {
             return;
         }
 
-        info!("Laravel LSP: Project files registered with Salsa for reference finding");
+        info!("Laravel: Project files registered with Salsa for reference finding");
 
         // Disk-cache restore. Loads previously-parsed patterns into the
         // shared pattern_cache, dropping any entry whose on-disk mtime
@@ -3721,7 +3721,7 @@ impl LaravelLanguageServer {
 
             let elapsed = started_at.elapsed();
             info!(
-                "🔥 Laravel LSP: pattern cache warmed ({} newly parsed, {} from disk, total {}, in {:?})",
+                "🔥 Laravel: pattern cache warmed ({} newly parsed, {} from disk, total {}, in {:?})",
                 imported, cached_hits, total, elapsed
             );
 
@@ -3795,11 +3795,11 @@ impl LaravelLanguageServer {
             let content = if let Ok(env_uri) = Url::from_file_path(&env_path) {
                 if let Some((buffer_content, _version)) = documents.get(&env_uri) {
                     // Use editor buffer content (includes unsaved changes)
-                    debug!("Laravel LSP: Registering .env from buffer: {:?}", env_path);
+                    debug!("Laravel: Registering .env from buffer: {:?}", env_path);
                     Some(buffer_content.clone())
                 } else if env_path.exists() {
                     // Read from disk
-                    debug!("Laravel LSP: Registering .env from disk: {:?}", env_path);
+                    debug!("Laravel: Registering .env from disk: {:?}", env_path);
                     std::fs::read_to_string(&env_path).ok()
                 } else {
                     None
@@ -3828,7 +3828,7 @@ impl LaravelLanguageServer {
 
         if registered_count > 0 {
             info!(
-                "Laravel LSP: {} env files registered with Salsa",
+                "Laravel: {} env files registered with Salsa",
                 registered_count
             );
         }
@@ -4079,7 +4079,7 @@ impl LaravelLanguageServer {
 
         if registered_count > 0 {
             info!(
-                "Laravel LSP: {} service provider files registered with Salsa",
+                "Laravel: {} service provider files registered with Salsa",
                 registered_count
             );
         }
@@ -4783,7 +4783,7 @@ impl LaravelLanguageServer {
                     .await;
 
                 // Re-validate all open documents since config changed (view paths, component paths, etc.)
-                info!("Laravel LSP: Re-validating all open documents due to config change");
+                info!("Laravel: Re-validating all open documents due to config change");
                 let documents = self.documents.read().await;
                 for (doc_uri, (doc_text, _version)) in documents.iter() {
                     self.validate_and_publish_diagnostics(doc_uri, doc_text)
@@ -13175,7 +13175,7 @@ return [
                         }
                     } else {
                         // Middleware not in registry - try to resolve it by convention
-                        info!("Laravel LSP: Middleware '{}' NOT found in registry, attempting resolution by convention", middleware_name);
+                        info!("Laravel: Middleware '{}' NOT found in registry, attempting resolution by convention", middleware_name);
 
                         // Strip parameters (e.g., 'auth:sanctum' -> 'auth') before converting,
                         // otherwise PascalCase produces invalid class names like 'Auth:Sanctum'.
@@ -13187,11 +13187,11 @@ return [
 
                         // Try to resolve as App\Http\Middleware\{ClassName}
                         if let Some(mw_file_path) = resolve_class_to_file(&app_class, root) {
-                            info!("Laravel LSP: Attempting to resolve middleware '{}' as class '{}' at {:?}", middleware_name, app_class, mw_file_path);
+                            info!("Laravel: Attempting to resolve middleware '{}' as class '{}' at {:?}", middleware_name, app_class, mw_file_path);
 
                             if !mw_file_path.exists() {
                                 // ERROR - middleware not in config and class file doesn't exist
-                                info!("Laravel LSP: Creating ERROR diagnostic for unresolved middleware: {}", middleware_name);
+                                info!("Laravel: Creating ERROR diagnostic for unresolved middleware: {}", middleware_name);
                                 let diagnostic = Diagnostic {
                                     range: Range {
                                         start: Position {
@@ -13218,11 +13218,11 @@ return [
                                 };
                                 diagnostics.push(diagnostic);
                             } else {
-                                info!("Laravel LSP: Middleware '{}' resolved by convention, file exists at {:?}", middleware_name, mw_file_path);
+                                info!("Laravel: Middleware '{}' resolved by convention, file exists at {:?}", middleware_name, mw_file_path);
                             }
                         } else {
                             // Can't resolve - show INFO as we don't know where to check
-                            info!("Laravel LSP: Middleware '{}' NOT found in registry and can't resolve file path, creating INFO diagnostic", middleware_name);
+                            info!("Laravel: Middleware '{}' NOT found in registry and can't resolve file path, creating INFO diagnostic", middleware_name);
                             let diagnostic = Diagnostic {
                                 range: Range {
                                     start: Position {
@@ -13307,7 +13307,7 @@ return [
                             if let Some(ref bind_file_path) = binding_data.file_path {
                                 if !bind_file_path.exists() {
                                     // ERROR - binding exists but class file is missing
-                                    info!("Laravel LSP: Creating ERROR diagnostic for binding with missing class: {}", binding_name);
+                                    info!("Laravel: Creating ERROR diagnostic for binding with missing class: {}", binding_name);
 
                                     // Build the diagnostic message with registration location
                                     let mut message = format!(
@@ -13400,7 +13400,10 @@ return [
                                 }
 
                                 // ERROR - binding not found and not a known framework binding
-                                info!("Laravel LSP: Creating ERROR diagnostic for undefined binding: {}", binding_name);
+                                info!(
+                                    "Laravel: Creating ERROR diagnostic for undefined binding: {}",
+                                    binding_name
+                                );
                                 let diagnostic = Diagnostic {
                                     range: Range {
                                         start: Position {
@@ -15146,7 +15149,7 @@ fn symbol_entry_kind_to_lsp(kind: laravel_lsp::document_symbols::SymbolEntryKind
 impl LanguageServer for LaravelLanguageServer {
     async fn initialize(&self, params: InitializeParams) -> jsonrpc::Result<InitializeResult> {
         let init_start = std::time::Instant::now();
-        info!("Laravel LSP: INITIALIZE");
+        info!("Laravel: INITIALIZE");
 
         // Read initial settings from initialization_options (if provided)
         // These can be overridden at runtime via did_change_configuration
@@ -15167,7 +15170,7 @@ impl LanguageServer for LaravelLanguageServer {
         if let Some(root_uri) = params.root_uri {
             if let Ok(path) = root_uri.to_file_path() {
                 *self.root_path.write().await = Some(path.clone());
-                info!("✅ Laravel LSP: Root path set to {:?}", path);
+                info!("✅ Laravel: Root path set to {:?}", path);
 
                 // Load ALL cached data (config, middleware, bindings, env) using batch registration (fast)
                 // This uses 2 round-trips instead of N round-trips for N entries
@@ -15322,10 +15325,7 @@ impl LanguageServer for LaravelLanguageServer {
 
     async fn initialized(&self, _: InitializedParams) {
         info!("========================================");
-        info!(
-            "🚀 Laravel LSP: INITIALIZED (build {}) - spawning background work",
-            env!("LARAVEL_LSP_GIT_HASH")
-        );
+        info!("🚀 Laravel ({}) initialized", env!("LARAVEL_LSP_GIT_HASH"));
         info!("========================================");
 
         // Get root path
@@ -15439,7 +15439,7 @@ impl LanguageServer for LaravelLanguageServer {
     }
 
     async fn shutdown(&self) -> jsonrpc::Result<()> {
-        info!("Laravel LSP: Shutting down - cleaning up resources");
+        info!("Laravel: Shutting down - cleaning up resources");
 
         // Cancel all pending diagnostic tasks
         {
@@ -15461,7 +15461,7 @@ impl LanguageServer for LaravelLanguageServer {
             debug!("Salsa actor shutdown: {}", e);
         }
 
-        info!("Laravel LSP: Shutdown complete");
+        info!("Laravel: Shutdown complete");
         Ok(())
     }
 
@@ -15545,10 +15545,7 @@ impl LanguageServer for LaravelLanguageServer {
         let version = params.text_document.version;
 
         if let Some(change) = params.content_changes.into_iter().next() {
-            debug!(
-                "Laravel LSP: Document changed: {} (version: {})",
-                uri, version
-            );
+            debug!("Laravel: Document changed: {} (version: {})", uri, version);
 
             // Store in documents buffer immediately (for goto_definition during debounce)
             self.documents
@@ -15567,7 +15564,7 @@ impl LanguageServer for LaravelLanguageServer {
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
         let uri = params.text_document.uri;
-        info!("🔔 Laravel LSP: did_save called for {}", uri);
+        info!("🔔 Laravel: did_save called for {}", uri);
 
         // Check for lock file changes that trigger rescans
         if let Ok(path) = uri.to_file_path() {
@@ -15633,7 +15630,7 @@ impl LanguageServer for LaravelLanguageServer {
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let uri = params.text_document.uri;
-        debug!("Laravel LSP: Document closed: {}", uri);
+        debug!("Laravel: Document closed: {}", uri);
 
         // Cancel any pending debounced diagnostics
         if let Some(handle) = self.pending_diagnostics.write().await.remove(&uri) {
@@ -15866,11 +15863,11 @@ impl LanguageServer for LaravelLanguageServer {
         let patterns = match self.salsa.get_patterns(file_path).await {
             Ok(Some(p)) => p,
             Ok(None) => {
-                debug!("Laravel LSP: No patterns cached for file");
+                debug!("Laravel: No patterns cached for file");
                 return Ok(None);
             }
             Err(e) => {
-                debug!("Laravel LSP: Error getting patterns: {:?}", e);
+                debug!("Laravel: Error getting patterns: {:?}", e);
                 return Ok(None);
             }
         };
@@ -15913,30 +15910,30 @@ impl LanguageServer for LaravelLanguageServer {
         // Create location based on pattern type
         let location = match pattern {
             PatternAtPosition::View(view) => {
-                debug!("Laravel LSP: Found view: {}", view.name);
+                debug!("Laravel: Found view: {}", view.name);
                 self.create_view_location_from_salsa(&view).await
             }
             PatternAtPosition::Component(comp) => {
-                debug!("Laravel LSP: Found component: {}", comp.name);
+                debug!("Laravel: Found component: {}", comp.name);
                 self.create_component_location_from_salsa(&comp).await
             }
             PatternAtPosition::Livewire(lw) => {
-                debug!("Laravel LSP: Found livewire: {}", lw.name);
+                debug!("Laravel: Found livewire: {}", lw.name);
                 self.create_livewire_location_from_salsa(&lw).await
             }
             PatternAtPosition::Directive(dir) => {
                 info!(
-                    "🎯 Laravel LSP: Found directive: {} with args {:?} at {}:{}-{}",
+                    "🎯 Laravel: Found directive: {} with args {:?} at {}:{}-{}",
                     dir.name, dir.arguments, dir.line, dir.column, dir.end_column
                 );
                 self.create_directive_location_from_salsa(&dir).await
             }
             PatternAtPosition::EnvRef(env) => {
-                debug!("Laravel LSP: Found env: {}", env.name);
+                debug!("Laravel: Found env: {}", env.name);
                 self.create_env_location_from_salsa(&env).await
             }
             PatternAtPosition::ConfigRef(config) => {
-                debug!("Laravel LSP: Found config: {}", config.key);
+                debug!("Laravel: Found config: {}", config.key);
                 self.create_config_location_from_salsa(&config).await
             }
             PatternAtPosition::Middleware(mw) => {
@@ -15955,39 +15952,39 @@ impl LanguageServer for LaravelLanguageServer {
             }
             PatternAtPosition::Translation(trans) => {
                 info!(
-                    "🎯 Laravel LSP: Found translation pattern: '{}' at {}:{}-{}",
+                    "🎯 Laravel: Found translation pattern: '{}' at {}:{}-{}",
                     trans.key, trans.line, trans.column, trans.end_column
                 );
                 self.create_translation_location_from_salsa(&trans).await
             }
             PatternAtPosition::Asset(asset) => {
-                debug!("Laravel LSP: Found asset: {}", asset.path);
+                debug!("Laravel: Found asset: {}", asset.path);
                 self.create_asset_location_from_salsa(&asset).await
             }
             PatternAtPosition::Binding(binding) => {
-                debug!("Laravel LSP: Found binding: {}", binding.name);
+                debug!("Laravel: Found binding: {}", binding.name);
                 self.create_binding_location_from_salsa(&binding).await
             }
             PatternAtPosition::Route(route) => {
-                debug!("Laravel LSP: Found route: {}", route.name);
+                debug!("Laravel: Found route: {}", route.name);
                 self.create_route_location_from_salsa(&route).await
             }
             PatternAtPosition::Url(url) => {
-                debug!("Laravel LSP: Found url: {}", url.path);
+                debug!("Laravel: Found url: {}", url.path);
                 self.create_url_location_from_salsa(&url).await
             }
             PatternAtPosition::Action(action) => {
-                debug!("Laravel LSP: Found action: {}", action.action);
+                debug!("Laravel: Found action: {}", action.action);
                 self.create_action_location_from_salsa(&action).await
             }
             PatternAtPosition::Feature(feature) => {
-                debug!("Laravel LSP: Found feature: {}", feature.feature_name);
+                debug!("Laravel: Found feature: {}", feature.feature_name);
                 self.create_feature_location_from_salsa(&feature).await
             }
         };
 
         if location.is_none() {
-            debug!("Laravel LSP: Could not resolve location for pattern");
+            debug!("Laravel: Could not resolve location for pattern");
         }
 
         Ok(location)

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -15322,7 +15322,10 @@ impl LanguageServer for LaravelLanguageServer {
 
     async fn initialized(&self, _: InitializedParams) {
         info!("========================================");
-        info!("🚀 Laravel LSP: INITIALIZED - spawning background work");
+        info!(
+            "🚀 Laravel LSP: INITIALIZED (build {}) - spawning background work",
+            env!("LARAVEL_LSP_GIT_HASH")
+        );
         info!("========================================");
 
         // Get root path

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -15350,7 +15350,7 @@ impl LanguageServer for LaravelLanguageServer {
             // status bar answers without anyone opening the log panel.
             let mut progress = laravel_lsp::indexing_progress::IndexingProgress::begin(
                 client,
-                format!("Laravel ({})", env!("LARAVEL_LSP_GIT_HASH")),
+                format!("🚀 Laravel ({})", env!("LARAVEL_LSP_GIT_HASH")),
                 "Starting indexer…",
             )
             .await;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2819,18 +2819,59 @@ impl LaravelLanguageServer {
         };
 
         if items.is_empty() {
-            info!(
-                "🔗 chain completion: matched {:?} but produced 0 items — \
-                 likely DB unreachable or table/columns not in introspected schema. \
-                 Check the database WARN above; .env DB_HOST may not resolve \
-                 outside of Docker/Sail.",
-                ctx.expecting
-            );
+            // Distinguish two empty-result causes for the log/diagnostic:
+            // (a) DB is unreachable — actionable, user can fix .env. Show a
+            //     one-time INFO toast so they discover the dependency.
+            // (b) DB is reachable but the specific table/columns aren't in
+            //     the introspected schema (e.g., user typed a typo, table
+            //     was dropped, schema cache stale). Stay silent — toasting
+            //     every time would be noisy.
+            let connection_error = db.get_last_error().await;
+            drop(db_guard);
+
+            if let Some(error) = connection_error {
+                info!(
+                    "🔗 chain completion: matched {:?} but produced 0 items — \
+                     DB connection error: {}",
+                    ctx.expecting, error.message
+                );
+                self.maybe_notify_db_unreachable(&error.message).await;
+            } else {
+                info!(
+                    "🔗 chain completion: matched {:?} but produced 0 items — \
+                     schema reachable but table/columns absent",
+                    ctx.expecting
+                );
+            }
         } else {
             info!("🔗 chain completion: returning {} items", items.len());
         }
 
         Some(items)
+    }
+
+    /// Send a one-time `window/showMessage` informing the user that table
+    /// and column autocomplete requires a working DB connection. Shares the
+    /// `database_diagnostic_shown` flag with the existing exists:/unique:
+    /// diagnostic path, so the user only sees ONE notification per LSP
+    /// session no matter how they hit the unreachable DB.
+    async fn maybe_notify_db_unreachable(&self, error_message: &str) {
+        let mut shown = self.database_diagnostic_shown.write().await;
+        if *shown {
+            return;
+        }
+        *shown = true;
+        drop(shown);
+
+        let message = format!(
+            "Laravel LSP: Database is unreachable, so table and column \
+             autocompletion is disabled. Fix DB connectivity in .env \
+             (DB_HOST / DB_PORT / credentials) and reload the window to \
+             enable. Error: {error_message}"
+        );
+        self.client
+            .show_message(tower_lsp::lsp_types::MessageType::INFO, message)
+            .await;
     }
 
     fn new(client: Client) -> Self {

--- a/laravel-lsp/src/model_analyzer.rs
+++ b/laravel-lsp/src/model_analyzer.rs
@@ -153,15 +153,21 @@ impl ModelMetadata {
             let Some(parent_raw) = Self::extract_parent_class(&content) else {
                 return false;
             };
-            let basename = parent_raw.rsplit('\\').next().unwrap_or(&parent_raw);
-            if basename == "Model" {
-                // Stop here — the walker that builds `ModelMetadata` does
-                // the same. We've confirmed an Eloquent ancestor exists.
-                return true;
-            }
+            // Resolve the raw parent name through the file's use aliases
+            // FIRST, then check the basename. The raw name can be an alias
+            // (`use Illuminate\Database\Eloquent\Model as EloquentModel;`),
+            // in which case the basename of `parent_raw` is "EloquentModel"
+            // but the resolved FQCN ends in "Model" — that's what we want
+            // to match.
             let aliases = Self::extract_use_aliases_from_php(&content);
             let ns = Self::extract_namespace(&content);
             let parent_fqcn = Self::resolve_to_fqcn(&parent_raw, ns.as_deref(), &aliases);
+            let resolved_basename = parent_fqcn.rsplit('\\').next().unwrap_or(&parent_fqcn);
+            if resolved_basename == "Model" {
+                // Confirmed an Eloquent ancestor. Stop walking — same
+                // sentinel `from_file_with_inheritance` uses.
+                return true;
+            }
             current = crate::class_locator::find_php_class_file_in_app_or_vendor(
                 &parent_fqcn,
                 project_root,

--- a/laravel-lsp/src/model_analyzer.rs
+++ b/laravel-lsp/src/model_analyzer.rs
@@ -432,6 +432,21 @@ impl ModelMetadata {
     fn extract_relationships(content: &str) -> Vec<RelationshipInfo> {
         let mut relationships = Vec::new();
 
+        // Resolve `Post::class` references through THIS file's namespace +
+        // use statements once, then reuse for every relationship. If we
+        // stored just the basename (`"Post"`), a later dotted-path hop
+        // would basename-walk and could land on the wrong file (e.g.
+        // `app/Nova/Filters/Post.php` instead of the actual model).
+        // Resolving to FQCN at extraction time fixes that — the
+        // basename `Post::class` inside `namespace App\Models;` becomes
+        // the full FQCN `App\Models\Post`, ready for Composer's PSR-4
+        // resolver to find the right file.
+        let file_namespace = Self::extract_namespace(content);
+        let use_aliases = Self::extract_use_aliases_from_php(content);
+        let resolve_class = |bare: String| -> String {
+            Self::resolve_to_fqcn(&bare, file_namespace.as_deref(), &use_aliases)
+        };
+
         // Common relationship types - ordered longest first to avoid partial matches
         let relationship_types = [
             "belongsToMany",
@@ -466,7 +481,8 @@ impl ModelMetadata {
                             let related_model = Self::extract_related_model_from_relationship(
                                 content,
                                 &method_name,
-                            );
+                            )
+                            .map(&resolve_class);
                             relationships.push(RelationshipInfo {
                                 method_name,
                                 relationship_type: rel_type.to_string(),
@@ -495,7 +511,8 @@ impl ModelMetadata {
                             let related_model = Self::extract_related_model_from_relationship(
                                 content,
                                 &method_name,
-                            );
+                            )
+                            .map(&resolve_class);
                             relationships.push(RelationshipInfo {
                                 method_name,
                                 relationship_type: rel_type.to_string(),
@@ -582,9 +599,15 @@ pub fn map_cast_to_php_type(cast: &str) -> String {
     }
 }
 
-/// Get the PHP type for a relationship
+/// Get the PHP type for a relationship.
+///
+/// `related_model` may be a FQCN (`App\Models\Post`) or a bare class
+/// name (`Post`). The displayed label always uses the simple name —
+/// completion details should be short, and the model's namespace
+/// rarely adds value at a glance.
 pub fn relationship_to_php_type(rel_type: &str, related_model: Option<&str>) -> String {
-    let model = related_model.unwrap_or("Model");
+    let model_full = related_model.unwrap_or("Model");
+    let model = model_full.rsplit('\\').next().unwrap_or(model_full);
 
     match rel_type {
         // Single model relationships

--- a/laravel-lsp/src/model_analyzer.rs
+++ b/laravel-lsp/src/model_analyzer.rs
@@ -159,13 +159,14 @@ impl ModelMetadata {
                 let parent_fqcn =
                     Self::resolve_to_fqcn(&parent_raw, file_namespace.as_deref(), &use_aliases);
 
-                let parent_path = Self::find_class_file_by_fqcn(&parent_fqcn, project_root)
-                    .or_else(|| {
-                        crate::class_locator::find_php_class_file_in_app_or_vendor(
-                            &parent_fqcn,
-                            project_root,
-                        )
-                    });
+                // Single call covers both PSR-4 paths (App\ and vendor/)
+                // and falls back to basename walk if neither shape exists.
+                // The PSR-4 ordering inside `find_php_class_file_in_app_or_vendor`
+                // means project-local classes shadow vendor classes.
+                let parent_path = crate::class_locator::find_php_class_file_in_app_or_vendor(
+                    &parent_fqcn,
+                    project_root,
+                );
 
                 if let Some(parent_path) = parent_path {
                     if let Some(parent_meta) =
@@ -254,69 +255,12 @@ impl ModelMetadata {
         name.to_string()
     }
 
-    /// Map a fully-qualified class name to its source file path using
-    /// Laravel/Composer conventions:
-    ///
-    /// - `App\Models\User` → `app/Models/User.php`
-    ///   (or `src/...` if the project uses `src/` for app code)
-    /// - `Laravel\Passport\Token` →
-    ///   `vendor/laravel/passport/src/Token.php`
-    ///   (lowercased vendor + package, then `src/`, then remaining
-    ///   segments as path)
-    /// - `Spatie\Permission\Models\Role` →
-    ///   `vendor/spatie/permission/src/Models/Role.php`
-    ///
-    /// Returns `None` if none of the candidate paths exist on disk.
-    /// The caller then falls back to a basename walk via class_locator.
-    fn find_class_file_by_fqcn(fqcn: &str, project_root: &Path) -> Option<PathBuf> {
-        let segments: Vec<&str> = fqcn.split('\\').filter(|s| !s.is_empty()).collect();
-        if segments.is_empty() {
-            return None;
-        }
-        let class_name = *segments.last().unwrap();
-        let ns_segments = &segments[..segments.len() - 1];
-
-        // App\Models\User → app/Models/User.php (and src/ alternative)
-        if ns_segments.first().map(|s| s.to_ascii_lowercase()) == Some("app".to_string()) {
-            let rest = &ns_segments[1..];
-            for app_dir in ["app", "src"] {
-                let mut path = project_root.join(app_dir);
-                for seg in rest {
-                    path = path.join(seg);
-                }
-                path = path.join(format!("{class_name}.php"));
-                if path.exists() {
-                    return Some(path);
-                }
-            }
-        }
-
-        // Vendor convention: lowercase first two segments → package
-        // directory; remaining segments are paths under `src/` (or
-        // under the package root if `src/` doesn't exist for this
-        // particular package).
-        if ns_segments.len() >= 2 {
-            let vendor = ns_segments[0].to_ascii_lowercase();
-            let pkg = ns_segments[1].to_ascii_lowercase();
-            let rest = &ns_segments[2..];
-
-            for src_segment in ["src", ""] {
-                let mut path = project_root.join("vendor").join(&vendor).join(&pkg);
-                if !src_segment.is_empty() {
-                    path = path.join(src_segment);
-                }
-                for seg in rest {
-                    path = path.join(seg);
-                }
-                path = path.join(format!("{class_name}.php"));
-                if path.exists() {
-                    return Some(path);
-                }
-            }
-        }
-
-        None
-    }
+    // `find_class_file_by_fqcn` lived here until Phase 5.9, then moved
+    // into class_locator so non-inheritance callers (columns_for_builder,
+    // relations, resolve_related_model) also benefit. The inheritance
+    // walker now calls `class_locator::find_php_class_file_in_app_or_vendor`
+    // directly — it already chains the FQCN-aware lookup with the
+    // basename-walk fallback.
 
     /// Extract the parent class name from `class X extends Y`. Returns
     /// the parent as written (may be a simple name like `Token` or a

--- a/laravel-lsp/src/model_analyzer.rs
+++ b/laravel-lsp/src/model_analyzer.rs
@@ -246,7 +246,7 @@ impl ModelMetadata {
     /// Doesn't handle grouped uses (`use Foo\{Bar, Baz};`),
     /// `use function`, or `use const` — none of those participate in
     /// class inheritance, which is what this walker resolves.
-    fn extract_use_aliases_from_php(content: &str) -> HashMap<String, String> {
+    pub fn extract_use_aliases_from_php(content: &str) -> HashMap<String, String> {
         let re = match Regex::new(r"(?m)^\s*use\s+([\w\\]+)(?:\s+as\s+(\w+))?\s*;") {
             Ok(r) => r,
             Err(_) => return HashMap::new(),
@@ -266,7 +266,7 @@ impl ModelMetadata {
     /// Extract the `namespace Foo\Bar;` declaration. Returns the
     /// namespace without the leading backslash. Returns `None` for
     /// files without a namespace declaration (global namespace).
-    fn extract_namespace(content: &str) -> Option<String> {
+    pub fn extract_namespace(content: &str) -> Option<String> {
         let re = Regex::new(r"(?m)^\s*namespace\s+([\w\\]+)\s*;").ok()?;
         re.captures(content)
             .and_then(|c| c.get(1))
@@ -284,7 +284,7 @@ impl ModelMetadata {
     ///   else prepend the file's namespace.
     /// - `Bar` (unqualified) — look in use aliases first, else
     ///   prepend the file's namespace.
-    fn resolve_to_fqcn(
+    pub fn resolve_to_fqcn(
         name: &str,
         file_namespace: Option<&str>,
         use_aliases: &HashMap<String, String>,

--- a/laravel-lsp/src/model_analyzer.rs
+++ b/laravel-lsp/src/model_analyzer.rs
@@ -7,7 +7,8 @@
 //! - Relationships (belongsTo, hasMany, etc.)
 
 use regex::Regex;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 /// Source of a model property
 #[derive(Debug, Clone, PartialEq)]
@@ -88,6 +89,127 @@ impl ModelMetadata {
             accessors,
             relationships,
         }
+    }
+
+    /// Parse a model file AND walk its `extends` chain, inheriting any
+    /// `$table`, casts, accessors, and relationships the child doesn't
+    /// declare itself.
+    ///
+    /// Real Laravel codebases often factor shared shape into a base
+    /// class — e.g. `OAuthAccessToken extends Token` where `Token`
+    /// declares `protected $table = 'oauth_access_tokens'`. Without
+    /// inheritance walking, the child's `ModelMetadata` has
+    /// `table_name = None` and we fall back to snake-pluralizing
+    /// "OAuthAccessToken" → "o_auth_access_tokens" (wrong) instead of
+    /// using the parent's explicit "oauth_access_tokens".
+    ///
+    /// PHP method/property resolution: child wins on conflict, parent
+    /// fills in what the child doesn't declare. We mirror that:
+    /// - `table_name`: child overrides; parent fills if child has none.
+    /// - `casts`: union; child entries take precedence per-key.
+    /// - `accessors` / `relationships`: appended from parent if not
+    ///   already declared by the same name on the child.
+    ///
+    /// Stops at Laravel's base `Model`, at any parent class file we
+    /// can't locate in the project (vendor classes without app/-side
+    /// shadowing aren't searched here yet), or at a 10-deep recursion
+    /// cap. Cycle-safe via a visited-set.
+    pub fn from_file_with_inheritance(path: &Path, project_root: &Path) -> Option<Self> {
+        let mut visited = HashSet::new();
+        Self::resolve_recursive(path, project_root, &mut visited, 0)
+    }
+
+    fn resolve_recursive(
+        path: &Path,
+        project_root: &Path,
+        visited: &mut HashSet<PathBuf>,
+        depth: usize,
+    ) -> Option<Self> {
+        if depth > 10 {
+            return None;
+        }
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        if !visited.insert(canonical) {
+            // Cycle — A extends B extends A. Shouldn't happen in valid
+            // PHP, but parsing is best-effort and we'd rather bail than
+            // recurse forever.
+            return None;
+        }
+
+        let content = std::fs::read_to_string(path).ok()?;
+        let mut metadata = Self::from_content(&content);
+
+        if let Some(parent_class) = Self::extract_parent_class(&content) {
+            // Stop at Eloquent's base class. Real Laravel models extend
+            // `Model` directly OR via `Authenticatable` (which itself
+            // extends Model). We only halt on Model — Authenticatable
+            // and Pivot etc. are worth walking into (they may declare
+            // their own $table fallbacks for specific use cases).
+            let basename = parent_class.rsplit('\\').next().unwrap_or(&parent_class);
+            if basename != "Model" {
+                if let Some(parent_path) =
+                    crate::class_locator::find_php_class_file(&parent_class, project_root)
+                {
+                    if let Some(parent_meta) =
+                        Self::resolve_recursive(&parent_path, project_root, visited, depth + 1)
+                    {
+                        metadata.merge_inherited(parent_meta);
+                    }
+                }
+                // If the parent isn't in app/-style search roots (e.g.
+                // vendor/ class without PSR-4 hookup here), just stop
+                // walking. We don't pretend to inherit something we
+                // can't read.
+            }
+        }
+
+        Some(metadata)
+    }
+
+    /// Extract the parent class name from `class X extends Y`. Returns
+    /// the parent as written (may be a simple name like `Token` or a
+    /// qualified name like `\App\Models\Token`); the caller resolves
+    /// it to a file via `class_locator::find_php_class_file`, which
+    /// matches by basename.
+    fn extract_parent_class(content: &str) -> Option<String> {
+        let re = Regex::new(r"class\s+\w+\s+extends\s+([\w\\]+)").ok()?;
+        re.captures(content)
+            .and_then(|caps| caps.get(1))
+            .map(|m| m.as_str().to_string())
+    }
+
+    /// PHP-style inheritance merge: child fields win, parent fills the
+    /// gaps. Called only after the parent's full chain is already
+    /// resolved (so grandparent fields are already merged into
+    /// `parent`).
+    fn merge_inherited(&mut self, parent: ModelMetadata) {
+        if self.table_name.is_none() {
+            self.table_name = parent.table_name;
+        }
+        for (k, v) in parent.casts {
+            self.casts.entry(k).or_insert(v);
+        }
+        for acc in parent.accessors {
+            if !self
+                .accessors
+                .iter()
+                .any(|a| a.property_name == acc.property_name)
+            {
+                self.accessors.push(acc);
+            }
+        }
+        for rel in parent.relationships {
+            if !self
+                .relationships
+                .iter()
+                .any(|r| r.method_name == rel.method_name)
+            {
+                self.relationships.push(rel);
+            }
+        }
+        // `class_name` always stays the child's — Laravel's
+        // `static::class` semantics inside model methods resolves to
+        // the concrete class, not its parents.
     }
 
     /// Extract the class name from the model file

--- a/laravel-lsp/src/model_analyzer.rs
+++ b/laravel-lsp/src/model_analyzer.rs
@@ -139,31 +139,183 @@ impl ModelMetadata {
         let content = std::fs::read_to_string(path).ok()?;
         let mut metadata = Self::from_content(&content);
 
-        if let Some(parent_class) = Self::extract_parent_class(&content) {
+        if let Some(parent_raw) = Self::extract_parent_class(&content) {
             // Stop at Eloquent's base class. Real Laravel models extend
             // `Model` directly OR via `Authenticatable` (which itself
             // extends Model). We only halt on Model — Authenticatable
             // and Pivot etc. are worth walking into (they may declare
             // their own $table fallbacks for specific use cases).
-            let basename = parent_class.rsplit('\\').next().unwrap_or(&parent_class);
+            let basename = parent_raw.rsplit('\\').next().unwrap_or(&parent_raw);
             if basename != "Model" {
-                if let Some(parent_path) =
-                    crate::class_locator::find_php_class_file(&parent_class, project_root)
-                {
+                // Resolve the parent through the child file's use
+                // statements + namespace so we get the actual FQCN
+                // (e.g. `Token` → `Laravel\Passport\Token`). Then map
+                // FQCN → file path via the Laravel/Composer
+                // convention. Falls back to a basename search if the
+                // FQCN path doesn't exist on disk — covers projects
+                // with non-standard PSR-4 layouts.
+                let use_aliases = Self::extract_use_aliases_from_php(&content);
+                let file_namespace = Self::extract_namespace(&content);
+                let parent_fqcn =
+                    Self::resolve_to_fqcn(&parent_raw, file_namespace.as_deref(), &use_aliases);
+
+                let parent_path = Self::find_class_file_by_fqcn(&parent_fqcn, project_root)
+                    .or_else(|| {
+                        crate::class_locator::find_php_class_file_in_app_or_vendor(
+                            &parent_fqcn,
+                            project_root,
+                        )
+                    });
+
+                if let Some(parent_path) = parent_path {
                     if let Some(parent_meta) =
                         Self::resolve_recursive(&parent_path, project_root, visited, depth + 1)
                     {
                         metadata.merge_inherited(parent_meta);
                     }
                 }
-                // If the parent isn't in app/-style search roots (e.g.
-                // vendor/ class without PSR-4 hookup here), just stop
-                // walking. We don't pretend to inherit something we
-                // can't read.
+                // No parent file found: built-in PHP class, missing
+                // dependency, or unconventional autoload. Walking stops.
             }
         }
 
         Some(metadata)
+    }
+
+    /// Extract `use Foo\Bar;` / `use Foo\Bar as Baz;` statements from
+    /// PHP source. Returns a `local_name → FQCN` map.
+    ///
+    /// Doesn't handle grouped uses (`use Foo\{Bar, Baz};`),
+    /// `use function`, or `use const` — none of those participate in
+    /// class inheritance, which is what this walker resolves.
+    fn extract_use_aliases_from_php(content: &str) -> HashMap<String, String> {
+        let re = match Regex::new(r"(?m)^\s*use\s+([\w\\]+)(?:\s+as\s+(\w+))?\s*;") {
+            Ok(r) => r,
+            Err(_) => return HashMap::new(),
+        };
+        let mut aliases = HashMap::new();
+        for caps in re.captures_iter(content) {
+            let fqcn = caps[1].trim_start_matches('\\').to_string();
+            let local = caps
+                .get(2)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_else(|| fqcn.rsplit('\\').next().unwrap_or(&fqcn).to_string());
+            aliases.insert(local, fqcn);
+        }
+        aliases
+    }
+
+    /// Extract the `namespace Foo\Bar;` declaration. Returns the
+    /// namespace without the leading backslash. Returns `None` for
+    /// files without a namespace declaration (global namespace).
+    fn extract_namespace(content: &str) -> Option<String> {
+        let re = Regex::new(r"(?m)^\s*namespace\s+([\w\\]+)\s*;").ok()?;
+        re.captures(content)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str().to_string())
+    }
+
+    /// Resolve a class reference (as it appears in `extends`,
+    /// `implements`, etc.) to its fully-qualified class name.
+    ///
+    /// Resolution rules mirror PHP:
+    /// - `\Foo\Bar` (leading backslash) is already fully qualified —
+    ///   strip the backslash.
+    /// - `Foo\Bar` (no leading backslash, contains backslash) is
+    ///   partially qualified — first segment may be an aliased use,
+    ///   else prepend the file's namespace.
+    /// - `Bar` (unqualified) — look in use aliases first, else
+    ///   prepend the file's namespace.
+    fn resolve_to_fqcn(
+        name: &str,
+        file_namespace: Option<&str>,
+        use_aliases: &HashMap<String, String>,
+    ) -> String {
+        if let Some(stripped) = name.strip_prefix('\\') {
+            return stripped.to_string();
+        }
+        if name.contains('\\') {
+            let first = name.split('\\').next().unwrap_or("");
+            if let Some(prefix) = use_aliases.get(first) {
+                let rest = &name[first.len()..]; // includes leading `\`
+                return format!("{prefix}{rest}");
+            }
+            if let Some(ns) = file_namespace {
+                return format!("{ns}\\{name}");
+            }
+            return name.to_string();
+        }
+        if let Some(fqcn) = use_aliases.get(name) {
+            return fqcn.clone();
+        }
+        if let Some(ns) = file_namespace {
+            return format!("{ns}\\{name}");
+        }
+        name.to_string()
+    }
+
+    /// Map a fully-qualified class name to its source file path using
+    /// Laravel/Composer conventions:
+    ///
+    /// - `App\Models\User` → `app/Models/User.php`
+    ///   (or `src/...` if the project uses `src/` for app code)
+    /// - `Laravel\Passport\Token` →
+    ///   `vendor/laravel/passport/src/Token.php`
+    ///   (lowercased vendor + package, then `src/`, then remaining
+    ///   segments as path)
+    /// - `Spatie\Permission\Models\Role` →
+    ///   `vendor/spatie/permission/src/Models/Role.php`
+    ///
+    /// Returns `None` if none of the candidate paths exist on disk.
+    /// The caller then falls back to a basename walk via class_locator.
+    fn find_class_file_by_fqcn(fqcn: &str, project_root: &Path) -> Option<PathBuf> {
+        let segments: Vec<&str> = fqcn.split('\\').filter(|s| !s.is_empty()).collect();
+        if segments.is_empty() {
+            return None;
+        }
+        let class_name = *segments.last().unwrap();
+        let ns_segments = &segments[..segments.len() - 1];
+
+        // App\Models\User → app/Models/User.php (and src/ alternative)
+        if ns_segments.first().map(|s| s.to_ascii_lowercase()) == Some("app".to_string()) {
+            let rest = &ns_segments[1..];
+            for app_dir in ["app", "src"] {
+                let mut path = project_root.join(app_dir);
+                for seg in rest {
+                    path = path.join(seg);
+                }
+                path = path.join(format!("{class_name}.php"));
+                if path.exists() {
+                    return Some(path);
+                }
+            }
+        }
+
+        // Vendor convention: lowercase first two segments → package
+        // directory; remaining segments are paths under `src/` (or
+        // under the package root if `src/` doesn't exist for this
+        // particular package).
+        if ns_segments.len() >= 2 {
+            let vendor = ns_segments[0].to_ascii_lowercase();
+            let pkg = ns_segments[1].to_ascii_lowercase();
+            let rest = &ns_segments[2..];
+
+            for src_segment in ["src", ""] {
+                let mut path = project_root.join("vendor").join(&vendor).join(&pkg);
+                if !src_segment.is_empty() {
+                    path = path.join(src_segment);
+                }
+                for seg in rest {
+                    path = path.join(seg);
+                }
+                path = path.join(format!("{class_name}.php"));
+                if path.exists() {
+                    return Some(path);
+                }
+            }
+        }
+
+        None
     }
 
     /// Extract the parent class name from `class X extends Y`. Returns

--- a/laravel-lsp/src/model_analyzer.rs
+++ b/laravel-lsp/src/model_analyzer.rs
@@ -119,6 +119,57 @@ impl ModelMetadata {
         Self::resolve_recursive(path, project_root, &mut visited, 0)
     }
 
+    /// Walk the `extends` chain from `path` and return `true` if any
+    /// ancestor is Eloquent's base `Model`. Used to decide whether to
+    /// surface Eloquent-style property completions (DB columns + casts +
+    /// accessors + relationships) versus generic public-property scans.
+    ///
+    /// The chain may pass through any number of intermediate base classes
+    /// — `OAuthAccessToken extends Token extends BaseModel extends Model`
+    /// counts as Eloquent. A literal `extends Model` regex misses that
+    /// shape entirely.
+    ///
+    /// Bounded by the same 10-deep recursion cap as
+    /// [`from_file_with_inheritance`] and cycle-safe via a visited set.
+    /// Uses [`crate::class_locator::find_php_class_file_in_app_or_vendor`]
+    /// so vendor-side base classes (e.g. an SDK's `BaseModel`) are found
+    /// through Composer's autoload data.
+    pub fn extends_eloquent_model(path: &Path, project_root: &Path) -> bool {
+        let mut visited: HashSet<PathBuf> = HashSet::new();
+        let mut current = Some(path.to_path_buf());
+        let mut depth = 0usize;
+        while let Some(p) = current.take() {
+            if depth > 10 {
+                return false;
+            }
+            depth += 1;
+            let canonical = p.canonicalize().unwrap_or_else(|_| p.clone());
+            if !visited.insert(canonical) {
+                return false;
+            }
+            let Ok(content) = std::fs::read_to_string(&p) else {
+                return false;
+            };
+            let Some(parent_raw) = Self::extract_parent_class(&content) else {
+                return false;
+            };
+            let basename = parent_raw.rsplit('\\').next().unwrap_or(&parent_raw);
+            if basename == "Model" {
+                // Stop here — the walker that builds `ModelMetadata` does
+                // the same. We've confirmed an Eloquent ancestor exists.
+                return true;
+            }
+            let aliases = Self::extract_use_aliases_from_php(&content);
+            let ns = Self::extract_namespace(&content);
+            let parent_fqcn = Self::resolve_to_fqcn(&parent_raw, ns.as_deref(), &aliases);
+            current = crate::class_locator::find_php_class_file_in_app_or_vendor(
+                &parent_fqcn,
+                project_root,
+            );
+        }
+        false
+    }
+
     fn resolve_recursive(
         path: &Path,
         project_root: &Path,

--- a/laravel-lsp/src/model_analyzer/tests.rs
+++ b/laravel-lsp/src/model_analyzer/tests.rs
@@ -762,6 +762,35 @@ class ContactForm extends Form {
 }
 
 #[test]
+fn extends_eloquent_model_resolves_aliased_model_class() {
+    // The crossbible-vapor vendor case: a base class extends
+    // `EloquentModel` which is `use Illuminate\Database\Eloquent\Model
+    // as EloquentModel`. Checking only the raw token (`EloquentModel`)
+    // misses — we have to resolve the alias and check the resolved
+    // FQCN's basename. Without this fix, the walker passes through
+    // and eventually returns false.
+    let dir = project_with_models(&[(
+        "BaseModel",
+        r#"<?php
+namespace App\Concerns;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+abstract class BaseModel extends EloquentModel {}
+"#,
+    )]);
+    std::fs::create_dir_all(dir.path().join("app/Concerns")).unwrap();
+    std::fs::rename(
+        dir.path().join("app/Models/BaseModel.php"),
+        dir.path().join("app/Concerns/BaseModel.php"),
+    )
+    .unwrap();
+    let path = dir.path().join("app/Concerns/BaseModel.php");
+    assert!(
+        ModelMetadata::extends_eloquent_model(&path, dir.path()),
+        "aliased `use Model as EloquentModel` should still resolve to Eloquent"
+    );
+}
+
+#[test]
 fn extends_eloquent_model_false_when_no_extends_clause() {
     // Plain old class with no extends — definitely not Eloquent.
     let dir = project_with_models(&[(

--- a/laravel-lsp/src/model_analyzer/tests.rs
+++ b/laravel-lsp/src/model_analyzer/tests.rs
@@ -191,3 +191,240 @@ fn test_relationship_to_php_type() {
         "Collection<Role>"
     );
 }
+
+// ---- Inheritance walking (Phase 5.6) -------------------------------------
+
+use tempfile::TempDir;
+
+/// Helper: spin up a tempdir Laravel-shaped project with multiple model
+/// files at `app/Models/`. Returns the project root.
+fn project_with_models(files: &[(&str, &str)]) -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    let models_dir = dir.path().join("app").join("Models");
+    std::fs::create_dir_all(&models_dir).expect("create models dir");
+    for (class_name, body) in files {
+        let path = models_dir.join(format!("{class_name}.php"));
+        std::fs::write(&path, body).expect("write model");
+    }
+    dir
+}
+
+#[test]
+fn inheritance_child_without_table_picks_up_parent_table() {
+    // Mike's exact case: OAuthAccessToken extends Token; Token declares
+    // `protected $table = 'oauth_access_tokens'`. The child should
+    // resolve to that table, not snake_pluralize('OAuthAccessToken').
+    let dir = project_with_models(&[
+        (
+            "OAuthAccessToken",
+            r#"<?php
+namespace App\Models;
+class OAuthAccessToken extends Token {}
+"#,
+        ),
+        (
+            "Token",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Token extends Model {
+    protected $table = 'oauth_access_tokens';
+}
+"#,
+        ),
+    ]);
+    let child_path = dir.path().join("app/Models/OAuthAccessToken.php");
+    let metadata = ModelMetadata::from_file_with_inheritance(&child_path, dir.path())
+        .expect("metadata resolves");
+    assert_eq!(metadata.class_name, "OAuthAccessToken");
+    assert_eq!(metadata.table_name.as_deref(), Some("oauth_access_tokens"));
+}
+
+#[test]
+fn inheritance_child_table_overrides_parent_table() {
+    // PHP semantics: when child declares its own $table, that wins.
+    let dir = project_with_models(&[
+        (
+            "Special",
+            r#"<?php
+namespace App\Models;
+class Special extends Base {
+    protected $table = 'special_table';
+}
+"#,
+        ),
+        (
+            "Base",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Base extends Model {
+    protected $table = 'base_table';
+}
+"#,
+        ),
+    ]);
+    let child_path = dir.path().join("app/Models/Special.php");
+    let metadata = ModelMetadata::from_file_with_inheritance(&child_path, dir.path()).unwrap();
+    assert_eq!(metadata.table_name.as_deref(), Some("special_table"));
+}
+
+#[test]
+fn inheritance_merges_casts_and_relationships() {
+    // The parent declares a relationship and a cast; the child adds its
+    // own. Both surface in the resolved metadata.
+    let dir = project_with_models(&[
+        (
+            "Child",
+            r#"<?php
+namespace App\Models;
+class Child extends Parent_ {
+    protected $casts = ['child_field' => 'array'];
+    public function profile() {
+        return $this->hasOne(Profile::class);
+    }
+}
+"#,
+        ),
+        (
+            "Parent_",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Parent_ extends Model {
+    protected $table = 'parent_table';
+    protected $casts = ['parent_field' => 'boolean'];
+    public function inherited_rel() {
+        return $this->hasMany(Other::class);
+    }
+}
+"#,
+        ),
+    ]);
+    let child_path = dir.path().join("app/Models/Child.php");
+    let metadata = ModelMetadata::from_file_with_inheritance(&child_path, dir.path()).unwrap();
+    // Table comes from parent (child has none).
+    assert_eq!(metadata.table_name.as_deref(), Some("parent_table"));
+    // Both casts present.
+    assert_eq!(
+        metadata.casts.get("child_field").map(|s| s.as_str()),
+        Some("array")
+    );
+    assert_eq!(
+        metadata.casts.get("parent_field").map(|s| s.as_str()),
+        Some("boolean")
+    );
+    // Both relationships present (child + inherited from parent).
+    let names: Vec<&str> = metadata
+        .relationships
+        .iter()
+        .map(|r| r.method_name.as_str())
+        .collect();
+    assert!(
+        names.contains(&"profile"),
+        "child relation missing; got {names:?}"
+    );
+    assert!(
+        names.contains(&"inherited_rel"),
+        "parent relation not inherited; got {names:?}"
+    );
+}
+
+#[test]
+fn inheritance_stops_at_eloquent_model_base() {
+    // A class that extends `Model` directly should not try to walk
+    // further (there's no Model.php in the project — that's vendor).
+    let dir = project_with_models(&[(
+        "Plain",
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Plain extends Model {}
+"#,
+    )]);
+    let path = dir.path().join("app/Models/Plain.php");
+    // Should resolve without erroring even though there's no parent file.
+    let metadata = ModelMetadata::from_file_with_inheritance(&path, dir.path()).unwrap();
+    assert_eq!(metadata.class_name, "Plain");
+    assert!(metadata.table_name.is_none());
+}
+
+#[test]
+fn inheritance_handles_missing_parent_gracefully() {
+    // Parent class file doesn't exist (could be a vendor class we don't
+    // search). The child's own metadata still resolves — we just don't
+    // inherit anything.
+    let dir = project_with_models(&[(
+        "Orphan",
+        r#"<?php
+namespace App\Models;
+class Orphan extends SomeVendorClass {
+    protected $table = 'orphans';
+}
+"#,
+    )]);
+    let path = dir.path().join("app/Models/Orphan.php");
+    let metadata = ModelMetadata::from_file_with_inheritance(&path, dir.path()).unwrap();
+    assert_eq!(metadata.table_name.as_deref(), Some("orphans"));
+}
+
+#[test]
+fn inheritance_survives_cycles() {
+    // A extends B, B extends A — invalid PHP, but the walker shouldn't
+    // recurse forever. Visited-set short-circuits the second visit.
+    let dir = project_with_models(&[
+        (
+            "A",
+            r#"<?php
+namespace App\Models;
+class A extends B {}
+"#,
+        ),
+        (
+            "B",
+            r#"<?php
+namespace App\Models;
+class B extends A {}
+"#,
+        ),
+    ]);
+    let path = dir.path().join("app/Models/A.php");
+    // Either returns Some with whatever it could collect, or None — but
+    // critically it MUST NOT hang or stack-overflow.
+    let _ = ModelMetadata::from_file_with_inheritance(&path, dir.path());
+}
+
+#[test]
+fn inheritance_walks_grandparent() {
+    // Multi-level chain: Child → Parent → Grandparent (which has the
+    // $table). All three levels walked.
+    let dir = project_with_models(&[
+        (
+            "Grandchild",
+            r#"<?php
+namespace App\Models;
+class Grandchild extends Middle {}
+"#,
+        ),
+        (
+            "Middle",
+            r#"<?php
+namespace App\Models;
+class Middle extends Grandparent {}
+"#,
+        ),
+        (
+            "Grandparent",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Grandparent extends Model {
+    protected $table = 'grandparent_table';
+}
+"#,
+        ),
+    ]);
+    let path = dir.path().join("app/Models/Grandchild.php");
+    let metadata = ModelMetadata::from_file_with_inheritance(&path, dir.path()).unwrap();
+    assert_eq!(metadata.table_name.as_deref(), Some("grandparent_table"));
+}

--- a/laravel-lsp/src/model_analyzer/tests.rs
+++ b/laravel-lsp/src/model_analyzer/tests.rs
@@ -686,3 +686,93 @@ class Grandparent extends Model {
     let metadata = ModelMetadata::from_file_with_inheritance(&path, dir.path()).unwrap();
     assert_eq!(metadata.table_name.as_deref(), Some("grandparent_table"));
 }
+
+#[test]
+fn extends_eloquent_model_recognizes_direct_extends() {
+    // The simplest case: `class Foo extends Model` — true.
+    let dir = project_with_models(&[(
+        "Direct",
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Direct extends Model {}
+"#,
+    )]);
+    let path = dir.path().join("app/Models/Direct.php");
+    assert!(ModelMetadata::extends_eloquent_model(&path, dir.path()));
+}
+
+#[test]
+fn extends_eloquent_model_walks_through_intermediate_base_classes() {
+    // The crossbible-vapor shape: `Version extends BaseModel` where
+    // BaseModel itself extends Model via several hops. The literal
+    // "extends Model" regex misses this — the inheritance walk catches
+    // it. This is the exact case Phase 9.1 fixes.
+    let dir = project_with_models(&[
+        (
+            "Version",
+            r#"<?php
+namespace App\Models;
+use App\Concerns\BaseModel;
+class Version extends BaseModel {}
+"#,
+        ),
+        (
+            "BaseModel",
+            r#"<?php
+namespace App\Concerns;
+use Illuminate\Database\Eloquent\Model;
+class BaseModel extends Model {
+    protected $connection = 'tenant';
+}
+"#,
+        ),
+    ]);
+    // BaseModel lives in app/Concerns/, not app/Models/. Place it there.
+    std::fs::create_dir_all(dir.path().join("app/Concerns")).unwrap();
+    std::fs::rename(
+        dir.path().join("app/Models/BaseModel.php"),
+        dir.path().join("app/Concerns/BaseModel.php"),
+    )
+    .unwrap();
+    let path = dir.path().join("app/Models/Version.php");
+    assert!(
+        ModelMetadata::extends_eloquent_model(&path, dir.path()),
+        "two-level inheritance through BaseModel should still be Eloquent"
+    );
+}
+
+#[test]
+fn extends_eloquent_model_false_for_non_eloquent_classes() {
+    // A Livewire Form (extends Form) should NOT be classified as
+    // Eloquent — `extract_generic_class_properties` is the right
+    // fallback for these.
+    let dir = project_with_models(&[(
+        "ContactForm",
+        r#"<?php
+namespace App\Livewire\Forms;
+use Livewire\Form;
+class ContactForm extends Form {
+    public string $name = '';
+}
+"#,
+    )]);
+    let path = dir.path().join("app/Models/ContactForm.php");
+    assert!(!ModelMetadata::extends_eloquent_model(&path, dir.path()));
+}
+
+#[test]
+fn extends_eloquent_model_false_when_no_extends_clause() {
+    // Plain old class with no extends — definitely not Eloquent.
+    let dir = project_with_models(&[(
+        "Plain",
+        r#"<?php
+namespace App\Models;
+class Plain {
+    public string $foo = '';
+}
+"#,
+    )]);
+    let path = dir.path().join("app/Models/Plain.php");
+    assert!(!ModelMetadata::extends_eloquent_model(&path, dir.path()));
+}

--- a/laravel-lsp/src/model_analyzer/tests.rs
+++ b/laravel-lsp/src/model_analyzer/tests.rs
@@ -155,6 +155,67 @@ fn test_extract_relationships() {
 }
 
 #[test]
+fn related_model_is_resolved_to_fqcn_using_namespace() {
+    // Phase 5.11: the bare `Book::class` reference inside a namespaced
+    // file should resolve to the full FQCN. Without this, dotted-path
+    // walking (`Version::with('books.|')`) falls back to basename
+    // search and may land on the wrong file when a same-named class
+    // exists in a different namespace (e.g. an unrelated Nova filter).
+    let content = r#"<?php
+namespace CrossBibleInc\BibleModels\Models;
+
+class Version
+{
+    public function books(): HasMany
+    {
+        return $this->hasMany(Book::class);
+    }
+}
+"#;
+    let metadata = ModelMetadata::from_content(content);
+    let books = metadata
+        .relationships
+        .iter()
+        .find(|r| r.method_name == "books")
+        .expect("books relationship");
+    assert_eq!(
+        books.related_model.as_deref(),
+        Some("CrossBibleInc\\BibleModels\\Models\\Book"),
+        "bare Book::class in namespaced file should resolve to FQCN"
+    );
+}
+
+#[test]
+fn related_model_resolves_aliased_class_via_use_statement() {
+    // `use App\Models\Post as Article;` — referring to Article::class
+    // inside the class body should resolve to the imported FQCN.
+    let content = r#"<?php
+namespace App\Http\Controllers;
+
+use App\Models\Post as Article;
+
+class FeedController
+{
+    public function items(): HasMany
+    {
+        return $this->hasMany(Article::class);
+    }
+}
+"#;
+    let metadata = ModelMetadata::from_content(content);
+    let items = metadata
+        .relationships
+        .iter()
+        .find(|r| r.method_name == "items")
+        .expect("items relationship");
+    assert_eq!(
+        items.related_model.as_deref(),
+        Some("App\\Models\\Post"),
+        "use alias should be resolved to its target FQCN"
+    );
+}
+
+#[test]
 fn test_pascal_to_snake() {
     assert_eq!(ModelMetadata::pascal_to_snake("FirstName"), "first_name");
     assert_eq!(

--- a/laravel-lsp/src/model_analyzer/tests.rs
+++ b/laravel-lsp/src/model_analyzer/tests.rs
@@ -395,6 +395,203 @@ class B extends A {}
 }
 
 #[test]
+fn inheritance_finds_parent_in_vendor_directory() {
+    // Mike's actual case: OAuthAccessToken (in app/Models) extends
+    // Laravel\Passport\Token (in vendor/laravel/passport/src/Token.php).
+    // The inheritance walker should find the parent in vendor/.
+    let dir = TempDir::new().expect("tempdir");
+    let app_models = dir.path().join("app/Models");
+    std::fs::create_dir_all(&app_models).unwrap();
+    std::fs::write(
+        app_models.join("OAuthAccessToken.php"),
+        r#"<?php
+namespace App\Models;
+use Laravel\Passport\Token;
+class OAuthAccessToken extends Token {}
+"#,
+    )
+    .unwrap();
+
+    // Mimic vendor/laravel/passport/src/Token.php — the realistic place
+    // for a Passport class.
+    let vendor_passport = dir.path().join("vendor/laravel/passport/src");
+    std::fs::create_dir_all(&vendor_passport).unwrap();
+    std::fs::write(
+        vendor_passport.join("Token.php"),
+        r#"<?php
+namespace Laravel\Passport;
+use Illuminate\Database\Eloquent\Model;
+class Token extends Model {
+    protected $table = 'oauth_access_tokens';
+}
+"#,
+    )
+    .unwrap();
+
+    let child_path = app_models.join("OAuthAccessToken.php");
+    let metadata = ModelMetadata::from_file_with_inheritance(&child_path, dir.path())
+        .expect("metadata resolves");
+    assert_eq!(metadata.class_name, "OAuthAccessToken");
+    assert_eq!(
+        metadata.table_name.as_deref(),
+        Some("oauth_access_tokens"),
+        "should inherit $table from vendor parent class"
+    );
+}
+
+#[test]
+fn inheritance_app_class_wins_over_vendor_when_same_name() {
+    // If a project ships its own `Token` class in app/Models AND there's
+    // also a `Token` in vendor/, the app-side one wins (PSR-4 in real
+    // Laravel would resolve to the project class; we match that
+    // intuition).
+    let dir = TempDir::new().expect("tempdir");
+    let app_models = dir.path().join("app/Models");
+    std::fs::create_dir_all(&app_models).unwrap();
+    std::fs::write(
+        app_models.join("Child.php"),
+        r#"<?php
+namespace App\Models;
+class Child extends Token {}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        app_models.join("Token.php"),
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Token extends Model {
+    protected $table = 'app_tokens';
+}
+"#,
+    )
+    .unwrap();
+
+    // Plant a different Token in vendor — should be ignored.
+    let vendor = dir.path().join("vendor/some/pkg/src");
+    std::fs::create_dir_all(&vendor).unwrap();
+    std::fs::write(
+        vendor.join("Token.php"),
+        r#"<?php
+namespace Some\Pkg;
+use Illuminate\Database\Eloquent\Model;
+class Token extends Model {
+    protected $table = 'vendor_tokens';
+}
+"#,
+    )
+    .unwrap();
+
+    let child_path = app_models.join("Child.php");
+    let metadata = ModelMetadata::from_file_with_inheritance(&child_path, dir.path()).unwrap();
+    assert_eq!(
+        metadata.table_name.as_deref(),
+        Some("app_tokens"),
+        "app-side parent should win over a vendor parent of the same basename"
+    );
+}
+
+#[test]
+fn inheritance_follows_use_statement_to_vendor_psr4_path() {
+    // The realistic Laravel shape: child file declares its namespace and
+    // `use`s the parent class explicitly. The walker should resolve
+    // `extends Token` → `Laravel\Passport\Token` (via use), then map the
+    // FQCN to `vendor/laravel/passport/src/Token.php` (Composer convention).
+    let dir = TempDir::new().expect("tempdir");
+    let app_models = dir.path().join("app/Models");
+    std::fs::create_dir_all(&app_models).unwrap();
+    std::fs::write(
+        app_models.join("OAuthAccessToken.php"),
+        r#"<?php
+namespace App\Models;
+use Laravel\Passport\Token;
+class OAuthAccessToken extends Token {}
+"#,
+    )
+    .unwrap();
+
+    // BOTH a vendor Passport Token AND an unrelated Token elsewhere — to
+    // prove that the use-statement-based resolver picks the right one,
+    // not the first basename match.
+    let vendor_passport = dir.path().join("vendor/laravel/passport/src");
+    std::fs::create_dir_all(&vendor_passport).unwrap();
+    std::fs::write(
+        vendor_passport.join("Token.php"),
+        r#"<?php
+namespace Laravel\Passport;
+use Illuminate\Database\Eloquent\Model;
+class Token extends Model {
+    protected $table = 'oauth_access_tokens';
+}
+"#,
+    )
+    .unwrap();
+
+    // A red-herring Token in a different vendor package — basename-only
+    // matching would pick whichever appeared first in the walk order.
+    let vendor_other = dir.path().join("vendor/some/other-pkg/src");
+    std::fs::create_dir_all(&vendor_other).unwrap();
+    std::fs::write(
+        vendor_other.join("Token.php"),
+        r#"<?php
+namespace Some\OtherPkg;
+use Illuminate\Database\Eloquent\Model;
+class Token extends Model {
+    protected $table = 'WRONG_TABLE';
+}
+"#,
+    )
+    .unwrap();
+
+    let child_path = app_models.join("OAuthAccessToken.php");
+    let metadata = ModelMetadata::from_file_with_inheritance(&child_path, dir.path()).unwrap();
+    assert_eq!(
+        metadata.table_name.as_deref(),
+        Some("oauth_access_tokens"),
+        "should follow `use Laravel\\Passport\\Token;` to the Passport class, \
+         NOT pick the first basename match"
+    );
+}
+
+#[test]
+fn inheritance_aliased_use_resolves_to_target() {
+    // `use Laravel\Passport\Token as PassportToken;` — the child extends
+    // PassportToken. Walker should resolve PassportToken (the alias) to
+    // the FQCN and find the vendor file.
+    let dir = TempDir::new().expect("tempdir");
+    let app_models = dir.path().join("app/Models");
+    std::fs::create_dir_all(&app_models).unwrap();
+    std::fs::write(
+        app_models.join("MyToken.php"),
+        r#"<?php
+namespace App\Models;
+use Laravel\Passport\Token as PassportToken;
+class MyToken extends PassportToken {}
+"#,
+    )
+    .unwrap();
+
+    let vendor = dir.path().join("vendor/laravel/passport/src");
+    std::fs::create_dir_all(&vendor).unwrap();
+    std::fs::write(
+        vendor.join("Token.php"),
+        r#"<?php
+namespace Laravel\Passport;
+use Illuminate\Database\Eloquent\Model;
+class Token extends Model {
+    protected $table = 'oauth_tokens';
+}
+"#,
+    )
+    .unwrap();
+
+    let child_path = app_models.join("MyToken.php");
+    let metadata = ModelMetadata::from_file_with_inheritance(&child_path, dir.path()).unwrap();
+    assert_eq!(metadata.table_name.as_deref(), Some("oauth_tokens"));
+}
+
+#[test]
 fn inheritance_walks_grandparent() {
     // Multi-level chain: Child → Parent → Grandparent (which has the
     // $table). All three levels walked.

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -18,8 +18,11 @@
 //!   valid alongside DB columns.
 
 pub mod chain;
+pub mod cursor;
+pub mod eloquent_completion;
 pub mod extractor;
 pub mod methods;
 
 pub use chain::*;
+pub use cursor::{detect_chain_context_at, position_to_byte_offset};
 pub use extractor::extract_chains;

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -26,8 +26,8 @@ pub mod use_aliases;
 
 pub use chain::*;
 pub use cursor::{
-    detect_chain_context_at, detect_chain_context_at_diagnostic, position_to_byte_offset,
-    ChainResolveFailure,
+    detect_chain_context_at, detect_chain_context_at_diagnostic, fixup_for_completion,
+    position_to_byte_offset, ChainResolveFailure,
 };
 pub use extractor::extract_chains;
 pub use use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -1,0 +1,23 @@
+//! Eloquent query builder chain completion.
+//!
+//! Recognises fluent chains in PHP source, identifies the model or table they're
+//! rooted at, and answers the question "what columns or relations are valid at
+//! the cursor". Phase 1 implements static method completion for direct chains;
+//! the data structures (`BuilderChain`, `ChainContext`) are designed to also
+//! support Phase 2's diagnostics and goto-definition-on-column.
+//!
+//! Three chain modes drive completion:
+//!
+//! - `EloquentBuilder` — pre-execution Eloquent (`User::where(...)`). `where()`
+//!   offers DB columns; `with()` offers relations.
+//! - `BaseBuilder` — `DB::table('users')` or post-`toBase()`. `where()` offers
+//!   raw schema columns; `with()` returns nothing (no relations on the base
+//!   query builder).
+//! - `EloquentCollection` — post-execution Eloquent (`User::all()->where(...)`).
+//!   `where()` filters a hydrated collection, so accessors and cast names are
+//!   valid alongside DB columns.
+
+pub mod chain;
+pub mod methods;
+
+pub use chain::*;

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -25,6 +25,9 @@ pub mod methods;
 pub mod use_aliases;
 
 pub use chain::*;
-pub use cursor::{detect_chain_context_at, position_to_byte_offset};
+pub use cursor::{
+    detect_chain_context_at, detect_chain_context_at_diagnostic, position_to_byte_offset,
+    ChainResolveFailure,
+};
 pub use extractor::extract_chains;
 pub use use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -27,7 +27,7 @@ pub mod use_aliases;
 pub use chain::*;
 pub use cursor::{
     detect_chain_context_at, detect_chain_context_at_diagnostic, fixup_for_completion,
-    position_to_byte_offset, ChainResolveFailure,
+    position_to_byte_offset, ChainResolveFailure, CompletionPrep,
 };
 pub use extractor::extract_chains;
 pub use use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -18,6 +18,8 @@
 //!   valid alongside DB columns.
 
 pub mod chain;
+pub mod extractor;
 pub mod methods;
 
 pub use chain::*;
+pub use extractor::extract_chains;

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -23,6 +23,7 @@ pub mod eloquent_completion;
 pub mod extractor;
 pub mod methods;
 pub mod use_aliases;
+pub mod var_type;
 
 pub use chain::*;
 pub use cursor::{

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -22,7 +22,9 @@ pub mod cursor;
 pub mod eloquent_completion;
 pub mod extractor;
 pub mod methods;
+pub mod use_aliases;
 
 pub use chain::*;
 pub use cursor::{detect_chain_context_at, position_to_byte_offset};
 pub use extractor::extract_chains;
+pub use use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};

--- a/laravel-lsp/src/query_chain/chain.rs
+++ b/laravel-lsp/src/query_chain/chain.rs
@@ -6,14 +6,14 @@
 //! same tree-sitter pass as everything else and consumers (completion today,
 //! diagnostics and goto-def in Phase 2) read it without re-parsing.
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BuilderChain {
     pub receiver: ChainReceiver,
     pub span_byte_range: (usize, usize),
     pub links: Vec<ChainLink>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ChainReceiver {
     Eloquent(EloquentReceiver),
     DbTable {
@@ -23,7 +23,7 @@ pub enum ChainReceiver {
     Unknown,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum EloquentReceiver {
     /// `User::query()`, `User::where(...)`, etc. — any static call against a
     /// class that resolves to an Eloquent model.
@@ -38,7 +38,7 @@ pub enum EloquentReceiver {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ChainLink {
     pub method: String,
     /// What kind of argument this method expects at its first interesting
@@ -54,7 +54,7 @@ pub struct ChainLink {
 
 /// What kind of argument the cursor's link expects. Used at the cursor only —
 /// for prior links, the walker reads `effect` instead.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ArgKind {
     /// `where`, `orderBy`, `select`, `pluck`, `sortBy`, … — first string arg
     /// is a column name. Which sources count as "a column" depends on the
@@ -76,7 +76,7 @@ pub enum ArgKind {
 }
 
 /// What the walker does when it processes this link en route to the cursor.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ChainEffect {
     /// No change to context. Includes `Column` / `Relation` methods that
     /// don't terminate (`where`, `with`, …) and the explicit transparent
@@ -96,7 +96,7 @@ pub enum ChainEffect {
     Terminate,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ChainArg {
     StringLit {
         value: String,
@@ -110,7 +110,7 @@ pub enum ChainArg {
     Other,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ClosureParam {
     pub name: String,
     pub php_type: Option<String>,
@@ -141,7 +141,7 @@ pub struct ChainContext {
     pub quote: char,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum BuilderMode {
     /// Pre-execution Eloquent: full property/relation/cast support.
     EloquentBuilder,

--- a/laravel-lsp/src/query_chain/chain.rs
+++ b/laravel-lsp/src/query_chain/chain.rs
@@ -11,6 +11,47 @@ pub struct BuilderChain {
     pub receiver: ChainReceiver,
     pub span_byte_range: (usize, usize),
     pub links: Vec<ChainLink>,
+    /// Closure-scope binding when this chain's `$var` receiver is bound
+    /// by an enclosing relation closure — `whereHas('rel', fn ($q) => …)`
+    /// or `with(['rel' => fn ($q) => …])`. The cursor resolver finds the
+    /// parent chain (by span containment), looks up the relation on its
+    /// effective model, and uses the related model as this chain's
+    /// effective model. `None` for chains that aren't inside a
+    /// recognized closure context.
+    #[serde(default)]
+    pub closure_scope: Option<ClosureScopeBinding>,
+}
+
+/// Records that this chain's receiver `$var` is bound by an outer
+/// closure-carrying method. Two flavors:
+///
+/// - `RelationHop`: the closure receives a builder for a *related*
+///   model, like `whereHas('posts', fn ($q) => …)` or `with(['rel' =>
+///   fn ($q) => …])`. The cursor resolver walks one relation hop on the
+///   parent chain's model to get the actual class.
+/// - `SameModel`: the closure receives the *same* builder as the outer
+///   chain, like `where(function ($q) { $q->where(…)->orWhere(…); })` or
+///   `when($cond, fn ($q) => $q->where(…))`. The cursor resolver
+///   inherits the parent chain's effective model directly — no relation
+///   hop needed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct ClosureScopeBinding {
+    /// The closure parameter name — must match the chain's
+    /// `InstanceVar::var` for the binding to apply. Captured so
+    /// `whereHas('posts', function ($outer) use ($inner) { … })` doesn't
+    /// accidentally bind a different variable.
+    pub param_var: String,
+    pub kind: ClosureScopeKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum ClosureScopeKind {
+    /// `whereHas('posts', closure)` / `with(['rel' => closure])` — bind
+    /// to the related model's builder.
+    RelationHop { relation_name: String },
+    /// `where(closure)` / `when($cond, closure)` / `having(closure)` /
+    /// `tap(closure)` etc. — bind to the same model as the outer chain.
+    SameModel,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -149,6 +190,13 @@ pub struct ChainContext {
     /// user has already typed after the last dot. Completion items filter
     /// against this and `insert_text` is just the current segment.
     pub dotted_prefix: Option<String>,
+    /// Set when the chain is inside a recognized relation closure
+    /// (`whereHas('posts', fn ($q) => $q->where('|'))` or
+    /// `with(['posts' => fn ($q) => $q->where('|')])`). When `Some(rel)`,
+    /// `effective_model` is the *parent* chain's model and the handler
+    /// must resolve `rel` against it (one relation hop) to get the
+    /// actual model to complete against.
+    pub closure_relation_hop: Option<String>,
     /// The quote character the user is typing inside (`'` or `"`). Used so the
     /// completion item doesn't double up quotes when inserting.
     pub quote: char,

--- a/laravel-lsp/src/query_chain/chain.rs
+++ b/laravel-lsp/src/query_chain/chain.rs
@@ -111,6 +111,15 @@ pub enum ChainArg {
         params: Vec<ClosureParam>,
         body_byte_range: (usize, usize),
     },
+    /// Array literal: `['posts', 'comments']`, `[$var, 'col']`, etc.
+    /// `elements` recursively classifies each entry (string literals are
+    /// kept as `StringLit` so the cursor resolver can walk them; values
+    /// we don't model become `Other`). The span covers the entire array
+    /// expression including the brackets.
+    Array {
+        elements: Vec<ChainArg>,
+        span_byte_range: (usize, usize),
+    },
     Other,
 }
 

--- a/laravel-lsp/src/query_chain/chain.rs
+++ b/laravel-lsp/src/query_chain/chain.rs
@@ -1,0 +1,156 @@
+//! Types describing an Eloquent / DB query builder chain extracted from PHP source.
+//!
+//! A `BuilderChain` is the precomputed shape of one fluent chain
+//! (e.g. `User::where(...)->with(...)->get()`). It lives in the Salsa pattern
+//! cache alongside other extracted patterns, so chain extraction happens in the
+//! same tree-sitter pass as everything else and consumers (completion today,
+//! diagnostics and goto-def in Phase 2) read it without re-parsing.
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BuilderChain {
+    pub receiver: ChainReceiver,
+    pub span_byte_range: (usize, usize),
+    pub links: Vec<ChainLink>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ChainReceiver {
+    Eloquent(EloquentReceiver),
+    DbTable {
+        table: String,
+        name_byte_range: (usize, usize),
+    },
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum EloquentReceiver {
+    /// `User::query()`, `User::where(...)`, etc. — any static call against a
+    /// class that resolves to an Eloquent model.
+    StaticModel(String),
+    /// `$user->newQuery()` or any chain rooted at an instance variable. The
+    /// `php_type` is filled by [`crate::query_chain`]'s `var_type` resolver
+    /// (docblock + typed function param scan); when `None`, the receiver
+    /// cannot be resolved and completion silently returns nothing.
+    InstanceVar {
+        var: String,
+        php_type: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChainLink {
+    pub method: String,
+    /// What kind of argument this method expects at its first interesting
+    /// position — drives completion when the cursor is inside this link.
+    pub arg: ArgKind,
+    /// What this link does to the walker's chain context — drives mode flips
+    /// and chain termination as the walker processes prior links to arrive
+    /// at the cursor.
+    pub effect: ChainEffect,
+    pub span_byte_range: (usize, usize),
+    pub args: Vec<ChainArg>,
+}
+
+/// What kind of argument the cursor's link expects. Used at the cursor only —
+/// for prior links, the walker reads `effect` instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ArgKind {
+    /// `where`, `orderBy`, `select`, `pluck`, `sortBy`, … — first string arg
+    /// is a column name. Which sources count as "a column" depends on the
+    /// current `BuilderMode` at this point in the chain.
+    Column,
+    /// `with`, `load`, `withCount`, … — first string arg is a relation name
+    /// on the current effective model. Eloquent-only.
+    Relation,
+    /// `whereHas`, `whereDoesntHave`, `withCount`, … — first arg names a
+    /// relation, second arg is a closure whose builder parameter is bound
+    /// to the related model. The cursor can be inside either the relation
+    /// name (treated as `Relation`) or the closure body (handled by closure
+    /// scope tracking).
+    ClosureCarrier,
+    /// This link doesn't expose a completable argument we recognise — used
+    /// for terminators with no relevant string args, mode-flippers, and
+    /// transparent transformers.
+    None,
+}
+
+/// What the walker does when it processes this link en route to the cursor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChainEffect {
+    /// No change to context. Includes `Column` / `Relation` methods that
+    /// don't terminate (`where`, `with`, …) and the explicit transparent
+    /// transformers (`clone`, `tap`, `when`, `unless`).
+    None,
+    /// `toBase`, `getQuery` — switches `EloquentBuilder` → `BaseBuilder`.
+    FlipToBase,
+    /// `get`, `pluck`, `cursor`, `paginate`, … — switches `EloquentBuilder`
+    /// → `EloquentCollection`. After execution, `where()` filters in memory
+    /// and accessors become valid arguments. Note that `pluck` is both
+    /// `ArgKind::Column` (cursor inside expects a column) and `ChainEffect::
+    /// FlipToCollection` (subsequent links operate on a Collection).
+    FlipToCollection,
+    /// `first`, `find`, `count`, `update`, … — ends the chain entirely. No
+    /// further completion for chained calls; the result is a Model, scalar,
+    /// or void.
+    Terminate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ChainArg {
+    StringLit {
+        value: String,
+        quote: char,
+        span_byte_range: (usize, usize),
+    },
+    Closure {
+        params: Vec<ClosureParam>,
+        body_byte_range: (usize, usize),
+    },
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ClosureParam {
+    pub name: String,
+    pub php_type: Option<String>,
+}
+
+/// Completion-time context produced fresh from a `BuilderChain` plus a cursor
+/// position. Not stored — recomputed on each completion request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainContext {
+    pub mode: BuilderMode,
+    /// The DB table to query for columns. `None` only when completion cannot
+    /// fire (unresolved receiver, unknown chain).
+    pub effective_table: Option<String>,
+    /// The current Eloquent model class. `None` for pure `DbTable` chains;
+    /// `Some` for Eloquent chains, including post-`toBase()` (where the model
+    /// is still known even though the mode is `BaseBuilder`).
+    pub effective_model: Option<String>,
+    /// What the link at the cursor expects — `Column` or `Relation` drive
+    /// completion; `ClosureCarrier` is handled by closure-scope descent;
+    /// `None` means no completion.
+    pub expecting: ArgKind,
+    /// For dotted relation paths like `with('posts.author.|')`, the prefix the
+    /// user has already typed after the last dot. Completion items filter
+    /// against this and `insert_text` is just the current segment.
+    pub dotted_prefix: Option<String>,
+    /// The quote character the user is typing inside (`'` or `"`). Used so the
+    /// completion item doesn't double up quotes when inserting.
+    pub quote: char,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BuilderMode {
+    /// Pre-execution Eloquent: full property/relation/cast support.
+    EloquentBuilder,
+    /// `DB::table()` or any Eloquent chain after `->toBase()` / `->getQuery()`.
+    /// Schema columns only; no relations, no accessors, no casts.
+    BaseBuilder,
+    /// Post-execution Eloquent (after `->get()`, `->pluck()`, `->all()`, …).
+    /// Filtering happens in memory on a hydrated Collection, so accessors and
+    /// cast names join DB columns as valid arguments. Relations remain valid
+    /// via `load()`.
+    EloquentCollection,
+}

--- a/laravel-lsp/src/query_chain/chain.rs
+++ b/laravel-lsp/src/query_chain/chain.rs
@@ -69,6 +69,10 @@ pub enum ArgKind {
     /// name (treated as `Relation`) or the closure body (handled by closure
     /// scope tracking).
     ClosureCarrier,
+    /// `DB::table('|')` — first string arg names a database table. Set by
+    /// the extractor after receiver detection (the method name alone doesn't
+    /// reveal this; we need to know the class is `DB`).
+    Table,
     /// This link doesn't expose a completable argument we recognise — used
     /// for terminators with no relevant string args, mode-flippers, and
     /// transparent transformers.

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -280,13 +280,23 @@ fn find_chain_containing(
 }
 
 fn detect_in_chain(chain: &BuilderChain, byte_offset: usize) -> Option<ChainContext> {
-    // Initial mode + table + model from the receiver. Phase 3 only handles
-    // DbTable; Eloquent returns None until model lookup lands.
+    // Initial mode + table + model from the receiver.
+    //
+    // - DbTable carries the table directly; no model lookup needed.
+    // - Eloquent static receivers (`User::where(...)`) carry the class FQCN;
+    //   the handler will resolve it to a `ModelMetadata` async (file I/O).
+    //   `effective_table` stays `None` here — the handler fills it in.
+    // - Eloquent instance receivers (`$user->newQuery()`) need `@var`
+    //   docblock + typed-param scanning to resolve the class; that lands in
+    //   Phase 9. Return `None` until then.
     let (mut mode, effective_table, effective_model) = match &chain.receiver {
         ChainReceiver::DbTable { table, .. } => {
             (BuilderMode::BaseBuilder, Some(table.clone()), None)
         }
-        ChainReceiver::Eloquent(_) => return None,
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class)) => {
+            (BuilderMode::EloquentBuilder, None, Some(class.clone()))
+        }
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { .. }) => return None,
         ChainReceiver::Unknown => return None,
     };
 

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -63,6 +63,32 @@ pub fn detect_chain_context_at(
     detect_in_chain(chain, byte_offset)
 }
 
+/// Diagnostic variant of [`detect_chain_context_at`] that also returns a
+/// reason string describing why resolution failed. Used by the LSP handler
+/// to emit specific INFO logs (chain not found vs. cursor outside a string
+/// arg vs. unsupported receiver). Same logic, just plumbed-through reasons.
+pub fn detect_chain_context_at_diagnostic<'a>(
+    chains: &'a [Arc<BuilderChain>],
+    byte_offset: usize,
+) -> Result<ChainContext, ChainResolveFailure<'a>> {
+    let chain = find_chain_containing(chains, byte_offset)
+        .ok_or(ChainResolveFailure::NoChainAtCursor { chains })?;
+    detect_in_chain(chain, byte_offset).ok_or(ChainResolveFailure::InChain { chain })
+}
+
+/// Why `detect_chain_context_at_diagnostic` returned no context.
+#[derive(Debug)]
+pub enum ChainResolveFailure<'a> {
+    /// No chain in the file's chain list has a span containing the cursor.
+    /// The full chain list is returned so the caller can log spans for
+    /// comparison against the cursor byte.
+    NoChainAtCursor { chains: &'a [Arc<BuilderChain>] },
+    /// A chain contains the cursor but the cursor isn't in a completable
+    /// position within it (e.g., between method tokens, or the receiver is
+    /// an Eloquent model we can't resolve synchronously yet).
+    InChain { chain: &'a BuilderChain },
+}
+
 fn find_chain_containing(
     chains: &[Arc<BuilderChain>],
     byte_offset: usize,

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -12,6 +12,59 @@
 use super::chain::*;
 use std::sync::Arc;
 
+/// At completion time the user is mid-typing and the file often has an
+/// unterminated string at the cursor (e.g., `DB::table('|`). Tree-sitter
+/// recovers by extending the `string` node up to the next quote anywhere in
+/// the file — which is usually thousands of bytes away and produces nonsense
+/// spans. Chain extraction sees this and ends up with `ChainArg::Other`
+/// instead of a real `StringLit`, so cursor detection fails.
+///
+/// This helper scans the line up to the cursor, tracks PHP single/double
+/// quote balance (with `\` escapes), and returns a content string with a
+/// matching closing quote injected at `byte_offset` if a quote is open.
+/// Returns `None` if no fixup is needed (the cursor isn't inside an
+/// unterminated string).
+///
+/// We deliberately don't model heredocs/nowdocs — those don't appear in
+/// query chain arguments in any real code. We also stop the scan at the
+/// previous newline, so quotes that opened on prior lines don't confuse us
+/// (multi-line strings inside chain args are vanishingly rare).
+pub fn fixup_for_completion(content: &str, byte_offset: usize) -> Option<String> {
+    if byte_offset > content.len() {
+        return None;
+    }
+    let line_start = content[..byte_offset]
+        .rfind('\n')
+        .map(|n| n + 1)
+        .unwrap_or(0);
+    let line_to_cursor = &content[line_start..byte_offset];
+
+    // Tiny state machine: `None` = not in a string, `Some(q)` = inside a
+    // string opened with quote `q`. Escapes consume the next character so
+    // `\'` and `\"` inside the matching quote style don't toggle the state.
+    let mut state: Option<char> = None;
+    let mut iter = line_to_cursor.chars();
+    while let Some(c) = iter.next() {
+        match (state, c) {
+            (None, '\'') => state = Some('\''),
+            (None, '"') => state = Some('"'),
+            (Some(_), '\\') => {
+                // Skip the next char (escaped).
+                iter.next();
+            }
+            (Some(open), close) if open == close => state = None,
+            _ => {}
+        }
+    }
+
+    let unclosed = state?;
+    let mut result = String::with_capacity(content.len() + 1);
+    result.push_str(&content[..byte_offset]);
+    result.push(unclosed);
+    result.push_str(&content[byte_offset..]);
+    Some(result)
+}
+
 /// Translate an LSP `Position` (0-based line + character) into a byte offset
 /// inside `content`. Characters are treated as Unicode code points, not
 /// UTF-16 code units — this matches every existing position handler in the

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -367,7 +367,7 @@ fn detect_in_chain(
     // The cursor must be inside a string-literal arg of the cursor link.
     // `pluck` is `ArgKind::Column` even though it terminates the chain —
     // we still complete inside its first arg.
-    let (quote, _dotted_prefix) = string_arg_at(cursor_link, byte_offset)?;
+    let (quote, string_value) = string_arg_at(cursor_link, byte_offset)?;
 
     if !matches!(
         cursor_link.arg,
@@ -376,15 +376,31 @@ fn detect_in_chain(
         return None;
     }
 
+    // Phase 7: dotted-relation paths in relation positions. For
+    // `with('posts.author.|')` the value is "posts.author." — everything
+    // before the LAST dot is the relation chain to walk
+    // ("posts" → Post, then "author" on Post → Author), and the portion
+    // after is the typing prefix that the editor uses for fuzzy
+    // filtering. Only meaningful for Relation / ClosureCarrier args
+    // — Column args don't follow dotted hops (`where('a.b')` isn't a
+    // thing) and Table args are single-segment.
+    let dotted_prefix = if matches!(cursor_link.arg, ArgKind::Relation | ArgKind::ClosureCarrier) {
+        // Find the last `.` in the string value. If present, return the
+        // substring up to (not including) that dot — those are the
+        // segments we walk.
+        string_value
+            .rfind('.')
+            .map(|idx| string_value[..idx].to_string())
+    } else {
+        None
+    };
+
     Some(ChainContext {
         mode,
         effective_table,
         effective_model,
         expecting: cursor_link.arg,
-        // Dotted-relation prefix splitting lives in Phase 7. Phase 3 doesn't
-        // need it (DB::table chains don't have relation methods), and Phase 4
-        // (Eloquent columns) is single-segment.
-        dotted_prefix: None,
+        dotted_prefix,
         closure_relation_hop,
         quote,
     })
@@ -433,14 +449,14 @@ fn parent_chain_eloquent_model(
 }
 
 /// Find the string-literal arg of `link` that contains the cursor, returning
-/// its quote character. Walks both top-level `StringLit` args and string
-/// literals nested inside an `Array` arg, so `with(['posts'|, 'comments'])`
+/// its quote character and value. Walks both top-level `StringLit` args and
+/// string literals nested inside an `Array` arg, so `with(['posts'|, 'comments'])`
 /// resolves the same as `with('posts'|)`. Returns `None` if no string arg
 /// covers the cursor.
-fn string_arg_at(link: &ChainLink, byte_offset: usize) -> Option<(char, ())> {
+fn string_arg_at(link: &ChainLink, byte_offset: usize) -> Option<(char, String)> {
     for arg in &link.args {
-        if let Some(quote) = string_arg_in(arg, byte_offset) {
-            return Some((quote, ()));
+        if let Some((quote, value)) = string_arg_in(arg, byte_offset) {
+            return Some((quote, value));
         }
     }
     None
@@ -448,26 +464,26 @@ fn string_arg_at(link: &ChainLink, byte_offset: usize) -> Option<(char, ())> {
 
 /// Check whether a single arg (or any of its nested string elements, for
 /// `Array` args) contains the cursor and is a string literal. Returns the
-/// quote character on hit. Pulled out as a separate helper so `Array`
-/// can recurse into its elements without duplicating the span check.
-fn string_arg_in(arg: &ChainArg, byte_offset: usize) -> Option<char> {
+/// quote character + literal value on hit. Pulled out as a separate helper
+/// so `Array` can recurse into its elements without duplicating the span check.
+fn string_arg_in(arg: &ChainArg, byte_offset: usize) -> Option<(char, String)> {
     match arg {
         ChainArg::StringLit {
             quote,
+            value,
             span_byte_range,
-            ..
         } => {
             let (start, end) = *span_byte_range;
             if byte_offset >= start && byte_offset <= end {
-                Some(*quote)
+                Some((*quote, value.clone()))
             } else {
                 None
             }
         }
         ChainArg::Array { elements, .. } => {
             for elem in elements {
-                if let Some(q) = string_arg_in(elem, byte_offset) {
-                    return Some(q);
+                if let Some(found) = string_arg_in(elem, byte_offset) {
+                    return Some(found);
                 }
             }
             None

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -353,22 +353,47 @@ fn detect_in_chain(chain: &BuilderChain, byte_offset: usize) -> Option<ChainCont
 }
 
 /// Find the string-literal arg of `link` that contains the cursor, returning
-/// its quote character. Returns `None` if no string arg covers the cursor.
+/// its quote character. Walks both top-level `StringLit` args and string
+/// literals nested inside an `Array` arg, so `with(['posts'|, 'comments'])`
+/// resolves the same as `with('posts'|)`. Returns `None` if no string arg
+/// covers the cursor.
 fn string_arg_at(link: &ChainLink, byte_offset: usize) -> Option<(char, ())> {
     for arg in &link.args {
-        if let ChainArg::StringLit {
-            quote,
-            span_byte_range,
-            ..
-        } = arg
-        {
-            let (start, end) = *span_byte_range;
-            if byte_offset >= start && byte_offset <= end {
-                return Some((*quote, ()));
-            }
+        if let Some(quote) = string_arg_in(arg, byte_offset) {
+            return Some((quote, ()));
         }
     }
     None
+}
+
+/// Check whether a single arg (or any of its nested string elements, for
+/// `Array` args) contains the cursor and is a string literal. Returns the
+/// quote character on hit. Pulled out as a separate helper so `Array`
+/// can recurse into its elements without duplicating the span check.
+fn string_arg_in(arg: &ChainArg, byte_offset: usize) -> Option<char> {
+    match arg {
+        ChainArg::StringLit {
+            quote,
+            span_byte_range,
+            ..
+        } => {
+            let (start, end) = *span_byte_range;
+            if byte_offset >= start && byte_offset <= end {
+                Some(*quote)
+            } else {
+                None
+            }
+        }
+        ChainArg::Array { elements, .. } => {
+            for elem in elements {
+                if let Some(q) = string_arg_in(elem, byte_offset) {
+                    return Some(q);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
 }
 
 /// Count literal `(` minus `)` on a single line. Does NOT try to skip

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -305,7 +305,7 @@ fn detect_in_chain(
             Some(class.clone()),
             None,
         ),
-        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) => {
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, php_type }) => {
             // Phase 8: if the chain's receiver var is bound by an enclosing
             // closure carrier, inherit the parent chain's effective model.
             // Two flavors:
@@ -316,6 +316,13 @@ fn detect_in_chain(
             // - SameModel (`where(closure)`, `when($cond, closure)`,
             //   `having(closure)`, etc.): closure binds to the *same* model
             //   as the parent. Inherit `effective_model` directly; no hop.
+            //
+            // Phase 9 (fallback): no closure scope match? Try the resolved
+            // `php_type` captured at extraction time from a typed function
+            // parameter (`function show(User $user)`) or a `@var` docblock
+            // (`/** @var User $u */`). This is what makes the idiomatic
+            // controller-style `public function show(User $user) {
+            // $user->newQuery()->where('|'); }` work end-to-end.
             match chain.closure_scope.as_ref() {
                 Some(binding) if &binding.param_var == var => {
                     let parent_model = parent_chain_eloquent_model(chains, chain)?;
@@ -331,7 +338,15 @@ fn detect_in_chain(
                         }
                     }
                 }
-                _ => return None,
+                _ => match php_type {
+                    Some(class) => (
+                        BuilderMode::EloquentBuilder,
+                        None,
+                        Some(class.clone()),
+                        None,
+                    ),
+                    None => return None,
+                },
             }
         }
         ChainReceiver::Unknown => return None,

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -105,7 +105,7 @@ pub fn fixup_for_completion(content: &str, byte_offset: usize) -> Option<Complet
                 .map(|n| line_start + n)
                 .unwrap_or(content.len());
             let full_line = &content[line_start..line_end];
-            if line_paren_balance_outside_strings(full_line) > 0 {
+            if line_paren_balance(full_line) > 0 {
                 // Insertion point: one byte past the auto-paired close quote.
                 let insert_at = byte_offset + unclosed.len_utf8();
                 let mut fixed = String::with_capacity(content.len() + 1);
@@ -122,9 +122,27 @@ pub fn fixup_for_completion(content: &str, byte_offset: usize) -> Option<Complet
             return Some(CompletionPrep::unchanged(content));
         }
 
-        let mut fixed = String::with_capacity(content.len() + 1);
+        // The matching close quote isn't at the cursor — inject it. While
+        // we're at it, also check whether the cursor's line has unbalanced
+        // parens (e.g. user deleted back to `DB::table('trua` — no close
+        // quote, no `)`). If so, inject `)` after the close quote so the
+        // call expression terminates cleanly. Without the paren patch
+        // tree-sitter recovers by extending the call across the next
+        // statement, and the string arg falls out of the argument list.
+        let line_end = content[line_start..]
+            .find('\n')
+            .map(|n| line_start + n)
+            .unwrap_or(content.len());
+        let full_line = &content[line_start..line_end];
+        let needs_close_paren = line_paren_balance(full_line) > 0;
+
+        let mut fixed =
+            String::with_capacity(content.len() + if needs_close_paren { 2 } else { 1 });
         fixed.push_str(&content[..byte_offset]);
         fixed.push(unclosed);
+        if needs_close_paren {
+            fixed.push(')');
+        }
         fixed.push_str(&content[byte_offset..]);
         return Some(CompletionPrep {
             fixed_content: fixed,
@@ -343,28 +361,21 @@ fn string_arg_at(link: &ChainLink, byte_offset: usize) -> Option<(char, ())> {
     None
 }
 
-/// Count `(` minus `)` on a single line, skipping over the contents of
-/// single- and double-quoted string literals. Backslash escapes inside a
-/// string are honored so `'\'')'` doesn't terminate the string early.
-///
-/// Used by the auto-pair-safety branch of [`fixup_for_completion`] to
-/// decide whether the call expression still needs a `)` injected after the
-/// editor's auto-paired close quote.
-fn line_paren_balance_outside_strings(line: &str) -> i32 {
+/// Count literal `(` minus `)` on a single line. Does NOT try to skip
+/// string contents — when the cursor is inside an unclosed string, a
+/// string-aware counter treats the rest of the line as "in string" and
+/// ignores any `)` there, leading us to inject an unwanted second close
+/// paren. The literal count is dumber but more robust: if the line has
+/// any `)` at all, even one nominally inside a string, we won't
+/// double-inject. The edge case where someone writes `'foo)'` with an
+/// unmatched outer paren is rare; worst case we leave the source as-is
+/// (degraded behavior, not wrong behavior).
+fn line_paren_balance(line: &str) -> i32 {
     let mut balance: i32 = 0;
-    let mut in_string: Option<char> = None;
-    let mut chars = line.chars();
-    while let Some(c) = chars.next() {
-        match (in_string, c) {
-            (Some(_), '\\') => {
-                // Skip the next char (escaped).
-                chars.next();
-            }
-            (Some(q), c) if c == q => in_string = None,
-            (None, '\'') => in_string = Some('\''),
-            (None, '"') => in_string = Some('"'),
-            (None, '(') => balance += 1,
-            (None, ')') => balance -= 1,
+    for c in line.chars() {
+        match c {
+            '(' => balance += 1,
+            ')' => balance -= 1,
             _ => {}
         }
     }

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -92,6 +92,33 @@ pub fn fixup_for_completion(content: &str, byte_offset: usize) -> Option<Complet
         // cursor (the editor inserted it), don't inject another — that
         // produces `'''` and breaks the parse worse than the original.
         if content[byte_offset..].starts_with(unclosed) {
+            // BUT: the editor only auto-pairs the quote, not the surrounding
+            // `)`. If the user typed `DB::table('` and the editor inserted
+            // the second `'`, the source is `DB::table('')` with no closing
+            // paren. Tree-sitter recovers by extending the call expression
+            // downstream, which causes the empty-string arg to fall out of
+            // the argument list entirely (classified as `Other` instead of
+            // `StringLit`). Inject `)` right after the close quote so the
+            // call expression terminates cleanly.
+            let line_end = content[line_start..]
+                .find('\n')
+                .map(|n| line_start + n)
+                .unwrap_or(content.len());
+            let full_line = &content[line_start..line_end];
+            if line_paren_balance_outside_strings(full_line) > 0 {
+                // Insertion point: one byte past the auto-paired close quote.
+                let insert_at = byte_offset + unclosed.len_utf8();
+                let mut fixed = String::with_capacity(content.len() + 1);
+                fixed.push_str(&content[..insert_at]);
+                fixed.push(')');
+                fixed.push_str(&content[insert_at..]);
+                return Some(CompletionPrep {
+                    fixed_content: fixed,
+                    // Source already has both quotes — completion items go
+                    // in bare.
+                    quote_for_insertion: None,
+                });
+            }
             return Some(CompletionPrep::unchanged(content));
         }
 
@@ -314,6 +341,34 @@ fn string_arg_at(link: &ChainLink, byte_offset: usize) -> Option<(char, ())> {
         }
     }
     None
+}
+
+/// Count `(` minus `)` on a single line, skipping over the contents of
+/// single- and double-quoted string literals. Backslash escapes inside a
+/// string are honored so `'\'')'` doesn't terminate the string early.
+///
+/// Used by the auto-pair-safety branch of [`fixup_for_completion`] to
+/// decide whether the call expression still needs a `)` injected after the
+/// editor's auto-paired close quote.
+fn line_paren_balance_outside_strings(line: &str) -> i32 {
+    let mut balance: i32 = 0;
+    let mut in_string: Option<char> = None;
+    let mut chars = line.chars();
+    while let Some(c) = chars.next() {
+        match (in_string, c) {
+            (Some(_), '\\') => {
+                // Skip the next char (escaped).
+                chars.next();
+            }
+            (Some(q), c) if c == q => in_string = None,
+            (None, '\'') => in_string = Some('\''),
+            (None, '"') => in_string = Some('"'),
+            (None, '(') => balance += 1,
+            (None, ')') => balance -= 1,
+            _ => {}
+        }
+    }
+    balance
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -133,7 +133,7 @@ fn detect_in_chain(chain: &BuilderChain, byte_offset: usize) -> Option<ChainCont
 
     if !matches!(
         cursor_link.arg,
-        ArgKind::Column | ArgKind::Relation | ArgKind::ClosureCarrier
+        ArgKind::Column | ArgKind::Relation | ArgKind::ClosureCarrier | ArgKind::Table
     ) {
         return None;
     }

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -225,7 +225,7 @@ pub fn detect_chain_context_at(
     byte_offset: usize,
 ) -> Option<ChainContext> {
     let chain = find_chain_containing(chains, byte_offset)?;
-    detect_in_chain(chain, byte_offset)
+    detect_in_chain(chains, chain, byte_offset)
 }
 
 /// Diagnostic variant of [`detect_chain_context_at`] that also returns a
@@ -238,7 +238,7 @@ pub fn detect_chain_context_at_diagnostic<'a>(
 ) -> Result<ChainContext, ChainResolveFailure<'a>> {
     let chain = find_chain_containing(chains, byte_offset)
         .ok_or(ChainResolveFailure::NoChainAtCursor { chains })?;
-    detect_in_chain(chain, byte_offset).ok_or(ChainResolveFailure::InChain { chain })
+    detect_in_chain(chains, chain, byte_offset).ok_or(ChainResolveFailure::InChain { chain })
 }
 
 /// Why `detect_chain_context_at_diagnostic` returned no context.
@@ -279,7 +279,11 @@ fn find_chain_containing(
     best
 }
 
-fn detect_in_chain(chain: &BuilderChain, byte_offset: usize) -> Option<ChainContext> {
+fn detect_in_chain(
+    chains: &[Arc<BuilderChain>],
+    chain: &BuilderChain,
+    byte_offset: usize,
+) -> Option<ChainContext> {
     // Initial mode + table + model from the receiver.
     //
     // - DbTable carries the table directly; no model lookup needed.
@@ -288,15 +292,48 @@ fn detect_in_chain(chain: &BuilderChain, byte_offset: usize) -> Option<ChainCont
     //   `effective_table` stays `None` here — the handler fills it in.
     // - Eloquent instance receivers (`$user->newQuery()`) need `@var`
     //   docblock + typed-param scanning to resolve the class; that lands in
-    //   Phase 9. Return `None` until then.
-    let (mut mode, effective_table, effective_model) = match &chain.receiver {
+    //   Phase 9. Phase 8 handles the special case of `$q` bound by an
+    //   enclosing relation closure: the parent chain's model + the closure's
+    //   relation name resolve via one async hop in the handler.
+    let (mut mode, effective_table, effective_model, closure_relation_hop) = match &chain.receiver {
         ChainReceiver::DbTable { table, .. } => {
-            (BuilderMode::BaseBuilder, Some(table.clone()), None)
+            (BuilderMode::BaseBuilder, Some(table.clone()), None, None)
         }
-        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class)) => {
-            (BuilderMode::EloquentBuilder, None, Some(class.clone()))
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class)) => (
+            BuilderMode::EloquentBuilder,
+            None,
+            Some(class.clone()),
+            None,
+        ),
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) => {
+            // Phase 8: if the chain's receiver var is bound by an enclosing
+            // closure carrier, inherit the parent chain's effective model.
+            // Two flavors:
+            //
+            // - RelationHop (`whereHas('rel', closure)` / `with(['rel' =>
+            //   closure])`): closure binds to a *related* model's builder.
+            //   The handler walks one hop on the parent's model.
+            // - SameModel (`where(closure)`, `when($cond, closure)`,
+            //   `having(closure)`, etc.): closure binds to the *same* model
+            //   as the parent. Inherit `effective_model` directly; no hop.
+            match chain.closure_scope.as_ref() {
+                Some(binding) if &binding.param_var == var => {
+                    let parent_model = parent_chain_eloquent_model(chains, chain)?;
+                    match &binding.kind {
+                        ClosureScopeKind::RelationHop { relation_name } => (
+                            BuilderMode::EloquentBuilder,
+                            None,
+                            Some(parent_model),
+                            Some(relation_name.clone()),
+                        ),
+                        ClosureScopeKind::SameModel => {
+                            (BuilderMode::EloquentBuilder, None, Some(parent_model), None)
+                        }
+                    }
+                }
+                _ => return None,
+            }
         }
-        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { .. }) => return None,
         ChainReceiver::Unknown => return None,
     };
 
@@ -348,8 +385,51 @@ fn detect_in_chain(chain: &BuilderChain, byte_offset: usize) -> Option<ChainCont
         // need it (DB::table chains don't have relation methods), and Phase 4
         // (Eloquent columns) is single-segment.
         dotted_prefix: None,
+        closure_relation_hop,
         quote,
     })
+}
+
+/// Phase 8 helper: find the smallest chain in `chains` whose span strictly
+/// contains `child`'s span and whose receiver is an Eloquent static model.
+/// Returns the model's class name (FQCN if it was resolved through
+/// use-aliases at extraction time).
+///
+/// Used when a child chain's receiver is `$q` bound by an enclosing
+/// `whereHas` / `with` closure — the parent's model is the starting point
+/// for the relation hop the handler will perform.
+fn parent_chain_eloquent_model(
+    chains: &[Arc<BuilderChain>],
+    child: &BuilderChain,
+) -> Option<String> {
+    let (cs, ce) = child.span_byte_range;
+    let mut best: Option<&BuilderChain> = None;
+    for chain in chains {
+        let (ps, pe) = chain.span_byte_range;
+        // Strictly contains (not equal — that'd be the child itself).
+        if ps <= cs && pe >= ce && (ps, pe) != (cs, ce) {
+            // Pick the SMALLEST containing chain — that's the innermost
+            // parent, the one whose method invoked the closure.
+            let new_size = pe - ps;
+            let pick = match best {
+                None => true,
+                Some(b) => {
+                    let cur_size = b.span_byte_range.1 - b.span_byte_range.0;
+                    new_size < cur_size
+                }
+            };
+            if pick {
+                best = Some(chain.as_ref());
+            }
+        }
+    }
+    let parent = best?;
+    match &parent.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class)) => Some(class.clone()),
+        // Future: also support `(new self)` receivers etc. — already
+        // produce StaticModel via Phase 5.1.
+        _ => None,
+    }
 }
 
 /// Find the string-literal arg of `link` that contains the cursor, returning

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -1,0 +1,174 @@
+//! Cursor → [`ChainContext`] resolution.
+//!
+//! Given the extracted chains for a file and a byte position (typically
+//! translated from an LSP `Position`), find the chain that contains the
+//! cursor, walk preceding links to determine the effective `BuilderMode` and
+//! table, and report what kind of completion to offer at the cursor's link.
+//!
+//! Phase 3 supports DB-table receivers fully and reports `None` for Eloquent
+//! receivers — those need model lookup which is async I/O and lands in
+//! later phases.
+
+use super::chain::*;
+use std::sync::Arc;
+
+/// Translate an LSP `Position` (0-based line + character) into a byte offset
+/// inside `content`. Characters are treated as Unicode code points, not
+/// UTF-16 code units — this matches every existing position handler in the
+/// LSP and works correctly for ASCII Laravel source (which is ~all of it).
+/// If `line` is beyond the file or `character` is beyond the line length,
+/// the offset clamps to the end of that line.
+pub fn position_to_byte_offset(content: &str, line: u32, character: u32) -> Option<usize> {
+    // Build a small index of line-start byte offsets up to and including the
+    // requested line. Linear scan — the file is already in memory, this is
+    // dominated by the byte iteration which is L1-cache-fast.
+    let mut line_start = 0usize;
+    let mut current_line: u32 = 0;
+    for (idx, b) in content.bytes().enumerate() {
+        if current_line == line {
+            break;
+        }
+        if b == b'\n' {
+            current_line += 1;
+            line_start = idx + 1;
+        }
+    }
+    if current_line < line {
+        return None;
+    }
+
+    let line_end = content[line_start..]
+        .find('\n')
+        .map(|n| line_start + n)
+        .unwrap_or(content.len());
+
+    let line_slice = &content[line_start..line_end];
+    let byte_in_line: usize = line_slice
+        .chars()
+        .take(character as usize)
+        .map(char::len_utf8)
+        .sum();
+    Some(line_start + byte_in_line)
+}
+
+/// Resolve a cursor inside a parsed file to a `ChainContext`. Returns `None`
+/// when no chain contains the cursor, when the chain's receiver can't be
+/// resolved without async I/O (Eloquent — handled by later phases), or when
+/// the cursor isn't inside an argument we know how to complete.
+pub fn detect_chain_context_at(
+    chains: &[Arc<BuilderChain>],
+    byte_offset: usize,
+) -> Option<ChainContext> {
+    let chain = find_chain_containing(chains, byte_offset)?;
+    detect_in_chain(chain, byte_offset)
+}
+
+fn find_chain_containing(
+    chains: &[Arc<BuilderChain>],
+    byte_offset: usize,
+) -> Option<&BuilderChain> {
+    // Pick the innermost chain — for nested chains (e.g., `$q->where('|')`
+    // inside a `whereHas` closure) we want the inner chain. Linear scan is
+    // fine; chains-per-file is typically <100.
+    let mut best: Option<&BuilderChain> = None;
+    for chain in chains {
+        let (start, end) = chain.span_byte_range;
+        if byte_offset >= start && byte_offset <= end {
+            let chain_ref: &BuilderChain = chain.as_ref();
+            // Prefer the shorter (more deeply nested) chain.
+            match best {
+                None => best = Some(chain_ref),
+                Some(prev) if (end - start) < (prev.span_byte_range.1 - prev.span_byte_range.0) => {
+                    best = Some(chain_ref);
+                }
+                _ => {}
+            }
+        }
+    }
+    best
+}
+
+fn detect_in_chain(chain: &BuilderChain, byte_offset: usize) -> Option<ChainContext> {
+    // Initial mode + table + model from the receiver. Phase 3 only handles
+    // DbTable; Eloquent returns None until model lookup lands.
+    let (mut mode, effective_table, effective_model) = match &chain.receiver {
+        ChainReceiver::DbTable { table, .. } => {
+            (BuilderMode::BaseBuilder, Some(table.clone()), None)
+        }
+        ChainReceiver::Eloquent(_) => return None,
+        ChainReceiver::Unknown => return None,
+    };
+
+    // Walk links in source order. For each link, decide: (a) does the cursor
+    // sit inside this link? (b) if not, apply this link's effect and move on.
+    let mut cursor_link_idx: Option<usize> = None;
+    for (idx, link) in chain.links.iter().enumerate() {
+        let (start, end) = link.span_byte_range;
+        if byte_offset >= start && byte_offset <= end {
+            cursor_link_idx = Some(idx);
+            break;
+        }
+        // The cursor is past this link — apply its effect to the running mode.
+        match link.effect {
+            ChainEffect::FlipToBase => mode = BuilderMode::BaseBuilder,
+            ChainEffect::FlipToCollection => {
+                // Only Eloquent transitions to Collection; Base stays Base
+                // (a base query builder doesn't have a collection variant
+                // worth distinguishing here).
+                if mode == BuilderMode::EloquentBuilder {
+                    mode = BuilderMode::EloquentCollection;
+                }
+            }
+            ChainEffect::Terminate => return None,
+            ChainEffect::None => {}
+        }
+    }
+
+    let cursor_link = &chain.links[cursor_link_idx?];
+
+    // The cursor must be inside a string-literal arg of the cursor link.
+    // `pluck` is `ArgKind::Column` even though it terminates the chain —
+    // we still complete inside its first arg.
+    let (quote, _dotted_prefix) = string_arg_at(cursor_link, byte_offset)?;
+
+    if !matches!(
+        cursor_link.arg,
+        ArgKind::Column | ArgKind::Relation | ArgKind::ClosureCarrier
+    ) {
+        return None;
+    }
+
+    Some(ChainContext {
+        mode,
+        effective_table,
+        effective_model,
+        expecting: cursor_link.arg,
+        // Dotted-relation prefix splitting lives in Phase 7. Phase 3 doesn't
+        // need it (DB::table chains don't have relation methods), and Phase 4
+        // (Eloquent columns) is single-segment.
+        dotted_prefix: None,
+        quote,
+    })
+}
+
+/// Find the string-literal arg of `link` that contains the cursor, returning
+/// its quote character. Returns `None` if no string arg covers the cursor.
+fn string_arg_at(link: &ChainLink, byte_offset: usize) -> Option<(char, ())> {
+    for arg in &link.args {
+        if let ChainArg::StringLit {
+            quote,
+            span_byte_range,
+            ..
+        } = arg
+        {
+            let (start, end) = *span_byte_range;
+            if byte_offset >= start && byte_offset <= end {
+                return Some((*quote, ()));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -12,24 +12,56 @@
 use super::chain::*;
 use std::sync::Arc;
 
-/// At completion time the user is mid-typing and the file often has an
-/// unterminated string at the cursor (e.g., `DB::table('|`). Tree-sitter
-/// recovers by extending the `string` node up to the next quote anywhere in
-/// the file — which is usually thousands of bytes away and produces nonsense
-/// spans. Chain extraction sees this and ends up with `ChainArg::Other`
-/// instead of a real `StringLit`, so cursor detection fails.
+/// Result of preparing source content for chain-completion at the cursor.
+/// Carries the (possibly fixed) content to parse PLUS metadata the items
+/// builder needs to format `insert_text` correctly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletionPrep {
+    /// Content to feed to tree-sitter for chain extraction. May be the
+    /// original `content` unchanged, or modified to balance an unterminated
+    /// string or to seed an empty-string arg right after an open paren.
+    pub fixed_content: String,
+    /// If `Some(q)`, the user is in a position where the source doesn't
+    /// yet have a quote pair around the string arg (typically immediately
+    /// after `(` was typed). Completion items should wrap their value with
+    /// `q` so the inserted text is a valid string literal.
+    ///
+    /// If `None`, the source already contains the quotes (the cursor is
+    /// inside an existing string, fixed-up or not), and items should be
+    /// inserted bare without extra quotes.
+    pub quote_for_insertion: Option<char>,
+}
+
+impl CompletionPrep {
+    fn unchanged(content: &str) -> Self {
+        Self {
+            fixed_content: content.to_string(),
+            quote_for_insertion: None,
+        }
+    }
+}
+
+/// Prepare the source for chain-completion at the cursor. Handles three
+/// cases the user might be in:
 ///
-/// This helper scans the line up to the cursor, tracks PHP single/double
-/// quote balance (with `\` escapes), and returns a content string with a
-/// matching closing quote injected at `byte_offset` if a quote is open.
-/// Returns `None` if no fixup is needed (the cursor isn't inside an
-/// unterminated string).
+/// 1. **Inside an unterminated string** (e.g. `DB::table('|`). Inject the
+///    matching close quote so tree-sitter doesn't extend the `string` node
+///    thousands of bytes downstream. Insertions stay bare.
+///
+/// 2. **Inside an already-closed empty/partial string** (e.g. the
+///    auto-paired `DB::table('|')`). No fixup — the source parses cleanly
+///    and the auto-paired close is right there. Insertions stay bare.
+///
+/// 3. **Right after `(` with no string yet** (e.g. `DB::table(|`). Inject
+///    `''` (or `''` plus `)` if no close paren exists) so the call expression
+///    parses with an empty-string first arg. Insertions wrap with `'` because
+///    the source doesn't have quotes around the would-be arg.
+///
+/// Anything else: content unchanged, no quote wrapping.
 ///
 /// We deliberately don't model heredocs/nowdocs — those don't appear in
-/// query chain arguments in any real code. We also stop the scan at the
-/// previous newline, so quotes that opened on prior lines don't confuse us
-/// (multi-line strings inside chain args are vanishingly rare).
-pub fn fixup_for_completion(content: &str, byte_offset: usize) -> Option<String> {
+/// query chain arguments in any real code.
+pub fn fixup_for_completion(content: &str, byte_offset: usize) -> Option<CompletionPrep> {
     if byte_offset > content.len() {
         return None;
     }
@@ -39,9 +71,7 @@ pub fn fixup_for_completion(content: &str, byte_offset: usize) -> Option<String>
         .unwrap_or(0);
     let line_to_cursor = &content[line_start..byte_offset];
 
-    // Tiny state machine: `None` = not in a string, `Some(q)` = inside a
-    // string opened with quote `q`. Escapes consume the next character so
-    // `\'` and `\"` inside the matching quote style don't toggle the state.
+    // ---- Case 1/2: open quote at cursor? -----------------------------------
     let mut state: Option<char> = None;
     let mut iter = line_to_cursor.chars();
     while let Some(c) = iter.next() {
@@ -57,12 +87,49 @@ pub fn fixup_for_completion(content: &str, byte_offset: usize) -> Option<String>
         }
     }
 
-    let unclosed = state?;
-    let mut result = String::with_capacity(content.len() + 1);
-    result.push_str(&content[..byte_offset]);
-    result.push(unclosed);
-    result.push_str(&content[byte_offset..]);
-    Some(result)
+    if let Some(unclosed) = state {
+        // Auto-pair safety: if the matching close quote is already at the
+        // cursor (the editor inserted it), don't inject another — that
+        // produces `'''` and breaks the parse worse than the original.
+        if content[byte_offset..].starts_with(unclosed) {
+            return Some(CompletionPrep::unchanged(content));
+        }
+
+        let mut fixed = String::with_capacity(content.len() + 1);
+        fixed.push_str(&content[..byte_offset]);
+        fixed.push(unclosed);
+        fixed.push_str(&content[byte_offset..]);
+        return Some(CompletionPrep {
+            fixed_content: fixed,
+            quote_for_insertion: None, // source already has the open quote
+        });
+    }
+
+    // ---- Case 3: cursor immediately after `(`? -----------------------------
+    // Scan back through any whitespace; if the previous non-whitespace char
+    // is `(`, we're in "user just opened the paren" territory. Inject `''`
+    // (and `)` if the paren is unclosed) so the parser sees a well-formed
+    // call expression with an empty-string first arg. Items will wrap with
+    // `'` since the source has no quotes around the arg.
+    let trimmed_before: &str = line_to_cursor.trim_end_matches([' ', '\t', '\r']);
+    if trimmed_before.ends_with('(') {
+        let after_cursor = content[byte_offset..].trim_start_matches([' ', '\t']);
+        let inject: &str = if after_cursor.starts_with(')') {
+            "''"
+        } else {
+            "'')"
+        };
+        let mut fixed = String::with_capacity(content.len() + inject.len());
+        fixed.push_str(&content[..byte_offset]);
+        fixed.push_str(inject);
+        fixed.push_str(&content[byte_offset..]);
+        return Some(CompletionPrep {
+            fixed_content: fixed,
+            quote_for_insertion: Some('\''),
+        });
+    }
+
+    None
 }
 
 /// Translate an LSP `Position` (0-based line + character) into a byte offset

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -270,6 +270,18 @@ fn detects_db_table_inside_where_string() {
 }
 
 #[test]
+fn detects_db_table_inside_empty_where_string() {
+    // The "backspace to empty" case Mike hit. Source is well-formed
+    // (`where('')`), cursor is between the two `'`. Should still resolve
+    // to a Column completion context so the handler returns all columns.
+    let ctx = detect("DB::table('users')->where('|');")
+        .expect("empty where() arg should still produce a ChainContext");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(ctx.effective_table.as_deref(), Some("users"));
+    assert_eq!(ctx.expecting, ArgKind::Column);
+}
+
+#[test]
 fn detects_db_table_with_double_quoted_arg() {
     let ctx = detect("DB::table('users')->where(\"em|\");").expect("ctx");
     assert_eq!(ctx.quote, '"');

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -37,73 +37,106 @@ fn detect(src_with_cursor: &str) -> Option<ChainContext> {
 // ---- fixup_for_completion ---------------------------------------------
 
 #[test]
-fn fixup_returns_none_when_no_open_quote() {
+fn fixup_returns_none_when_nothing_to_fix() {
     let src = "$x = 1;";
     assert!(fixup_for_completion(src, src.len()).is_none());
 }
 
 #[test]
-fn fixup_balanced_quotes_returns_none() {
-    let src = "DB::table('users')->where('";
-    // First `'`/`'` balanced (`'users'`), then a second `'` opened — that's
-    // unbalanced. But fixup_for_completion sees one open, no close, so it
-    // SHOULD return Some. Pin that.
-    let fixed = fixup_for_completion(src, src.len()).expect("unbalanced");
-    assert_eq!(fixed, "DB::table('users')->where(''");
-}
-
-#[test]
-fn fixup_injects_single_quote_for_unterminated_db_table() {
+fn fixup_unterminated_quote_injects_close() {
     let src = "DB::table('";
-    let fixed = fixup_for_completion(src, src.len()).expect("unbalanced single quote");
-    assert_eq!(fixed, "DB::table(''");
+    let prep = fixup_for_completion(src, src.len()).expect("unbalanced single quote");
+    assert_eq!(prep.fixed_content, "DB::table(''");
+    // Source already had an open quote, so insertion stays bare.
+    assert_eq!(prep.quote_for_insertion, None);
 }
 
 #[test]
-fn fixup_injects_double_quote_for_unterminated_double_string() {
+fn fixup_unterminated_double_quote_injects_close() {
     let src = "DB::table(\"";
-    let fixed = fixup_for_completion(src, src.len()).expect("unbalanced double quote");
-    assert_eq!(fixed, "DB::table(\"\"");
+    let prep = fixup_for_completion(src, src.len()).expect("unbalanced double quote");
+    assert_eq!(prep.fixed_content, "DB::table(\"\"");
+    assert_eq!(prep.quote_for_insertion, None);
+}
+
+#[test]
+fn fixup_auto_paired_close_returns_unchanged_no_quoting() {
+    // Editor auto-paired: source is `DB::table('')` and cursor is between
+    // the two `'`. State scan sees one `'` open at cursor, but the next char
+    // IS `'` (auto-paired close), so don't double-inject.
+    let src = "DB::table('')";
+    let cursor_between_quotes = "DB::table('".len(); // byte right after the first `'`
+    let prep = fixup_for_completion(src, cursor_between_quotes)
+        .expect("should still return Some for the auto-pair case (just no fixup)");
+    assert_eq!(prep.fixed_content, src, "must NOT inject another quote");
+    assert_eq!(prep.quote_for_insertion, None);
+}
+
+#[test]
+fn fixup_after_open_paren_injects_empty_string_and_close_paren() {
+    // User just typed `(`. No quotes yet. Inject `'')` so the call parses
+    // with an empty-string first arg AND a closing paren.
+    let src = "DB::table(";
+    let prep = fixup_for_completion(src, src.len()).expect("after-paren case");
+    assert_eq!(prep.fixed_content, "DB::table('')");
+    // Source has no quotes, so items must wrap with `'`.
+    assert_eq!(prep.quote_for_insertion, Some('\''));
+}
+
+#[test]
+fn fixup_after_open_paren_with_existing_close_paren_injects_just_quotes() {
+    // `DB::table(|)` — the `)` is already there (editor auto-pair on `(`).
+    // Only inject `''`, not `'')`.
+    let src = "DB::table()";
+    let cursor_between_parens = "DB::table(".len();
+    let prep = fixup_for_completion(src, cursor_between_parens).expect("after-paren case");
+    assert_eq!(prep.fixed_content, "DB::table('')");
+    assert_eq!(prep.quote_for_insertion, Some('\''));
+}
+
+#[test]
+fn fixup_after_open_paren_with_whitespace_still_fires() {
+    // `DB::table(   |` — whitespace between `(` and cursor still counts.
+    let src = "DB::table(   ";
+    let prep = fixup_for_completion(src, src.len()).expect("after-paren w/ whitespace");
+    assert_eq!(prep.fixed_content, "DB::table(   '')");
+    assert_eq!(prep.quote_for_insertion, Some('\''));
 }
 
 #[test]
 fn fixup_respects_escapes() {
     // `\'` inside a `'`-string doesn't toggle the state.
     let src = "DB::table('it\\'s ";
-    let fixed = fixup_for_completion(src, src.len()).expect("still open after \\'");
-    assert_eq!(fixed, "DB::table('it\\'s '");
+    let prep = fixup_for_completion(src, src.len()).expect("still open after \\'");
+    assert_eq!(prep.fixed_content, "DB::table('it\\'s '");
+    assert_eq!(prep.quote_for_insertion, None);
 }
 
 #[test]
 fn fixup_stops_at_line_boundary() {
     // Quote opened on a previous line doesn't bleed into the current line.
-    // (We deliberately ignore those — multi-line strings in chain args are
-    // rare, and treating them per-line is safer than chasing arbitrary
-    // history.)
     let src = "'unterminated\nDB::table(";
-    // Cursor at end of `DB::table(` — current line has no opened quote,
-    // even though the previous line did.
-    let fixed = fixup_for_completion(src, src.len());
-    assert!(
-        fixed.is_none(),
-        "previous-line quote shouldn't trigger fixup, got: {:?}",
-        fixed
-    );
+    // Current line is `DB::table(` — no open quote on this line; after-paren
+    // case applies.
+    let prep = fixup_for_completion(src, src.len()).expect("after-paren on new line");
+    assert!(prep.fixed_content.ends_with("DB::table('')"));
+    assert_eq!(prep.quote_for_insertion, Some('\''));
 }
 
 #[test]
 fn fixup_handles_inner_double_inside_single() {
-    // `'has "double" inside'` — inner `"` doesn't toggle when we're inside `'`.
     let src = "echo 'a \"b\" c";
-    let fixed = fixup_for_completion(src, src.len()).expect("single still open");
-    assert_eq!(fixed, "echo 'a \"b\" c'");
+    let prep = fixup_for_completion(src, src.len()).expect("single still open");
+    assert_eq!(prep.fixed_content, "echo 'a \"b\" c'");
+    assert_eq!(prep.quote_for_insertion, None);
 }
 
 #[test]
 fn fixup_handles_inner_single_inside_double() {
     let src = "echo \"a 'b' c";
-    let fixed = fixup_for_completion(src, src.len()).expect("double still open");
-    assert_eq!(fixed, "echo \"a 'b' c\"");
+    let prep = fixup_for_completion(src, src.len()).expect("double still open");
+    assert_eq!(prep.fixed_content, "echo \"a 'b' c\"");
+    assert_eq!(prep.quote_for_insertion, None);
 }
 
 #[test]

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -756,9 +756,8 @@ fn find_chain_containing_picks_innermost() {
         chains_of("DB::table('users')->where('exists', function ($q) { $q->where('a', 1); });");
     // Find offset of the inner `$q->where('a', 1)` — pick a byte inside
     // the inner where's args.
-    let wrapped = format!(
-        "<?php\nDB::table('users')->where('exists', function ($q) {{ $q->where('a', 1); }});"
-    );
+    let wrapped =
+        "<?php\nDB::table('users')->where('exists', function ($q) { $q->where('a', 1); });";
     // Look for the second occurrence of 'a' inside the chains
     let inner_offset = wrapped.rfind("'a'").unwrap() + 1; // mid 'a'
     let chain = find_chain_containing(&chains, inner_offset).expect("chain at inner offset");

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -1,0 +1,178 @@
+use super::*;
+use crate::parser::parse_php;
+use crate::query_chain::extract_chains;
+
+/// Parse a snippet, extract chains, and wrap them in Arc to match the shape
+/// the caller hands in at runtime (chains live behind Arc inside
+/// `ParsedPatternsData`).
+fn chains_of(src: &str) -> (String, Vec<Arc<BuilderChain>>) {
+    let wrapped = format!("<?php\n{src}");
+    let tree = parse_php(&wrapped).expect("parse");
+    let chains = extract_chains(&tree, &wrapped)
+        .into_iter()
+        .map(Arc::new)
+        .collect();
+    (wrapped, chains)
+}
+
+/// Find the byte offset of the single `|` marker inside the wrapped source.
+fn cursor_at(src: &str) -> (String, usize) {
+    let wrapped = format!("<?php\n{src}");
+    let pos = wrapped.find('|').expect("test fixture missing `|` marker");
+    // Remove the `|` so the parsed source matches what the user actually has.
+    let cleaned = wrapped.replacen('|', "", 1);
+    (cleaned, pos)
+}
+
+fn detect(src_with_cursor: &str) -> Option<ChainContext> {
+    let (wrapped, byte_offset) = cursor_at(src_with_cursor);
+    let tree = parse_php(&wrapped).expect("parse");
+    let chains: Vec<Arc<BuilderChain>> = extract_chains(&tree, &wrapped)
+        .into_iter()
+        .map(Arc::new)
+        .collect();
+    detect_chain_context_at(&chains, byte_offset)
+}
+
+// ---- position_to_byte_offset ------------------------------------------
+
+#[test]
+fn position_first_line_first_char() {
+    let content = "abc\ndef";
+    assert_eq!(position_to_byte_offset(content, 0, 0), Some(0));
+}
+
+#[test]
+fn position_first_line_mid() {
+    let content = "abc\ndef";
+    assert_eq!(position_to_byte_offset(content, 0, 2), Some(2));
+}
+
+#[test]
+fn position_second_line() {
+    let content = "abc\ndef";
+    assert_eq!(position_to_byte_offset(content, 1, 0), Some(4));
+    assert_eq!(position_to_byte_offset(content, 1, 2), Some(6));
+}
+
+#[test]
+fn position_beyond_line_end_clamps() {
+    // Asking for character 10 on a 3-char line should clamp to end of line.
+    let content = "abc\ndef";
+    assert_eq!(position_to_byte_offset(content, 0, 10), Some(3));
+}
+
+#[test]
+fn position_beyond_eof_returns_none() {
+    let content = "abc";
+    assert!(position_to_byte_offset(content, 5, 0).is_none());
+}
+
+// ---- detect_chain_context_at: DB::table ----------------------------------
+
+#[test]
+fn detects_db_table_inside_where_string() {
+    let ctx = detect("DB::table('users')->where('email|');")
+        .expect("cursor inside where() string arg should produce a ChainContext");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(ctx.effective_table.as_deref(), Some("users"));
+    assert!(ctx.effective_model.is_none());
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(ctx.quote, '\'');
+}
+
+#[test]
+fn detects_db_table_with_double_quoted_arg() {
+    let ctx = detect("DB::table('users')->where(\"em|\");").expect("ctx");
+    assert_eq!(ctx.quote, '"');
+}
+
+#[test]
+fn db_table_with_chained_where_still_base_mode() {
+    // Cursor on the second where() — preceding where() doesn't flip the mode.
+    let ctx = detect("DB::table('users')->where('a', 1)->where('b|');").expect("ctx");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(ctx.effective_table.as_deref(), Some("users"));
+}
+
+#[test]
+fn db_table_inside_table_arg_itself_returns_none() {
+    // Cursor on the `'users|'` arg of DB::table() — the `table` link has
+    // ArgKind::None (the receiver is a table, not a column), so no completion.
+    let ctx = detect("DB::table('users|')->where('a', 1);");
+    assert!(ctx.is_none(), "expected None, got {:?}", ctx);
+}
+
+#[test]
+fn db_table_cursor_outside_string_returns_none() {
+    // Cursor on the method name `wher|e` — not inside a string arg.
+    let ctx = detect("DB::table('users')->wher|e('a', 1);");
+    assert!(ctx.is_none());
+}
+
+// ---- detect_chain_context_at: Eloquent (Phase 4+ — current expectation) -
+
+#[test]
+fn eloquent_receiver_returns_none_for_now() {
+    // Eloquent model resolution is async — Phase 3's sync detector returns
+    // None for Eloquent chains. Phase 4 will hook in the async resolver.
+    let ctx = detect("User::where('em|');");
+    assert!(
+        ctx.is_none(),
+        "Phase 3 expects Eloquent chains to return None"
+    );
+}
+
+// ---- Chain terminators end completion -----------------------------------
+
+#[test]
+fn terminator_before_cursor_returns_none() {
+    // count() is a ChainTerminator — anything after it isn't a builder
+    // operation. We've decided not to complete past a terminator.
+    let ctx = detect("DB::table('users')->count()->where('a|');");
+    assert!(ctx.is_none());
+}
+
+// ---- Nested chains ------------------------------------------------------
+
+#[test]
+fn nested_chain_picks_inner_chain() {
+    // Inside the closure, $q is its own chain. The cursor sits inside the
+    // inner $q->where(). The receiver is InstanceVar (Eloquent), so Phase 3
+    // returns None — but `find_chain_containing` should pick the *inner*
+    // chain, not the outer one. We confirm that indirectly: with Eloquent
+    // chains returning None, this returns None. (In Phase 9 with var-type
+    // resolution this becomes a real completion.)
+    let ctx = detect("DB::table('users')->where('exists', function ($q) { $q->where('a|'); });");
+    // The outer chain is DB::table (Base) — but the cursor falls within the
+    // inner chain ($q->where), so we pick that one and return None.
+    // If find_chain_containing picked the outer chain instead, we'd see
+    // BaseBuilder + 'users' here.
+    assert!(
+        ctx.is_none(),
+        "expected None (inner $q chain wins); got {:?}",
+        ctx
+    );
+}
+
+// ---- find_chain_containing direct test ---------------------------------
+
+#[test]
+fn find_chain_containing_picks_innermost() {
+    let (_src, chains) =
+        chains_of("DB::table('users')->where('exists', function ($q) { $q->where('a', 1); });");
+    // Find offset of the inner `$q->where('a', 1)` — pick a byte inside
+    // the inner where's args.
+    let wrapped = format!(
+        "<?php\nDB::table('users')->where('exists', function ($q) {{ $q->where('a', 1); }});"
+    );
+    // Look for the second occurrence of 'a' inside the chains
+    let inner_offset = wrapped.rfind("'a'").unwrap() + 1; // mid 'a'
+    let chain = find_chain_containing(&chains, inner_offset).expect("chain at inner offset");
+    match &chain.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) => {
+            assert_eq!(var, "q", "innermost chain should be $q's");
+        }
+        other => panic!("expected $q's chain, got {other:?}"),
+    }
+}

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -34,6 +34,84 @@ fn detect(src_with_cursor: &str) -> Option<ChainContext> {
     detect_chain_context_at(&chains, byte_offset)
 }
 
+// ---- fixup_for_completion ---------------------------------------------
+
+#[test]
+fn fixup_returns_none_when_no_open_quote() {
+    let src = "$x = 1;";
+    assert!(fixup_for_completion(src, src.len()).is_none());
+}
+
+#[test]
+fn fixup_balanced_quotes_returns_none() {
+    let src = "DB::table('users')->where('";
+    // First `'`/`'` balanced (`'users'`), then a second `'` opened — that's
+    // unbalanced. But fixup_for_completion sees one open, no close, so it
+    // SHOULD return Some. Pin that.
+    let fixed = fixup_for_completion(src, src.len()).expect("unbalanced");
+    assert_eq!(fixed, "DB::table('users')->where(''");
+}
+
+#[test]
+fn fixup_injects_single_quote_for_unterminated_db_table() {
+    let src = "DB::table('";
+    let fixed = fixup_for_completion(src, src.len()).expect("unbalanced single quote");
+    assert_eq!(fixed, "DB::table(''");
+}
+
+#[test]
+fn fixup_injects_double_quote_for_unterminated_double_string() {
+    let src = "DB::table(\"";
+    let fixed = fixup_for_completion(src, src.len()).expect("unbalanced double quote");
+    assert_eq!(fixed, "DB::table(\"\"");
+}
+
+#[test]
+fn fixup_respects_escapes() {
+    // `\'` inside a `'`-string doesn't toggle the state.
+    let src = "DB::table('it\\'s ";
+    let fixed = fixup_for_completion(src, src.len()).expect("still open after \\'");
+    assert_eq!(fixed, "DB::table('it\\'s '");
+}
+
+#[test]
+fn fixup_stops_at_line_boundary() {
+    // Quote opened on a previous line doesn't bleed into the current line.
+    // (We deliberately ignore those — multi-line strings in chain args are
+    // rare, and treating them per-line is safer than chasing arbitrary
+    // history.)
+    let src = "'unterminated\nDB::table(";
+    // Cursor at end of `DB::table(` — current line has no opened quote,
+    // even though the previous line did.
+    let fixed = fixup_for_completion(src, src.len());
+    assert!(
+        fixed.is_none(),
+        "previous-line quote shouldn't trigger fixup, got: {:?}",
+        fixed
+    );
+}
+
+#[test]
+fn fixup_handles_inner_double_inside_single() {
+    // `'has "double" inside'` — inner `"` doesn't toggle when we're inside `'`.
+    let src = "echo 'a \"b\" c";
+    let fixed = fixup_for_completion(src, src.len()).expect("single still open");
+    assert_eq!(fixed, "echo 'a \"b\" c'");
+}
+
+#[test]
+fn fixup_handles_inner_single_inside_double() {
+    let src = "echo \"a 'b' c";
+    let fixed = fixup_for_completion(src, src.len()).expect("double still open");
+    assert_eq!(fixed, "echo \"a 'b' c\"");
+}
+
+#[test]
+fn fixup_offset_beyond_eof_returns_none() {
+    let src = "abc";
+    assert!(fixup_for_completion(src, 100).is_none());
+}
+
 // ---- position_to_byte_offset ------------------------------------------
 
 #[test]

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -466,6 +466,34 @@ fn eloquent_static_where_has_first_arg_resolves_to_closure_carrier() {
 }
 
 #[test]
+fn eloquent_static_with_array_arg_resolves_to_relation_completion() {
+    // Mike's reported case: `User::with([''])` with cursor between the
+    // two `'`s inside the array. Without Phase 5.2 the array arg was
+    // ChainArg::Other and string_arg_at found nothing; now we recurse
+    // into Array elements and the StringLit inside is reachable.
+    let ctx = detect("User::with(['|']);")
+        .expect("cursor inside array-arg string should resolve to Relation");
+    assert_eq!(ctx.mode, BuilderMode::EloquentBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Relation);
+    assert_eq!(ctx.effective_model.as_deref(), Some("User"));
+}
+
+#[test]
+fn eloquent_static_with_array_arg_multiple_strings() {
+    // `User::with(['posts', 'co|mments'])` — cursor on the second string
+    // in the array. Same resolution as the single-string case.
+    let ctx = detect("User::with(['posts', 'co|mments']);").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Relation);
+}
+
+#[test]
+fn eloquent_static_select_array_arg_resolves_to_column() {
+    // `User::select(['na|me', 'email'])` — column completion in array form.
+    let ctx = detect("User::select(['na|me', 'email']);").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Column);
+}
+
+#[test]
 fn eloquent_static_load_first_arg_resolves_to_relation() {
     // `User::load(...)` doesn't actually exist as a static (load is on the
     // model instance / collection), but `loadCount` and similar are on

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -396,16 +396,58 @@ fn db_table_with_auto_paired_quotes_no_close_paren_resolves_to_table_completion(
     assert_eq!(ctx.effective_table.as_deref(), Some(""));
 }
 
-// ---- detect_chain_context_at: Eloquent (Phase 4+ — current expectation) -
+// ---- detect_chain_context_at: Eloquent static receivers (Phase 4) -------
 
 #[test]
-fn eloquent_receiver_returns_none_for_now() {
-    // Eloquent model resolution is async — Phase 3's sync detector returns
-    // None for Eloquent chains. Phase 4 will hook in the async resolver.
-    let ctx = detect("User::where('em|');");
+fn eloquent_static_receiver_resolves_to_builder_mode_with_model_set() {
+    // `User::where('em|')` — receiver is Eloquent::StaticModel. detect_in_chain
+    // populates `effective_model` with the class name and leaves
+    // `effective_table` as `None`; the handler is responsible for resolving
+    // the model file → table name via async I/O.
+    let ctx = detect("User::where('em|');")
+        .expect("Eloquent static receivers should produce a ChainContext in Phase 4+");
+    assert_eq!(ctx.mode, BuilderMode::EloquentBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert!(
+        ctx.effective_table.is_none(),
+        "table is resolved at the handler, not in detect_in_chain"
+    );
+    assert_eq!(
+        ctx.effective_model.as_deref(),
+        Some("User"),
+        "the FQCN (or short name if no `use`) should be preserved for the handler"
+    );
+}
+
+#[test]
+fn eloquent_static_receiver_with_use_alias_carries_fqcn() {
+    // `use App\Models\User;` in the file should make the receiver's class
+    // name fully qualified, so the handler can resolve it directly without
+    // re-running use-alias resolution.
+    let src = "<?php\nuse App\\Models\\User;\nUser::where('em|');";
+    let pos = src.find('|').expect("test fixture missing `|` marker");
+    let cleaned = src.replacen('|', "", 1);
+    let tree = crate::parser::parse_php(&cleaned).expect("parse");
+    let chains: Vec<Arc<BuilderChain>> = crate::query_chain::extract_chains(&tree, &cleaned)
+        .into_iter()
+        .map(Arc::new)
+        .collect();
+    let ctx = detect_chain_context_at(&chains, pos).expect("ctx");
+    assert_eq!(
+        ctx.effective_model.as_deref(),
+        Some("App\\Models\\User"),
+        "use-alias should produce the FQCN, not the short name"
+    );
+}
+
+#[test]
+fn eloquent_instance_receiver_still_returns_none_until_phase_9() {
+    // `$user->newQuery()->where('|')` — InstanceVar receiver still needs
+    // `@var` / typed-param scanning (Phase 9). For now, return None.
+    let ctx = detect("$user->newQuery()->where('em|');");
     assert!(
         ctx.is_none(),
-        "Phase 3 expects Eloquent chains to return None"
+        "instance-var receivers still return None until Phase 9 lands var-type resolution"
     );
 }
 

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -578,6 +578,85 @@ fn closure_scope_with_unrelated_var_returns_none() {
     );
 }
 
+// ---- Mode flips: toBase / Collection terminators (Phase 6) -------------
+
+#[test]
+fn to_base_flips_mode_to_base_builder() {
+    // `User::where(...)->toBase()->where('|')` — after toBase, the chain
+    // is operating on a Query Builder. Mode should be BaseBuilder; the
+    // model is still known (handler resolves the table from it).
+    let ctx = detect("User::where('a', 1)->toBase()->where('em|', 2);")
+        .expect("cursor after ->toBase() should still resolve");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(
+        ctx.effective_model.as_deref(),
+        Some("User"),
+        "model is preserved across toBase() — handler resolves table from it"
+    );
+}
+
+#[test]
+fn to_base_then_with_returns_none_no_relations_on_base() {
+    // `User::where(...)->toBase()->with('|')` — Query Builder has no
+    // relation methods, so `with` would fail at runtime. The walker
+    // detects expecting=Relation in BaseBuilder mode and the handler
+    // returns empty.
+    let ctx = detect("User::where('a', 1)->toBase()->with('po|');").expect("ctx");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Relation);
+    // (The HANDLER returns empty for this combo; cursor just reports
+    // the mode + expecting accurately.)
+}
+
+#[test]
+fn get_terminator_flips_to_collection_mode() {
+    // `User::where(...)->get()->where('|')` — get() is a CollectionTerminator,
+    // so the chain is now operating on a Collection. Same model.
+    let ctx = detect("User::where('a', 1)->get()->where('em|', 2);").expect("ctx");
+    assert_eq!(ctx.mode, BuilderMode::EloquentCollection);
+    assert_eq!(ctx.effective_model.as_deref(), Some("User"));
+}
+
+#[test]
+fn all_static_starter_flips_to_collection_mode() {
+    // `User::all()->where('|')` — `all` is a Collection terminator at
+    // the static-call entry point. Mode should be EloquentCollection
+    // (not EloquentBuilder) by the time the cursor's link runs.
+    let ctx = detect("User::all()->where('na|me', 'jim');").expect("ctx");
+    assert_eq!(ctx.mode, BuilderMode::EloquentCollection);
+    assert_eq!(ctx.effective_model.as_deref(), Some("User"));
+}
+
+#[test]
+fn collection_load_resolves_to_relation() {
+    // Collection's `load('|')` takes relation names, same as Builder's
+    // `with('|')`. expecting should be Relation, mode EloquentCollection.
+    let ctx = detect("User::all()->load('po|sts');").expect("ctx");
+    assert_eq!(ctx.mode, BuilderMode::EloquentCollection);
+    assert_eq!(ctx.expecting, ArgKind::Relation);
+}
+
+#[test]
+fn chain_terminator_count_kills_further_completion() {
+    // `count` is a ChainTerminator — it returns an int, so any chained
+    // method that follows can't be a builder operation. detect_in_chain
+    // returns None for cursors past a terminator.
+    let ctx = detect("User::where('a', 1)->count()->where('em|', 2);");
+    assert!(
+        ctx.is_none(),
+        "chain terminator should prevent further completion; got {ctx:?}"
+    );
+}
+
+#[test]
+fn chain_terminator_first_kills_further_completion() {
+    // `first` returns a Model|null, not a builder. Subsequent chained
+    // calls aren't builder ops either; completion stops.
+    let ctx = detect("User::where('a', 1)->first()->where('em|', 2);");
+    assert!(ctx.is_none(), "first() terminates the chain");
+}
+
 // ---- Chain terminators end completion -----------------------------------
 
 #[test]

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -441,6 +441,42 @@ fn eloquent_static_receiver_with_use_alias_carries_fqcn() {
 }
 
 #[test]
+fn eloquent_static_with_first_arg_resolves_to_relation_completion() {
+    // `User::with('po|')` — `with` is a RELATION_METHOD, so the cursor's
+    // arg kind is Relation. Handler reads the model's relationships.
+    let ctx = detect("User::with('po|');")
+        .expect("Eloquent with() arg should produce a ChainContext expecting=Relation");
+    assert_eq!(ctx.mode, BuilderMode::EloquentBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Relation);
+    assert_eq!(ctx.effective_model.as_deref(), Some("User"));
+}
+
+#[test]
+fn eloquent_static_where_has_first_arg_resolves_to_closure_carrier() {
+    // `User::whereHas('po|', closure)` — `whereHas` is in CLOSURE_CARRIERS
+    // which wins precedence over RELATION_METHODS in arg_kind(). For the
+    // first string arg the meaning is identical (a relation name), so the
+    // handler accepts both Relation and ClosureCarrier as relation-name
+    // positions.
+    let ctx = detect("User::whereHas('po|', function ($q) {});")
+        .expect("whereHas() first arg should produce a ChainContext");
+    assert_eq!(ctx.mode, BuilderMode::EloquentBuilder);
+    assert_eq!(ctx.expecting, ArgKind::ClosureCarrier);
+    assert_eq!(ctx.effective_model.as_deref(), Some("User"));
+}
+
+#[test]
+fn eloquent_static_load_first_arg_resolves_to_relation() {
+    // `User::load(...)` doesn't actually exist as a static (load is on the
+    // model instance / collection), but `loadCount` and similar are on
+    // builder. Use `with` as the canonical static-position relation method
+    // and `withCount` for the closure-carrier-on-Eloquent-builder shape.
+    let ctx = detect("User::withCount('po|');").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::ClosureCarrier);
+    assert_eq!(ctx.effective_model.as_deref(), Some("User"));
+}
+
+#[test]
 fn eloquent_instance_receiver_still_returns_none_until_phase_9() {
     // `$user->newQuery()->where('|')` — InstanceVar receiver still needs
     // `@var` / typed-param scanning (Phase 9). For now, return None.

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -515,6 +515,69 @@ fn eloquent_instance_receiver_still_returns_none_until_phase_9() {
     );
 }
 
+// ---- Closure-scope resolution (Phase 8) ---------------------------------
+
+#[test]
+fn where_has_closure_resolves_to_parent_model_and_hop() {
+    // `User::whereHas('posts', fn ($q) => $q->where('publi|shed', 1))` —
+    // the inner cursor should produce a ChainContext with effective_model
+    // = "User" (the parent) and closure_relation_hop = Some("posts").
+    // The handler resolves the hop async to flip effective_model to Post.
+    let ctx = detect("User::whereHas('posts', fn ($q) => $q->where('publi|shed', 1));")
+        .expect("inner cursor in whereHas closure should resolve");
+    assert_eq!(ctx.mode, BuilderMode::EloquentBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(ctx.effective_model.as_deref(), Some("User"));
+    assert_eq!(ctx.closure_relation_hop.as_deref(), Some("posts"));
+}
+
+#[test]
+fn with_keyed_array_closure_resolves_to_parent_model_and_hop() {
+    // The shape Mike reported:
+    // `OAuthClient::with(['tokens' => function ($q) { $q->where('expi|red', 1); }])`
+    let src = "OAuthClient::with(['tokens' => function ($q) { $q->where('expi|red', 1); }]);";
+    let ctx = detect(src).expect("inner cursor in with-keyed-array closure should resolve");
+    assert_eq!(ctx.mode, BuilderMode::EloquentBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(ctx.effective_model.as_deref(), Some("OAuthClient"));
+    assert_eq!(ctx.closure_relation_hop.as_deref(), Some("tokens"));
+}
+
+#[test]
+fn nested_where_closure_inherits_parent_model() {
+    // `User::where(function ($q) { $q->where('em|', 1); })` — same-model
+    // closure: $q is bound to a User builder. effective_model = "User",
+    // closure_relation_hop = None (no hop, inherit directly).
+    let ctx = detect("User::where(function ($q) { $q->where('em|', 1); });")
+        .expect("inner cursor in same-model closure should resolve");
+    assert_eq!(ctx.mode, BuilderMode::EloquentBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(ctx.effective_model.as_deref(), Some("User"));
+    assert!(
+        ctx.closure_relation_hop.is_none(),
+        "same-model bindings shouldn't set closure_relation_hop"
+    );
+}
+
+#[test]
+fn when_closure_inherits_parent_model() {
+    let ctx = detect("User::when($cond, function ($q) { $q->where('na|me', 1); });").expect("ctx");
+    assert_eq!(ctx.effective_model.as_deref(), Some("User"));
+    assert!(ctx.closure_relation_hop.is_none());
+}
+
+#[test]
+fn closure_scope_with_unrelated_var_returns_none() {
+    // The closure receiver is `$other`, not the closure param `$q`. We
+    // shouldn't bind — return None.
+    let ctx =
+        detect("User::whereHas('posts', function ($q) use ($other) { $other->where('a|', 1); });");
+    assert!(
+        ctx.is_none(),
+        "unrelated-var receivers inside the closure shouldn't get the parent's model"
+    );
+}
+
 // ---- Chain terminators end completion -----------------------------------
 
 #[test]

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -96,11 +96,27 @@ fn db_table_with_chained_where_still_base_mode() {
 }
 
 #[test]
-fn db_table_inside_table_arg_itself_returns_none() {
-    // Cursor on the `'users|'` arg of DB::table() — the `table` link has
-    // ArgKind::None (the receiver is a table, not a column), so no completion.
-    let ctx = detect("DB::table('users|')->where('a', 1);");
-    assert!(ctx.is_none(), "expected None, got {:?}", ctx);
+fn db_table_inside_table_arg_offers_table_completion() {
+    // Cursor on the `'users|'` arg of DB::table() — the `table` link's first
+    // string arg gets ArgKind::Table so the completion handler returns the
+    // list of database tables.
+    let ctx = detect("DB::table('users|')->where('a', 1);")
+        .expect("cursor inside DB::table() string arg should produce a ChainContext");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Table);
+    assert_eq!(ctx.quote, '\'');
+}
+
+#[test]
+fn lowercase_db_facade_resolves_too() {
+    // PHP class names are case-insensitive, so `db::table('|')` works just
+    // like `DB::table('|')`. The receiver is DbTable, the link is Table.
+    let ctx = detect("db::table('|');").expect("db (lowercase) should resolve to DB facade");
+    assert_eq!(ctx.expecting, ArgKind::Table);
+    match ctx.effective_table.as_deref() {
+        Some("") => {} // empty table name — the user just typed `'`
+        other => panic!("unexpected table: {:?}", other),
+    }
 }
 
 #[test]

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -282,6 +282,29 @@ fn detects_db_table_inside_empty_where_string() {
 }
 
 #[test]
+fn detects_empty_where_with_no_close_paren_end_to_end() {
+    // The exact case Mike reported: user had `where('a'` (no close paren),
+    // hit delete on `a`, ended up with `where(''` (cursor between the two
+    // `'`, still no close paren). Without paren fixup in case-1a the chain
+    // misparses; with it the empty string parses as a `where` arg and the
+    // ctx resolves to Column completion.
+    let raw = "<?php\nDB::table('transaction_type')->where(''";
+    let cursor_byte = "<?php\nDB::table('transaction_type')->where('".len();
+    let prep = fixup_for_completion(raw, cursor_byte).expect("auto-pair + paren fixup");
+    let tree = crate::parser::parse_php(&prep.fixed_content).expect("parse");
+    let chains: Vec<Arc<BuilderChain>> =
+        crate::query_chain::extract_chains(&tree, &prep.fixed_content)
+            .into_iter()
+            .map(Arc::new)
+            .collect();
+    let ctx = detect_chain_context_at(&chains, cursor_byte)
+        .expect("after fixup the chain should resolve to a Column completion context");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(ctx.effective_table.as_deref(), Some("transaction_type"));
+}
+
+#[test]
 fn detects_db_table_with_double_quoted_arg() {
     let ctx = detect("DB::table('users')->where(\"em|\");").expect("ctx");
     assert_eq!(ctx.quote, '"');

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -73,6 +73,44 @@ fn fixup_auto_paired_close_returns_unchanged_no_quoting() {
 }
 
 #[test]
+fn fixup_auto_paired_quotes_but_unclosed_paren_injects_close_paren() {
+    // The real-world Sail-typing case: editor auto-paired the quotes
+    // (`DB::table('')`) but the `)` was never typed. Without injecting `)`,
+    // tree-sitter recovers by extending the call expression downstream and
+    // the `''` arg ends up classified as ChainArg::Other — completion
+    // silently misses. We need to leave the cursor's open quote alone but
+    // patch the missing paren so the call expression terminates at the
+    // close quote.
+    let src = "DB::table(''\n        \\Log::info('keep going');\n";
+    let cursor_between_quotes = "DB::table('".len();
+    let prep =
+        fixup_for_completion(src, cursor_between_quotes).expect("auto-pair safety + paren fixup");
+    // Insertion stays bare — the source already has the open quote and the
+    // editor auto-paired the close.
+    assert_eq!(prep.quote_for_insertion, None);
+    // The `)` must land right after the auto-paired close quote, so the
+    // call expression is `DB::table('')` and the rest of the file parses
+    // independently.
+    assert!(
+        prep.fixed_content.starts_with("DB::table('')"),
+        "got: {:?}",
+        prep.fixed_content
+    );
+}
+
+#[test]
+fn fixup_auto_paired_quotes_with_balanced_parens_stays_unchanged() {
+    // Same shape as the bug-fix case above, but the `)` IS already present
+    // (full auto-pair, or user typed `)` after seeing autocomplete). Don't
+    // inject another `)`.
+    let src = "DB::table('')";
+    let cursor_between_quotes = "DB::table('".len();
+    let prep = fixup_for_completion(src, cursor_between_quotes).expect("balanced");
+    assert_eq!(prep.fixed_content, src);
+    assert_eq!(prep.quote_for_insertion, None);
+}
+
+#[test]
 fn fixup_after_open_paren_injects_empty_string_and_close_paren() {
     // User just typed `(`. No quotes yet. Inject `'')` so the call parses
     // with an empty-string first arg AND a closing paren.
@@ -235,6 +273,31 @@ fn db_table_cursor_outside_string_returns_none() {
     // Cursor on the method name `wher|e` — not inside a string arg.
     let ctx = detect("DB::table('users')->wher|e('a', 1);");
     assert!(ctx.is_none());
+}
+
+#[test]
+fn db_table_with_auto_paired_quotes_no_close_paren_resolves_to_table_completion() {
+    // The Sail-typing case end-to-end: user typed `DB::table('` and the
+    // editor auto-paired the `'`, leaving source as `DB::table('')` with no
+    // `)` yet. Without the paren fixup tree-sitter recovers by extending
+    // the call expression, and detect_chain_context_at returns None — the
+    // bug we're fixing. After fixup, we should land on BaseBuilder /
+    // expecting=Table with an empty effective_table (user hasn't typed
+    // anything yet — show all tables).
+    let raw = "<?php\nDB::table('')";
+    let cursor_byte = "<?php\nDB::table('".len();
+    let prep = fixup_for_completion(raw, cursor_byte).expect("auto-pair + paren fixup");
+    let tree = crate::parser::parse_php(&prep.fixed_content).expect("parse");
+    let chains: Vec<Arc<BuilderChain>> =
+        crate::query_chain::extract_chains(&tree, &prep.fixed_content)
+            .into_iter()
+            .map(Arc::new)
+            .collect();
+    let ctx = detect_chain_context_at(&chains, cursor_byte)
+        .expect("after fixup injects `)`, the cursor should resolve to a Table completion context");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Table);
+    assert_eq!(ctx.effective_table.as_deref(), Some(""));
 }
 
 // ---- detect_chain_context_at: Eloquent (Phase 4+ — current expectation) -

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -44,9 +44,11 @@ fn fixup_returns_none_when_nothing_to_fix() {
 
 #[test]
 fn fixup_unterminated_quote_injects_close() {
+    // No `)` either, so the fixup injects both quote and paren to keep
+    // tree-sitter from extending the call expression downstream.
     let src = "DB::table('";
     let prep = fixup_for_completion(src, src.len()).expect("unbalanced single quote");
-    assert_eq!(prep.fixed_content, "DB::table(''");
+    assert_eq!(prep.fixed_content, "DB::table('')");
     // Source already had an open quote, so insertion stays bare.
     assert_eq!(prep.quote_for_insertion, None);
 }
@@ -55,7 +57,7 @@ fn fixup_unterminated_quote_injects_close() {
 fn fixup_unterminated_double_quote_injects_close() {
     let src = "DB::table(\"";
     let prep = fixup_for_completion(src, src.len()).expect("unbalanced double quote");
-    assert_eq!(prep.fixed_content, "DB::table(\"\"");
+    assert_eq!(prep.fixed_content, "DB::table(\"\")");
     assert_eq!(prep.quote_for_insertion, None);
 }
 
@@ -96,6 +98,42 @@ fn fixup_auto_paired_quotes_but_unclosed_paren_injects_close_paren() {
         "got: {:?}",
         prep.fixed_content
     );
+}
+
+#[test]
+fn fixup_unterminated_quote_also_injects_close_paren_when_unbalanced() {
+    // The delete-from-end case: user backspaced to `DB::table('trua` and
+    // kept typing. No close quote, no `)`. Case-1b previously only
+    // injected the `'`, leaving the `(` dangling and tree-sitter free to
+    // extend the call expression downstream. The fixup must now also
+    // inject `)` after the close quote when the line's parens are
+    // unbalanced.
+    let src = "DB::table('trua\n        return 0;\n";
+    let cursor = "DB::table('trua".len();
+    let prep =
+        fixup_for_completion(src, cursor).expect("unterminated quote + unbalanced paren fixup");
+    // Both `'` and `)` should land — `DB::table('trua')` — so the call
+    // terminates on this line.
+    assert!(
+        prep.fixed_content.starts_with("DB::table('trua')"),
+        "expected close quote + close paren injected; got: {:?}",
+        prep.fixed_content
+    );
+    // Source has the open quote; insertion goes in bare.
+    assert_eq!(prep.quote_for_insertion, None);
+}
+
+#[test]
+fn fixup_unterminated_quote_only_when_parens_already_balanced() {
+    // If the call's parens are already balanced (e.g. the `)` is on the
+    // same line later because the editor auto-paired it), don't
+    // double-inject `)`.
+    let src = "DB::table('trua)";
+    let cursor = "DB::table('trua".len();
+    let prep = fixup_for_completion(src, cursor).expect("unterminated quote only");
+    // Just `'` — no extra `)` since the line already has a closing paren.
+    assert_eq!(prep.fixed_content, "DB::table('trua')");
+    assert_eq!(prep.quote_for_insertion, None);
 }
 
 #[test]
@@ -143,10 +181,11 @@ fn fixup_after_open_paren_with_whitespace_still_fires() {
 
 #[test]
 fn fixup_respects_escapes() {
-    // `\'` inside a `'`-string doesn't toggle the state.
+    // `\'` inside a `'`-string doesn't toggle the state. Line still has an
+    // unbalanced `(`, so the fixup injects both `'` and `)`.
     let src = "DB::table('it\\'s ";
     let prep = fixup_for_completion(src, src.len()).expect("still open after \\'");
-    assert_eq!(prep.fixed_content, "DB::table('it\\'s '");
+    assert_eq!(prep.fixed_content, "DB::table('it\\'s ')");
     assert_eq!(prep.quote_for_insertion, None);
 }
 
@@ -273,6 +312,28 @@ fn db_table_cursor_outside_string_returns_none() {
     // Cursor on the method name `wher|e` — not inside a string arg.
     let ctx = detect("DB::table('users')->wher|e('a', 1);");
     assert!(ctx.is_none());
+}
+
+#[test]
+fn db_table_with_open_quote_and_partial_text_no_close_paren_resolves() {
+    // The delete-from-end case end-to-end: source line is `DB::table('trua`
+    // with cursor at the end. No close quote, no `)`. After fixup, the
+    // chain should resolve to a Table completion with the partial text
+    // `trua` as the effective_table prefix.
+    let raw = "<?php\nDB::table('trua\n        return 0;\n";
+    let cursor_byte = "<?php\nDB::table('trua".len();
+    let prep = fixup_for_completion(raw, cursor_byte).expect("quote + paren fixup");
+    let tree = crate::parser::parse_php(&prep.fixed_content).expect("parse");
+    let chains: Vec<Arc<BuilderChain>> =
+        crate::query_chain::extract_chains(&tree, &prep.fixed_content)
+            .into_iter()
+            .map(Arc::new)
+            .collect();
+    let ctx = detect_chain_context_at(&chains, cursor_byte)
+        .expect("after fixup the chain should resolve to a Table completion context");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Table);
+    assert_eq!(ctx.effective_table.as_deref(), Some("trua"));
 }
 
 #[test]

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -578,6 +578,65 @@ fn closure_scope_with_unrelated_var_returns_none() {
     );
 }
 
+// ---- Dotted relation paths (Phase 7) -------------------------------------
+
+#[test]
+fn dotted_relation_path_single_hop_sets_prefix() {
+    // `User::with('posts.|')` — cursor right after the dot.
+    // dotted_prefix = "posts" (the hop to walk before listing relations).
+    let ctx = detect("User::with('posts.|');").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Relation);
+    assert_eq!(ctx.dotted_prefix.as_deref(), Some("posts"));
+}
+
+#[test]
+fn dotted_relation_path_multi_hop_sets_full_prefix() {
+    // `User::with('posts.author.|')` — two hops. The walker resolves
+    // posts → Post, then author → Author. Items will be Author's
+    // relations.
+    let ctx = detect("User::with('posts.author.|');").expect("ctx");
+    assert_eq!(ctx.dotted_prefix.as_deref(), Some("posts.author"));
+}
+
+#[test]
+fn dotted_relation_path_cursor_mid_last_segment_still_uses_prior_dots() {
+    // `User::with('posts.au|thor')` — cursor inside the last segment.
+    // The prefix is everything before the last dot ("posts"); the
+    // editor handles fuzzy-filtering by what the user typed of the
+    // final segment.
+    let ctx = detect("User::with('posts.au|thor');").expect("ctx");
+    assert_eq!(ctx.dotted_prefix.as_deref(), Some("posts"));
+}
+
+#[test]
+fn dotted_relation_path_no_dot_means_no_prefix() {
+    // `User::with('posts|')` — no dot. We're listing User's relations
+    // at the top level, no hops needed.
+    let ctx = detect("User::with('posts|');").expect("ctx");
+    assert!(ctx.dotted_prefix.is_none());
+}
+
+#[test]
+fn dotted_path_only_applies_to_relation_args_not_columns() {
+    // `User::where('a.b|', 1)` — column args don't have dotted-path
+    // semantics. We should NOT set dotted_prefix here.
+    let ctx = detect("User::where('a.b|', 1);").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert!(
+        ctx.dotted_prefix.is_none(),
+        "dotted prefix should only fire for Relation/ClosureCarrier args"
+    );
+}
+
+#[test]
+fn dotted_path_in_where_has_closure_carrier_also_works() {
+    // `User::whereHas('posts.author.|', closure)` — whereHas's first
+    // arg is a relation name, supports dotted paths the same as with().
+    let ctx = detect("User::whereHas('posts.author.|', function ($q) {});").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::ClosureCarrier);
+    assert_eq!(ctx.dotted_prefix.as_deref(), Some("posts.author"));
+}
+
 // ---- Mode flips: toBase / Collection terminators (Phase 6) -------------
 
 #[test]

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -276,12 +276,41 @@ pub async fn relations(
     wrap_with_quote: Option<char>,
     project_root: &Path,
 ) -> Vec<CompletionItem> {
-    let Some(class) = &ctx.effective_model else {
+    let Some(starting_class) = &ctx.effective_model else {
         info!("🔗 relations: ctx.effective_model is None — returning 0 items");
         return Vec::new();
     };
 
-    let Some(path) = find_php_class_file(class, project_root) else {
+    // Phase 7: if the user is typing a dotted relation path like
+    // `with('posts.author.|')`, walk each hop on the starting model to
+    // arrive at the final model whose relations we'll list. The cursor
+    // resolver populates `dotted_prefix` with everything before the last
+    // `.`; the editor handles fuzzy-filtering the part after.
+    let class = if let Some(prefix) = ctx.dotted_prefix.as_deref() {
+        match walk_dotted_hops(starting_class, prefix, project_root).await {
+            Some(resolved) => {
+                if resolved != *starting_class {
+                    info!(
+                        "🔗 relations: dotted-path hop {:?} on {:?} → {:?}",
+                        prefix, starting_class, resolved
+                    );
+                }
+                resolved
+            }
+            None => {
+                info!(
+                    "🔗 relations: dotted-path hop {:?} failed on {:?} \
+                     (segment doesn't resolve to a known relation)",
+                    prefix, starting_class
+                );
+                return Vec::new();
+            }
+        }
+    } else {
+        starting_class.clone()
+    };
+
+    let Some(path) = find_php_class_file(&class, project_root) else {
         info!(
             "🔗 relations: no PHP file found for class {:?} under {:?}",
             class, project_root
@@ -348,6 +377,38 @@ pub async fn relations(
             }
         })
         .collect()
+}
+
+/// Phase 7 helper: walk a dotted relation path, returning the model
+/// class at the FINAL hop. Each segment must resolve as a relation on
+/// the previous segment's model.
+///
+/// Examples:
+/// - `walk_dotted_hops("User", "posts", root)` → `Some("Post")` (one hop)
+/// - `walk_dotted_hops("User", "posts.author", root)` → `Some("Author")`
+/// - `walk_dotted_hops("User", "posts.author.profile", root)` → `Some("Profile")`
+/// - Any segment that fails to resolve → `None`
+///
+/// Returns the starting model unchanged if `dotted_prefix` is empty.
+pub async fn walk_dotted_hops(
+    starting_model: &str,
+    dotted_prefix: &str,
+    project_root: &Path,
+) -> Option<String> {
+    if dotted_prefix.is_empty() {
+        return Some(starting_model.to_string());
+    }
+    let mut current = starting_model.to_string();
+    for segment in dotted_prefix.split('.') {
+        if segment.is_empty() {
+            // Empty segment means the user typed two consecutive dots
+            // (e.g. `with('posts..|')`). Treat as a no-op — keep the
+            // current model, don't try to resolve "".
+            continue;
+        }
+        current = resolve_related_model(&current, segment, project_root).await?;
+    }
+    Some(current)
 }
 
 /// Phase 8 helper: walk one relation hop. Given a parent class name and

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -20,23 +20,36 @@ use super::chain::*;
 use crate::database::DatabaseSchemaProvider;
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
 
-/// Build table-name completions for the cursor inside `DB::table('|')`.
-/// Reads `DatabaseSchema::get_tables()` and returns one item per table.
-/// Independent of `BuilderMode` — `DB::table` is always BaseBuilder by the
-/// time anything chains off it, but at this point in the chain we're
-/// completing the chain *entry* itself.
-pub async fn tables(db: &DatabaseSchemaProvider) -> Vec<CompletionItem> {
+/// Build table-name completions for the cursor inside `DB::table('|')` or
+/// right after `DB::table(|`. Reads `DatabaseSchema::get_tables()` and
+/// returns one item per table.
+///
+/// `wrap_with_quote` controls `insert_text` formatting:
+/// - `None` — the source already has quotes around the cursor (user typed
+///   `'` and we're inside it). Insert bare.
+/// - `Some(q)` — the source has no quotes (user just typed `(`). Insert
+///   wrapped: `q + name + q`.
+pub async fn tables(
+    db: &DatabaseSchemaProvider,
+    wrap_with_quote: Option<char>,
+) -> Vec<CompletionItem> {
     db.get_tables()
         .await
         .into_iter()
-        .map(|name| CompletionItem {
-            label: name.clone(),
-            kind: Some(CompletionItemKind::CLASS),
-            detail: Some("table".to_string()),
-            sort_text: Some(format!("1_{name}")),
-            filter_text: Some(name.clone()),
-            insert_text: Some(name),
-            ..Default::default()
+        .map(|name| {
+            let insert_text = match wrap_with_quote {
+                Some(q) => format!("{q}{name}{q}"),
+                None => name.clone(),
+            };
+            CompletionItem {
+                label: name.clone(),
+                kind: Some(CompletionItemKind::CLASS),
+                detail: Some("table".to_string()),
+                sort_text: Some(format!("1_{name}")),
+                filter_text: Some(name),
+                insert_text: Some(insert_text),
+                ..Default::default()
+            }
         })
         .collect()
 }
@@ -49,7 +62,11 @@ pub async fn tables(db: &DatabaseSchemaProvider) -> Vec<CompletionItem> {
 ///   coming out of the cursor resolver, but guarded for safety)
 /// - The database schema isn't introspected yet (cold start, no DB connection,
 ///   or the table doesn't exist in the introspected schema)
-pub async fn columns_raw(ctx: &ChainContext, db: &DatabaseSchemaProvider) -> Vec<CompletionItem> {
+pub async fn columns_raw(
+    ctx: &ChainContext,
+    db: &DatabaseSchemaProvider,
+    wrap_with_quote: Option<char>,
+) -> Vec<CompletionItem> {
     let Some(table) = &ctx.effective_table else {
         return Vec::new();
     };
@@ -58,6 +75,10 @@ pub async fn columns_raw(ctx: &ChainContext, db: &DatabaseSchemaProvider) -> Vec
     columns
         .into_iter()
         .map(|(name, php_type)| {
+            let insert_text = match wrap_with_quote {
+                Some(q) => format!("{q}{name}{q}"),
+                None => name.clone(),
+            };
             CompletionItem {
                 label: name.clone(),
                 kind: Some(CompletionItemKind::FIELD),
@@ -65,8 +86,8 @@ pub async fn columns_raw(ctx: &ChainContext, db: &DatabaseSchemaProvider) -> Vec
                 // DB columns rank first; later modes will add accessors at
                 // sort_text = "2_…" so columns still rank above them.
                 sort_text: Some(format!("1_{name}")),
-                filter_text: Some(name.clone()),
-                insert_text: Some(name),
+                filter_text: Some(name),
+                insert_text: Some(insert_text),
                 ..Default::default()
             }
         })

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -18,7 +18,8 @@
 
 use super::chain::*;
 use crate::database::DatabaseSchemaProvider;
-use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
+use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, CompletionItemLabelDetails};
+use tracing::info;
 
 /// Build table-name completions for the cursor inside `DB::table('|')` or
 /// right after `DB::table(|`. Reads `DatabaseSchema::get_tables()` and
@@ -44,6 +45,13 @@ pub async fn tables(
             CompletionItem {
                 label: name.clone(),
                 kind: Some(CompletionItemKind::CLASS),
+                // Single muted "table" badge to the right of the name. Mirrors
+                // the column-item shape so the popup stays visually consistent
+                // when switching between table-name and column-name positions.
+                label_details: Some(CompletionItemLabelDetails {
+                    detail: None,
+                    description: Some("table".to_string()),
+                }),
                 detail: Some("table".to_string()),
                 sort_text: Some(format!("1_{name}")),
                 filter_text: Some(name),
@@ -68,10 +76,18 @@ pub async fn columns_raw(
     wrap_with_quote: Option<char>,
 ) -> Vec<CompletionItem> {
     let Some(table) = &ctx.effective_table else {
+        info!("🔗 columns_raw: ctx.effective_table is None — returning 0 items");
         return Vec::new();
     };
 
     let columns = db.get_columns_with_types(table).await;
+    if columns.is_empty() {
+        info!(
+            "🔗 columns_raw: get_columns_with_types({:?}) returned 0 columns \
+             (schema cache may not have this table, or DB not yet warmed)",
+            table
+        );
+    }
     columns
         .into_iter()
         .map(|(name, php_type)| {
@@ -82,6 +98,17 @@ pub async fn columns_raw(
             CompletionItem {
                 label: name.clone(),
                 kind: Some(CompletionItemKind::FIELD),
+                // Use `label_details` (LSP 3.17) so the type renders right
+                // next to the column name (e.g., "email   string") and the
+                // source table renders as a dimmer suffix on the right
+                // ("from users"). Editors that support it (Zed, VS Code)
+                // render each piece distinctly; older clients fall back to
+                // `detail` below, which we still set as a single-string
+                // approximation.
+                label_details: Some(CompletionItemLabelDetails {
+                    detail: Some(format!("  {php_type}")),
+                    description: Some(table.clone()),
+                }),
                 detail: Some(format!("{php_type} ({table})")),
                 // DB columns rank first; later modes will add accessors at
                 // sort_text = "2_…" so columns still rank above them.

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -17,7 +17,10 @@
 //! their wiring sites can compile against the same module surface.
 
 use super::chain::*;
+use crate::class_locator::find_php_class_file;
 use crate::database::DatabaseSchemaProvider;
+use crate::model_analyzer::{map_cast_to_php_type, ModelMetadata};
+use std::path::Path;
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, CompletionItemLabelDetails};
 use tracing::info;
 
@@ -120,3 +123,160 @@ pub async fn columns_raw(
         })
         .collect()
 }
+
+/// Build column completions for an `EloquentBuilder` chain — a chain rooted
+/// at a static call on a model class (`User::where('|')`, `User::query()->
+/// where('|')`, `User::firstWhere('|')`, etc.).
+///
+/// Two extra hops compared to [`columns_raw`]:
+/// 1. Resolve the class FQCN in `ctx.effective_model` to a model file path
+///    (uses [`find_php_class_file`]) and parse it to a [`ModelMetadata`].
+/// 2. Determine the table: prefer the model's `$table` property, else
+///    snake-pluralize the class basename (Laravel convention).
+///
+/// Once the table is known, fetch DB columns and apply cast-aware PHP types
+/// — if the model has a cast for a column, the cast's PHP type wins over
+/// the raw SQL → PHP mapping. The cast is also surfaced in `label_details`
+/// so the user can tell at a glance which columns are auto-cast.
+///
+/// Returns an empty `Vec` for any of the failure modes (model not found,
+/// not actually an Eloquent model, table missing from DB schema, etc.) and
+/// logs the cause at INFO so the LSP log is the source of truth for "why
+/// did completion produce nothing here?"
+pub async fn columns_for_builder(
+    ctx: &ChainContext,
+    db: &DatabaseSchemaProvider,
+    wrap_with_quote: Option<char>,
+    project_root: &Path,
+) -> Vec<CompletionItem> {
+    let Some(class) = &ctx.effective_model else {
+        info!("🔗 columns_for_builder: ctx.effective_model is None — returning 0 items");
+        return Vec::new();
+    };
+
+    // Resolve class FQCN → file path.
+    let Some(path) = find_php_class_file(class, project_root) else {
+        info!(
+            "🔗 columns_for_builder: no PHP file found for class {:?} under {:?}",
+            class, project_root
+        );
+        return Vec::new();
+    };
+
+    // Read + parse to ModelMetadata. Async file I/O so the LSP doesn't
+    // block the runtime on slow disks.
+    let content = match tokio::fs::read_to_string(&path).await {
+        Ok(c) => c,
+        Err(err) => {
+            info!("🔗 columns_for_builder: failed to read {:?}: {}", path, err);
+            return Vec::new();
+        }
+    };
+    let metadata = ModelMetadata::from_content(&content);
+
+    // Resolve the table: prefer `$table`, fall back to Laravel's
+    // snake_case + pluralize convention on the class basename. Naive plural
+    // rules — covers >95% of real models. Custom-pluralized models declare
+    // `$table` explicitly.
+    let simple_class = class.rsplit('\\').next().unwrap_or(class);
+    let table = metadata
+        .table_name
+        .clone()
+        .unwrap_or_else(|| snake_pluralize(simple_class));
+
+    let columns = db.get_columns_with_types(&table).await;
+    if columns.is_empty() {
+        info!(
+            "🔗 columns_for_builder: get_columns_with_types({:?}) returned 0 columns \
+             (model class {:?}, resolved file {:?}, table derived from {})",
+            table,
+            class,
+            path,
+            if metadata.table_name.is_some() {
+                "$table property"
+            } else {
+                "snake_pluralize convention"
+            }
+        );
+    }
+
+    columns
+        .into_iter()
+        .map(|(name, sql_php_type)| {
+            // Cast override: if the model declares a cast for this column,
+            // its PHP type wins. Example: a JSON column with
+            // `'options' => 'array'` cast surfaces as `array`, not `string`.
+            let (php_type, has_cast) = match metadata.casts.get(&name) {
+                Some(cast) => (map_cast_to_php_type(cast), true),
+                None => (sql_php_type, false),
+            };
+            let insert_text = match wrap_with_quote {
+                Some(q) => format!("{q}{name}{q}"),
+                None => name.clone(),
+            };
+            // Annotate cast-overridden types so the user can tell at a
+            // glance which columns are model-cast vs raw DB-typed.
+            let detail_suffix = if has_cast { " · cast" } else { "" };
+            CompletionItem {
+                label: name.clone(),
+                kind: Some(CompletionItemKind::FIELD),
+                label_details: Some(CompletionItemLabelDetails {
+                    detail: Some(format!("  {php_type}{detail_suffix}")),
+                    description: Some(table.clone()),
+                }),
+                detail: Some(format!("{php_type}{detail_suffix} ({table})")),
+                sort_text: Some(format!("1_{name}")),
+                filter_text: Some(name),
+                insert_text: Some(insert_text),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+/// Convert a PascalCase class basename to Laravel's default table name:
+/// snake_case + naive pluralization. Models with non-standard pluralization
+/// (people, octopi, child → children) declare `$table` explicitly; this
+/// fallback only covers the convention case.
+///
+/// Examples:
+///   `User` → `users`
+///   `BlogPost` → `blog_posts`
+///   `Category` → `categories`
+///   `Address` → `addresses`
+fn snake_pluralize(class_basename: &str) -> String {
+    // PascalCase → snake_case.
+    let mut snake = String::with_capacity(class_basename.len() + 4);
+    for (i, c) in class_basename.chars().enumerate() {
+        if c.is_uppercase() && i > 0 {
+            snake.push('_');
+        }
+        snake.extend(c.to_lowercase());
+    }
+    // Naive English pluralization rules — match Laravel's
+    // `Str::plural` behavior for the common cases.
+    if snake.ends_with('y')
+        && !snake
+            .chars()
+            .nth_back(1)
+            .map(|c| "aeiou".contains(c))
+            .unwrap_or(false)
+    {
+        // consonant + y → ies (category → categories, but NOT day → daies)
+        snake.pop();
+        snake.push_str("ies");
+    } else if snake.ends_with('s')
+        || snake.ends_with('x')
+        || snake.ends_with('z')
+        || snake.ends_with("ch")
+        || snake.ends_with("sh")
+    {
+        snake.push_str("es");
+    } else {
+        snake.push('s');
+    }
+    snake
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -19,7 +19,7 @@
 use super::chain::*;
 use crate::class_locator::find_php_class_file;
 use crate::database::DatabaseSchemaProvider;
-use crate::model_analyzer::{map_cast_to_php_type, ModelMetadata};
+use crate::model_analyzer::{map_cast_to_php_type, relationship_to_php_type, ModelMetadata};
 use std::path::Path;
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, CompletionItemLabelDetails};
 use tracing::info;
@@ -225,6 +225,96 @@ pub async fn columns_for_builder(
                     description: Some(table.clone()),
                 }),
                 detail: Some(format!("{php_type}{detail_suffix} ({table})")),
+                sort_text: Some(format!("1_{name}")),
+                filter_text: Some(name),
+                insert_text: Some(insert_text),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+/// Build relation completions for an `EloquentBuilder` chain — the first
+/// string arg of methods like `with('|')`, `whereHas('|', closure)`,
+/// `load('|')`, `withCount('|')`, etc.
+///
+/// Reads the model's `ModelMetadata::relationships` (already extracted by
+/// the existing model analyzer — same source the property completion path
+/// uses) and surfaces one item per relationship method, with a
+/// Laravel-aware return type like `HasMany<Post>` or `BelongsTo<User>` in
+/// the popup detail. Items use `CompletionItemKind::REFERENCE` so the
+/// icon matches what users expect for "method that returns something
+/// related."
+///
+/// Returns an empty `Vec` when the model file isn't found or the model
+/// has no relationships. Same failure-mode pattern as
+/// [`columns_for_builder`]: log INFO and yield empty so the LSP log is
+/// the source of truth.
+///
+/// Base-builder chains (`DB::table(...)`) never reach here — the handler
+/// dispatch returns empty for `(BaseBuilder, Relation)`. That's
+/// load-bearing: Query Builder doesn't have relation methods, so a `with`
+/// on a `DB::table()` chain is user error and we shouldn't pretend
+/// otherwise by listing relations.
+pub async fn relations(
+    ctx: &ChainContext,
+    wrap_with_quote: Option<char>,
+    project_root: &Path,
+) -> Vec<CompletionItem> {
+    let Some(class) = &ctx.effective_model else {
+        info!("🔗 relations: ctx.effective_model is None — returning 0 items");
+        return Vec::new();
+    };
+
+    let Some(path) = find_php_class_file(class, project_root) else {
+        info!(
+            "🔗 relations: no PHP file found for class {:?} under {:?}",
+            class, project_root
+        );
+        return Vec::new();
+    };
+
+    let content = match tokio::fs::read_to_string(&path).await {
+        Ok(c) => c,
+        Err(err) => {
+            info!("🔗 relations: failed to read {:?}: {}", path, err);
+            return Vec::new();
+        }
+    };
+    let metadata = ModelMetadata::from_content(&content);
+
+    if metadata.relationships.is_empty() {
+        info!(
+            "🔗 relations: model {:?} (file {:?}) has no relationships extracted",
+            class, path
+        );
+    }
+
+    metadata
+        .relationships
+        .into_iter()
+        .map(|rel| {
+            let php_type =
+                relationship_to_php_type(&rel.relationship_type, rel.related_model.as_deref());
+            let name = rel.method_name;
+            let insert_text = match wrap_with_quote {
+                Some(q) => format!("{q}{name}{q}"),
+                None => name.clone(),
+            };
+            CompletionItem {
+                label: name.clone(),
+                // REFERENCE icon — semantically "this points to another
+                // entity," which matches relationships better than FIELD
+                // (column) or CLASS (table).
+                kind: Some(CompletionItemKind::REFERENCE),
+                label_details: Some(CompletionItemLabelDetails {
+                    detail: Some(format!("  {php_type}")),
+                    description: Some(rel.relationship_type.clone()),
+                }),
+                detail: Some(format!("{php_type} ({})", rel.relationship_type)),
+                // Same `1_` prefix as columns so when both are surfaced
+                // (different ArgKind branches in the handler, so they
+                // shouldn't collide in practice) they rank together.
                 sort_text: Some(format!("1_{name}")),
                 filter_text: Some(name),
                 insert_text: Some(insert_text),

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -324,6 +324,34 @@ pub async fn relations(
         .collect()
 }
 
+/// Phase 8 helper: walk one relation hop. Given a parent class name and
+/// a relation name, find the parent's model file, read its
+/// `ModelMetadata::relationships`, and return the related model class.
+///
+/// Used when the cursor is inside a relation closure like
+/// `OAuthClient::with(['tokens' => fn ($q) => $q->where('|')])` — we know
+/// the parent model (`OAuthClient`) and the relation name (`tokens`), and
+/// need the related model (e.g. `OAuthToken`) so column/relation
+/// completion runs against the correct class.
+///
+/// Returns `None` when the parent file can't be located, the
+/// relation isn't defined on the parent, or the relation has no
+/// resolvable `related_model` (e.g. a polymorphic `morphTo`).
+pub async fn resolve_related_model(
+    parent_class: &str,
+    relation_name: &str,
+    project_root: &Path,
+) -> Option<String> {
+    let path = find_php_class_file(parent_class, project_root)?;
+    let content = tokio::fs::read_to_string(&path).await.ok()?;
+    let metadata = ModelMetadata::from_content(&content);
+    let rel = metadata
+        .relationships
+        .into_iter()
+        .find(|r| r.method_name == relation_name)?;
+    rel.related_model
+}
+
 /// Convert a PascalCase class basename to Laravel's default table name:
 /// snake_case + naive pluralization. Models with non-standard pluralization
 /// (people, octopi, child → children) declare `$table` explicitly; this

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -1,0 +1,53 @@
+//! Build LSP `CompletionItem`s from a resolved [`ChainContext`].
+//!
+//! Three column-completion helpers, picked by `BuilderMode`:
+//!
+//! - [`columns_raw`] — DB schema only. Used by `BaseBuilder` chains
+//!   (`DB::table(...)` and post-`toBase()` Eloquent chains). No casts, no
+//!   accessors, no relations.
+//! - `columns_for_builder` (Phase 4) — DB columns with cast-aware PHP types
+//!   in `detail`. Eloquent builder pre-execution.
+//! - `columns_for_collection` (Phase 6) — DB columns + accessors + cast
+//!   property names. Eloquent collection post-execution.
+//!
+//! `relations` (Phase 5) — Eloquent-only relation list for `with()` /
+//! `whereHas()` / `load()` etc.
+//!
+//! Phase 3 ships only `columns_raw`. The other functions are stubbed so
+//! their wiring sites can compile against the same module surface.
+
+use super::chain::*;
+use crate::database::DatabaseSchemaProvider;
+use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
+
+/// Build column completions for a `BaseBuilder` chain. Reads the schema
+/// directly — no model lookup, no casts, no accessors.
+///
+/// Returns an empty `Vec` when:
+/// - The context has no `effective_table` (shouldn't happen for Base chains
+///   coming out of the cursor resolver, but guarded for safety)
+/// - The database schema isn't introspected yet (cold start, no DB connection,
+///   or the table doesn't exist in the introspected schema)
+pub async fn columns_raw(ctx: &ChainContext, db: &DatabaseSchemaProvider) -> Vec<CompletionItem> {
+    let Some(table) = &ctx.effective_table else {
+        return Vec::new();
+    };
+
+    let columns = db.get_columns_with_types(table).await;
+    columns
+        .into_iter()
+        .map(|(name, php_type)| {
+            CompletionItem {
+                label: name.clone(),
+                kind: Some(CompletionItemKind::FIELD),
+                detail: Some(format!("{php_type} ({table})")),
+                // DB columns rank first; later modes will add accessors at
+                // sort_text = "2_…" so columns still rank above them.
+                sort_text: Some(format!("1_{name}")),
+                filter_text: Some(name.clone()),
+                insert_text: Some(name),
+                ..Default::default()
+            }
+        })
+        .collect()
+}

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -163,16 +163,31 @@ pub async fn columns_for_builder(
         return Vec::new();
     };
 
-    // Read + parse to ModelMetadata. Async file I/O so the LSP doesn't
-    // block the runtime on slow disks.
-    let content = match tokio::fs::read_to_string(&path).await {
-        Ok(c) => c,
+    // Read + parse to ModelMetadata, walking `extends` chains so the
+    // child inherits its parent's `$table` / casts / accessors /
+    // relationships when it doesn't declare them itself. Runs the sync
+    // walker on a blocking thread so the LSP runtime stays responsive
+    // even for deep inheritance trees on slow disks.
+    let path_for_blocking = path.clone();
+    let root_for_blocking = project_root.to_path_buf();
+    let metadata = match tokio::task::spawn_blocking(move || {
+        ModelMetadata::from_file_with_inheritance(&path_for_blocking, &root_for_blocking)
+    })
+    .await
+    {
+        Ok(Some(m)) => m,
+        Ok(None) => {
+            info!(
+                "🔗 columns_for_builder: failed to read/parse {:?} (or no inheritable parent found)",
+                path
+            );
+            return Vec::new();
+        }
         Err(err) => {
-            info!("🔗 columns_for_builder: failed to read {:?}: {}", path, err);
+            info!("🔗 columns_for_builder: blocking task panicked: {}", err);
             return Vec::new();
         }
     };
-    let metadata = ModelMetadata::from_content(&content);
 
     // Resolve the table: prefer `$table`, fall back to Laravel's
     // snake_case + pluralize convention on the class basename. Naive plural
@@ -274,14 +289,25 @@ pub async fn relations(
         return Vec::new();
     };
 
-    let content = match tokio::fs::read_to_string(&path).await {
-        Ok(c) => c,
+    // Walk `extends` chain so child classes pick up relationships
+    // declared on their parents.
+    let path_for_blocking = path.clone();
+    let root_for_blocking = project_root.to_path_buf();
+    let metadata = match tokio::task::spawn_blocking(move || {
+        ModelMetadata::from_file_with_inheritance(&path_for_blocking, &root_for_blocking)
+    })
+    .await
+    {
+        Ok(Some(m)) => m,
+        Ok(None) => {
+            info!("🔗 relations: failed to read/parse {:?}", path);
+            return Vec::new();
+        }
         Err(err) => {
-            info!("🔗 relations: failed to read {:?}: {}", path, err);
+            info!("🔗 relations: blocking task panicked: {}", err);
             return Vec::new();
         }
     };
-    let metadata = ModelMetadata::from_content(&content);
 
     if metadata.relationships.is_empty() {
         info!(
@@ -343,8 +369,16 @@ pub async fn resolve_related_model(
     project_root: &Path,
 ) -> Option<String> {
     let path = find_php_class_file(parent_class, project_root)?;
-    let content = tokio::fs::read_to_string(&path).await.ok()?;
-    let metadata = ModelMetadata::from_content(&content);
+    // Inheritance-aware: a relationship declared on the parent class
+    // should be findable when the chain is rooted at a child class.
+    let path_clone = path.clone();
+    let root_clone = project_root.to_path_buf();
+    let metadata = tokio::task::spawn_blocking(move || {
+        ModelMetadata::from_file_with_inheritance(&path_clone, &root_clone)
+    })
+    .await
+    .ok()
+    .flatten()?;
     let rel = metadata
         .relationships
         .into_iter()

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -20,6 +20,27 @@ use super::chain::*;
 use crate::database::DatabaseSchemaProvider;
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
 
+/// Build table-name completions for the cursor inside `DB::table('|')`.
+/// Reads `DatabaseSchema::get_tables()` and returns one item per table.
+/// Independent of `BuilderMode` — `DB::table` is always BaseBuilder by the
+/// time anything chains off it, but at this point in the chain we're
+/// completing the chain *entry* itself.
+pub async fn tables(db: &DatabaseSchemaProvider) -> Vec<CompletionItem> {
+    db.get_tables()
+        .await
+        .into_iter()
+        .map(|name| CompletionItem {
+            label: name.clone(),
+            kind: Some(CompletionItemKind::CLASS),
+            detail: Some("table".to_string()),
+            sort_text: Some(format!("1_{name}")),
+            filter_text: Some(name.clone()),
+            insert_text: Some(name),
+            ..Default::default()
+        })
+        .collect()
+}
+
 /// Build column completions for a `BaseBuilder` chain. Reads the schema
 /// directly — no model lookup, no casts, no accessors.
 ///

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -386,6 +386,105 @@ pub async fn resolve_related_model(
     rel.related_model
 }
 
+/// Phase 6 helper: resolve a model class to its table name.
+///
+/// Used for the post-`->toBase()` case where the chain has flipped to
+/// `BuilderMode::BaseBuilder` but `effective_table` is still `None` —
+/// we know the model, we just haven't asked which table it points at.
+///
+/// Reads `ModelMetadata` (with inheritance walking, so subclasses of a
+/// vendor model inherit the parent's `$table`), then either returns the
+/// explicit `$table` or falls back to snake_pluralize of the class
+/// basename.
+pub async fn resolve_table_for_model(class: &str, project_root: &Path) -> Option<String> {
+    let path = find_php_class_file(class, project_root)?;
+    let path_clone = path.clone();
+    let root_clone = project_root.to_path_buf();
+    let metadata = tokio::task::spawn_blocking(move || {
+        ModelMetadata::from_file_with_inheritance(&path_clone, &root_clone)
+    })
+    .await
+    .ok()
+    .flatten()?;
+    let simple_class = class.rsplit('\\').next().unwrap_or(class);
+    Some(
+        metadata
+            .table_name
+            .unwrap_or_else(|| snake_pluralize(simple_class)),
+    )
+}
+
+/// Phase 6: column completion for an `EloquentCollection` chain — a
+/// chain that's been executed via `->get()` / `->all()` / `->pluck()` /
+/// `->cursor()` etc. After execution, the result is a hydrated
+/// `Collection<Model>` and Collection's `where()` filters in MEMORY
+/// against model property access — not SQL. That means accessors
+/// (`getFullNameAttribute`, `Attribute::make(get:)`) are valid `where()`
+/// args even though they don't exist as DB columns.
+///
+/// Returns DB columns (with cast-aware types) FIRST, then accessor items
+/// after them via sort_text ordering. Accessors are kinded as `PROPERTY`
+/// to visually distinguish them from `FIELD` DB columns.
+pub async fn columns_for_collection(
+    ctx: &ChainContext,
+    db: &DatabaseSchemaProvider,
+    wrap_with_quote: Option<char>,
+    project_root: &Path,
+) -> Vec<CompletionItem> {
+    // Start with DB columns + cast-aware types — same set the builder
+    // mode returns. Collection adds to this; doesn't replace.
+    let mut items = columns_for_builder(ctx, db, wrap_with_quote, project_root).await;
+
+    // Add accessors. Read metadata again (cheap: OS cache + tokio
+    // blocking pool); we don't plumb metadata through columns_for_builder's
+    // return since the helper's signature is shaped for the pre-execution
+    // case where accessors don't apply.
+    let Some(class) = &ctx.effective_model else {
+        return items;
+    };
+    let Some(path) = find_php_class_file(class, project_root) else {
+        return items;
+    };
+    let path_clone = path.clone();
+    let root_clone = project_root.to_path_buf();
+    let metadata = match tokio::task::spawn_blocking(move || {
+        ModelMetadata::from_file_with_inheritance(&path_clone, &root_clone)
+    })
+    .await
+    {
+        Ok(Some(m)) => m,
+        _ => return items,
+    };
+
+    for accessor in metadata.accessors {
+        let name = accessor.property_name;
+        let php_type = accessor.return_type.unwrap_or_else(|| "mixed".to_string());
+        let insert_text = match wrap_with_quote {
+            Some(q) => format!("{q}{name}{q}"),
+            None => name.clone(),
+        };
+        items.push(CompletionItem {
+            label: name.clone(),
+            // PROPERTY kind — semantically "computed property of the
+            // hydrated model", distinct from FIELD (DB column).
+            kind: Some(CompletionItemKind::PROPERTY),
+            label_details: Some(CompletionItemLabelDetails {
+                detail: Some(format!("  {php_type}")),
+                description: Some("accessor".to_string()),
+            }),
+            detail: Some(format!("{php_type} (accessor)")),
+            // Sort AFTER DB columns (which use "1_…"). When the popup
+            // is fuzzy-filtered the explicit DB columns rank first.
+            sort_text: Some(format!("2_{name}")),
+            filter_text: Some(name),
+            insert_text: Some(insert_text),
+            ..Default::default()
+        });
+    }
+
+    items
+}
+
 /// Convert a PascalCase class basename to Laravel's default table name:
 /// snake_case + naive pluralization. Models with non-standard pluralization
 /// (people, octopi, child → children) declare `$table` explicitly; this

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -1,0 +1,245 @@
+use super::*;
+
+// ---- snake_pluralize: Laravel convention `Str::plural(snake_case($class))` --
+
+#[test]
+fn snake_pluralize_single_word_pascal() {
+    assert_eq!(snake_pluralize("User"), "users");
+    assert_eq!(snake_pluralize("Post"), "posts");
+}
+
+#[test]
+fn snake_pluralize_multi_word_pascal() {
+    // BlogPost → blog_posts. The `_` insertion happens *before* the
+    // pluralization step, so the suffix logic operates on the snake form.
+    assert_eq!(snake_pluralize("BlogPost"), "blog_posts");
+    assert_eq!(snake_pluralize("UserProfile"), "user_profiles");
+    assert_eq!(snake_pluralize("OrderLineItem"), "order_line_items");
+}
+
+#[test]
+fn snake_pluralize_consonant_y_becomes_ies() {
+    // category → categories, country → countries.
+    assert_eq!(snake_pluralize("Category"), "categories");
+    assert_eq!(snake_pluralize("Country"), "countries");
+}
+
+#[test]
+fn snake_pluralize_vowel_y_just_adds_s() {
+    // day → days (NOT daies). The vowel-before-y check guards against the
+    // ies rule kicking in for words like "play", "boy", "key", "day".
+    assert_eq!(snake_pluralize("Day"), "days");
+    assert_eq!(snake_pluralize("Key"), "keys");
+    assert_eq!(snake_pluralize("Boy"), "boys");
+}
+
+#[test]
+fn snake_pluralize_sibilants_add_es() {
+    // address → addresses, box → boxes, watch → watches, dish → dishes.
+    assert_eq!(snake_pluralize("Address"), "addresses");
+    assert_eq!(snake_pluralize("Box"), "boxes");
+    assert_eq!(snake_pluralize("Watch"), "watches");
+    assert_eq!(snake_pluralize("Dish"), "dishes");
+}
+
+#[test]
+fn snake_pluralize_single_letter_class() {
+    // Pathological but should not panic: a single uppercase letter
+    // shouldn't trigger the `i > 0` underscore insertion.
+    assert_eq!(snake_pluralize("A"), "as");
+}
+
+// ---- columns_for_builder: model resolution + table derivation -------------
+
+use crate::database::DatabaseSchemaProvider;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// Helper: spin up a tempdir with a writeable model file at the standard
+/// Laravel `app/Models/` location. Returns the tempdir handle (which the
+/// caller must hold to keep the dir alive) and the project root path.
+fn project_with_model(class_name: &str, model_body: &str) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let models_dir = dir.path().join("app").join("Models");
+    std::fs::create_dir_all(&models_dir).expect("create models dir");
+    let file = models_dir.join(format!("{class_name}.php"));
+    std::fs::write(&file, model_body).expect("write model");
+    let root = dir.path().to_path_buf();
+    (dir, root)
+}
+
+/// Helper: build a minimal `DatabaseSchemaProvider` and seed its cache
+/// directly so the test doesn't need a live MySQL/Postgres. The provider's
+/// public surface includes `set_test_schema` (test-only) for exactly this.
+async fn provider_with_table(
+    root: PathBuf,
+    table: &str,
+    columns: Vec<(&str, &str)>,
+) -> DatabaseSchemaProvider {
+    use crate::database::DatabaseSchema;
+    use std::collections::HashMap;
+    use std::time::Instant;
+
+    let mut columns_map = HashMap::new();
+    let mut columns_with_types = HashMap::new();
+    columns_map.insert(
+        table.to_string(),
+        columns.iter().map(|(n, _)| n.to_string()).collect(),
+    );
+    columns_with_types.insert(
+        table.to_string(),
+        columns
+            .iter()
+            .map(|(n, t)| (n.to_string(), t.to_string()))
+            .collect(),
+    );
+    let schema = DatabaseSchema {
+        tables: vec![table.to_string()],
+        columns: columns_map,
+        columns_with_types,
+        cached_at: Instant::now(),
+    };
+    let provider = DatabaseSchemaProvider::new(root);
+    provider.set_test_schema(schema).await;
+    provider
+}
+
+fn make_ctx(class: &str) -> ChainContext {
+    ChainContext {
+        mode: BuilderMode::EloquentBuilder,
+        effective_table: None,
+        effective_model: Some(class.to_string()),
+        expecting: ArgKind::Column,
+        dotted_prefix: None,
+        quote: '\'',
+    }
+}
+
+#[tokio::test]
+async fn columns_for_builder_uses_explicit_table_property() {
+    // Model declares `$table = 'people'` — the snake_pluralize fallback
+    // ("Person" → "persons") should NOT fire.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Person extends Model {
+    protected $table = 'people';
+}
+"#;
+    let (_dir, root) = project_with_model("Person", body);
+    let db = provider_with_table(
+        root.clone(),
+        "people",
+        vec![("id", "int"), ("full_name", "string")],
+    )
+    .await;
+    let ctx = make_ctx("App\\Models\\Person");
+    let items = columns_for_builder(&ctx, &db, None, &root).await;
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert_eq!(labels, vec!["id", "full_name"]);
+}
+
+#[tokio::test]
+async fn columns_for_builder_falls_back_to_snake_pluralize() {
+    // No `$table` property — the helper should derive the table from the
+    // class basename via snake_pluralize ("User" → "users").
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let db = provider_with_table(
+        root.clone(),
+        "users",
+        vec![("id", "int"), ("email", "string")],
+    )
+    .await;
+    let ctx = make_ctx("App\\Models\\User");
+    let items = columns_for_builder(&ctx, &db, None, &root).await;
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert_eq!(labels, vec!["id", "email"]);
+}
+
+#[tokio::test]
+async fn columns_for_builder_applies_cast_override() {
+    // Model declares `$casts = ['options' => 'array']`. The DB column type
+    // is `string` (JSON column), but the cast should win in the popup's
+    // detail string.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Setting extends Model {
+    protected $casts = [
+        'options' => 'array',
+    ];
+}
+"#;
+    let (_dir, root) = project_with_model("Setting", body);
+    let db = provider_with_table(
+        root.clone(),
+        "settings",
+        vec![("id", "int"), ("options", "string")],
+    )
+    .await;
+    let ctx = make_ctx("App\\Models\\Setting");
+    let items = columns_for_builder(&ctx, &db, None, &root).await;
+    let options_item = items
+        .iter()
+        .find(|i| i.label == "options")
+        .expect("options column");
+    let detail = options_item.detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains("array"),
+        "cast type should win in detail; got: {detail:?}"
+    );
+    assert!(
+        detail.contains("cast"),
+        "cast-overridden columns should be annotated; got: {detail:?}"
+    );
+}
+
+#[tokio::test]
+async fn columns_for_builder_returns_empty_when_class_file_missing() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let db = provider_with_table(root.clone(), "ghosts", vec![("id", "int")]).await;
+    let ctx = make_ctx("App\\Models\\Ghost"); // no file written
+    let items = columns_for_builder(&ctx, &db, None, &root).await;
+    assert!(items.is_empty());
+}
+
+#[tokio::test]
+async fn columns_for_builder_returns_empty_when_table_not_in_schema() {
+    // Model file exists, but the DB schema doesn't have the table.
+    // Could happen if introspection hasn't finished or the model points
+    // to a table that doesn't exist.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Phantom extends Model {}
+"#;
+    let (_dir, root) = project_with_model("Phantom", body);
+    let db = provider_with_table(root.clone(), "users", vec![("id", "int")]).await;
+    let ctx = make_ctx("App\\Models\\Phantom");
+    let items = columns_for_builder(&ctx, &db, None, &root).await;
+    assert!(items.is_empty());
+}
+
+#[tokio::test]
+async fn columns_for_builder_wraps_insert_text_when_no_source_quotes() {
+    // Mirror of the table-completion behavior: if the cursor sits right
+    // after `(` with no quotes typed, the insertion needs to wrap the
+    // value in quotes so the resulting source is a valid string literal.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let db = provider_with_table(root.clone(), "users", vec![("email", "string")]).await;
+    let ctx = make_ctx("App\\Models\\User");
+    let items = columns_for_builder(&ctx, &db, Some('\''), &root).await;
+    let item = items.iter().find(|i| i.label == "email").expect("email");
+    assert_eq!(item.insert_text.as_deref(), Some("'email'"));
+}

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -530,3 +530,199 @@ async fn columns_for_collection_falls_back_when_model_missing() {
     let items = columns_for_collection(&ctx, &db, None, &root).await;
     assert!(items.is_empty());
 }
+
+// ---- walk_dotted_hops (Phase 7) ------------------------------------------
+
+/// Helper: scaffolding for the relation-hop tests. Build a tempdir with
+/// the given (class_name, body) model files, then return the root.
+async fn project_with_models_helper(files: &[(&str, &str)]) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let models_dir = dir.path().join("app/Models");
+    std::fs::create_dir_all(&models_dir).unwrap();
+    for (name, body) in files {
+        std::fs::write(models_dir.join(format!("{name}.php")), body).unwrap();
+    }
+    let root = dir.path().to_path_buf();
+    (dir, root)
+}
+
+#[tokio::test]
+async fn walk_dotted_hops_empty_prefix_returns_starting_model() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let resolved = walk_dotted_hops("App\\Models\\User", "", &root).await;
+    assert_eq!(resolved.as_deref(), Some("App\\Models\\User"));
+}
+
+#[tokio::test]
+async fn walk_dotted_hops_single_segment_one_hop() {
+    let (_dir, root) = project_with_models_helper(&[
+        (
+            "User",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() { return $this->hasMany(Post::class); }
+}
+"#,
+        ),
+        (
+            "Post",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Post extends Model {}
+"#,
+        ),
+    ])
+    .await;
+    let resolved = walk_dotted_hops("App\\Models\\User", "posts", &root).await;
+    assert_eq!(resolved.as_deref(), Some("Post"));
+}
+
+#[tokio::test]
+async fn walk_dotted_hops_multi_segment_chains_relations() {
+    let (_dir, root) = project_with_models_helper(&[
+        (
+            "User",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() { return $this->hasMany(Post::class); }
+}
+"#,
+        ),
+        (
+            "Post",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Post extends Model {
+    public function author() { return $this->belongsTo(Author::class); }
+}
+"#,
+        ),
+        (
+            "Author",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Author extends Model {
+    public function profile() { return $this->hasOne(Profile::class); }
+}
+"#,
+        ),
+        (
+            "Profile",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Profile extends Model {}
+"#,
+        ),
+    ])
+    .await;
+    let resolved = walk_dotted_hops("App\\Models\\User", "posts.author.profile", &root).await;
+    assert_eq!(
+        resolved.as_deref(),
+        Some("Profile"),
+        "three hops should land at Profile"
+    );
+}
+
+#[tokio::test]
+async fn walk_dotted_hops_unresolved_segment_returns_none() {
+    let (_dir, root) = project_with_models_helper(&[(
+        "User",
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() { return $this->hasMany(Post::class); }
+}
+"#,
+    )])
+    .await;
+    // User has `posts` but no `nonexistent` relation.
+    let resolved = walk_dotted_hops("App\\Models\\User", "nonexistent", &root).await;
+    assert!(resolved.is_none(), "missing relation should yield None");
+}
+
+// ---- relations with dotted_prefix (Phase 7) ------------------------------
+
+#[tokio::test]
+async fn relations_walks_dotted_prefix_to_final_models_relations() {
+    // `User::with('posts.|')` — should resolve `posts` to Post, then
+    // return Post's relations (Author).
+    let (_dir, root) = project_with_models_helper(&[
+        (
+            "User",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() { return $this->hasMany(Post::class); }
+}
+"#,
+        ),
+        (
+            "Post",
+            r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Post extends Model {
+    public function author() { return $this->belongsTo(Author::class); }
+    public function comments() { return $this->hasMany(Comment::class); }
+}
+"#,
+        ),
+    ])
+    .await;
+    let ctx = ChainContext {
+        mode: BuilderMode::EloquentBuilder,
+        effective_table: None,
+        effective_model: Some("App\\Models\\User".to_string()),
+        expecting: ArgKind::Relation,
+        dotted_prefix: Some("posts".to_string()),
+        closure_relation_hop: None,
+        quote: '\'',
+    };
+    let items = relations(&ctx, None, &root).await;
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"author"),
+        "expected Post::author in dotted-path result; got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"comments"),
+        "expected Post::comments; got {labels:?}"
+    );
+}
+
+#[tokio::test]
+async fn relations_with_failing_dotted_hop_returns_empty() {
+    let (_dir, root) = project_with_models_helper(&[(
+        "User",
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() { return $this->hasMany(Post::class); }
+}
+"#,
+    )])
+    .await;
+    let ctx = ChainContext {
+        mode: BuilderMode::EloquentBuilder,
+        effective_table: None,
+        effective_model: Some("App\\Models\\User".to_string()),
+        expecting: ArgKind::Relation,
+        dotted_prefix: Some("nonexistent".to_string()),
+        closure_relation_hop: None,
+        quote: '\'',
+    };
+    let items = relations(&ctx, None, &root).await;
+    assert!(items.is_empty(), "unresolvable hop should yield no items");
+}

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -400,3 +400,133 @@ class User extends Model {
     let posts = items.iter().find(|i| i.label == "posts").expect("posts");
     assert_eq!(posts.insert_text.as_deref(), Some("'posts'"));
 }
+
+// ---- resolve_table_for_model (Phase 6) -----------------------------------
+
+#[tokio::test]
+async fn resolve_table_for_model_uses_explicit_table() {
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Person extends Model {
+    protected $table = 'people';
+}
+"#;
+    let (_dir, root) = project_with_model("Person", body);
+    let table = resolve_table_for_model("App\\Models\\Person", &root).await;
+    assert_eq!(table.as_deref(), Some("people"));
+}
+
+#[tokio::test]
+async fn resolve_table_for_model_falls_back_to_snake_pluralize() {
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class BlogPost extends Model {}
+"#;
+    let (_dir, root) = project_with_model("BlogPost", body);
+    let table = resolve_table_for_model("App\\Models\\BlogPost", &root).await;
+    assert_eq!(table.as_deref(), Some("blog_posts"));
+}
+
+// ---- columns_for_collection (Phase 6) ------------------------------------
+
+#[tokio::test]
+async fn columns_for_collection_includes_db_columns_and_accessors() {
+    // Collection's where() filters in-memory against properties, so
+    // both DB columns AND model accessors are valid args.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function getFullNameAttribute(): string {
+        return $this->first_name . ' ' . $this->last_name;
+    }
+}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let db = provider_with_table(
+        root.clone(),
+        "users",
+        vec![
+            ("id", "int"),
+            ("first_name", "string"),
+            ("last_name", "string"),
+        ],
+    )
+    .await;
+    let ctx = make_ctx("App\\Models\\User");
+    let items = columns_for_collection(&ctx, &db, None, &root).await;
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    // DB columns present
+    assert!(labels.contains(&"id"), "missing id; got {labels:?}");
+    assert!(
+        labels.contains(&"first_name"),
+        "missing first_name; got {labels:?}"
+    );
+    // Accessor present
+    assert!(
+        labels.contains(&"full_name"),
+        "accessor 'full_name' should be a Collection-mode completion; got {labels:?}"
+    );
+}
+
+#[tokio::test]
+async fn columns_for_collection_ranks_db_columns_before_accessors() {
+    // DB columns sort_text = "1_…", accessors = "2_…", so DB columns
+    // win in popup ordering when both match the user's filter.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function getNameAttribute(): string {
+        return $this->first_name;
+    }
+}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let db = provider_with_table(
+        root.clone(),
+        "users",
+        vec![("id", "int"), ("name", "string")],
+    )
+    .await;
+    let ctx = make_ctx("App\\Models\\User");
+    let items = columns_for_collection(&ctx, &db, None, &root).await;
+    // Find the DB column "name" and the accessor "name" (same label —
+    // both exist when the column name and accessor name collide).
+    let name_items: Vec<&CompletionItem> = items.iter().filter(|i| i.label == "name").collect();
+    // There may be one or two — depending on whether a DB column
+    // "name" actually exists. Our schema has one, the accessor also
+    // exposes "name". They're separate items in the list.
+    assert!(
+        !name_items.is_empty(),
+        "should have at least one 'name' item"
+    );
+    // The DB-column item ranks with "1_", the accessor with "2_". If
+    // both are present, the DB one comes first lexicographically.
+    let sort_texts: Vec<&str> = name_items
+        .iter()
+        .map(|i| i.sort_text.as_deref().unwrap_or(""))
+        .collect();
+    if sort_texts.len() == 2 {
+        assert!(
+            sort_texts.iter().any(|s| s.starts_with("1_")),
+            "DB column should have 1_ prefix; got {sort_texts:?}"
+        );
+        assert!(
+            sort_texts.iter().any(|s| s.starts_with("2_")),
+            "accessor should have 2_ prefix; got {sort_texts:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn columns_for_collection_falls_back_when_model_missing() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let db = provider_with_table(root.clone(), "users", vec![("id", "int")]).await;
+    let ctx = make_ctx("App\\Models\\Phantom");
+    let items = columns_for_collection(&ctx, &db, None, &root).await;
+    assert!(items.is_empty());
+}

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -243,3 +243,116 @@ class User extends Model {}
     let item = items.iter().find(|i| i.label == "email").expect("email");
     assert_eq!(item.insert_text.as_deref(), Some("'email'"));
 }
+
+// ---- relations: Eloquent relation-name completion (Phase 5) -------------
+
+#[tokio::test]
+async fn relations_surfaces_model_relationships() {
+    // Standard relationship shapes: hasMany, belongsTo, hasOne. The
+    // existing ModelMetadata extractor finds all three; the helper just
+    // formats them as completion items.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() {
+        return $this->hasMany(Post::class);
+    }
+    public function company() {
+        return $this->belongsTo(Company::class);
+    }
+    public function profile() {
+        return $this->hasOne(Profile::class);
+    }
+}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let ctx = make_ctx("App\\Models\\User");
+    let items = relations(&ctx, None, &root).await;
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"posts"),
+        "expected `posts`; got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"company"),
+        "expected `company`; got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"profile"),
+        "expected `profile`; got {labels:?}"
+    );
+}
+
+#[tokio::test]
+async fn relations_includes_related_model_in_detail() {
+    // The completion item's detail should surface the related model class
+    // (e.g., `HasMany<Post>`) so the user can tell at a glance what the
+    // relation points to.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() {
+        return $this->hasMany(Post::class);
+    }
+}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let ctx = make_ctx("App\\Models\\User");
+    let items = relations(&ctx, None, &root).await;
+    let posts = items.iter().find(|i| i.label == "posts").expect("posts");
+    let detail = posts.detail.as_deref().unwrap_or("");
+    assert!(
+        detail.contains("Post"),
+        "related model should appear in detail; got {detail:?}"
+    );
+    assert!(
+        detail.contains("hasMany"),
+        "relationship type should appear in detail; got {detail:?}"
+    );
+}
+
+#[tokio::test]
+async fn relations_returns_empty_when_model_file_missing() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let ctx = make_ctx("App\\Models\\Phantom");
+    let items = relations(&ctx, None, &root).await;
+    assert!(items.is_empty());
+}
+
+#[tokio::test]
+async fn relations_returns_empty_when_model_has_no_relationships() {
+    // Plain model — no relationship methods defined. Should yield empty,
+    // not crash, not pretend.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Bare extends Model {}
+"#;
+    let (_dir, root) = project_with_model("Bare", body);
+    let ctx = make_ctx("App\\Models\\Bare");
+    let items = relations(&ctx, None, &root).await;
+    assert!(items.is_empty());
+}
+
+#[tokio::test]
+async fn relations_wraps_insert_text_when_no_source_quotes() {
+    // Same shape as columns_for_builder — wrap with quotes when the
+    // source has none (case-3 fixup path).
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() {
+        return $this->hasMany(Post::class);
+    }
+}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let ctx = make_ctx("App\\Models\\User");
+    let items = relations(&ctx, Some('\''), &root).await;
+    let posts = items.iter().find(|i| i.label == "posts").expect("posts");
+    assert_eq!(posts.insert_text.as_deref(), Some("'posts'"));
+}

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -111,6 +111,7 @@ fn make_ctx(class: &str) -> ChainContext {
         effective_model: Some(class.to_string()),
         expecting: ArgKind::Column,
         dotted_prefix: None,
+        closure_relation_hop: None,
         quote: '\'',
     }
 }
@@ -335,6 +336,49 @@ class Bare extends Model {}
     let ctx = make_ctx("App\\Models\\Bare");
     let items = relations(&ctx, None, &root).await;
     assert!(items.is_empty());
+}
+
+// ---- resolve_related_model (Phase 8): one-hop relation walk ------------
+
+#[tokio::test]
+async fn resolve_related_model_finds_target_class() {
+    // Parent model declares `tokens` as `hasMany(OAuthToken::class)`. The
+    // helper should return "OAuthToken" so the closure-scope hop can use
+    // it as the effective model for the inner chain.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class OAuthClient extends Model {
+    public function tokens() {
+        return $this->hasMany(OAuthToken::class);
+    }
+}
+"#;
+    let (_dir, root) = project_with_model("OAuthClient", body);
+    let related = resolve_related_model("App\\Models\\OAuthClient", "tokens", &root).await;
+    assert_eq!(related.as_deref(), Some("OAuthToken"));
+}
+
+#[tokio::test]
+async fn resolve_related_model_returns_none_when_relation_missing() {
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() { return $this->hasMany(Post::class); }
+}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let related = resolve_related_model("App\\Models\\User", "comments", &root).await;
+    assert!(related.is_none(), "missing relation should yield None");
+}
+
+#[tokio::test]
+async fn resolve_related_model_returns_none_when_class_file_missing() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let related = resolve_related_model("App\\Models\\Ghost", "anything", &root).await;
+    assert!(related.is_none());
 }
 
 #[tokio::test]

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -342,9 +342,13 @@ class Bare extends Model {}
 
 #[tokio::test]
 async fn resolve_related_model_finds_target_class() {
-    // Parent model declares `tokens` as `hasMany(OAuthToken::class)`. The
-    // helper should return "OAuthToken" so the closure-scope hop can use
-    // it as the effective model for the inner chain.
+    // Parent model declares `tokens` as `hasMany(OAuthToken::class)`.
+    // Phase 5.11 resolves the bare `OAuthToken::class` reference through
+    // the source file's namespace, so the helper returns the FQCN
+    // `App\Models\OAuthToken`. Storing the FQCN (not just the basename)
+    // is what makes dotted-path walking work for relationships whose
+    // related model lives in a different namespace from a basename
+    // collision elsewhere in the project.
     let body = r#"<?php
 namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
@@ -356,7 +360,7 @@ class OAuthClient extends Model {
 "#;
     let (_dir, root) = project_with_model("OAuthClient", body);
     let related = resolve_related_model("App\\Models\\OAuthClient", "tokens", &root).await;
-    assert_eq!(related.as_deref(), Some("OAuthToken"));
+    assert_eq!(related.as_deref(), Some("App\\Models\\OAuthToken"));
 }
 
 #[tokio::test]
@@ -578,7 +582,8 @@ class Post extends Model {}
     ])
     .await;
     let resolved = walk_dotted_hops("App\\Models\\User", "posts", &root).await;
-    assert_eq!(resolved.as_deref(), Some("Post"));
+    // Phase 5.11: related_model is the resolved FQCN, not the basename.
+    assert_eq!(resolved.as_deref(), Some("App\\Models\\Post"));
 }
 
 #[tokio::test]
@@ -625,10 +630,14 @@ class Profile extends Model {}
     ])
     .await;
     let resolved = walk_dotted_hops("App\\Models\\User", "posts.author.profile", &root).await;
+    // Phase 5.11: each hop's related_model is now the resolved FQCN,
+    // so the final resolved class is `App\Models\Profile`, not the
+    // bare basename. That's what makes class-locator route correctly
+    // when there's a same-named class in another namespace.
     assert_eq!(
         resolved.as_deref(),
-        Some("Profile"),
-        "three hops should land at Profile"
+        Some("App\\Models\\Profile"),
+        "three hops should land at App\\Models\\Profile"
     );
 }
 

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -484,10 +484,15 @@ fn member_chain_receiver(node: Node, bytes: &[u8], aliases: &UseAliases) -> Chai
                 return ChainReceiver::Unknown;
             };
             let var = raw.trim_start_matches('$').to_string();
-            ChainReceiver::Eloquent(EloquentReceiver::InstanceVar {
-                var,
-                php_type: None, // var_type::resolve fills this in later
-            })
+            // Phase 9: try to resolve `$var`'s declared class via either a
+            // typed function parameter (`function show(User $user)`) or an
+            // `@var` docblock immediately above the variable's assignment.
+            // Both forms are common in Laravel controllers, repositories,
+            // and Livewire components. `None` is acceptable — receiver
+            // resolution will still fall back to Phase 8's closure-scope
+            // path if applicable; otherwise completion silently no-ops.
+            let php_type = super::var_type::resolve(node, bytes, &var, aliases);
+            ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, php_type })
         }
         // `(new self)->with(...)` / `(new User)->where(...)` etc. — the
         // common Laravel pattern of starting a chain from a freshly-

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -21,7 +21,9 @@
 //! independently (the cursor descends into every child).
 
 use super::chain::*;
-use super::methods::{arg_kind, chain_effect};
+use super::methods::{
+    arg_kind, chain_effect, CLOSURE_CARRIERS, RELATION_METHODS, SAME_MODEL_CLOSURE_CARRIERS,
+};
 use super::use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};
 use tree_sitter::{Node, Tree};
 
@@ -189,6 +191,7 @@ fn build_chain_from_root(root: Node, bytes: &[u8], aliases: &UseAliases) -> Opti
                     receiver,
                     span_byte_range,
                     links: links_reversed,
+                    closure_scope: None,
                 });
             }
             // member-call: keep descending through .object
@@ -200,11 +203,23 @@ fn build_chain_from_root(root: Node, bytes: &[u8], aliases: &UseAliases) -> Opti
             // We've descended past the calls. The current node is the
             // receiver expression (variable, parenthesised expr, etc.).
             let receiver = member_chain_receiver(node, bytes, aliases);
+            // If this chain's receiver is `$var`, see whether it's bound
+            // by an enclosing relation closure (`whereHas('rel', fn ($var)
+            // => …)` or `with(['rel' => fn ($var) => …])`). We record the
+            // binding here so detect_in_chain can resolve `$var`'s
+            // effective model from the parent chain at completion time.
+            let closure_scope = match &receiver {
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) => {
+                    detect_closure_scope(root, bytes, var)
+                }
+                _ => None,
+            };
             links_reversed.reverse();
             return Some(BuilderChain {
                 receiver,
                 span_byte_range,
                 links: links_reversed,
+                closure_scope,
             });
         }
     }
@@ -571,6 +586,194 @@ fn enclosing_class_name(node: Node, bytes: &[u8]) -> Option<String> {
         current = n.parent();
     }
     None
+}
+
+/// Phase 8: detect whether `chain_root` sits inside a relation-bearing
+/// closure that binds `$receiver_var` to a Builder for some relation.
+///
+/// Two shapes we recognize:
+///
+/// 1. `whereHas('rel', fn ($q) => …)` — the closure is the 2nd argument
+///    of a method call (`whereHas` / `doesntHave` / `whereDoesntHave` /
+///    `withCount` etc.). The 1st argument is a string literal holding
+///    the relation name.
+///
+/// 2. `with(['rel' => fn ($q) => …])` — the closure is the value of a
+///    keyed array-element initializer inside the array argument of a
+///    relation method (`with` / `load` / `loadMissing` etc.). The
+///    array element's KEY is the relation name.
+///
+/// Returns `Some(binding)` only when:
+///
+/// - The chain root is genuinely inside such a closure
+/// - The closure's first parameter name matches `receiver_var` (so we
+///   don't accidentally bind a different variable that happens to be
+///   used inside the same closure body)
+/// - A relation-name string is in the right position
+/// - The enclosing call's method name is one we recognise as
+///   relation-carrying
+fn detect_closure_scope(
+    chain_root: Node,
+    bytes: &[u8],
+    receiver_var: &str,
+) -> Option<ClosureScopeBinding> {
+    // Find the nearest enclosing closure by walking parents.
+    let mut current = chain_root.parent();
+    let closure = loop {
+        let n = current?;
+        match n.kind() {
+            "anonymous_function_creation_expression" | "anonymous_function" | "arrow_function" => {
+                break n
+            }
+            _ => current = n.parent(),
+        }
+    };
+
+    // The closure's first formal parameter must be `$receiver_var` —
+    // otherwise the chain's receiver isn't the closure-bound builder,
+    // it's some unrelated variable being used inside.
+    let params = closure.child_by_field_name("parameters")?;
+    let mut params_cursor = params.walk();
+    let first_param = params
+        .named_children(&mut params_cursor)
+        .find(|n| matches!(n.kind(), "simple_parameter" | "variadic_parameter"))?;
+    let name_node = first_param.child_by_field_name("name")?;
+    let raw_name = node_text(name_node, bytes)?;
+    let param_var = raw_name.trim_start_matches('$').to_string();
+    if param_var != receiver_var {
+        return None;
+    }
+
+    // Walk up from the closure to determine which shape we're in.
+    let closure_parent = closure.parent()?;
+    match closure_parent.kind() {
+        // Shape: keyed-array value — `with(['rel' => closure])` (related-model)
+        "array_element_initializer" => {
+            detect_closure_scope_array_keyed(closure, closure_parent, bytes, param_var)
+        }
+        // Shape: positional argument — either `whereHas('rel', closure)`
+        // (related-model hop) or `where(closure)` / `when($cond,
+        // closure)` / `having(closure)` (same-model). The helper
+        // distinguishes based on the enclosing call's method name.
+        "argument" => detect_closure_scope_positional(closure, closure_parent, bytes, param_var),
+        _ => None,
+    }
+}
+
+/// Resolve closure-bearing positional-arg shapes. Two flavors handled:
+///
+/// - Relation-hop carriers (`whereHas('rel', closure)`): the closure
+///   binds to the *related* model's builder. Relation name extracted
+///   from the FIRST string-literal arg.
+/// - Same-model carriers (`where(closure)`, `when($cond, closure)`,
+///   `having(closure)`, `tap(closure)`): the closure binds to the same
+///   model as the outer chain. No relation hop needed.
+fn detect_closure_scope_positional(
+    _closure: Node,
+    arg_node: Node,
+    bytes: &[u8],
+    param_var: String,
+) -> Option<ClosureScopeBinding> {
+    let args_node = arg_node.parent()?;
+    if args_node.kind() != "arguments" {
+        return None;
+    }
+    let call_node = args_node.parent()?;
+    if !matches!(
+        call_node.kind(),
+        "member_call_expression" | "scoped_call_expression"
+    ) {
+        return None;
+    }
+    let method_name_node = call_node.child_by_field_name("name")?;
+    let method_name = node_text(method_name_node, bytes)?;
+
+    // Relation-hop carrier? Extract the relation name from the first
+    // string arg.
+    if CLOSURE_CARRIERS.contains(&method_name) {
+        let mut args_cursor = args_node.walk();
+        let first_arg = args_node
+            .named_children(&mut args_cursor)
+            .find(|n| n.kind() == "argument")?;
+        let first_inner = first_arg.named_child(0)?;
+        let relation_name = match first_inner.kind() {
+            "string" => single_quoted_string(first_inner, bytes).map(|(s, _)| s)?,
+            "encapsed_string" => encapsed_string_content(first_inner, bytes)?,
+            _ => return None,
+        };
+        return Some(ClosureScopeBinding {
+            param_var,
+            kind: ClosureScopeKind::RelationHop { relation_name },
+        });
+    }
+
+    // Same-model carrier? Bind to the outer chain's effective model.
+    if SAME_MODEL_CLOSURE_CARRIERS.contains(&method_name) {
+        return Some(ClosureScopeBinding {
+            param_var,
+            kind: ClosureScopeKind::SameModel,
+        });
+    }
+
+    None
+}
+
+/// Resolve `with(['rel' => fn ($q) => …])` shape. The closure is the
+/// `value` side of an `array_element_initializer` whose `key` is the
+/// relation-name string. The enclosing array_creation_expression must be
+/// the first argument of a relation-carrying method call.
+fn detect_closure_scope_array_keyed(
+    closure: Node,
+    element_node: Node,
+    bytes: &[u8],
+    param_var: String,
+) -> Option<ClosureScopeBinding> {
+    // Locate the key — the array_element_initializer's named children are
+    // [key, value] for keyed pairs, or just [value] for plain entries.
+    // The key is whichever named child ISN'T the closure.
+    let mut elem_cursor = element_node.walk();
+    let key_node = element_node
+        .named_children(&mut elem_cursor)
+        .find(|n| n.id() != closure.id())?;
+    let relation_name = match key_node.kind() {
+        "string" => single_quoted_string(key_node, bytes).map(|(s, _)| s)?,
+        "encapsed_string" => encapsed_string_content(key_node, bytes)?,
+        _ => return None,
+    };
+
+    // Walk up: element → array → argument → arguments → call.
+    let array_node = element_node.parent()?;
+    if array_node.kind() != "array_creation_expression" {
+        return None;
+    }
+    let arg_node = array_node.parent()?;
+    if arg_node.kind() != "argument" {
+        return None;
+    }
+    let args_node = arg_node.parent()?;
+    if args_node.kind() != "arguments" {
+        return None;
+    }
+    let call_node = args_node.parent()?;
+    if !matches!(
+        call_node.kind(),
+        "member_call_expression" | "scoped_call_expression"
+    ) {
+        return None;
+    }
+    let method_name_node = call_node.child_by_field_name("name")?;
+    let method_name = node_text(method_name_node, bytes)?;
+    // For the keyed-array shape, the method is in RELATION_METHODS
+    // (`with`, `load`, `loadMissing`, `loadCount`, etc.). CLOSURE_CARRIERS
+    // also use a keyed-array form sometimes, so accept either.
+    if !RELATION_METHODS.contains(&method_name) && !CLOSURE_CARRIERS.contains(&method_name) {
+        return None;
+    }
+
+    Some(ClosureScopeBinding {
+        param_var,
+        kind: ClosureScopeKind::RelationHop { relation_name },
+    })
 }
 
 /// Extract a single-quoted string's content. Returns `(value, '\'')` on

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -22,6 +22,7 @@
 
 use super::chain::*;
 use super::methods::{arg_kind, chain_effect};
+use super::use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};
 use tree_sitter::{Node, Tree};
 
 /// Shift every byte range in a chain by `(byte_offset - wrapper_prefix_len)`.
@@ -76,14 +77,19 @@ pub fn shift_chain_byte_ranges(
 /// Extract every builder chain in the file. Order of return is depth-first
 /// pre-order across the AST — callers that need positional lookup should
 /// build their own index.
+///
+/// `use` statement aliases are resolved as part of this pass so chains like
+/// `Database::table(...)` (when imported as `use ... DB as Database;`) get
+/// classified as `DbTable` receivers, not Eloquent models.
 pub fn extract_chains(tree: &Tree, source: &str) -> Vec<BuilderChain> {
     let bytes = source.as_bytes();
+    let aliases = extract_use_aliases(tree, source);
     let mut chains = Vec::new();
     let mut stack: Vec<Node> = vec![tree.root_node()];
 
     while let Some(node) = stack.pop() {
         if is_chain_root(node) {
-            if let Some(chain) = build_chain_from_root(node, bytes) {
+            if let Some(chain) = build_chain_from_root(node, bytes, &aliases) {
                 chains.push(chain);
             }
         }
@@ -128,7 +134,7 @@ fn is_chain_root(node: Node) -> bool {
 /// Walk down the `object` chain from `root`, collecting links in reverse, then
 /// reverse to source order. Returns `None` if the chain receiver can't be
 /// identified at all (the chain is then uninteresting for completion).
-fn build_chain_from_root(root: Node, bytes: &[u8]) -> Option<BuilderChain> {
+fn build_chain_from_root(root: Node, bytes: &[u8], aliases: &UseAliases) -> Option<BuilderChain> {
     let span_byte_range = (root.start_byte(), root.end_byte());
 
     // Collect links bottom-up: start at `root`, walk its `object` until we
@@ -148,7 +154,7 @@ fn build_chain_from_root(root: Node, bytes: &[u8]) -> Option<BuilderChain> {
             // the scope is the receiver, not another call).
             if kind == "scoped_call_expression" {
                 // Bottom of the chain. The scope is the receiver.
-                let receiver = scoped_call_receiver(node, bytes, &links_reversed);
+                let receiver = scoped_call_receiver(node, bytes, &links_reversed, aliases);
 
                 // For `DB::table('|')`, the bottom link's first string arg
                 // names a table. Annotate it so the cursor resolver can
@@ -310,22 +316,32 @@ fn closure_body_range(closure: Node) -> Option<(usize, usize)> {
 /// call (the one whose scope is the receiver) sits at `links_reversed.last()`.
 /// That's the link we inspect to spot `DB::table('users')`: scope is `DB`,
 /// method is `table`, first arg is a string literal naming the table.
+///
+/// `aliases` lets us resolve `use ... as Foo; Foo::table(...)` — without it
+/// aliased imports of the DB facade would slip through as Eloquent models.
 fn scoped_call_receiver(
     call_node: Node,
     bytes: &[u8],
     links_reversed: &[ChainLink],
+    aliases: &UseAliases,
 ) -> ChainReceiver {
     let Some(scope_node) = call_node.child_by_field_name("scope") else {
         return ChainReceiver::Unknown;
     };
-    let Some(class_name) = node_text(scope_node, bytes) else {
+    let Some(class_name_raw) = node_text(scope_node, bytes) else {
         return ChainReceiver::Unknown;
     };
+
+    // Resolve the class name through `use` aliases. Examples:
+    //   `Database::table` with `use ... DB as Database;` → `Illuminate\...\DB`
+    //   `DB::table` with `use Illuminate\...\DB;` → `Illuminate\...\DB`
+    //   `DB::table` with no `use` → `DB` (unchanged; Laravel's global alias)
+    let resolved = resolve_class_name(class_name_raw, aliases);
 
     // PHP class names are case-insensitive — `db::table()` and `DB::table()`
     // resolve to the same class at runtime. Match accordingly so `db::`
     // chains aren't silently misclassified as Eloquent models.
-    if is_db_facade(class_name) {
+    if is_db_facade(&resolved) {
         if let Some(bottom_link) = links_reversed.last() {
             if bottom_link.method.eq_ignore_ascii_case("table") {
                 if let Some(ChainArg::StringLit {
@@ -343,11 +359,12 @@ fn scoped_call_receiver(
         }
     }
 
-    // Strip a leading backslash so `\App\Models\User` and `User` produce the
-    // same `StaticModel("User")` — receiver resolution later in the pipeline
-    // does the actual class lookup.
-    let class_name = class_name.trim_start_matches('\\').to_string();
-    ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class_name))
+    // Not the DB facade — emit an Eloquent model receiver using the
+    // *resolved* class name. This means `use App\Models\User as MyUser;
+    // MyUser::query()` will land as `StaticModel("App\Models\User")`, which
+    // resolves cleanly in later phases. The leading backslash is already
+    // stripped by `resolve_class_name`.
+    ChainReceiver::Eloquent(EloquentReceiver::StaticModel(resolved))
 }
 
 /// Whether `class_name` (as it appears in the source — possibly with `\`

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -24,6 +24,55 @@ use super::chain::*;
 use super::methods::{arg_kind, chain_effect};
 use tree_sitter::{Node, Tree};
 
+/// Shift every byte range in a chain by `(byte_offset - wrapper_prefix_len)`.
+///
+/// Used when chains are extracted from a Blade-embedded PHP region that was
+/// wrapped with `<?php ` before parsing: snippet-local byte `N` corresponds
+/// to outer-file byte `byte_offset + (N - wrapper_prefix_len)`. Applies to
+/// every span on the chain — the chain itself, every link, every string-arg
+/// and closure-body, and the DbTable receiver's `name_byte_range`.
+///
+/// `saturating_sub` guards against the (impossible-in-practice) case of a
+/// snippet position before the wrapper prefix.
+pub fn shift_chain_byte_ranges(
+    chain: &mut BuilderChain,
+    byte_offset: usize,
+    wrapper_prefix_len: usize,
+) {
+    let shift = |b: usize| byte_offset + b.saturating_sub(wrapper_prefix_len);
+
+    chain.span_byte_range = (
+        shift(chain.span_byte_range.0),
+        shift(chain.span_byte_range.1),
+    );
+
+    if let ChainReceiver::DbTable {
+        name_byte_range, ..
+    } = &mut chain.receiver
+    {
+        *name_byte_range = (shift(name_byte_range.0), shift(name_byte_range.1));
+    }
+
+    for link in &mut chain.links {
+        link.span_byte_range = (shift(link.span_byte_range.0), shift(link.span_byte_range.1));
+        for arg in &mut link.args {
+            match arg {
+                ChainArg::StringLit {
+                    span_byte_range, ..
+                } => {
+                    *span_byte_range = (shift(span_byte_range.0), shift(span_byte_range.1));
+                }
+                ChainArg::Closure {
+                    body_byte_range, ..
+                } => {
+                    *body_byte_range = (shift(body_byte_range.0), shift(body_byte_range.1));
+                }
+                ChainArg::Other => {}
+            }
+        }
+    }
+}
+
 /// Extract every builder chain in the file. Order of return is depth-first
 /// pre-order across the AST — callers that need positional lookup should
 /// build their own index.

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -57,20 +57,37 @@ pub fn shift_chain_byte_ranges(
     for link in &mut chain.links {
         link.span_byte_range = (shift(link.span_byte_range.0), shift(link.span_byte_range.1));
         for arg in &mut link.args {
-            match arg {
-                ChainArg::StringLit {
-                    span_byte_range, ..
-                } => {
-                    *span_byte_range = (shift(span_byte_range.0), shift(span_byte_range.1));
-                }
-                ChainArg::Closure {
-                    body_byte_range, ..
-                } => {
-                    *body_byte_range = (shift(body_byte_range.0), shift(body_byte_range.1));
-                }
-                ChainArg::Other => {}
+            shift_arg(arg, &shift);
+        }
+    }
+}
+
+/// Recursively shift byte ranges inside a single `ChainArg`. Handles
+/// `Array` by walking its elements (which themselves are `ChainArg`s) so
+/// nested string literals inside `with(['posts'])` survive the Blade
+/// span re-base.
+fn shift_arg(arg: &mut ChainArg, shift: &impl Fn(usize) -> usize) {
+    match arg {
+        ChainArg::StringLit {
+            span_byte_range, ..
+        } => {
+            *span_byte_range = (shift(span_byte_range.0), shift(span_byte_range.1));
+        }
+        ChainArg::Closure {
+            body_byte_range, ..
+        } => {
+            *body_byte_range = (shift(body_byte_range.0), shift(body_byte_range.1));
+        }
+        ChainArg::Array {
+            elements,
+            span_byte_range,
+        } => {
+            *span_byte_range = (shift(span_byte_range.0), shift(span_byte_range.1));
+            for elem in elements {
+                shift_arg(elem, shift);
             }
         }
+        ChainArg::Other => {}
     }
 }
 
@@ -261,7 +278,72 @@ fn extract_args(args_node: Node, bytes: &[u8]) -> Vec<ChainArg> {
                     body_byte_range: body,
                 });
             }
+            Some(("array_creation_expression", n)) => {
+                // `with(['posts', 'comments'])`, `select(['name', 'email'])`,
+                // etc. — recursively classify the elements so the cursor
+                // resolver can find string literals inside the array.
+                let elements = extract_array_elements(n, bytes);
+                out.push(ChainArg::Array {
+                    elements,
+                    span_byte_range: (n.start_byte(), n.end_byte()),
+                });
+            }
             _ => out.push(ChainArg::Other),
+        }
+    }
+    out
+}
+
+/// Decode an `array_creation_expression` into a flat `Vec<ChainArg>` of
+/// its top-level elements. We don't recurse into nested arrays — Laravel
+/// idioms (`with([…])`, `select([…])`) put strings directly inside, and
+/// surfacing string literals from a 2D array would mis-fire completion.
+///
+/// Each array element in tree-sitter PHP is wrapped in an
+/// `array_element_initializer` whose `value` field holds the actual
+/// expression. For keyed pairs (`'key' => $value`), we look at the
+/// `value` side — that's what completion typically targets (e.g.
+/// `with(['posts' => fn ($q) => …])`, the cursor in `'posts'` is the
+/// relation; the closure is the constraint).
+fn extract_array_elements(array_node: Node, bytes: &[u8]) -> Vec<ChainArg> {
+    let mut out = Vec::new();
+    let mut cursor = array_node.walk();
+    for child in array_node.named_children(&mut cursor) {
+        if child.kind() != "array_element_initializer" {
+            continue;
+        }
+        // Look at every named child of the element — we want to surface
+        // BOTH the key string (in `'foo' => …`, the user might be on
+        // 'foo') AND the value string (in `'foo'` non-keyed, that's the
+        // value). Iterating both means a cursor on either side gets
+        // matched.
+        let mut inner_cursor = child.walk();
+        for sub in child.named_children(&mut inner_cursor) {
+            match sub.kind() {
+                "string" => {
+                    if let Some((value, quote)) = single_quoted_string(sub, bytes) {
+                        out.push(ChainArg::StringLit {
+                            value,
+                            quote,
+                            span_byte_range: (sub.start_byte(), sub.end_byte()),
+                        });
+                    } else {
+                        out.push(ChainArg::Other);
+                    }
+                }
+                "encapsed_string" => {
+                    if let Some(value) = encapsed_string_content(sub, bytes) {
+                        out.push(ChainArg::StringLit {
+                            value,
+                            quote: '"',
+                            span_byte_range: (sub.start_byte(), sub.end_byte()),
+                        });
+                    } else {
+                        out.push(ChainArg::Other);
+                    }
+                }
+                _ => out.push(ChainArg::Other),
+            }
         }
     }
     out

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -149,6 +149,18 @@ fn build_chain_from_root(root: Node, bytes: &[u8]) -> Option<BuilderChain> {
             if kind == "scoped_call_expression" {
                 // Bottom of the chain. The scope is the receiver.
                 let receiver = scoped_call_receiver(node, bytes, &links_reversed);
+
+                // For `DB::table('|')`, the bottom link's first string arg
+                // names a table. Annotate it so the cursor resolver can
+                // distinguish "table name" from "column name" at the
+                // ArgKind level. The bottom link is the one we just pushed
+                // (last in links_reversed before reversal).
+                if matches!(receiver, ChainReceiver::DbTable { .. }) {
+                    if let Some(bottom) = links_reversed.last_mut() {
+                        bottom.arg = ArgKind::Table;
+                    }
+                }
+
                 links_reversed.reverse();
                 return Some(BuilderChain {
                     receiver,
@@ -310,9 +322,12 @@ fn scoped_call_receiver(
         return ChainReceiver::Unknown;
     };
 
-    if class_name == "DB" || class_name.ends_with("\\DB") {
+    // PHP class names are case-insensitive — `db::table()` and `DB::table()`
+    // resolve to the same class at runtime. Match accordingly so `db::`
+    // chains aren't silently misclassified as Eloquent models.
+    if is_db_facade(class_name) {
         if let Some(bottom_link) = links_reversed.last() {
-            if bottom_link.method == "table" {
+            if bottom_link.method.eq_ignore_ascii_case("table") {
                 if let Some(ChainArg::StringLit {
                     value,
                     span_byte_range,
@@ -333,6 +348,15 @@ fn scoped_call_receiver(
     // does the actual class lookup.
     let class_name = class_name.trim_start_matches('\\').to_string();
     ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class_name))
+}
+
+/// Whether `class_name` (as it appears in the source — possibly with `\`
+/// segments) refers to the Laravel `DB` facade. PHP class names are
+/// case-insensitive, so `DB`, `db`, `Db`, and `\Illuminate\Support\Facades\DB`
+/// all match.
+fn is_db_facade(class_name: &str) -> bool {
+    let basename = class_name.rsplit('\\').next().unwrap_or(class_name);
+    basename.eq_ignore_ascii_case("DB")
 }
 
 /// Receiver for a chain whose deepest call is a `member_call_expression`

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -182,7 +182,7 @@ fn build_chain_from_root(root: Node, bytes: &[u8], aliases: &UseAliases) -> Opti
         } else {
             // We've descended past the calls. The current node is the
             // receiver expression (variable, parenthesised expr, etc.).
-            let receiver = member_chain_receiver(node, bytes);
+            let receiver = member_chain_receiver(node, bytes, aliases);
             links_reversed.reverse();
             return Some(BuilderChain {
                 receiver,
@@ -380,7 +380,7 @@ fn is_db_facade(class_name: &str) -> bool {
 /// against something that isn't itself a call — most commonly a `$var`. For
 /// anything we don't recognise, return `Unknown`; completion will silently
 /// no-op rather than guess.
-fn member_chain_receiver(node: Node, bytes: &[u8]) -> ChainReceiver {
+fn member_chain_receiver(node: Node, bytes: &[u8], aliases: &UseAliases) -> ChainReceiver {
     match node.kind() {
         "variable_name" => {
             let Some(raw) = node_text(node, bytes) else {
@@ -392,11 +392,103 @@ fn member_chain_receiver(node: Node, bytes: &[u8]) -> ChainReceiver {
                 php_type: None, // var_type::resolve fills this in later
             })
         }
-        // (Future) parenthesised expressions, `$this->prop->...`, etc. fall
-        // through. Phase 2 keeps the receiver detection conservative; richer
-        // shapes land alongside the var-type resolver in Phase 9.
+        // `(new self)->with(...)` / `(new User)->where(...)` etc. — the
+        // common Laravel pattern of starting a chain from a freshly-
+        // constructed model instance. Unwrap the parens and try the inner
+        // expression. If it's an object_creation_expression, resolve the
+        // class name (including self/static against the enclosing class
+        // declaration) and route through the same EloquentBuilder path as
+        // static calls.
+        "parenthesized_expression" => parenthesized_receiver(node, bytes, aliases),
+        // (Future) `$this->prop->...`, `$obj->method()->...`, etc. fall
+        // through. Lands alongside the var-type resolver in Phase 9.
         _ => ChainReceiver::Unknown,
     }
+}
+
+/// Resolve `(new X)->...` style receivers. The parens wrap exactly one
+/// inner expression — we look at its first named child. For an
+/// `object_creation_expression`, we extract the class name and return an
+/// Eloquent static receiver pointing at it. For anything else (a paren'd
+/// variable, a method call, etc.) we recurse so `($var)->method()` still
+/// resolves like `$var->method()`.
+fn parenthesized_receiver(node: Node, bytes: &[u8], aliases: &UseAliases) -> ChainReceiver {
+    let Some(inner) = node.named_child(0) else {
+        return ChainReceiver::Unknown;
+    };
+    if inner.kind() == "object_creation_expression" {
+        // Extract the class-name node. PHP tree-sitter gives this back via
+        // a `name`, `qualified_name`, or — for `self`/`static`/`parent` —
+        // as the relevant keyword node. Walk the named children looking
+        // for whichever shape appears.
+        let mut class_text: Option<String> = None;
+        let mut cursor = inner.walk();
+        for child in inner.named_children(&mut cursor) {
+            match child.kind() {
+                "name" | "qualified_name" | "relative_name" => {
+                    class_text = node_text(child, bytes).map(|s| s.to_string());
+                    break;
+                }
+                _ => {}
+            }
+        }
+        // `new self`, `new static`, `new parent` — these are anonymous in
+        // some tree-sitter PHP grammar versions (no `name` named-child;
+        // the keyword sits as an unnamed child). Fall back to scanning the
+        // raw text of the object_creation_expression node.
+        if class_text.is_none() {
+            if let Some(raw) = node_text(inner, bytes) {
+                let after_new = raw.trim_start_matches("new").trim_start();
+                let token = after_new
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '\\')
+                    .collect::<String>();
+                if !token.is_empty() {
+                    class_text = Some(token);
+                }
+            }
+        }
+        let Some(raw_class) = class_text else {
+            return ChainReceiver::Unknown;
+        };
+
+        // Resolve self / static / parent against the enclosing class
+        // declaration. `self` and `static` map to the containing class.
+        // `parent` would map to its parent class — that needs cross-file
+        // resolution, so for now we punt and return Unknown.
+        let resolved = match raw_class.as_str() {
+            "self" | "static" => match enclosing_class_name(inner, bytes) {
+                Some(cls) => cls,
+                None => return ChainReceiver::Unknown,
+            },
+            "parent" => return ChainReceiver::Unknown,
+            other => super::use_aliases::resolve_class_name(other, aliases),
+        };
+
+        return ChainReceiver::Eloquent(EloquentReceiver::StaticModel(resolved));
+    }
+    // `($var)->method()` — the parens are syntactic noise around a
+    // variable receiver. Recurse so var-type resolution (Phase 9) can
+    // still kick in.
+    member_chain_receiver(inner, bytes, aliases)
+}
+
+/// Walk up the syntax tree from `node` looking for the nearest enclosing
+/// `class_declaration`. Returns the class's short name (no namespace) on
+/// success — that's what `self` / `static` refer to within the class body.
+/// Callers can then push the short name through `resolve_class_name` to
+/// get the FQCN if the file's namespace declaration is in scope.
+fn enclosing_class_name(node: Node, bytes: &[u8]) -> Option<String> {
+    let mut current = node.parent();
+    while let Some(n) = current {
+        if n.kind() == "class_declaration" {
+            // The `name` field holds the class identifier.
+            let name_node = n.child_by_field_name("name")?;
+            return node_text(name_node, bytes).map(|s| s.to_string());
+        }
+        current = n.parent();
+    }
+    None
 }
 
 /// Extract a single-quoted string's content. Returns `(value, '\'')` on

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -1,0 +1,363 @@
+//! Tree-sitter walker that extracts [`BuilderChain`] values from a parsed PHP
+//! file.
+//!
+//! The walker visits every `scoped_call_expression` (e.g. `User::query()`,
+//! `DB::table(...)`) and `member_call_expression` (e.g. `$x->where(...)`),
+//! identifies the ones that sit at the top of a chain, walks down through the
+//! `object` field to discover the chain root (the receiver), then collects
+//! every link in source order with its classification and parsed arguments.
+//!
+//! Why imperative and not a tree-sitter `.scm` query? Captures are great for
+//! "match this exact shape" — but chains are recursive and the same node
+//! (`member_call_expression`) appears at every depth. We'd need to either
+//! capture every node and filter post-hoc (defeating the point of declarative
+//! matching) or write a query that pattern-matches the whole chain (which
+//! tree-sitter query syntax doesn't compose well for arbitrary depth).
+//!
+//! The walker is iterative — it uses a stack of tree-cursor positions rather
+//! than recursion — so deeply-nested chains can't blow the stack on real-world
+//! files. Closures inside chains are extracted as `ChainArg::Closure` with
+//! their formal parameters; the bodies inside those closures are walked
+//! independently (the cursor descends into every child).
+
+use super::chain::*;
+use super::methods::{arg_kind, chain_effect};
+use tree_sitter::{Node, Tree};
+
+/// Extract every builder chain in the file. Order of return is depth-first
+/// pre-order across the AST — callers that need positional lookup should
+/// build their own index.
+pub fn extract_chains(tree: &Tree, source: &str) -> Vec<BuilderChain> {
+    let bytes = source.as_bytes();
+    let mut chains = Vec::new();
+    let mut stack: Vec<Node> = vec![tree.root_node()];
+
+    while let Some(node) = stack.pop() {
+        if is_chain_root(node) {
+            if let Some(chain) = build_chain_from_root(node, bytes) {
+                chains.push(chain);
+            }
+        }
+
+        // Push children in reverse so the visit order is left-to-right.
+        // (Iteration order doesn't affect correctness — chain extraction is
+        // independent per root — but it makes test fixtures predictable.)
+        let mut cursor = node.walk();
+        let children: Vec<Node> = node.children(&mut cursor).collect();
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
+    }
+
+    chains
+}
+
+/// A node is a chain root if it's a call expression AND its parent is NOT a
+/// call expression that holds it as the `object` field. In other words:
+/// `User::query()->where(...)` has one root (the outer `where` call); the
+/// inner `query()` call is part of that chain, not a separate root.
+fn is_chain_root(node: Node) -> bool {
+    let kind = node.kind();
+    if kind != "member_call_expression" && kind != "scoped_call_expression" {
+        return false;
+    }
+    let Some(parent) = node.parent() else {
+        return true;
+    };
+    if parent.kind() != "member_call_expression" {
+        return true;
+    }
+    // Parent is a member-call. We're the chain root unless the parent uses
+    // this node as its `object` (i.e., we're earlier in the chain than the
+    // parent).
+    let Some(object_field) = parent.child_by_field_name("object") else {
+        return true;
+    };
+    object_field.id() != node.id()
+}
+
+/// Walk down the `object` chain from `root`, collecting links in reverse, then
+/// reverse to source order. Returns `None` if the chain receiver can't be
+/// identified at all (the chain is then uninteresting for completion).
+fn build_chain_from_root(root: Node, bytes: &[u8]) -> Option<BuilderChain> {
+    let span_byte_range = (root.start_byte(), root.end_byte());
+
+    // Collect links bottom-up: start at `root`, walk its `object` until we
+    // hit a non-call node. The deepest call is the bottom; its `scope` (for
+    // scoped-call) or `object` (for member-call against a variable) defines
+    // the receiver.
+    let mut links_reversed: Vec<ChainLink> = Vec::new();
+    let mut node = root;
+
+    loop {
+        let kind = node.kind();
+        if kind == "member_call_expression" || kind == "scoped_call_expression" {
+            if let Some(link) = extract_link(node, bytes) {
+                links_reversed.push(link);
+            }
+            // Descend into the `object` (member-call) or stop (scoped-call —
+            // the scope is the receiver, not another call).
+            if kind == "scoped_call_expression" {
+                // Bottom of the chain. The scope is the receiver.
+                let receiver = scoped_call_receiver(node, bytes, &links_reversed);
+                links_reversed.reverse();
+                return Some(BuilderChain {
+                    receiver,
+                    span_byte_range,
+                    links: links_reversed,
+                });
+            }
+            // member-call: keep descending through .object
+            match node.child_by_field_name("object") {
+                Some(next) => node = next,
+                None => break,
+            }
+        } else {
+            // We've descended past the calls. The current node is the
+            // receiver expression (variable, parenthesised expr, etc.).
+            let receiver = member_chain_receiver(node, bytes);
+            links_reversed.reverse();
+            return Some(BuilderChain {
+                receiver,
+                span_byte_range,
+                links: links_reversed,
+            });
+        }
+    }
+
+    None
+}
+
+/// Extract one link from a call expression node. Returns `None` if the node
+/// doesn't have a method name we can read (malformed AST).
+fn extract_link(call_node: Node, bytes: &[u8]) -> Option<ChainLink> {
+    let name_node = call_node.child_by_field_name("name")?;
+    let method = node_text(name_node, bytes)?.to_string();
+
+    let args_node = call_node.child_by_field_name("arguments");
+    let args = args_node
+        .map(|n| extract_args(n, bytes))
+        .unwrap_or_default();
+
+    Some(ChainLink {
+        arg: arg_kind(&method),
+        effect: chain_effect(&method),
+        method,
+        span_byte_range: (call_node.start_byte(), call_node.end_byte()),
+        args,
+    })
+}
+
+/// Decode an `arguments` node into a `Vec<ChainArg>` in source order. We only
+/// recognise the shapes that matter for completion — string literals and
+/// closures — everything else collapses to `ChainArg::Other`.
+fn extract_args(args_node: Node, bytes: &[u8]) -> Vec<ChainArg> {
+    let mut out = Vec::new();
+    let mut cursor = args_node.walk();
+    for child in args_node.children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        // An `argument` wraps a single expression. Look at its first named
+        // child.
+        let inner = child.named_child(0);
+        match inner.map(|n| (n.kind(), n)) {
+            Some(("string", n)) => {
+                if let Some((value, quote)) = single_quoted_string(n, bytes) {
+                    out.push(ChainArg::StringLit {
+                        value,
+                        quote,
+                        span_byte_range: (n.start_byte(), n.end_byte()),
+                    });
+                } else {
+                    out.push(ChainArg::Other);
+                }
+            }
+            Some(("encapsed_string", n)) => {
+                if let Some(value) = encapsed_string_content(n, bytes) {
+                    out.push(ChainArg::StringLit {
+                        value,
+                        quote: '"',
+                        span_byte_range: (n.start_byte(), n.end_byte()),
+                    });
+                } else {
+                    out.push(ChainArg::Other);
+                }
+            }
+            Some(("anonymous_function_creation_expression", n))
+            | Some(("anonymous_function", n))
+            | Some(("arrow_function", n)) => {
+                let params = extract_closure_params(n, bytes);
+                let body = closure_body_range(n).unwrap_or((n.start_byte(), n.end_byte()));
+                out.push(ChainArg::Closure {
+                    params,
+                    body_byte_range: body,
+                });
+            }
+            _ => out.push(ChainArg::Other),
+        }
+    }
+    out
+}
+
+/// Pull the parameter list out of a closure node, recording the parameter
+/// names and (when present) their type hints. The PHP-side default is
+/// untyped (`function ($q) { ... }`); typed params show up as
+/// `simple_parameter` with a `type` field.
+fn extract_closure_params(closure: Node, bytes: &[u8]) -> Vec<ClosureParam> {
+    let Some(params_node) = closure.child_by_field_name("parameters") else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    let mut cursor = params_node.walk();
+    for param in params_node.children(&mut cursor) {
+        if param.kind() != "simple_parameter" && param.kind() != "variadic_parameter" {
+            continue;
+        }
+        // The `name` field holds a `variable_name` like `$q`. Strip the `$`.
+        let Some(name_node) = param.child_by_field_name("name") else {
+            continue;
+        };
+        let Some(raw) = node_text(name_node, bytes) else {
+            continue;
+        };
+        let name = raw.trim_start_matches('$').to_string();
+        let php_type = param
+            .child_by_field_name("type")
+            .and_then(|t| node_text(t, bytes))
+            .map(|s| s.to_string());
+        out.push(ClosureParam { name, php_type });
+    }
+    out
+}
+
+/// Byte range of the closure body. For traditional closures this is the
+/// `{ ... }` compound statement; for arrow functions it's the expression
+/// after `=>`. Falls back to the full closure span if neither field is
+/// present.
+fn closure_body_range(closure: Node) -> Option<(usize, usize)> {
+    closure
+        .child_by_field_name("body")
+        .map(|b| (b.start_byte(), b.end_byte()))
+}
+
+/// Receiver for a bottomed-out chain whose deepest call is a
+/// `scoped_call_expression` (`Class::method(...)`).
+///
+/// `links_reversed` holds the chain's links in root-first order — we pushed
+/// the outermost call first and descended through `.object`, so the deepest
+/// call (the one whose scope is the receiver) sits at `links_reversed.last()`.
+/// That's the link we inspect to spot `DB::table('users')`: scope is `DB`,
+/// method is `table`, first arg is a string literal naming the table.
+fn scoped_call_receiver(
+    call_node: Node,
+    bytes: &[u8],
+    links_reversed: &[ChainLink],
+) -> ChainReceiver {
+    let Some(scope_node) = call_node.child_by_field_name("scope") else {
+        return ChainReceiver::Unknown;
+    };
+    let Some(class_name) = node_text(scope_node, bytes) else {
+        return ChainReceiver::Unknown;
+    };
+
+    if class_name == "DB" || class_name.ends_with("\\DB") {
+        if let Some(bottom_link) = links_reversed.last() {
+            if bottom_link.method == "table" {
+                if let Some(ChainArg::StringLit {
+                    value,
+                    span_byte_range,
+                    ..
+                }) = bottom_link.args.first().cloned()
+                {
+                    return ChainReceiver::DbTable {
+                        table: value,
+                        name_byte_range: span_byte_range,
+                    };
+                }
+            }
+        }
+    }
+
+    // Strip a leading backslash so `\App\Models\User` and `User` produce the
+    // same `StaticModel("User")` — receiver resolution later in the pipeline
+    // does the actual class lookup.
+    let class_name = class_name.trim_start_matches('\\').to_string();
+    ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class_name))
+}
+
+/// Receiver for a chain whose deepest call is a `member_call_expression`
+/// against something that isn't itself a call — most commonly a `$var`. For
+/// anything we don't recognise, return `Unknown`; completion will silently
+/// no-op rather than guess.
+fn member_chain_receiver(node: Node, bytes: &[u8]) -> ChainReceiver {
+    match node.kind() {
+        "variable_name" => {
+            let Some(raw) = node_text(node, bytes) else {
+                return ChainReceiver::Unknown;
+            };
+            let var = raw.trim_start_matches('$').to_string();
+            ChainReceiver::Eloquent(EloquentReceiver::InstanceVar {
+                var,
+                php_type: None, // var_type::resolve fills this in later
+            })
+        }
+        // (Future) parenthesised expressions, `$this->prop->...`, etc. fall
+        // through. Phase 2 keeps the receiver detection conservative; richer
+        // shapes land alongside the var-type resolver in Phase 9.
+        _ => ChainReceiver::Unknown,
+    }
+}
+
+/// Extract a single-quoted string's content. Returns `(value, '\'')` on
+/// success. Returns `None` for malformed strings or empty content nodes.
+fn single_quoted_string(node: Node, bytes: &[u8]) -> Option<(String, char)> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "string_content" {
+            if let Some(s) = node_text(child, bytes) {
+                return Some((s.to_string(), '\''));
+            }
+        }
+    }
+    // Empty string literal (`''`) — string node with no string_content child.
+    if let Some(text) = node_text(node, bytes) {
+        if text == "''" {
+            return Some((String::new(), '\''));
+        }
+    }
+    None
+}
+
+/// Extract a double-quoted string's content, joining any `string_content`
+/// children. Interpolations are skipped — for a chain like
+/// `where("col_$idx")` we don't try to resolve the variable; just return the
+/// literal slice so callers can decide whether to use it.
+fn encapsed_string_content(node: Node, bytes: &[u8]) -> Option<String> {
+    let mut cursor = node.walk();
+    let mut parts = Vec::new();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "string_content" {
+            if let Some(s) = node_text(child, bytes) {
+                parts.push(s.to_string());
+            }
+        }
+    }
+    if parts.is_empty() {
+        // Empty double-quoted string (`""`) — return empty content.
+        if node_text(node, bytes).map(|t| t == "\"\"").unwrap_or(false) {
+            return Some(String::new());
+        }
+        return None;
+    }
+    Some(parts.concat())
+}
+
+fn node_text<'a>(node: Node<'_>, bytes: &'a [u8]) -> Option<&'a str> {
+    let start = node.start_byte();
+    let end = node.end_byte();
+    std::str::from_utf8(bytes.get(start..end)?).ok()
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -1,0 +1,302 @@
+use super::*;
+use crate::parser::parse_php;
+
+fn parse(src: &str) -> tree_sitter::Tree {
+    let wrapped = format!("<?php\n{src}");
+    parse_php(&wrapped).expect("parse")
+}
+
+fn extract(src: &str) -> Vec<BuilderChain> {
+    let wrapped = format!("<?php\n{src}");
+    let tree = parse(src);
+    super::extract_chains(&tree, &wrapped)
+}
+
+fn method_names(chain: &BuilderChain) -> Vec<&str> {
+    chain.links.iter().map(|l| l.method.as_str()).collect()
+}
+
+// ---- Eloquent static receivers ------------------------------------------
+
+#[test]
+fn extracts_static_query_chain() {
+    let chains = extract("User::query()->where('email', $email)->with('posts');");
+    assert_eq!(chains.len(), 1);
+    let c = &chains[0];
+    assert_eq!(
+        c.receiver,
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel("User".to_string()))
+    );
+    assert_eq!(method_names(c), vec!["query", "where", "with"]);
+}
+
+#[test]
+fn extracts_idiomatic_where_form_without_query() {
+    // The common form: User::where(...)->with(...).
+    let chains = extract("User::where('email', $e)->with('posts')->get();");
+    assert_eq!(chains.len(), 1);
+    let c = &chains[0];
+    assert_eq!(
+        c.receiver,
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel("User".to_string()))
+    );
+    assert_eq!(method_names(c), vec!["where", "with", "get"]);
+}
+
+#[test]
+fn extracts_idiomatic_find_form() {
+    let chains = extract("Post::find($id);");
+    assert_eq!(chains.len(), 1);
+    assert_eq!(
+        chains[0].receiver,
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel("Post".to_string()))
+    );
+}
+
+#[test]
+fn fqcn_static_call_keeps_basename() {
+    // \App\Models\User::query() — receiver resolution later does the real
+    // class lookup; here we just want the leading backslash stripped so the
+    // class name matches resolver expectations.
+    let chains = extract("\\App\\Models\\User::query()->where('a', 1);");
+    assert_eq!(chains.len(), 1);
+    match &chains[0].receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(name)) => {
+            assert_eq!(name, "App\\Models\\User");
+        }
+        other => panic!("unexpected receiver: {other:?}"),
+    }
+}
+
+// ---- Eloquent instance receivers ----------------------------------------
+
+#[test]
+fn extracts_instance_chain_with_unresolved_type() {
+    let chains = extract("$user->newQuery()->where('email', $e);");
+    assert_eq!(chains.len(), 1);
+    let c = &chains[0];
+    match &c.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, php_type }) => {
+            assert_eq!(var, "user");
+            // Phase 9 fills this in; Phase 2 reports it as unresolved.
+            assert!(php_type.is_none());
+        }
+        other => panic!("unexpected receiver: {other:?}"),
+    }
+    assert_eq!(method_names(c), vec!["newQuery", "where"]);
+}
+
+// ---- DB::table receivers ------------------------------------------------
+
+#[test]
+fn extracts_db_table_chain() {
+    let chains = extract("DB::table('users')->where('email', 'a@b.c');");
+    assert_eq!(chains.len(), 1);
+    let c = &chains[0];
+    match &c.receiver {
+        ChainReceiver::DbTable { table, .. } => assert_eq!(table, "users"),
+        other => panic!("unexpected receiver: {other:?}"),
+    }
+    // The first link is still `table` — DB::table is a real call with a
+    // string arg; the receiver just captures the table name out of it.
+    assert_eq!(method_names(c), vec!["table", "where"]);
+}
+
+#[test]
+fn extracts_db_table_with_double_quotes() {
+    let chains = extract("DB::table(\"users\")->where('id', 1);");
+    assert_eq!(chains.len(), 1);
+    match &chains[0].receiver {
+        ChainReceiver::DbTable { table, .. } => assert_eq!(table, "users"),
+        other => panic!("unexpected receiver: {other:?}"),
+    }
+}
+
+// ---- Link classification ------------------------------------------------
+
+#[test]
+fn link_arg_and_effect_populated() {
+    let chains = extract("User::query()->where('email', $e)->get();");
+    let c = &chains[0];
+    let links = &c.links;
+    assert_eq!(links[0].method, "query");
+    assert_eq!(links[0].arg, ArgKind::None);
+    assert_eq!(links[0].effect, ChainEffect::None);
+    assert_eq!(links[1].method, "where");
+    assert_eq!(links[1].arg, ArgKind::Column);
+    assert_eq!(links[1].effect, ChainEffect::None);
+    assert_eq!(links[2].method, "get");
+    assert_eq!(links[2].arg, ArgKind::None);
+    assert_eq!(links[2].effect, ChainEffect::FlipToCollection);
+}
+
+#[test]
+fn pluck_carries_column_arg_and_collection_effect() {
+    let chains = extract("User::query()->pluck('email');");
+    let c = &chains[0];
+    let pluck = c.links.iter().find(|l| l.method == "pluck").unwrap();
+    assert_eq!(pluck.arg, ArgKind::Column);
+    assert_eq!(pluck.effect, ChainEffect::FlipToCollection);
+}
+
+#[test]
+fn to_base_classified_as_mode_flip() {
+    let chains = extract("User::where('a', 1)->toBase()->where('b', 2);");
+    let c = &chains[0];
+    let to_base = c.links.iter().find(|l| l.method == "toBase").unwrap();
+    assert_eq!(to_base.effect, ChainEffect::FlipToBase);
+}
+
+// ---- String argument extraction ----------------------------------------
+
+#[test]
+fn string_arg_records_value_quote_and_span() {
+    let chains = extract("User::where('email', $e);");
+    let where_link = &chains[0].links[0];
+    assert_eq!(where_link.args.len(), 2);
+    match &where_link.args[0] {
+        ChainArg::StringLit { value, quote, .. } => {
+            assert_eq!(value, "email");
+            assert_eq!(*quote, '\'');
+        }
+        other => panic!("expected StringLit, got {other:?}"),
+    }
+    // Second arg is a variable — Other.
+    assert!(matches!(where_link.args[1], ChainArg::Other));
+}
+
+#[test]
+fn double_quoted_string_arg() {
+    let chains = extract("User::where(\"email\", 1);");
+    let where_link = &chains[0].links[0];
+    match &where_link.args[0] {
+        ChainArg::StringLit { value, quote, .. } => {
+            assert_eq!(value, "email");
+            assert_eq!(*quote, '"');
+        }
+        other => panic!("expected StringLit, got {other:?}"),
+    }
+}
+
+// ---- Closure arguments --------------------------------------------------
+
+#[test]
+fn closure_arg_records_parameter_name() {
+    let chains =
+        extract("User::whereHas('posts', function ($q) { $q->where('published', 1); })->get();");
+    // Outer chain
+    let c = chains
+        .iter()
+        .find(|c| c.links.iter().any(|l| l.method == "whereHas"))
+        .expect("outer chain present");
+    let where_has = c.links.iter().find(|l| l.method == "whereHas").unwrap();
+    assert_eq!(where_has.arg, ArgKind::ClosureCarrier);
+    assert_eq!(where_has.args.len(), 2);
+    // First arg: 'posts'
+    match &where_has.args[0] {
+        ChainArg::StringLit { value, .. } => assert_eq!(value, "posts"),
+        other => panic!("expected 'posts' string, got {other:?}"),
+    }
+    // Second arg: closure with $q
+    match &where_has.args[1] {
+        ChainArg::Closure { params, .. } => {
+            assert_eq!(params.len(), 1);
+            assert_eq!(params[0].name, "q");
+            assert!(params[0].php_type.is_none());
+        }
+        other => panic!("expected Closure, got {other:?}"),
+    }
+}
+
+#[test]
+fn arrow_function_closure_arg() {
+    let chains = extract("User::whereHas('posts', fn ($q) => $q->where('published', 1));");
+    let outer = chains
+        .iter()
+        .find(|c| c.links.iter().any(|l| l.method == "whereHas"))
+        .expect("outer chain present");
+    let where_has = outer.links.iter().find(|l| l.method == "whereHas").unwrap();
+    match &where_has.args[1] {
+        ChainArg::Closure { params, .. } => {
+            assert_eq!(params.len(), 1);
+            assert_eq!(params[0].name, "q");
+        }
+        other => panic!("expected arrow Closure, got {other:?}"),
+    }
+}
+
+// ---- Nested / sibling chains --------------------------------------------
+
+#[test]
+fn nested_chains_extract_independently() {
+    // The outer chain rooted at User and the inner chain inside the closure
+    // (rooted at $q) are BOTH chain roots — they're independent chains as
+    // far as extraction is concerned. Closure-scope binding (Phase 8) is
+    // what later links the inner chain's `$q` receiver back to `Post`.
+    let chains = extract("User::whereHas('posts', function ($q) { $q->where('published', 1); });");
+    // We expect at least 2 chains: outer User chain, inner $q chain.
+    let outer = chains
+        .iter()
+        .find(|c| c.links.iter().any(|l| l.method == "whereHas"))
+        .expect("outer User chain");
+    assert_eq!(
+        outer.receiver,
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel("User".to_string()))
+    );
+
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) if var == "q"
+            )
+        })
+        .expect("inner $q chain");
+    assert_eq!(method_names(inner), vec!["where"]);
+}
+
+#[test]
+fn multiple_top_level_chains_in_one_file() {
+    let chains = extract(
+        r#"
+        User::where('a', 1)->get();
+        Post::find(3);
+        DB::table('events')->count();
+        "#,
+    );
+    // 3 distinct chains, each with its own receiver.
+    assert_eq!(chains.len(), 3);
+    let receivers: Vec<&ChainReceiver> = chains.iter().map(|c| &c.receiver).collect();
+    assert!(receivers.iter().any(|r| matches!(
+        r,
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(s)) if s == "User"
+    )));
+    assert!(receivers.iter().any(|r| matches!(
+        r,
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(s)) if s == "Post"
+    )));
+    assert!(receivers.iter().any(|r| matches!(
+        r,
+        ChainReceiver::DbTable { table, .. } if table == "events"
+    )));
+}
+
+// ---- Negative cases -----------------------------------------------------
+
+#[test]
+fn non_call_code_produces_no_chains() {
+    let chains = extract("$a = 1; $b = $a + 2; echo $b;");
+    assert!(chains.is_empty());
+}
+
+#[test]
+fn unknown_receiver_classified_as_unknown() {
+    // `($qb)` — parenthesised expression as receiver. We don't try to
+    // resolve these in Phase 2; the chain just gets ChainReceiver::Unknown.
+    let chains = extract("($qb)->where('a', 1);");
+    // The extractor still produces a chain (the chain root exists), but the
+    // receiver is Unknown.
+    assert_eq!(chains.len(), 1);
+    assert_eq!(chains[0].receiver, ChainReceiver::Unknown);
+}

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -290,6 +290,221 @@ fn non_call_code_produces_no_chains() {
     assert!(chains.is_empty());
 }
 
+// ---- shift_chain_byte_ranges -------------------------------------------
+
+#[test]
+fn shift_chain_byte_ranges_shifts_every_span() {
+    // Build a chain manually with snippet-local byte ranges, shift it,
+    // verify every span moved correctly. Receiver, links, args, and
+    // closure body all participate.
+    let mut chain = BuilderChain {
+        receiver: ChainReceiver::DbTable {
+            table: "users".to_string(),
+            name_byte_range: (10, 17),
+        },
+        span_byte_range: (6, 50),
+        links: vec![ChainLink {
+            method: "where".to_string(),
+            arg: ArgKind::Column,
+            effect: ChainEffect::None,
+            span_byte_range: (30, 45),
+            args: vec![
+                ChainArg::StringLit {
+                    value: "email".to_string(),
+                    quote: '\'',
+                    span_byte_range: (37, 43),
+                },
+                ChainArg::Closure {
+                    params: vec![ClosureParam {
+                        name: "q".to_string(),
+                        php_type: None,
+                    }],
+                    body_byte_range: (44, 48),
+                },
+            ],
+        }],
+    };
+    // Region starts at outer byte 100. Wrapper prefix is 6 bytes (<?php ).
+    // So snippet byte 6 (start of content) maps to outer byte 100.
+    // Every span shifts by 100 - 6 = 94.
+    super::shift_chain_byte_ranges(&mut chain, 100, 6);
+
+    assert_eq!(chain.span_byte_range, (100, 144));
+    match &chain.receiver {
+        ChainReceiver::DbTable {
+            name_byte_range, ..
+        } => assert_eq!(*name_byte_range, (104, 111)),
+        _ => panic!("receiver type changed"),
+    }
+    let link = &chain.links[0];
+    assert_eq!(link.span_byte_range, (124, 139));
+    match &link.args[0] {
+        ChainArg::StringLit {
+            span_byte_range, ..
+        } => assert_eq!(*span_byte_range, (131, 137)),
+        _ => panic!("arg type changed"),
+    }
+    match &link.args[1] {
+        ChainArg::Closure {
+            body_byte_range, ..
+        } => assert_eq!(*body_byte_range, (138, 142)),
+        _ => panic!("arg type changed"),
+    }
+}
+
+// ---- Blade-embedded chain extraction (Phase 3.5) ----------------------
+
+/// Replicate the in-LSP flow for a Blade source: extract regions, parse each
+/// as wrapped PHP, extract chains, shift ranges back to outer coordinates.
+/// Returns chains in outer-file byte-range space.
+fn extract_blade_chains(source: &str) -> Vec<BuilderChain> {
+    use crate::blade_embedded_php::{extract_php_regions, PHP_WRAPPER_PREFIX_LEN};
+    use crate::parser::parse_php;
+    let mut chains = Vec::new();
+    for region in extract_php_regions(source) {
+        let wrapped = format!("<?php {}", region.content);
+        let Ok(tree) = parse_php(&wrapped) else {
+            continue;
+        };
+        for mut chain in super::extract_chains(&tree, &wrapped) {
+            super::shift_chain_byte_ranges(
+                &mut chain,
+                region.byte_offset,
+                PHP_WRAPPER_PREFIX_LEN as usize,
+            );
+            chains.push(chain);
+        }
+    }
+    chains
+}
+
+#[test]
+fn blade_echo_chain_lands_at_outer_byte_offset() {
+    // Source layout (byte positions in comments):
+    //   0:  <div>{{ DB::table('users')->where('email', 1) }}</div>
+    //              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //              starts at byte 8 (after `<div>{{ `)
+    let source = "<div>{{ DB::table('users')->where('email', 1) }}</div>";
+    let chains = extract_blade_chains(source);
+    assert_eq!(chains.len(), 1);
+    let c = &chains[0];
+    // Receiver is DbTable. The chain span should fall inside the source —
+    // specifically, the chain starts at the `DB` token (byte 8) and ends
+    // somewhere before the closing `)`.
+    assert!(c.span_byte_range.0 >= 8, "{:?}", c.span_byte_range);
+    assert!(
+        c.span_byte_range.1 <= source.len(),
+        "{:?}",
+        c.span_byte_range
+    );
+    // The byte slice for the chain span should look like a chain.
+    let slice = &source[c.span_byte_range.0..c.span_byte_range.1];
+    assert!(slice.starts_with("DB::table"), "slice = {:?}", slice);
+    assert!(slice.contains("where"), "slice = {:?}", slice);
+    // The 'email' string-arg byte range should also be on the outer file.
+    let where_link = c.links.iter().find(|l| l.method == "where").unwrap();
+    if let ChainArg::StringLit {
+        span_byte_range, ..
+    } = &where_link.args[0]
+    {
+        let arg_slice = &source[span_byte_range.0..span_byte_range.1];
+        assert_eq!(arg_slice, "'email'", "arg slice mismatch");
+    } else {
+        panic!("expected StringLit for first where arg");
+    }
+}
+
+#[test]
+fn blade_raw_echo_chain() {
+    let source = "<p>{!! User::where('a', 1)->pluck('email') !!}</p>";
+    let chains = extract_blade_chains(source);
+    assert!(
+        chains.iter().any(|c| matches!(
+            &c.receiver,
+            ChainReceiver::Eloquent(EloquentReceiver::StaticModel(s)) if s == "User"
+        )),
+        "User chain missing from {:?}",
+        chains.iter().map(|c| &c.receiver).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn blade_php_block_chain() {
+    let source = r#"<div>
+@php
+    $users = DB::table('users')->where('active', 1)->get();
+@endphp
+</div>"#;
+    let chains = extract_blade_chains(source);
+    assert_eq!(chains.len(), 1);
+    let c = &chains[0];
+    match &c.receiver {
+        ChainReceiver::DbTable { table, .. } => assert_eq!(table, "users"),
+        other => panic!("expected DbTable, got {other:?}"),
+    }
+    let slice = &source[c.span_byte_range.0..c.span_byte_range.1];
+    assert!(
+        slice.starts_with("DB::table"),
+        "outer-byte slice didn't land on chain start: {:?}",
+        slice
+    );
+}
+
+#[test]
+fn blade_php_inline_short_form_chain() {
+    let source = "<x-card>@php($users = DB::table('users')->where('id', 1)->get())</x-card>";
+    let chains = extract_blade_chains(source);
+    assert_eq!(chains.len(), 1);
+    let c = &chains[0];
+    match &c.receiver {
+        ChainReceiver::DbTable { table, .. } => assert_eq!(table, "users"),
+        other => panic!("expected DbTable, got {other:?}"),
+    }
+    let slice = &source[c.span_byte_range.0..c.span_byte_range.1];
+    assert!(slice.starts_with("DB::table"), "slice = {:?}", slice);
+}
+
+#[test]
+fn blade_native_php_tag_chain() {
+    let source = "<div><?php $u = User::where('id', 1)->get(); ?></div>";
+    let chains = extract_blade_chains(source);
+    let user_chain = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::StaticModel(s)) if s == "User"
+            )
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "User chain missing from native <?php ?> region; got receivers {:?}",
+                chains.iter().map(|c| &c.receiver).collect::<Vec<_>>()
+            )
+        });
+    let slice = &source[user_chain.span_byte_range.0..user_chain.span_byte_range.1];
+    assert!(slice.starts_with("User::where"), "slice = {:?}", slice);
+}
+
+#[test]
+fn blade_multiline_chain_in_php_block() {
+    // Multi-line chain inside @php ... @endphp — byte ranges must still land
+    // correctly even though the chain spans multiple lines.
+    let source = r#"@php
+$rows = DB::table('users')
+    ->where('a', 1)
+    ->where('b', 2)
+    ->get();
+@endphp"#;
+    let chains = extract_blade_chains(source);
+    assert_eq!(chains.len(), 1);
+    let c = &chains[0];
+    // Span should cover the whole chain.
+    let slice = &source[c.span_byte_range.0..c.span_byte_range.1];
+    assert!(slice.starts_with("DB::table"), "slice start = {:?}", slice);
+    assert!(slice.contains("'b'"), "slice = {:?}", slice);
+}
+
 #[test]
 fn unknown_receiver_classified_as_unknown() {
     // `($qb)` — parenthesised expression as receiver. We don't try to

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -787,6 +787,69 @@ fn new_parent_returns_unknown_for_now() {
     assert_eq!(chain.receiver, ChainReceiver::Unknown);
 }
 
+// ---- Array-syntax args (Phase 5.2) ---------------------------------------
+
+#[test]
+fn with_array_arg_classifies_as_array_with_string_elements() {
+    // `with(['posts', 'comments'])` — the first arg is an array of strings.
+    // ChainArg::Array carries the elements as nested ChainArgs.
+    let chains = extract("User::with(['posts', 'comments']);");
+    assert_eq!(chains.len(), 1);
+    let with_link = &chains[0].links[0];
+    assert_eq!(with_link.args.len(), 1);
+    match &with_link.args[0] {
+        ChainArg::Array { elements, .. } => {
+            assert_eq!(elements.len(), 2);
+            match (&elements[0], &elements[1]) {
+                (ChainArg::StringLit { value: v1, .. }, ChainArg::StringLit { value: v2, .. }) => {
+                    assert_eq!(v1, "posts");
+                    assert_eq!(v2, "comments");
+                }
+                other => panic!("expected two StringLit elements, got {other:?}"),
+            }
+        }
+        other => panic!("expected Array arg, got {other:?}"),
+    }
+}
+
+#[test]
+fn empty_array_arg_carries_no_elements() {
+    // `with([''])` — single empty string. Useful as the cursor-between-
+    // quotes shape Mike hit when the array form is auto-paired.
+    let chains = extract("User::with(['']);");
+    let with_link = &chains[0].links[0];
+    match &with_link.args[0] {
+        ChainArg::Array { elements, .. } => {
+            assert_eq!(elements.len(), 1);
+            match &elements[0] {
+                ChainArg::StringLit { value, .. } => assert_eq!(value, ""),
+                other => panic!("expected empty StringLit, got {other:?}"),
+            }
+        }
+        other => panic!("expected Array arg, got {other:?}"),
+    }
+}
+
+#[test]
+fn array_arg_with_non_string_element_falls_through_to_other() {
+    // `select([$col, 'name'])` — first element is a variable (Other),
+    // second is a string. Both surface so the cursor resolver can find
+    // the string element.
+    let chains = extract("User::select([$col, 'name']);");
+    let select_link = &chains[0].links[0];
+    match &select_link.args[0] {
+        ChainArg::Array { elements, .. } => {
+            assert_eq!(elements.len(), 2);
+            assert!(matches!(elements[0], ChainArg::Other));
+            match &elements[1] {
+                ChainArg::StringLit { value, .. } => assert_eq!(value, "name"),
+                other => panic!("expected StringLit name, got {other:?}"),
+            }
+        }
+        other => panic!("expected Array arg, got {other:?}"),
+    }
+}
+
 #[test]
 fn unknown_receiver_falls_through_when_inner_is_unhandled() {
     // A parenthesised expression whose inner shape we don't recognise

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -296,6 +296,44 @@ fn double_quoted_string_arg() {
     }
 }
 
+#[test]
+fn empty_string_arg_is_stringlit_not_other() {
+    // After fixup, the source the extractor sees often contains `('')` —
+    // either because the editor auto-paired the quote, or because case-3
+    // in fixup_for_completion injected an empty string. The extractor MUST
+    // classify the empty `''` as a StringLit (so the cursor-resolver finds
+    // it via string_arg_at and completion fires), not fall through to
+    // ChainArg::Other. Same shape for double quotes.
+    let chains = extract("DB::table('users')->where('');");
+    let where_link = chains[0]
+        .links
+        .iter()
+        .find(|l| l.method == "where")
+        .expect("expected a `where` link");
+    assert_eq!(where_link.args.len(), 1);
+    match &where_link.args[0] {
+        ChainArg::StringLit { value, quote, .. } => {
+            assert_eq!(value, "", "empty literal should have empty value");
+            assert_eq!(*quote, '\'');
+        }
+        other => panic!("expected StringLit for empty arg, got {other:?}"),
+    }
+
+    let chains = extract("DB::table('users')->where(\"\");");
+    let where_link = chains[0]
+        .links
+        .iter()
+        .find(|l| l.method == "where")
+        .expect("expected a `where` link");
+    match &where_link.args[0] {
+        ChainArg::StringLit { value, quote, .. } => {
+            assert_eq!(value, "");
+            assert_eq!(*quote, '"');
+        }
+        other => panic!("expected StringLit, got {other:?}"),
+    }
+}
+
 // ---- Closure arguments --------------------------------------------------
 
 #[test]

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -662,12 +662,136 @@ $rows = DB::table('users')
 }
 
 #[test]
-fn unknown_receiver_classified_as_unknown() {
-    // `($qb)` — parenthesised expression as receiver. We don't try to
-    // resolve these in Phase 2; the chain just gets ChainReceiver::Unknown.
+fn parenthesized_var_receiver_unwraps_to_instance_var() {
+    // `($qb)->where('a', 1);` — parens are syntactic noise around a
+    // variable receiver. Phase 5.1 unwraps the parens and treats it the
+    // same as the un-parenthesised form. Phase 9's var-type resolution
+    // will then fill in `php_type` from a docblock / typed param if it
+    // can find one.
     let chains = extract("($qb)->where('a', 1);");
-    // The extractor still produces a chain (the chain root exists), but the
-    // receiver is Unknown.
+    assert_eq!(chains.len(), 1);
+    match &chains[0].receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, php_type }) => {
+            assert_eq!(var, "qb");
+            assert!(php_type.is_none());
+        }
+        other => panic!("expected InstanceVar through parens, got {other:?}"),
+    }
+}
+
+// ---- (new ClassName) / (new self) receivers (Phase 5.1) ------------------
+
+#[test]
+fn new_class_name_receiver_resolves_to_static_model() {
+    // `(new User)->where('|')` — common Laravel pattern. Treat the
+    // freshly-constructed instance as if it were `User::where('|')`.
+    let chains = extract("(new User)->where('email', $e);");
+    assert_eq!(chains.len(), 1);
+    match &chains[0].receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class)) => {
+            assert_eq!(class, "User");
+        }
+        other => panic!("expected StaticModel(User), got {other:?}"),
+    }
+}
+
+#[test]
+fn new_class_name_resolves_through_use_aliases() {
+    // With `use App\Models\User;`, the receiver's class should be
+    // fully-qualified before it reaches downstream handlers — same as
+    // `User::where(...)`.
+    let chains = extract("use App\\Models\\User;\n(new User)->where('email', $e);");
+    let chain = chains
+        .iter()
+        .find(|c| !c.links.is_empty() && c.links[0].method == "where")
+        .expect("expected a chain with where()");
+    match &chain.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class)) => {
+            assert_eq!(class, "App\\Models\\User");
+        }
+        other => panic!("expected StaticModel(App\\Models\\User), got {other:?}"),
+    }
+}
+
+#[test]
+fn new_self_resolves_against_enclosing_class() {
+    // `(new self)->with(...)` inside a class — `self` refers to that
+    // class. We extract the enclosing class name so the receiver is the
+    // same as `(new ClassName)->`.
+    let src = "class User { \
+               public static function active() { \
+                 return (new self)->where('active', 1)->with('roles'); \
+               } \
+             }";
+    let chains = extract(src);
+    let chain = chains
+        .iter()
+        .find(|c| c.links.iter().any(|l| l.method == "where"))
+        .expect("chain not found");
+    match &chain.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class)) => {
+            assert_eq!(class, "User", "self should resolve to the enclosing class");
+        }
+        other => panic!("expected StaticModel(User) from self, got {other:?}"),
+    }
+}
+
+#[test]
+fn new_static_resolves_against_enclosing_class() {
+    // `new static` behaves the same as `new self` for our purposes (we
+    // don't track late static binding's runtime semantics). Resolve to
+    // the enclosing class.
+    let src = "class Post { \
+               public static function published() { \
+                 return (new static)->where('published', true); \
+               } \
+             }";
+    let chains = extract(src);
+    let chain = chains
+        .iter()
+        .find(|c| c.links.iter().any(|l| l.method == "where"))
+        .expect("chain not found");
+    match &chain.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class)) => {
+            assert_eq!(class, "Post");
+        }
+        other => panic!("expected StaticModel(Post) from static, got {other:?}"),
+    }
+}
+
+#[test]
+fn new_self_outside_class_returns_unknown() {
+    // `(new self)` at the top level (no enclosing class) can't be
+    // resolved — `self` is meaningless. Return Unknown rather than
+    // guessing.
+    let chains = extract("(new self)->where('a', 1);");
+    assert_eq!(chains.len(), 1);
+    assert_eq!(chains[0].receiver, ChainReceiver::Unknown);
+}
+
+#[test]
+fn new_parent_returns_unknown_for_now() {
+    // `(new parent)` needs cross-file resolution (we'd have to read the
+    // parent class file). Punt for now; Phase 9's var-type work can pick
+    // this up.
+    let src = "class User extends BaseModel { \
+               public static function scope() { \
+                 return (new parent)->where('a', 1); \
+               } \
+             }";
+    let chains = extract(src);
+    let chain = chains
+        .iter()
+        .find(|c| c.links.iter().any(|l| l.method == "where"))
+        .expect("chain not found");
+    assert_eq!(chain.receiver, ChainReceiver::Unknown);
+}
+
+#[test]
+fn unknown_receiver_falls_through_when_inner_is_unhandled() {
+    // A parenthesised expression whose inner shape we don't recognise
+    // (e.g., a method call result) should still resolve to Unknown.
+    let chains = extract("(foo())->where('a', 1);");
     assert_eq!(chains.len(), 1);
     assert_eq!(chains[0].receiver, ChainReceiver::Unknown);
 }

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -459,6 +459,7 @@ fn shift_chain_byte_ranges_shifts_every_span() {
             name_byte_range: (10, 17),
         },
         span_byte_range: (6, 50),
+        closure_scope: None,
         links: vec![ChainLink {
             method: "where".to_string(),
             arg: ArgKind::Column,
@@ -847,6 +848,219 @@ fn array_arg_with_non_string_element_falls_through_to_other() {
             }
         }
         other => panic!("expected Array arg, got {other:?}"),
+    }
+}
+
+// ---- Closure-scope binding (Phase 8) -------------------------------------
+
+#[test]
+fn where_has_closure_records_relation_and_param_var() {
+    // `User::whereHas('posts', function ($q) { $q->where('published', 1); })`
+    // — the inner `$q->where(...)` chain should be flagged with closure_scope
+    // pointing at the `posts` relation and the `q` param var.
+    let chains = extract("User::whereHas('posts', function ($q) { $q->where('published', 1); });");
+    // Find the INNER chain (the one whose receiver is $q).
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) if var == "q"
+            )
+        })
+        .expect("inner $q chain not found");
+    let binding = inner
+        .closure_scope
+        .as_ref()
+        .expect("inner chain should have closure_scope set");
+    assert_eq!(binding.param_var, "q");
+    match &binding.kind {
+        ClosureScopeKind::RelationHop { relation_name } => {
+            assert_eq!(relation_name, "posts");
+        }
+        other => panic!("expected RelationHop, got {other:?}"),
+    }
+}
+
+#[test]
+fn arrow_fn_closure_in_where_has_also_records_binding() {
+    // Arrow-function variant: `User::whereHas('posts', fn ($q) =>
+    // $q->where('a', 1))`. Same binding semantics; we just have a
+    // different AST node kind to walk through.
+    let chains = extract("User::whereHas('posts', fn ($q) => $q->where('a', 1));");
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { .. })
+            )
+        })
+        .expect("inner chain");
+    let binding = inner.closure_scope.as_ref().expect("scope set");
+    assert!(matches!(
+        &binding.kind,
+        ClosureScopeKind::RelationHop { relation_name } if relation_name == "posts"
+    ));
+}
+
+#[test]
+fn with_keyed_array_closure_records_relation_from_key() {
+    // The shape Mike reported:
+    // `OAuthClient::with(['tokens' => function (Builder $q) { $q->where('|'); }])`
+    // — the relation name comes from the array element's KEY, not from a
+    // positional argument.
+    let chains =
+        extract("OAuthClient::with(['tokens' => function ($q) { $q->where('expired', 1); }]);");
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) if var == "q"
+            )
+        })
+        .expect("inner $q chain not found");
+    let binding = inner
+        .closure_scope
+        .as_ref()
+        .expect("closure_scope should be set for with-keyed-array closures");
+    assert_eq!(binding.param_var, "q");
+    assert!(matches!(
+        &binding.kind,
+        ClosureScopeKind::RelationHop { relation_name } if relation_name == "tokens"
+    ));
+}
+
+#[test]
+fn with_keyed_array_arrow_fn_also_records_binding() {
+    let chains = extract("User::with(['posts' => fn ($q) => $q->where('published', 1)]);");
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { .. })
+            )
+        })
+        .expect("inner chain");
+    let binding = inner.closure_scope.as_ref().expect("scope set");
+    assert!(matches!(
+        &binding.kind,
+        ClosureScopeKind::RelationHop { relation_name } if relation_name == "posts"
+    ));
+}
+
+// ---- Same-model closure carriers (`where(closure)`, `when`, `having`, etc.) -
+
+#[test]
+fn nested_where_closure_records_same_model_binding() {
+    // `User::where(function ($q) { $q->where('a', 1)->orWhere('b', 2); })`
+    // — the inner `$q->where(...)` is on the SAME model as the outer
+    // where(). Binding kind is SameModel (no relation hop).
+    let chains = extract("User::where(function ($q) { $q->where('a', 1)->orWhere('b', 2); });");
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) if var == "q"
+            )
+        })
+        .expect("inner $q chain");
+    let binding = inner.closure_scope.as_ref().expect("scope set");
+    assert_eq!(binding.param_var, "q");
+    assert!(matches!(binding.kind, ClosureScopeKind::SameModel));
+}
+
+#[test]
+fn when_closure_records_same_model_binding() {
+    // `User::when($cond, function ($q) { $q->where('|'); })` — `when`'s
+    // closure receives the same builder as the outer chain.
+    let chains = extract("User::when($cond, function ($q) { $q->where('a', 1); });");
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) if var == "q"
+            )
+        })
+        .expect("inner $q chain");
+    let binding = inner.closure_scope.as_ref().expect("scope set");
+    assert!(matches!(binding.kind, ClosureScopeKind::SameModel));
+}
+
+#[test]
+fn having_closure_records_same_model_binding() {
+    let chains = extract("User::having(function ($q) { $q->where('a', 1); });");
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { .. })
+            )
+        })
+        .expect("inner chain");
+    let binding = inner.closure_scope.as_ref().expect("scope set");
+    assert!(matches!(binding.kind, ClosureScopeKind::SameModel));
+}
+
+#[test]
+fn tap_closure_records_same_model_binding() {
+    let chains = extract("User::tap(function ($q) { $q->where('a', 1); });");
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { .. })
+            )
+        })
+        .expect("inner chain");
+    let binding = inner.closure_scope.as_ref().expect("scope set");
+    assert!(matches!(binding.kind, ClosureScopeKind::SameModel));
+}
+
+#[test]
+fn closure_param_var_mismatch_means_no_binding() {
+    // The inner chain's receiver is `$other`, not the closure's `$q` param —
+    // the closure binding only applies to the *param's* var, not arbitrary
+    // variables used inside the body.
+    let chains =
+        extract("User::whereHas('posts', function ($q) use ($other) { $other->where('a', 1); });");
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) if var == "other"
+            )
+        })
+        .expect("inner $other chain");
+    assert!(
+        inner.closure_scope.is_none(),
+        "closure_scope should be None when the receiver var doesn't match the closure param"
+    );
+}
+
+#[test]
+fn random_closure_argument_does_not_bind() {
+    // The closure is the 2nd arg of a method we don't recognize as a
+    // relation-carrier. Don't fabricate a binding from arbitrary
+    // closures.
+    let chains = extract("array_map(fn ($q) => $q->where('a', 1), $items);");
+    if let Some(inner) = chains.iter().find(|c| {
+        matches!(
+            &c.receiver,
+            ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { .. })
+        )
+    }) {
+        assert!(
+            inner.closure_scope.is_none(),
+            "non-relation method's closure shouldn't bind"
+        );
     }
 }
 

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -145,6 +145,91 @@ fn fqcn_db_facade_recognised() {
     }
 }
 
+// ---- use-alias resolution -----------------------------------------------
+
+#[test]
+fn use_aliased_db_facade_recognised() {
+    // `use ... as Database; Database::table('users')` — receiver name in
+    // source isn't `DB`, but the alias resolves to the DB facade FQCN.
+    let chains = extract(
+        "use Illuminate\\Support\\Facades\\DB as Database;\n\
+         Database::table('users')->where('email', 1);",
+    );
+    let db_chain = chains
+        .iter()
+        .find(|c| matches!(&c.receiver, ChainReceiver::DbTable { .. }))
+        .unwrap_or_else(|| {
+            panic!(
+                "aliased DB facade not recognised; got receivers {:?}",
+                chains.iter().map(|c| &c.receiver).collect::<Vec<_>>()
+            )
+        });
+    match &db_chain.receiver {
+        ChainReceiver::DbTable { table, .. } => assert_eq!(table, "users"),
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn use_imported_db_no_alias_still_recognised() {
+    // `use Illuminate\Support\Facades\DB; DB::table('users')` — the
+    // canonical Laravel import. Resolution maps `DB` → the FQCN; basename
+    // check still picks it up.
+    let chains = extract(
+        "use Illuminate\\Support\\Facades\\DB;\n\
+         DB::table('users')->where('email', 1);",
+    );
+    assert!(
+        chains
+            .iter()
+            .any(|c| matches!(&c.receiver, ChainReceiver::DbTable { .. })),
+        "imported DB facade not recognised; got {:?}",
+        chains.iter().map(|c| &c.receiver).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn use_aliased_eloquent_model_resolves_to_fqcn() {
+    // `use App\Models\User as MyUser; MyUser::where(...)` — the receiver
+    // string in source is `MyUser`, but the chain's receiver should hold
+    // the resolved FQCN. Phase 4's model resolver will find the file there.
+    let chains = extract(
+        "use App\\Models\\User as MyUser;\n\
+         MyUser::where('email', $e)->get();",
+    );
+    let model_chain = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::StaticModel(_))
+            )
+        })
+        .unwrap();
+    match &model_chain.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::StaticModel(name)) => {
+            assert_eq!(name, "App\\Models\\User");
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn shadowing_alias_does_not_match_db_facade() {
+    // `use Some\Other\Klass as DB;` — `DB` in source refers to
+    // Some\Other\Klass, NOT the facade. Don't classify as DbTable.
+    let chains = extract(
+        "use Some\\Other\\Klass as DB;\n\
+         DB::table('users')->where('email', 1);",
+    );
+    let chain = chains.first().expect("chain expected");
+    assert!(
+        !matches!(chain.receiver, ChainReceiver::DbTable { .. }),
+        "shadowed DB shouldn't be classified as facade; receiver: {:?}",
+        chain.receiver
+    );
+}
+
 // ---- Link classification ------------------------------------------------
 
 #[test]

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -112,6 +112,39 @@ fn extracts_db_table_with_double_quotes() {
     }
 }
 
+#[test]
+fn db_table_link_gets_table_arg_kind() {
+    // The bottom-most link (`table`) of a DB::table chain is annotated with
+    // ArgKind::Table so the cursor resolver can offer table-name completion.
+    let chains = extract("DB::table('users')->where('email', 1);");
+    let c = &chains[0];
+    let table_link = c.links.iter().find(|l| l.method == "table").unwrap();
+    assert_eq!(table_link.arg, ArgKind::Table);
+}
+
+#[test]
+fn lowercase_db_facade_recognised() {
+    // PHP class names are case-insensitive. `db::table('users')` resolves to
+    // the same DB facade and should produce a DbTable receiver.
+    let chains = extract("db::table('users')->where('email', 1);");
+    assert_eq!(chains.len(), 1);
+    match &chains[0].receiver {
+        ChainReceiver::DbTable { table, .. } => assert_eq!(table, "users"),
+        other => panic!("expected DbTable, got {other:?}"),
+    }
+}
+
+#[test]
+fn fqcn_db_facade_recognised() {
+    // \Illuminate\Support\Facades\DB::table('users') — fully-qualified form.
+    let chains = extract("\\Illuminate\\Support\\Facades\\DB::table('users')->where('email', 1);");
+    assert_eq!(chains.len(), 1);
+    match &chains[0].receiver {
+        ChainReceiver::DbTable { table, .. } => assert_eq!(table, "users"),
+        other => panic!("expected DbTable, got {other:?}"),
+    }
+}
+
 // ---- Link classification ------------------------------------------------
 
 #[test]

--- a/laravel-lsp/src/query_chain/methods.rs
+++ b/laravel-lsp/src/query_chain/methods.rs
@@ -135,10 +135,13 @@ pub const MODE_FLIP_TO_BASE: &[&str] = &["toBase", "getQuery"];
 /// After these, the chain is operating on a hydrated `Collection`, so
 /// accessors and cast names join DB columns as valid `where` arguments.
 ///
-/// Note: `all()` is a Collection-returning static starter (`User::all()`) but
-/// only appears as the chain entry point; handled at the receiver level rather
-/// than as a mid-chain terminator.
+/// `all()` is included here even though it's usually the static-call entry
+/// point on a model (`User::all()`). It still occupies a link in the chain
+/// (the first one) and the walker applies the effect AFTER that link runs
+/// — so the cursor at `User::all()->where('|')` correctly sees mode flipped
+/// to EloquentCollection.
 pub const COLLECTION_TERMINATORS: &[&str] = &[
+    "all",
     "get",
     "pluck",
     "cursor",

--- a/laravel-lsp/src/query_chain/methods.rs
+++ b/laravel-lsp/src/query_chain/methods.rs
@@ -96,6 +96,35 @@ pub const CLOSURE_CARRIERS: &[&str] = &[
     "withMax",
 ];
 
+/// Methods whose closure argument receives a builder of the SAME model as
+/// the outer chain. Used for grouping conditions (`where(fn ($q) =>
+/// $q->where(...)->orWhere(...))`), conditional clauses (`when($cond,
+/// fn ($q) => ...)` / `unless`), `having` groups, and `tap`. Inside the
+/// closure, completion should resolve against the outer chain's model
+/// directly — no relation hop.
+///
+/// `when` / `unless` actually take a closure as the *2nd* arg (with a
+/// boolean / condition as the 1st), and an optional default closure as
+/// the 3rd. Both closures bind the same way. We don't try to distinguish
+/// positions here — any closure inside one of these calls binds same-
+/// model.
+///
+/// Several of these also appear elsewhere with non-closure args
+/// (`where('column', $value)`) — the same-model binding only applies when
+/// the arg actually IS a closure, which the extractor checks at the
+/// closure-walking step.
+pub const SAME_MODEL_CLOSURE_CARRIERS: &[&str] = &[
+    "where",
+    "orWhere",
+    "whereNot",
+    "orWhereNot",
+    "having",
+    "orHaving",
+    "when",
+    "unless",
+    "tap",
+];
+
 /// Methods that flip the chain from Eloquent → base query builder. After
 /// these, the chain is operating on `Illuminate\Database\Query\Builder`, so
 /// relation methods would error at runtime — completion returns empty for

--- a/laravel-lsp/src/query_chain/methods.rs
+++ b/laravel-lsp/src/query_chain/methods.rs
@@ -1,0 +1,310 @@
+//! Classification tables for Eloquent / DB builder methods.
+//!
+//! Every method name we recognise falls into one of the `MethodKind` variants
+//! defined in [`super::chain`]. The categorisation here drives both link
+//! classification during extraction and the dispatch logic inside the chain
+//! walker: a `ModeFlipToBase` flips the mode, a `CollectionTerminator` flips
+//! to `EloquentCollection`, a `ChainTerminator` ends the chain entirely.
+//!
+//! The lists are small (~30 entries each) and the lookup is a linear scan
+//! over `&'static [&'static str]` slices. That's faster than a `HashMap`
+//! at this size and saves an allocation per call.
+
+use super::chain::{ArgKind, ChainEffect};
+
+/// Methods whose first string argument is a column name. Used both as static
+/// entry points (`Model::where(...)`) and as chained links (`->where(...)`).
+/// The same method name can also appear in `EloquentCollection` mode — the
+/// completion source changes (DB cols + accessors + cast names) but the
+/// classification stays the same.
+pub const COLUMN_METHODS: &[&str] = &[
+    "where",
+    "orWhere",
+    "whereIn",
+    "whereNotIn",
+    "whereNull",
+    "whereNotNull",
+    "whereBetween",
+    "whereNotBetween",
+    "whereDate",
+    "whereMonth",
+    "whereYear",
+    "whereTime",
+    "whereDay",
+    "whereColumn",
+    "orderBy",
+    "orderByDesc",
+    "latest",
+    "oldest",
+    "groupBy",
+    "having",
+    "havingRaw",
+    "select",
+    "addSelect",
+    "pluck",
+    "firstWhere",
+    "value",
+    "increment",
+    "decrement",
+    // Collection-shape methods that also accept column names as the first arg.
+    "sortBy",
+    "sortByDesc",
+    "keyBy",
+    "unique",
+    "uniqueStrict",
+];
+
+/// Methods whose first string argument is a relation name. Eloquent-only —
+/// these don't exist on the base query builder.
+pub const RELATION_METHODS: &[&str] = &[
+    "with",
+    "without",
+    "load",
+    "loadMissing",
+    "loadCount",
+    "loadSum",
+    "loadAvg",
+    "loadMin",
+    "loadMax",
+    "has",
+    "whereHas",
+    "doesntHave",
+    "whereDoesntHave",
+    "orWhereHas",
+    "orWhereDoesntHave",
+    "withCount",
+    "withSum",
+    "withAvg",
+    "withMin",
+    "withMax",
+    "withExists",
+];
+
+/// Methods whose second argument is a closure. Inside the closure body, the
+/// builder parameter is bound to the model resolved from the first argument
+/// (the relation name). Subset of `RELATION_METHODS`.
+pub const CLOSURE_CARRIERS: &[&str] = &[
+    "whereHas",
+    "doesntHave",
+    "whereDoesntHave",
+    "orWhereHas",
+    "orWhereDoesntHave",
+    "withCount",
+    "withSum",
+    "withAvg",
+    "withMin",
+    "withMax",
+];
+
+/// Methods that flip the chain from Eloquent → base query builder. After
+/// these, the chain is operating on `Illuminate\Database\Query\Builder`, so
+/// relation methods would error at runtime — completion returns empty for
+/// them.
+pub const MODE_FLIP_TO_BASE: &[&str] = &["toBase", "getQuery"];
+
+/// Methods that flip the chain from `EloquentBuilder` to `EloquentCollection`.
+/// After these, the chain is operating on a hydrated `Collection`, so
+/// accessors and cast names join DB columns as valid `where` arguments.
+///
+/// Note: `all()` is a Collection-returning static starter (`User::all()`) but
+/// only appears as the chain entry point; handled at the receiver level rather
+/// than as a mid-chain terminator.
+pub const COLLECTION_TERMINATORS: &[&str] = &[
+    "get",
+    "pluck",
+    "cursor",
+    "lazy",
+    "lazyById",
+    "paginate",
+    "simplePaginate",
+    "cursorPaginate",
+];
+
+/// Methods that end the chain. Subsequent calls are operating on a single
+/// Model, a scalar, or `void` — none of which is a builder, so completion
+/// stops paying attention.
+pub const CHAIN_TERMINATORS: &[&str] = &[
+    // Single-model terminators
+    "first",
+    "firstOrFail",
+    "firstOr",
+    "find",
+    "findOrFail",
+    "findOrNew",
+    "findMany",
+    "sole",
+    // Scalar terminators
+    "count",
+    "exists",
+    "doesntExist",
+    "sum",
+    "avg",
+    "average",
+    "min",
+    "max",
+    "median",
+    "mode",
+    // Mutation terminators
+    "update",
+    "delete",
+    "insert",
+    "insertOrIgnore",
+    "upsert",
+    "forceCreate",
+    "forceDelete",
+    "save",
+    "push",
+    "truncate",
+    "restore",
+    // Iteration patterns — take callbacks, don't chain meaningfully
+    "chunk",
+    "chunkById",
+    "each",
+    "eachById",
+    // Debug terminators — stop completion here for simplicity
+    "dd",
+    "dump",
+    "ddRawSql",
+    "dumpRawSql",
+];
+
+/// Methods that don't affect chain context — pass through unchanged. They
+/// return the same builder type with the same effective model.
+pub const TRANSPARENT: &[&str] = &[
+    "clone",
+    "cloneWithout",
+    "cloneWithoutBindings",
+    "tap",
+    "when",
+    "unless",
+];
+
+/// Static methods on an Eloquent model class that start a chain. This list
+/// disambiguates Eloquent static calls from unrelated static calls like
+/// `Carbon::now()` — the receiver detection still needs to confirm the class
+/// actually extends `Illuminate\Database\Eloquent\Model`, but if the static
+/// method isn't on this list (or the model's local scopes), it's not a chain
+/// starter.
+pub const ELOQUENT_STATIC_STARTERS: &[&str] = &[
+    "query",
+    "newQuery",
+    "on",
+    "onWriteConnection",
+    "where",
+    "whereIn",
+    "whereNotIn",
+    "whereNull",
+    "whereNotNull",
+    "whereBetween",
+    "find",
+    "findOrFail",
+    "findOrNew",
+    "findMany",
+    "first",
+    "firstWhere",
+    "firstOrFail",
+    "firstOrCreate",
+    "firstOrNew",
+    "firstOr",
+    "all",
+    "get",
+    "cursor",
+    "with",
+    "without",
+    "has",
+    "whereHas",
+    "doesntHave",
+    "whereDoesntHave",
+    "withCount",
+    "withSum",
+    "withAvg",
+    "withMin",
+    "withMax",
+    "create",
+    "make",
+    "forceCreate",
+    "insert",
+    "insertOrIgnore",
+    "upsert",
+    "count",
+    "exists",
+    "doesntExist",
+    "sum",
+    "avg",
+    "min",
+    "max",
+    "latest",
+    "oldest",
+    "orderBy",
+    "groupBy",
+    "having",
+    "select",
+    "addSelect",
+    "pluck",
+    "value",
+    "chunk",
+    "chunkById",
+    "each",
+    "paginate",
+    "simplePaginate",
+    "cursorPaginate",
+    "inRandomOrder",
+    "limit",
+    "take",
+    "skip",
+    "offset",
+    "forPage",
+    "withTrashed",
+    "onlyTrashed",
+    "withoutTrashed",
+];
+
+/// What kind of argument a method expects at its first interesting position.
+/// Used at the cursor's link only — the walker uses `chain_effect` for prior
+/// links.
+///
+/// Precedence handles methods that appear in multiple lists:
+/// - `ClosureCarrier` wins over `Relation` (drives closure scope descent)
+/// - `Relation` wins over `Column` (no current overlap, but reserved)
+/// - `Column` wins over `None` (methods like `pluck` are `Column` for cursor
+///   purposes even though they also terminate the chain — termination is a
+///   `ChainEffect`, orthogonal to `ArgKind`)
+pub fn arg_kind(name: &str) -> ArgKind {
+    if CLOSURE_CARRIERS.contains(&name) {
+        return ArgKind::ClosureCarrier;
+    }
+    if RELATION_METHODS.contains(&name) {
+        return ArgKind::Relation;
+    }
+    if COLUMN_METHODS.contains(&name) {
+        return ArgKind::Column;
+    }
+    ArgKind::None
+}
+
+/// What this method does to the walker's chain context as it processes prior
+/// links to reach the cursor. Orthogonal to `arg_kind` — `pluck` is both
+/// `ArgKind::Column` AND `ChainEffect::FlipToCollection`.
+pub fn chain_effect(name: &str) -> ChainEffect {
+    if CHAIN_TERMINATORS.contains(&name) {
+        return ChainEffect::Terminate;
+    }
+    if COLLECTION_TERMINATORS.contains(&name) {
+        return ChainEffect::FlipToCollection;
+    }
+    if MODE_FLIP_TO_BASE.contains(&name) {
+        return ChainEffect::FlipToBase;
+    }
+    ChainEffect::None
+}
+
+/// Whether this method, when called statically on an Eloquent model class,
+/// starts a query chain. Used by receiver detection — a static call that
+/// isn't on this list isn't treated as a chain starter (the call might be
+/// `Carbon::now()` or similar).
+pub fn is_eloquent_static_starter(name: &str) -> bool {
+    ELOQUENT_STATIC_STARTERS.contains(&name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/query_chain/methods/tests.rs
+++ b/laravel-lsp/src/query_chain/methods/tests.rs
@@ -1,0 +1,190 @@
+use super::*;
+
+// ---- arg_kind: what does the cursor's link expect? ---------------------
+
+#[test]
+fn arg_kind_where_is_column() {
+    assert_eq!(arg_kind("where"), ArgKind::Column);
+    assert_eq!(arg_kind("orWhere"), ArgKind::Column);
+    assert_eq!(arg_kind("whereIn"), ArgKind::Column);
+    assert_eq!(arg_kind("orderBy"), ArgKind::Column);
+}
+
+#[test]
+fn arg_kind_pluck_is_column_even_though_it_terminates() {
+    // pluck() takes a column name as its first arg AND terminates the chain
+    // by returning a Collection. ArgKind cares about the first; ChainEffect
+    // cares about the second. This test pins that orthogonality.
+    assert_eq!(arg_kind("pluck"), ArgKind::Column);
+    assert_eq!(chain_effect("pluck"), ChainEffect::FlipToCollection);
+}
+
+#[test]
+fn arg_kind_with_is_relation() {
+    assert_eq!(arg_kind("with"), ArgKind::Relation);
+    assert_eq!(arg_kind("load"), ArgKind::Relation);
+    assert_eq!(arg_kind("loadMissing"), ArgKind::Relation);
+    assert_eq!(arg_kind("has"), ArgKind::Relation);
+}
+
+#[test]
+fn arg_kind_closure_carriers_win_over_relation() {
+    // whereHas appears in both RELATION_METHODS and CLOSURE_CARRIERS.
+    // ClosureCarrier wins because the walker needs that signal to descend
+    // into the closure scope correctly.
+    assert_eq!(arg_kind("whereHas"), ArgKind::ClosureCarrier);
+    assert_eq!(arg_kind("whereDoesntHave"), ArgKind::ClosureCarrier);
+    assert_eq!(arg_kind("withCount"), ArgKind::ClosureCarrier);
+}
+
+#[test]
+fn arg_kind_terminators_have_no_arg() {
+    // Methods that just terminate the chain don't expose a completable arg.
+    assert_eq!(arg_kind("get"), ArgKind::None);
+    assert_eq!(arg_kind("first"), ArgKind::None);
+    assert_eq!(arg_kind("count"), ArgKind::None);
+    assert_eq!(arg_kind("toBase"), ArgKind::None);
+}
+
+#[test]
+fn arg_kind_transparent_has_no_arg() {
+    assert_eq!(arg_kind("clone"), ArgKind::None);
+    assert_eq!(arg_kind("tap"), ArgKind::None);
+    assert_eq!(arg_kind("when"), ArgKind::None);
+}
+
+#[test]
+fn arg_kind_unknown_is_none() {
+    assert_eq!(arg_kind("totallyMadeUp"), ArgKind::None);
+    assert_eq!(arg_kind(""), ArgKind::None);
+}
+
+// ---- chain_effect: what does the walker do for prior links? ------------
+
+#[test]
+fn chain_effect_to_base_flips_mode() {
+    assert_eq!(chain_effect("toBase"), ChainEffect::FlipToBase);
+    assert_eq!(chain_effect("getQuery"), ChainEffect::FlipToBase);
+}
+
+#[test]
+fn chain_effect_collection_terminators() {
+    assert_eq!(chain_effect("get"), ChainEffect::FlipToCollection);
+    assert_eq!(chain_effect("cursor"), ChainEffect::FlipToCollection);
+    assert_eq!(chain_effect("paginate"), ChainEffect::FlipToCollection);
+    assert_eq!(
+        chain_effect("simplePaginate"),
+        ChainEffect::FlipToCollection
+    );
+    assert_eq!(
+        chain_effect("cursorPaginate"),
+        ChainEffect::FlipToCollection
+    );
+    assert_eq!(chain_effect("lazy"), ChainEffect::FlipToCollection);
+    // pluck is also FlipToCollection — verified above; cross-checked here.
+    assert_eq!(chain_effect("pluck"), ChainEffect::FlipToCollection);
+}
+
+#[test]
+fn chain_effect_chain_terminators() {
+    assert_eq!(chain_effect("first"), ChainEffect::Terminate);
+    assert_eq!(chain_effect("find"), ChainEffect::Terminate);
+    assert_eq!(chain_effect("findOrFail"), ChainEffect::Terminate);
+    assert_eq!(chain_effect("count"), ChainEffect::Terminate);
+    assert_eq!(chain_effect("exists"), ChainEffect::Terminate);
+    assert_eq!(chain_effect("update"), ChainEffect::Terminate);
+    assert_eq!(chain_effect("delete"), ChainEffect::Terminate);
+    assert_eq!(chain_effect("dd"), ChainEffect::Terminate);
+}
+
+#[test]
+fn chain_effect_where_is_passthrough() {
+    // where/with/etc. accept args but don't change the chain context.
+    assert_eq!(chain_effect("where"), ChainEffect::None);
+    assert_eq!(chain_effect("with"), ChainEffect::None);
+    assert_eq!(chain_effect("whereHas"), ChainEffect::None);
+    assert_eq!(chain_effect("orderBy"), ChainEffect::None);
+}
+
+#[test]
+fn chain_effect_transparent_is_passthrough() {
+    assert_eq!(chain_effect("clone"), ChainEffect::None);
+    assert_eq!(chain_effect("tap"), ChainEffect::None);
+    assert_eq!(chain_effect("when"), ChainEffect::None);
+    assert_eq!(chain_effect("unless"), ChainEffect::None);
+}
+
+#[test]
+fn chain_effect_unknown_is_passthrough() {
+    // Unrecognised methods don't break the chain — they're treated as
+    // transparent so the walker keeps the current context.
+    assert_eq!(chain_effect("totallyMadeUp"), ChainEffect::None);
+    assert_eq!(chain_effect(""), ChainEffect::None);
+}
+
+// ---- is_eloquent_static_starter ----------------------------------------
+
+#[test]
+fn is_eloquent_static_starter_recognises_idiomatic_forms() {
+    // The common forms — not just query() — are all recognised.
+    assert!(is_eloquent_static_starter("query"));
+    assert!(is_eloquent_static_starter("where"));
+    assert!(is_eloquent_static_starter("find"));
+    assert!(is_eloquent_static_starter("findOrFail"));
+    assert!(is_eloquent_static_starter("first"));
+    assert!(is_eloquent_static_starter("firstWhere"));
+    assert!(is_eloquent_static_starter("all"));
+    assert!(is_eloquent_static_starter("with"));
+    assert!(is_eloquent_static_starter("create"));
+    assert!(is_eloquent_static_starter("count"));
+}
+
+#[test]
+fn is_eloquent_static_starter_rejects_unrelated_calls() {
+    // Carbon::now(), Str::random(), etc. — these aren't query starters.
+    assert!(!is_eloquent_static_starter("now"));
+    assert!(!is_eloquent_static_starter("random"));
+    assert!(!is_eloquent_static_starter("today"));
+    assert!(!is_eloquent_static_starter("frobnicate"));
+}
+
+// ---- dedupe sanity ------------------------------------------------------
+
+#[test]
+fn column_methods_are_unique() {
+    let mut sorted = COLUMN_METHODS.to_vec();
+    sorted.sort();
+    let mut deduped = sorted.clone();
+    deduped.dedup();
+    assert_eq!(
+        sorted, deduped,
+        "COLUMN_METHODS contains duplicates: {:?}",
+        sorted
+    );
+}
+
+#[test]
+fn relation_methods_are_unique() {
+    let mut sorted = RELATION_METHODS.to_vec();
+    sorted.sort();
+    let mut deduped = sorted.clone();
+    deduped.dedup();
+    assert_eq!(
+        sorted, deduped,
+        "RELATION_METHODS contains duplicates: {:?}",
+        sorted
+    );
+}
+
+#[test]
+fn chain_terminators_are_unique() {
+    let mut sorted = CHAIN_TERMINATORS.to_vec();
+    sorted.sort();
+    let mut deduped = sorted.clone();
+    deduped.dedup();
+    assert_eq!(
+        sorted, deduped,
+        "CHAIN_TERMINATORS contains duplicates: {:?}",
+        sorted
+    );
+}

--- a/laravel-lsp/src/query_chain/use_aliases.rs
+++ b/laravel-lsp/src/query_chain/use_aliases.rs
@@ -1,0 +1,206 @@
+//! Parse `use` statements in PHP source into an alias → fully-qualified-name
+//! map.
+//!
+//! PHP class names are case-insensitive but the alias *name* (the local
+//! identifier) is matched as-typed by source. We store keys as-typed.
+//! Resolution helpers do case-insensitive lookups so `db` and `DB` both
+//! resolve when an import says `use Foo\DB;`.
+//!
+//! Scope: top-level `use` statements (the `namespace_use_declaration` node).
+//! Grouped uses (`use Foo\{Bar, Baz as B};`) are also handled. Function and
+//! constant uses (`use function foo;`, `use const FOO;`) are ignored —
+//! chains never receive functions or constants as their static scope.
+
+use std::collections::HashMap;
+use tree_sitter::{Node, Tree};
+
+/// Map from the local name in source → the fully-qualified class name.
+///
+/// Examples:
+/// - `use Illuminate\Support\Facades\DB;` → `"DB"` → `"Illuminate\Support\Facades\DB"`
+/// - `use Illuminate\Support\Facades\DB as Database;` → `"Database"` → `"Illuminate\Support\Facades\DB"`
+/// - `use App\Models\{User, Post as P};` → `"User"` → `"App\Models\User"`, `"P"` → `"App\Models\Post"`
+pub type UseAliases = HashMap<String, String>;
+
+/// Extract every `use` import in the file. Returns an empty map if no
+/// imports exist or the file has parse errors.
+pub fn extract_use_aliases(tree: &Tree, source: &str) -> UseAliases {
+    let bytes = source.as_bytes();
+    let mut aliases: UseAliases = HashMap::new();
+
+    let mut stack: Vec<Node> = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "namespace_use_declaration" {
+            collect_from_declaration(node, bytes, &mut aliases);
+            // Don't recurse into the declaration — we've handled its children.
+            continue;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+
+    aliases
+}
+
+/// Resolve a class reference as it appears in source to its FQCN, by
+/// looking up the leading segment in the alias map. Falls back to the
+/// original string when no match — Laravel's global aliases (the
+/// `config/app.php` `aliases` array, which makes `\DB` etc. available
+/// everywhere) are NOT in PHP's use-statement scope so they end up here.
+///
+/// Examples:
+/// - `Database::table` with `Database → Illuminate\Support\Facades\DB` → `Illuminate\Support\Facades\DB`
+/// - `\DB::table` (leading `\`) → `DB` (unchanged after stripping leading `\`)
+/// - `DB::table` with no import → `DB` (unchanged; relies on global alias)
+/// - `App\Foo::method` (no segment in map) → `App\Foo` (unchanged)
+pub fn resolve_class_name(class: &str, aliases: &UseAliases) -> String {
+    let stripped = class.trim_start_matches('\\');
+    if let Some((head, rest)) = split_first_segment(stripped) {
+        // Case-insensitive lookup against the map keys.
+        for (alias, fqcn) in aliases {
+            if alias.eq_ignore_ascii_case(head) {
+                return if rest.is_empty() {
+                    fqcn.clone()
+                } else {
+                    format!("{fqcn}\\{rest}")
+                };
+            }
+        }
+    }
+    stripped.to_string()
+}
+
+/// Walk a `namespace_use_declaration` and add every clause to `aliases`.
+///
+/// AST shapes (from tree-sitter-php):
+///
+/// Flat: `use Foo\Bar as Baz;`
+/// ```text
+/// namespace_use_declaration
+///   use
+///   namespace_use_clause
+///     qualified_name    <- the FQCN
+///     as
+///     name              <- the alias (only present with `as`)
+/// ```
+///
+/// Grouped: `use Foo\{Bar, Baz as B};`
+/// ```text
+/// namespace_use_declaration
+///   use
+///   namespace_name      <- the shared prefix
+///   namespace_use_group
+///     namespace_use_clause
+///       name            <- "Bar" (no alias)
+///     namespace_use_clause
+///       name            <- "Baz"
+///       as
+///       name            <- "B"
+/// ```
+///
+/// Function/const: `use function foo;` — the `function` marker is INSIDE
+/// the clause, not at declaration level.
+fn collect_from_declaration(decl: Node, bytes: &[u8], aliases: &mut UseAliases) {
+    // Find the (optional) prefix and (optional) group, scanning direct
+    // children of the declaration.
+    let mut prefix: Option<String> = None;
+    let mut group: Option<Node> = None;
+    let mut cursor = decl.walk();
+    for child in decl.children(&mut cursor) {
+        match child.kind() {
+            "namespace_name" => prefix = node_text(child, bytes).map(String::from),
+            "namespace_use_group" => group = Some(child),
+            _ => {}
+        }
+    }
+
+    // Clauses live inside the group when present, otherwise directly under
+    // the declaration.
+    let clauses_parent = group.unwrap_or(decl);
+    let mut cursor = clauses_parent.walk();
+    for clause in clauses_parent.children(&mut cursor) {
+        if clause.kind() == "namespace_use_clause" {
+            insert_clause(clause, bytes, prefix.as_deref(), aliases);
+        }
+    }
+}
+
+/// Insert one `namespace_use_clause` into the alias map. `prefix` is the
+/// shared prefix from a grouped use, if any.
+///
+/// Skips `function` / `const` imports — those don't bind classes, so chains
+/// would never reference them as static receivers.
+fn insert_clause(clause: Node, bytes: &[u8], prefix: Option<&str>, aliases: &mut UseAliases) {
+    // Collect children once so we can scan for both the function/const
+    // modifier and the class name without re-walking.
+    let mut cursor = clause.walk();
+    let children: Vec<Node> = clause.children(&mut cursor).collect();
+
+    if children
+        .iter()
+        .any(|c| matches!(c.kind(), "function" | "const"))
+    {
+        return;
+    }
+
+    // The class name is the first `qualified_name` | `namespace_name` |
+    // `name` child. `name` covers the single-identifier case inside grouped
+    // imports (`{User, Post}`).
+    let name_node = children
+        .iter()
+        .find(|c| matches!(c.kind(), "qualified_name" | "namespace_name" | "name"))
+        .copied();
+    let Some(name_node) = name_node else {
+        return;
+    };
+    let Some(name_text) = node_text(name_node, bytes) else {
+        return;
+    };
+    let name_clean = name_text.trim_start_matches('\\');
+
+    let fqcn = match prefix {
+        Some(p) => format!("{p}\\{name_clean}"),
+        None => name_clean.to_string(),
+    };
+
+    // The alias name (if present) is the `name` node that comes AFTER an
+    // `as` token among the clause's direct children. Walk in source order
+    // so we don't mistake the class-name's `name` (in the grouped case) for
+    // an alias.
+    let mut alias: Option<String> = None;
+    let mut saw_as = false;
+    for child in &children {
+        if child.kind() == "as" {
+            saw_as = true;
+            continue;
+        }
+        if saw_as && child.kind() == "name" {
+            alias = node_text(*child, bytes).map(String::from);
+            break;
+        }
+    }
+
+    // No `as` — alias is the last segment of the FQCN.
+    let alias = alias.unwrap_or_else(|| fqcn.rsplit('\\').next().unwrap_or(&fqcn).to_string());
+
+    aliases.insert(alias, fqcn);
+}
+
+fn split_first_segment(class: &str) -> Option<(&str, &str)> {
+    match class.find('\\') {
+        Some(i) => Some((&class[..i], &class[i + 1..])),
+        None if class.is_empty() => None,
+        None => Some((class, "")),
+    }
+}
+
+fn node_text<'a>(node: Node<'_>, bytes: &'a [u8]) -> Option<&'a str> {
+    let start = node.start_byte();
+    let end = node.end_byte();
+    std::str::from_utf8(bytes.get(start..end)?).ok()
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/query_chain/use_aliases/tests.rs
+++ b/laravel-lsp/src/query_chain/use_aliases/tests.rs
@@ -1,0 +1,186 @@
+use super::*;
+use crate::parser::parse_php;
+
+fn aliases_for(src: &str) -> UseAliases {
+    let wrapped = format!("<?php\n{src}");
+    let tree = parse_php(&wrapped).expect("parse");
+    extract_use_aliases(&tree, &wrapped)
+}
+
+#[allow(dead_code)]
+fn dump_tree(src: &str) {
+    let wrapped = format!("<?php\n{src}");
+    let tree = parse_php(&wrapped).expect("parse");
+    fn walk(n: tree_sitter::Node, src: &str, depth: usize) {
+        let indent = "  ".repeat(depth);
+        let text = if n.child_count() == 0 {
+            format!(" :: {:?}", &src[n.start_byte()..n.end_byte()])
+        } else {
+            String::new()
+        };
+        eprintln!("{}{}{}", indent, n.kind(), text);
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            walk(ch, src, depth + 1);
+        }
+    }
+    walk(tree.root_node(), &wrapped, 0);
+}
+
+#[test]
+fn dump_simple_use() {
+    // Print the tree for diagnostic purposes — useful when AST shape
+    // changes break the alias parser.
+    dump_tree("use Illuminate\\Support\\Facades\\DB as Database;");
+}
+
+#[test]
+fn dump_grouped_use() {
+    dump_tree("use App\\Models\\{User, Post as P};");
+}
+
+#[test]
+fn dump_function_use() {
+    dump_tree("use function foo\\bar\\baz;");
+}
+
+#[test]
+fn no_use_statements_returns_empty() {
+    let aliases = aliases_for("DB::table('users');");
+    assert!(aliases.is_empty());
+}
+
+#[test]
+fn flat_use_no_alias_uses_last_segment() {
+    let aliases = aliases_for("use Illuminate\\Support\\Facades\\DB;");
+    assert_eq!(
+        aliases.get("DB").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\DB"),
+        "aliases: {:?}",
+        aliases
+    );
+}
+
+#[test]
+fn flat_use_with_as_alias() {
+    let aliases = aliases_for("use Illuminate\\Support\\Facades\\DB as Database;");
+    assert_eq!(
+        aliases.get("Database").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\DB")
+    );
+    assert!(
+        aliases.get("DB").is_none(),
+        "aliased import shouldn't also bind the bare name"
+    );
+}
+
+#[test]
+fn multiple_independent_imports() {
+    let src = r#"use Illuminate\Support\Facades\DB;
+use App\Models\User as MyUser;
+use App\Models\Post;"#;
+    let aliases = aliases_for(src);
+    assert_eq!(
+        aliases.get("DB").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\DB")
+    );
+    assert_eq!(
+        aliases.get("MyUser").map(String::as_str),
+        Some("App\\Models\\User")
+    );
+    assert_eq!(
+        aliases.get("Post").map(String::as_str),
+        Some("App\\Models\\Post")
+    );
+}
+
+#[test]
+fn grouped_use_distributes_prefix() {
+    let src = r#"use App\Models\{User, Post as P, Comment};"#;
+    let aliases = aliases_for(src);
+    assert_eq!(
+        aliases.get("User").map(String::as_str),
+        Some("App\\Models\\User")
+    );
+    assert_eq!(
+        aliases.get("P").map(String::as_str),
+        Some("App\\Models\\Post")
+    );
+    assert_eq!(
+        aliases.get("Comment").map(String::as_str),
+        Some("App\\Models\\Comment")
+    );
+}
+
+#[test]
+fn function_use_is_ignored() {
+    // `use function foo;` doesn't bind a class — chains never receive
+    // functions, so we don't track them.
+    let src = "use function foo\\bar\\baz;";
+    let aliases = aliases_for(src);
+    assert!(aliases.is_empty(), "got {:?}", aliases);
+}
+
+#[test]
+fn const_use_is_ignored() {
+    let src = "use const FOO\\BAR;";
+    let aliases = aliases_for(src);
+    assert!(aliases.is_empty(), "got {:?}", aliases);
+}
+
+// ---- resolve_class_name -------------------------------------------------
+
+#[test]
+fn resolve_with_no_aliases_returns_input_unchanged() {
+    let aliases = UseAliases::new();
+    assert_eq!(resolve_class_name("DB", &aliases), "DB");
+    assert_eq!(resolve_class_name("\\DB", &aliases), "DB");
+    assert_eq!(resolve_class_name("App\\Foo", &aliases), "App\\Foo");
+}
+
+#[test]
+fn resolve_replaces_leading_segment_with_aliased_fqcn() {
+    let mut aliases = UseAliases::new();
+    aliases.insert(
+        "Database".to_string(),
+        "Illuminate\\Support\\Facades\\DB".to_string(),
+    );
+    assert_eq!(
+        resolve_class_name("Database", &aliases),
+        "Illuminate\\Support\\Facades\\DB"
+    );
+}
+
+#[test]
+fn resolve_handles_namespaced_alias_use() {
+    // `use App\Models as M; M\User::query()` — the `M` segment resolves to
+    // `App\Models` and the rest of the path tacks on. (Rare in practice but
+    // legal PHP.)
+    let mut aliases = UseAliases::new();
+    aliases.insert("M".to_string(), "App\\Models".to_string());
+    assert_eq!(resolve_class_name("M\\User", &aliases), "App\\Models\\User");
+}
+
+#[test]
+fn resolve_is_case_insensitive_on_alias_head() {
+    // PHP class names are case-insensitive. `db::table()` should resolve
+    // via the `DB` alias.
+    let mut aliases = UseAliases::new();
+    aliases.insert(
+        "DB".to_string(),
+        "Illuminate\\Support\\Facades\\DB".to_string(),
+    );
+    assert_eq!(
+        resolve_class_name("db", &aliases),
+        "Illuminate\\Support\\Facades\\DB"
+    );
+}
+
+#[test]
+fn resolve_strips_leading_backslash() {
+    let aliases = UseAliases::new();
+    assert_eq!(
+        resolve_class_name("\\Illuminate\\Support\\Facades\\DB", &aliases),
+        "Illuminate\\Support\\Facades\\DB"
+    );
+}

--- a/laravel-lsp/src/query_chain/use_aliases/tests.rs
+++ b/laravel-lsp/src/query_chain/use_aliases/tests.rs
@@ -69,7 +69,7 @@ fn flat_use_with_as_alias() {
         Some("Illuminate\\Support\\Facades\\DB")
     );
     assert!(
-        aliases.get("DB").is_none(),
+        !aliases.contains_key("DB"),
         "aliased import shouldn't also bind the bare name"
     );
 }

--- a/laravel-lsp/src/query_chain/var_type.rs
+++ b/laravel-lsp/src/query_chain/var_type.rs
@@ -1,0 +1,282 @@
+//! Resolve a chain-receiver variable's declared PHP class.
+//!
+//! Used when a chain starts at an instance variable like `$user->newQuery()`.
+//! We need to know `$user` is a `User` to power column / relation completion
+//! against the right model. Two complementary strategies, tried in this order:
+//!
+//! 1. **Typed function/method parameter.** `function show(User $user)` →
+//!    `$user`'s declared type is `User`. Covers the common case in
+//!    controllers and services where action methods take typed args.
+//!
+//! 2. **`@var` docblock.** PHPDoc allows `/** @var User $u */` immediately
+//!    above an assignment. Used in places where PHP's static type system
+//!    isn't sufficient (e.g. `$u = $repo->findOne(...);` whose return type
+//!    is too generic).
+//!
+//! Both strategies resolve the bare class name through the file's `use`
+//! aliases via [`crate::query_chain::use_aliases::resolve_class_name`], so a
+//! parameter typed `Article` with `use App\Models\Post as Article;` returns
+//! `App\Models\Post` — ready to feed into Composer autoload.
+//!
+//! Misses (no type info, ambiguous type, unresolvable name) return `None`
+//! rather than guessing. Better no completion than a wrong one.
+
+use tree_sitter::Node;
+
+use super::use_aliases::{resolve_class_name, UseAliases};
+
+/// Return the resolved FQCN for `var_name` at `variable_node`'s position, or
+/// `None` if neither strategy yields a type. Caller stores the result in
+/// `EloquentReceiver::InstanceVar::php_type` for later use by the cursor
+/// context resolver.
+pub fn resolve(
+    variable_node: Node,
+    bytes: &[u8],
+    var_name: &str,
+    aliases: &UseAliases,
+) -> Option<String> {
+    if let Some(raw_type) = typed_param_for(variable_node, bytes, var_name) {
+        return Some(resolve_class_name(&raw_type, aliases));
+    }
+    if let Some(raw_type) = var_docblock_for(variable_node, bytes, var_name) {
+        return Some(resolve_class_name(&raw_type, aliases));
+    }
+    None
+}
+
+/// Walk up from `node` to the nearest function-like ancestor and scan its
+/// formal parameters for one named `var_name`. Returns the raw type string
+/// as written in source — caller handles use-alias resolution.
+fn typed_param_for(node: Node, bytes: &[u8], var_name: &str) -> Option<String> {
+    let mut cur = Some(node);
+    while let Some(n) = cur {
+        match n.kind() {
+            // Method on a class.
+            "method_declaration"
+            // Top-level function.
+            | "function_definition"
+            // `function () use (...) { ... }` — anonymous closure.
+            | "anonymous_function_creation_expression"
+            | "anonymous_function"
+            // `fn ($x) => ...` — short arrow.
+            | "arrow_function" => {
+                return scan_formal_parameters(n, bytes, var_name);
+            }
+            _ => cur = n.parent(),
+        }
+    }
+    None
+}
+
+/// Look at every direct child of the function's `parameters` (or
+/// `formal_parameters`) node. A typed `simple_parameter` contains both a
+/// type child (e.g. `named_type`, `union_type`) and a `variable_name`.
+fn scan_formal_parameters(fn_node: Node, bytes: &[u8], var_name: &str) -> Option<String> {
+    // tree-sitter-php names this field "parameters" for most function-like
+    // nodes. Falling back to a child-kind scan covers the variants where the
+    // field name differs.
+    let params = fn_node
+        .child_by_field_name("parameters")
+        .or_else(|| first_child_of_kind(fn_node, "formal_parameters"))?;
+    let mut cursor = params.walk();
+    for p in params.children(&mut cursor) {
+        if let Some(t) = param_type_if_matches(p, bytes, var_name) {
+            return Some(t);
+        }
+    }
+    None
+}
+
+fn first_child_of_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
+    let mut cursor = node.walk();
+    let mut found = None;
+    for c in node.children(&mut cursor) {
+        if c.kind() == kind {
+            found = Some(c);
+            break;
+        }
+    }
+    found
+}
+
+/// If `param` is a typed parameter binding `$var_name`, return its type
+/// string. Returns `None` for the no-type case (just `$user` with no
+/// annotation) — we can't help an untyped parameter.
+fn param_type_if_matches(param: Node, bytes: &[u8], var_name: &str) -> Option<String> {
+    let mut cursor = param.walk();
+    let mut type_text: Option<String> = None;
+    let mut matches_var = false;
+    for c in param.children(&mut cursor) {
+        match c.kind() {
+            // Tree-sitter-php uses several node kinds for type annotations
+            // depending on the shape: `named_type` for class refs,
+            // `primitive_type` for builtin (int/string/etc.), `union_type`,
+            // `intersection_type`, `optional_type` for `?Foo`. We capture
+            // the first one we see — `simplify_union` then trims it to a
+            // single class name.
+            "named_type" | "primitive_type" | "type_list" | "optional_type" | "union_type"
+            | "intersection_type" | "qualified_name"
+                if type_text.is_none() =>
+            {
+                type_text = node_text(c, bytes).map(|s| s.trim().to_string());
+            }
+            "variable_name" => {
+                if let Some(text) = node_text(c, bytes) {
+                    if text.trim_start_matches('$') == var_name {
+                        matches_var = true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    if !matches_var {
+        return None;
+    }
+    type_text.and_then(simplify_type)
+}
+
+/// Reduce a type expression to a single class name we can search for.
+///
+/// - `?User` → `User` (PHP nullable shorthand)
+/// - `User|null` → `User` (union with null)
+/// - `User|Post` → `User` (pick the first branch; rare in practice)
+/// - `int` / `string` etc. → `None` (primitives have no class file)
+/// - empty → `None`
+fn simplify_type(raw: String) -> Option<String> {
+    let cleaned = raw.trim_start_matches('?').trim();
+    let first = cleaned.split('|').next()?.trim();
+    if first.is_empty() || first.eq_ignore_ascii_case("null") {
+        return None;
+    }
+    // Primitives have no class file — skip them so the caller doesn't try
+    // to autoload `int.php`.
+    if matches!(
+        first.to_ascii_lowercase().as_str(),
+        "int"
+            | "integer"
+            | "float"
+            | "double"
+            | "string"
+            | "bool"
+            | "boolean"
+            | "array"
+            | "object"
+            | "mixed"
+            | "void"
+            | "never"
+            | "callable"
+            | "iterable"
+            | "self"
+            | "static"
+            | "parent"
+    ) {
+        return None;
+    }
+    Some(first.to_string())
+}
+
+/// Find a `@var` docblock declaring `var_name`'s type anywhere in the
+/// enclosing function-like scope. PHPDoc syntax:
+///
+/// ```php
+/// /** @var User $u */
+/// $u = $repo->findOne(...);
+/// $u->newQuery()->where('|');   // ← cursor here, docblock above the
+///                               //   assignment still applies.
+/// ```
+///
+/// We don't try to associate the docblock with a specific assignment —
+/// for Phase 9, any `@var Class $var` *in the same function* counts. PHP
+/// developers don't typically reassign the same variable to different
+/// types within one function; when they do, this picks the first
+/// declaration. Better than restricting to prev-sibling, which misses
+/// the common "docblock before assignment, var used several lines down"
+/// pattern.
+fn var_docblock_for(node: Node, bytes: &[u8], var_name: &str) -> Option<String> {
+    let scope = enclosing_scope(node)?;
+    scan_comments_for_var(scope, bytes, var_name)
+}
+
+/// Walk up to the closest function-like ancestor (or the file root if
+/// the variable lives at top level — rare but legal in scripts).
+fn enclosing_scope(node: Node) -> Option<Node> {
+    let mut cur = Some(node);
+    while let Some(n) = cur {
+        if matches!(
+            n.kind(),
+            "function_definition"
+                | "method_declaration"
+                | "anonymous_function"
+                | "anonymous_function_creation_expression"
+                | "arrow_function"
+                | "program"
+        ) {
+            return Some(n);
+        }
+        cur = n.parent();
+    }
+    None
+}
+
+/// DFS the scope's subtree for `comment` nodes containing a matching
+/// `@var ... $var_name` annotation. First match wins; we don't try to
+/// pick the "closest" docblock to the cursor — by convention PHP
+/// docblocks declare a variable once per scope.
+fn scan_comments_for_var(scope: Node, bytes: &[u8], var_name: &str) -> Option<String> {
+    let mut stack = vec![scope];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "comment" {
+            if let Some(text) = node_text(n, bytes) {
+                if let Some(t) = parse_var_docblock(text, var_name) {
+                    return Some(t);
+                }
+            }
+        }
+        let mut cursor = n.walk();
+        for c in n.children(&mut cursor) {
+            stack.push(c);
+        }
+    }
+    None
+}
+
+/// Parse a single comment string for `@var Type $var` (type-first, common)
+/// or `@var $var Type` (var-first, also valid PHPDoc). Returns the raw
+/// type string — caller does namespace resolution.
+fn parse_var_docblock(comment_text: &str, var_name: &str) -> Option<String> {
+    use once_cell::sync::Lazy;
+    use regex::Regex;
+
+    static RE_TYPE_FIRST: Lazy<Regex> = Lazy::new(|| {
+        // `@var <type> $<name>` — type may contain `\\` (FQCN) and `|`
+        // (union) but stops at whitespace. The name capture is the
+        // variable identifier.
+        Regex::new(r"@var\s+([^\s\$][^\s]*)\s+\$([A-Za-z_][A-Za-z0-9_]*)").unwrap()
+    });
+    static RE_VAR_FIRST: Lazy<Regex> = Lazy::new(|| {
+        // `@var $<name> <type>` — less common but valid.
+        Regex::new(r"@var\s+\$([A-Za-z_][A-Za-z0-9_]*)\s+([^\s\*\/][^\s\*\/]*)").unwrap()
+    });
+
+    for caps in RE_TYPE_FIRST.captures_iter(comment_text) {
+        if &caps[2] == var_name {
+            return Some(caps[1].to_string());
+        }
+    }
+    for caps in RE_VAR_FIRST.captures_iter(comment_text) {
+        if &caps[1] == var_name {
+            return Some(caps[2].to_string());
+        }
+    }
+    None
+}
+
+fn node_text<'a>(node: Node<'_>, bytes: &'a [u8]) -> Option<&'a str> {
+    let start = node.start_byte();
+    let end = node.end_byte();
+    std::str::from_utf8(bytes.get(start..end)?).ok()
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/query_chain/var_type/tests.rs
+++ b/laravel-lsp/src/query_chain/var_type/tests.rs
@@ -1,0 +1,197 @@
+use super::*;
+use crate::parser::parse_php;
+use crate::query_chain::use_aliases::extract_use_aliases;
+
+/// Parse a PHP snippet (no leading `<?php`) and find the first
+/// `variable_name` node whose text is `$<var>`. Returns the node and the
+/// wrapped source so callers can pass them to `resolve`.
+fn find_var_node<'tree>(
+    tree: &'tree tree_sitter::Tree,
+    bytes: &[u8],
+    var: &str,
+) -> Option<tree_sitter::Node<'tree>> {
+    let mut stack = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "variable_name" {
+            let start = node.start_byte();
+            let end = node.end_byte();
+            if let Ok(text) = std::str::from_utf8(&bytes[start..end]) {
+                if text.trim_start_matches('$') == var {
+                    return Some(node);
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+    None
+}
+
+/// End-to-end helper: parse the snippet, find the named variable, and run
+/// `resolve` against it. Returns the resolved FQCN.
+fn resolve_in(src: &str, var: &str) -> Option<String> {
+    let wrapped = format!("<?php\n{src}");
+    let tree = parse_php(&wrapped).expect("parse");
+    let bytes = wrapped.as_bytes();
+    let aliases = extract_use_aliases(&tree, &wrapped);
+    let node = find_var_node(&tree, bytes, var)?;
+    resolve(node, bytes, var, &aliases)
+}
+
+#[test]
+fn typed_function_param_resolves_to_local_class() {
+    // `function show(User $user)` — the receiver variable's type is `User`.
+    // No use alias, no namespace ⇒ bare class name is returned.
+    let src = r#"
+function show(User $user) {
+    $user->newQuery();
+}
+"#;
+    assert_eq!(resolve_in(src, "user").as_deref(), Some("User"));
+}
+
+#[test]
+fn typed_param_resolves_through_use_alias() {
+    // `use App\Models\Post as Article;` — a parameter declared `Article $a`
+    // should resolve to `App\Models\Post`. This is what makes downstream
+    // class-locator routing work: it never sees `Article`, only the FQCN.
+    let src = r#"
+use App\Models\Post as Article;
+
+function items(Article $a) {
+    $a->where('published', true);
+}
+"#;
+    assert_eq!(resolve_in(src, "a").as_deref(), Some("App\\Models\\Post"));
+}
+
+#[test]
+fn typed_param_handles_nullable_shorthand() {
+    // `?User` → `User`. PHP's nullable shorthand is just sugar for
+    // `User|null` — same resolution.
+    let src = r#"
+function maybeShow(?User $user) {
+    $user->newQuery();
+}
+"#;
+    assert_eq!(resolve_in(src, "user").as_deref(), Some("User"));
+}
+
+#[test]
+fn typed_param_handles_union_with_null() {
+    // `User|null` → `User`. Same idea as nullable but spelled out.
+    let src = r#"
+function maybeShow(User|null $user) {
+    $user->newQuery();
+}
+"#;
+    assert_eq!(resolve_in(src, "user").as_deref(), Some("User"));
+}
+
+#[test]
+fn typed_param_skips_primitives() {
+    // `int $count` → None. We don't try to autoload `int.php`.
+    let src = r#"
+function tally(int $count) {
+    $count;
+}
+"#;
+    assert_eq!(resolve_in(src, "count"), None);
+}
+
+#[test]
+fn typed_method_param_resolves_inside_class_method() {
+    // Same logic for method declarations, not just bare functions.
+    let src = r#"
+namespace App\Http\Controllers;
+
+use App\Models\User;
+
+class UserController
+{
+    public function show(User $user)
+    {
+        $user->newQuery();
+    }
+}
+"#;
+    assert_eq!(
+        resolve_in(src, "user").as_deref(),
+        Some("App\\Models\\User")
+    );
+}
+
+#[test]
+fn var_docblock_resolves_when_no_typed_param() {
+    // No typed param — the user wrote a docblock instead. We pick it up.
+    let src = r#"
+function pull($id) {
+    /** @var User $user */
+    $user = SomeRepository::findOne($id);
+    $user->newQuery();
+}
+"#;
+    assert_eq!(resolve_in(src, "user").as_deref(), Some("User"));
+}
+
+#[test]
+fn var_docblock_resolves_through_use_alias() {
+    // Same alias-resolution behavior as typed params.
+    let src = r#"
+use App\Models\Post as Article;
+
+function pull() {
+    /** @var Article $a */
+    $a = repo();
+    $a->where('published', true);
+}
+"#;
+    assert_eq!(resolve_in(src, "a").as_deref(), Some("App\\Models\\Post"));
+}
+
+#[test]
+fn var_docblock_multi_line_format() {
+    // Real-world docblocks span multiple lines. The comment node carries
+    // the full text so the regex still finds the @var line.
+    let src = r#"
+function pull() {
+    /**
+     * Loads the active user.
+     *
+     * @var User $user
+     */
+    $user = something();
+    $user->newQuery();
+}
+"#;
+    assert_eq!(resolve_in(src, "user").as_deref(), Some("User"));
+}
+
+#[test]
+fn missing_type_info_returns_none() {
+    // No docblock, no typed param — we have nothing to work with. Better
+    // None than a false positive that confuses completion.
+    let src = r#"
+function pull() {
+    $u = something();
+    $u->newQuery();
+}
+"#;
+    assert_eq!(resolve_in(src, "u"), None);
+}
+
+#[test]
+fn docblock_for_different_var_is_ignored() {
+    // A `@var X $other` shouldn't satisfy a query for `$user` — the
+    // variable name must match exactly.
+    let src = r#"
+function pull() {
+    /** @var Post $other */
+    $user = something();
+    $user->newQuery();
+}
+"#;
+    assert_eq!(resolve_in(src, "user"), None);
+}

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -4896,9 +4896,6 @@ impl SalsaActor {
                 // Extract Eloquent / DB query builder chains from the same
                 // parsed tree. No second parse — we reuse the `tree` already
                 // produced above for route/url/action/feature extraction.
-                // Blade-embedded chains are deferred to a later phase; chains
-                // inside `{{ }}` are rare and require byte-offset adjustment
-                // back into the outer file.
                 for chain in crate::query_chain::extract_chains(&tree, text) {
                     chains.push(Arc::new(chain));
                 }
@@ -5004,6 +5001,21 @@ impl SalsaActor {
                         column: col,
                         end_column: end_col,
                     }));
+                }
+
+                // Eloquent / DB query builder chains inside this Blade-
+                // embedded PHP region. Snippet-local byte ranges produced by
+                // the extractor reference the `<?php `-wrapped source; shift
+                // each range back into outer-file coordinates so the cursor
+                // resolver can find them by LSP byte offset.
+                use crate::blade_embedded_php::PHP_WRAPPER_PREFIX_LEN;
+                for mut chain in crate::query_chain::extract_chains(&snippet_tree, &wrapped) {
+                    crate::query_chain::extractor::shift_chain_byte_ranges(
+                        &mut chain,
+                        region.byte_offset,
+                        PHP_WRAPPER_PREFIX_LEN as usize,
+                    );
+                    chains.push(Arc::new(chain));
                 }
             }
         }

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2523,6 +2523,11 @@ pub struct ParsedPatternsData {
     pub url_refs: Vec<Arc<UrlReferenceData>>,
     pub action_refs: Vec<Arc<ActionReferenceData>>,
     pub feature_refs: Vec<Arc<FeatureReferenceData>>,
+    /// Eloquent / DB query builder chains extracted in the same PHP parse pass
+    /// as route/url/action/feature refs (see [`crate::query_chain::extractor`]).
+    /// Stored alongside the other patterns rather than as a `ParsedPatterns`
+    /// field because that struct is at Salsa's 12-element tuple-Hash cap.
+    pub chains: Vec<Arc<crate::query_chain::BuilderChain>>,
     /// Sorted index of all patterns by (line, column) for O(log n) lookup.
     /// Skipped during (de)serialization — when loading from the on-disk
     /// cache, the caller must invoke `build_position_index()` to rebuild
@@ -4835,6 +4840,7 @@ impl SalsaActor {
         let mut url_refs = Vec::new();
         let mut action_refs = Vec::new();
         let mut feature_refs = Vec::new();
+        let mut chains: Vec<Arc<crate::query_chain::BuilderChain>> = Vec::new();
 
         // Skip the full-file PHP parse for Blade files — same rationale as
         // in parse_file_patterns above. Blade-embedded route/url/action/
@@ -4885,6 +4891,16 @@ impl SalsaActor {
                             end_column: f.end_column as u32,
                         }));
                     }
+                }
+
+                // Extract Eloquent / DB query builder chains from the same
+                // parsed tree. No second parse — we reuse the `tree` already
+                // produced above for route/url/action/feature extraction.
+                // Blade-embedded chains are deferred to a later phase; chains
+                // inside `{{ }}` are rare and require byte-offset adjustment
+                // back into the outer file.
+                for chain in crate::query_chain::extract_chains(&tree, text) {
+                    chains.push(Arc::new(chain));
                 }
             }
         } // end if !path_is_blade
@@ -5007,6 +5023,7 @@ impl SalsaActor {
             url_refs,
             action_refs,
             feature_refs,
+            chains,
             sorted_positions: Vec::new(),
         };
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2527,6 +2527,12 @@ pub struct ParsedPatternsData {
     /// as route/url/action/feature refs (see [`crate::query_chain::extractor`]).
     /// Stored alongside the other patterns rather than as a `ParsedPatterns`
     /// field because that struct is at Salsa's 12-element tuple-Hash cap.
+    ///
+    /// `#[serde(default)]` so disk-cache entries written by older builds (which
+    /// lacked this field) deserialize with an empty chains list rather than
+    /// failing the whole entry. The next file edit re-runs extraction and
+    /// populates chains properly.
+    #[serde(default)]
     pub chains: Vec<Arc<crate::query_chain::BuilderChain>>,
     /// Sorted index of all patterns by (line, column) for O(log n) lookup.
     /// Skipped during (de)serialization — when loading from the on-disk


### PR DESCRIPTION
Draft PR for [#11](https://github.com/GeneaLabs/zed-laravel/issues/11) — Eloquent query builder chain completion (columns + relationships).

## Scope

Two phases per the issue:

- **Phase 1 — Static query method completion.** Detect query entry points (`Model::query()`, `Model::where(...)`, `$model->newQuery()`, `DB::table(...)`), then offer column completions inside `where`/`orderBy`/`select`/etc. and relationship completions inside `with`/`whereHas`/`withCount`/etc., including dotted relation paths and sub-query closures.
- **Phase 2 — Type inference across the chain.** Track model type through transformations, goto-definition on columns into migrations, diagnostics for unknown columns/relations.

## Plan

- [ ] Design spike — sketch the `BuilderChainContext` shape and how it threads through the parser → Salsa → completion handler path
- [ ] Phase 1 implementation
- [ ] Phase 1 tests
- [ ] Decide whether Phase 2 lands in this PR or a follow-up

The issue itself flags this as substantial ("Spike the design before committing to a sprint"), so this PR opens as a draft while the design lands.

Closes #11 (intended on merge).