### PR TITLE
feat: variable-flow type tracking for chain receivers (closes #23)

### DIFF
--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -21,6 +21,7 @@ pub mod chain;
 pub mod cursor;
 pub mod eloquent_completion;
 pub mod extractor;
+pub mod flow;
 pub mod methods;
 pub mod use_aliases;
 pub mod var_type;

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -1072,3 +1072,138 @@ fn unknown_receiver_falls_through_when_inner_is_unhandled() {
     assert_eq!(chains.len(), 1);
     assert_eq!(chains[0].receiver, ChainReceiver::Unknown);
 }
+
+// ---- Flow-tracked InstanceVar receivers (issue #23) --------------------
+//
+// The extractor calls `var_type::resolve` (which delegates to flow::resolve)
+// for every `member_chain_receiver` rooted at a variable. These tests
+// verify the end-to-end wiring: a multi-statement chain where the
+// receiver var is established by an earlier assignment ends up with
+// `php_type = Some(class)`.
+
+#[test]
+fn flow_tracks_var_seeded_from_static_query() {
+    // Single-function scope: $q is seeded from User::query(), used on a
+    // later line. The extractor sees the use site as the chain root
+    // and `var_type::resolve` walks back to the assignment.
+    let chains = extract(
+        r#"
+function search() {
+    $q = User::query();
+    $q->where('email', 'a@b.c');
+}
+"#,
+    );
+    let chain = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { .. })
+            )
+        })
+        .expect("should find an InstanceVar chain");
+    match &chain.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, php_type }) => {
+            assert_eq!(var, "q");
+            assert_eq!(php_type.as_deref(), Some("User"));
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn flow_tracks_var_through_self_reassignment() {
+    // The motivating example from issue #23: $query is rebuilt across
+    // conditional branches via $query = $query->where(...). The final
+    // use must still resolve to the original seed model.
+    let chains = extract(
+        r#"
+function search($activeOnly, $search) {
+    $query = User::query();
+
+    if ($activeOnly) {
+        $query = $query->where('active', true);
+    }
+
+    if ($search) {
+        $query = $query->where('name', 'like', '%foo%');
+    }
+
+    $query->orderBy('name');
+}
+"#,
+    );
+    // The final $query->orderBy('name') chain. Multiple InstanceVar
+    // chains exist (one per conditional branch's $query = $query->where);
+    // we want the LAST one in source order.
+    let last = chains
+        .iter()
+        .rfind(|c| matches!(&c.receiver, ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) if var == "query"))
+        .expect("should find $query chains");
+    match &last.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { php_type, .. }) => {
+            assert_eq!(php_type.as_deref(), Some("User"));
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn flow_walks_into_outer_scope_via_use_clause() {
+    // The use site is inside an anonymous function with `use ($query)`.
+    // Flow resolution must walk out of the closure to find the outer
+    // scope's User::query() seed.
+    let chains = extract(
+        r#"
+function show() {
+    $query = User::query();
+    collect([])->each(function ($item) use ($query) {
+        $query->where('id', $item);
+    });
+}
+"#,
+    );
+    let inner = chains
+        .iter()
+        .rfind(|c| matches!(&c.receiver, ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) if var == "query"))
+        .expect("should find a $query chain inside the closure");
+    match &inner.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { php_type, .. }) => {
+            assert_eq!(php_type.as_deref(), Some("User"));
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn flow_resolves_aliased_class_through_use_statement() {
+    // Reassignment from `Member::query()` where Member is an alias for
+    // App\Models\User. The flow-tracked class must be the FQCN, not
+    // the alias.
+    let chains = extract(
+        r#"
+use App\Models\User as Member;
+
+function search() {
+    $q = Member::query();
+    $q->where('email', 'a@b.c');
+}
+"#,
+    );
+    let chain = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { .. })
+            )
+        })
+        .expect("should find an InstanceVar chain");
+    match &chain.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { php_type, .. }) => {
+            assert_eq!(php_type.as_deref(), Some("App\\Models\\User"));
+        }
+        _ => unreachable!(),
+    }
+}

--- a/laravel-lsp/src/query_chain/flow.rs
+++ b/laravel-lsp/src/query_chain/flow.rs
@@ -1,0 +1,393 @@
+//! Intra-procedural flow-sensitive type tracking for chain receiver variables.
+//!
+//! Phase 9 (see [`super::var_type`]) resolves a chain-receiver variable's
+//! class from its declared form — a typed function parameter or a `@var`
+//! docblock. That's enough when the variable is the function arg itself,
+//! but breaks down for the very common Laravel pattern of building a
+//! query across multiple statements:
+//!
+//! ```php
+//! $query = User::query();
+//!
+//! if ($activeOnly) {
+//!     $query = $query->where('active', true);
+//! }
+//!
+//! $query->orderBy('|');   // ← here, $query is still rooted at User.
+//! ```
+//!
+//! There's no typed param, no docblock — just an assignment chain. This
+//! module walks backward from the use site through assignments in the
+//! enclosing scope, classifying each right-hand-side expression and
+//! propagating the type forward.
+//!
+//! ## What we recognise as an Eloquent-producing RHS
+//!
+//! - `Class::query()` / `Class::where(...)` / any Eloquent static
+//!   starter on a non-DB class — emits the resolved class FQCN.
+//! - `(new Class)->...` — same, with the class extracted from the
+//!   constructor expression.
+//! - `$other->method(...)->...` — recurses on `$other` using the same
+//!   resolution chain (boundary monotonically decreases, so cycles
+//!   terminate).
+//! - Anything else — emits `None`, which signals "flow tracking is
+//!   cleared." The caller then falls through to declared types
+//!   (typed_param / docblock) within the same scope — those represent
+//!   the user's asserted intent and aren't invalidated by an
+//!   unrecognised reassignment. See AC #3 in issue #23.
+//!
+//! ## `use ($var)` capture
+//!
+//! Closures with explicit `use ($outer)` clauses inherit the captured
+//! variable's tracked type from the parent scope. Arrow functions
+//! auto-capture by value — we treat every outer-scope variable mentioned
+//! in the body as captured. Methods and top-level functions don't
+//! capture at all (their scope is terminal).
+//!
+//! ## Closeness ordering
+//!
+//! Within each scope, the order is:
+//!
+//! 1. Latest assignment to `$var` before the use site (this module).
+//! 2. Typed parameter binding `$var` ([`super::var_type::typed_param_in`]).
+//! 3. `@var $var` docblock anywhere in scope ([`super::var_type::docblock_in`]).
+//!
+//! If none of those resolve, and the scope is a closure capturing `$var`,
+//! we step out one scope and try again. This is the "closest to use,
+//! walking backward" model — a reassignment overrides any declared type
+//! because PHP allows free retyping; a declared type is consulted only
+//! when no reassignment has happened in this scope.
+
+use tree_sitter::Node;
+
+use super::methods::is_eloquent_static_starter;
+use super::use_aliases::{resolve_class_name, UseAliases};
+
+/// Cap how many `$a = $b->...; $b = $a->...; ...` hops we'll follow.
+/// In practice a single hop is the common case (`$q = $q->where(...)`),
+/// and three or four hops covers any sane reassignment chain. Cycles
+/// terminate naturally via the monotonically-decreasing byte boundary
+/// (see below), so this guard exists only against pathological inputs.
+const MAX_RECURSION_DEPTH: usize = 8;
+
+/// Public entry point. Returns the resolved FQCN if `var_name`'s type at
+/// `use_site` can be inferred through any of the scope-walking strategies
+/// (flow > typed param > docblock, repeated outward through `use()`
+/// captures). `None` means we couldn't infer anything — completion
+/// callers treat this as "don't fire."
+pub fn resolve(
+    use_site: Node,
+    bytes: &[u8],
+    var_name: &str,
+    aliases: &UseAliases,
+) -> Option<String> {
+    let before_byte = use_site.start_byte();
+    resolve_with_boundary(use_site, before_byte, bytes, var_name, aliases, 0)
+}
+
+/// Like `resolve`, but the caller specifies the byte boundary explicitly.
+/// When classifying an assignment's RHS, recursion uses the assignment's
+/// own start byte as the new boundary — so a recursive lookup of `$q`
+/// inside `$q = $q->where(...)` finds an EARLIER `$q = User::query()`
+/// rather than re-discovering the assignment we're already inside.
+///
+/// Because the boundary strictly decreases with each recursive call (or
+/// stays the same only when we walk into an outer scope, where it
+/// becomes the closure node's own start), cycles terminate naturally.
+fn resolve_with_boundary(
+    use_site: Node,
+    mut before_byte: usize,
+    bytes: &[u8],
+    var_name: &str,
+    aliases: &UseAliases,
+    depth: usize,
+) -> Option<String> {
+    if depth > MAX_RECURSION_DEPTH {
+        return None;
+    }
+
+    let mut current = use_site;
+    loop {
+        let scope = enclosing_scope(current)?;
+
+        // Closest-first within this scope: a local assignment to `$var`
+        // is the strongest signal when we can classify its RHS — it
+        // reflects the most recent write to the variable. If the RHS
+        // can't be classified ("flow tracking is cleared"), we still
+        // fall through to declared types (`typed_param` / `docblock`),
+        // because those represent the user's stated intent — they're
+        // not silently invalidated by an unrecognised reassignment.
+        if let Some((rhs, assignment_start)) =
+            latest_assignment_rhs(scope, bytes, var_name, before_byte)
+        {
+            if let Some(class) = classify_rhs(rhs, bytes, aliases, depth, assignment_start) {
+                return Some(class);
+            }
+        }
+
+        // Declared types — typed param first, then docblock. Both are
+        // user-asserted intent that survives an unrecognised
+        // reassignment.
+        if let Some(raw) = super::var_type::typed_param_in(scope, bytes, var_name) {
+            return Some(resolve_class_name(&raw, aliases));
+        }
+        if let Some(raw) = super::var_type::docblock_in(scope, bytes, var_name) {
+            return Some(resolve_class_name(&raw, aliases));
+        }
+
+        // Nothing for `$var` in this scope. If this scope is a closure
+        // that captures `$var` (explicit `use ($var)` or arrow-function
+        // auto-capture), step out and try the parent scope. The new
+        // boundary becomes the closure's own start — assignments in the
+        // outer scope that come BEFORE the closure are visible; the
+        // closure itself isn't.
+        if !scope_captures_var(scope, bytes, var_name) {
+            return None;
+        }
+        before_byte = scope.start_byte();
+        current = scope.parent()?;
+    }
+}
+
+/// Walk up to the closest function-like ancestor (or the file root).
+pub fn enclosing_scope(node: Node) -> Option<Node> {
+    let mut cur = Some(node);
+    while let Some(n) = cur {
+        if matches!(
+            n.kind(),
+            "function_definition"
+                | "method_declaration"
+                | "anonymous_function"
+                | "anonymous_function_creation_expression"
+                | "arrow_function"
+                | "program"
+        ) {
+            return Some(n);
+        }
+        cur = n.parent();
+    }
+    None
+}
+
+/// Whether `scope` is a closure that captures `var_name` from its parent
+/// scope. Returns `false` for non-closure scopes (top-level functions,
+/// methods, `program`) — those don't capture anything.
+///
+/// Three flavors of closure:
+///
+/// - **Arrow function** (`fn ($x) => ...`): auto-captures every outer
+///   variable referenced in the body. We don't try to be precise about
+///   which ones — if the body would compile, the variable is captured.
+///   Returning `true` for arrow functions delegates the actual lookup
+///   to the parent scope.
+/// - **Anonymous function with `use ($a, $b)`**: explicit capture list.
+///   Variable must appear in the `anonymous_function_use_clause`.
+/// - **Anonymous function without `use`**: doesn't capture anything.
+fn scope_captures_var(scope: Node, bytes: &[u8], var_name: &str) -> bool {
+    match scope.kind() {
+        "arrow_function" => true,
+        "anonymous_function" | "anonymous_function_creation_expression" => {
+            // Find the use clause; if missing, nothing is captured.
+            let mut cursor = scope.walk();
+            for child in scope.children(&mut cursor) {
+                if child.kind() == "anonymous_function_use_clause" {
+                    let mut inner = child.walk();
+                    for v in child.children(&mut inner) {
+                        if v.kind() == "variable_name" {
+                            if let Some(t) = node_text(v, bytes) {
+                                if t.trim_start_matches('$') == var_name {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    return false;
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+/// Find the latest `$var_name = <rhs>` assignment in `scope` whose
+/// position is strictly before `before_byte`. Returns the RHS node and
+/// the assignment's start byte (so callers can use it as the new
+/// boundary for recursive resolution into the RHS).
+///
+/// We don't descend into nested closures / functions — those are their
+/// own scopes and an assignment inside them doesn't affect the outer
+/// `$var`'s tracking (PHP closures see captured vars by value unless
+/// declared `use (&$var)`, and we don't model by-reference captures
+/// here).
+fn latest_assignment_rhs<'tree>(
+    scope: Node<'tree>,
+    bytes: &[u8],
+    var_name: &str,
+    before_byte: usize,
+) -> Option<(Node<'tree>, usize)> {
+    let mut best: Option<Node> = None;
+    let mut best_byte: usize = 0;
+    let mut found = false;
+
+    let mut stack: Vec<Node> = vec![scope];
+    while let Some(n) = stack.pop() {
+        // Skip nested function-like scopes — assignments inside them are
+        // local to the inner scope, not visible to the outer chain.
+        if n.id() != scope.id()
+            && matches!(
+                n.kind(),
+                "function_definition"
+                    | "method_declaration"
+                    | "anonymous_function"
+                    | "anonymous_function_creation_expression"
+                    | "arrow_function"
+            )
+        {
+            continue;
+        }
+
+        if n.kind() == "assignment_expression" {
+            if let (Some(lhs), Some(rhs)) = (
+                n.child_by_field_name("left"),
+                n.child_by_field_name("right"),
+            ) {
+                let is_match = lhs.kind() == "variable_name"
+                    && node_text(lhs, bytes)
+                        .map(|t| t.trim_start_matches('$') == var_name)
+                        .unwrap_or(false)
+                    && n.start_byte() < before_byte;
+                if is_match && (!found || n.start_byte() >= best_byte) {
+                    best = Some(rhs);
+                    best_byte = n.start_byte();
+                    found = true;
+                }
+            }
+        }
+
+        let mut cursor = n.walk();
+        for c in n.children(&mut cursor) {
+            stack.push(c);
+        }
+    }
+
+    best.map(|rhs| (rhs, best_byte))
+}
+
+/// Classify an RHS expression as an Eloquent-producing chain and return
+/// the model FQCN. Three recognised shapes — anything else returns
+/// `None`, which clears flow tracking for the caller's variable.
+///
+/// `boundary_before` is the start byte of the assignment whose RHS we're
+/// classifying. When this RHS references another variable that needs
+/// resolution, we pass `boundary_before` as the new lookup boundary so
+/// the recursion looks for assignments strictly before this one — not
+/// inside the RHS itself.
+fn classify_rhs(
+    rhs: Node,
+    bytes: &[u8],
+    aliases: &UseAliases,
+    depth: usize,
+    boundary_before: usize,
+) -> Option<String> {
+    let node = unwrap_parens(rhs);
+    match node.kind() {
+        // `User::query()` — bottom of a chain or single static call.
+        "scoped_call_expression" => classify_scoped_call(node, bytes, aliases),
+
+        // `$x->...` chain. Walk down to the chain root and dispatch.
+        "member_call_expression" => {
+            let root = chain_root(node);
+            match root.kind() {
+                "scoped_call_expression" => classify_scoped_call(root, bytes, aliases),
+                "variable_name" => {
+                    let raw = node_text(root, bytes)?;
+                    let inner = raw.trim_start_matches('$').to_string();
+                    resolve_with_boundary(root, boundary_before, bytes, &inner, aliases, depth + 1)
+                }
+                "parenthesized_expression" => {
+                    let inner = unwrap_parens(root);
+                    classify_rhs(inner, bytes, aliases, depth + 1, boundary_before)
+                }
+                _ => None,
+            }
+        }
+
+        // `new Class` — bare, without parens. `(new Class)->...` lands
+        // here too after `unwrap_parens` strips the outer parens.
+        "object_creation_expression" => extract_new_class(node, bytes, aliases),
+
+        _ => None,
+    }
+}
+
+/// Walk down the `object` field of nested `member_call_expression`s
+/// until we hit a non-call node — that's the chain receiver.
+fn chain_root(mut node: Node) -> Node {
+    loop {
+        if node.kind() == "member_call_expression" {
+            match node.child_by_field_name("object") {
+                Some(o) => node = o,
+                None => return node,
+            }
+        } else {
+            return node;
+        }
+    }
+}
+
+/// Classify a static call like `User::query()`. Only emits the class
+/// name when the method is on the Eloquent static-starter list and the
+/// class isn't the DB facade (those produce base-builder receivers, not
+/// Eloquent models — handled elsewhere).
+fn classify_scoped_call(node: Node, bytes: &[u8], aliases: &UseAliases) -> Option<String> {
+    let scope = node.child_by_field_name("scope")?;
+    let name = node.child_by_field_name("name")?;
+    let method = node_text(name, bytes)?;
+    if !is_eloquent_static_starter(method) {
+        return None;
+    }
+    let class_text = node_text(scope, bytes)?;
+    let basename = class_text.rsplit('\\').next().unwrap_or(class_text);
+    if basename.eq_ignore_ascii_case("DB") {
+        return None;
+    }
+    Some(resolve_class_name(class_text, aliases))
+}
+
+/// Extract the class name from `new Class(...)`. Mirrors the
+/// `parenthesized_receiver` logic in [`super::extractor`] but without the
+/// `self` / `static` / `parent` handling — flow tracking for those is
+/// rare enough to skip in this phase.
+fn extract_new_class(node: Node, bytes: &[u8], aliases: &UseAliases) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        match child.kind() {
+            "name" | "qualified_name" | "relative_name" => {
+                let raw = node_text(child, bytes)?;
+                return Some(resolve_class_name(raw, aliases));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn unwrap_parens(mut node: Node) -> Node {
+    while node.kind() == "parenthesized_expression" {
+        match node.named_child(0) {
+            Some(inner) => node = inner,
+            None => return node,
+        }
+    }
+    node
+}
+
+fn node_text<'a>(node: Node<'_>, bytes: &'a [u8]) -> Option<&'a str> {
+    let start = node.start_byte();
+    let end = node.end_byte();
+    std::str::from_utf8(bytes.get(start..end)?).ok()
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/query_chain/flow/tests.rs
+++ b/laravel-lsp/src/query_chain/flow/tests.rs
@@ -1,0 +1,470 @@
+//! Tests for intra-procedural flow tracking.
+//!
+//! Every test calls [`resolve_at`] which parses a snippet, finds the
+//! Nth occurrence of `$<var>`, and runs the unified
+//! [`crate::query_chain::var_type::resolve`] (which delegates to
+//! [`super::resolve`]). The Nth occurrence lets us pin completion-side
+//! resolution to a specific use site — assignments before it apply,
+//! after it don't.
+
+use crate::parser::parse_php;
+use crate::query_chain::use_aliases::extract_use_aliases;
+use crate::query_chain::var_type::resolve;
+
+/// Find the Nth (0-indexed) `variable_name` node matching `$var` in the
+/// parse tree, depth-first pre-order. Used to pin tests to a specific
+/// occurrence of the variable.
+fn find_nth_var<'tree>(
+    tree: &'tree tree_sitter::Tree,
+    bytes: &[u8],
+    var: &str,
+    n: usize,
+) -> Option<tree_sitter::Node<'tree>> {
+    let mut stack = vec![tree.root_node()];
+    let mut hits = Vec::new();
+    // Pre-order DFS, left to right. We push children in reverse so they
+    // pop in source order.
+    while let Some(node) = stack.pop() {
+        if node.kind() == "variable_name" {
+            let start = node.start_byte();
+            let end = node.end_byte();
+            if let Ok(text) = std::str::from_utf8(&bytes[start..end]) {
+                if text.trim_start_matches('$') == var {
+                    hits.push(node);
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        let children: Vec<_> = node.children(&mut cursor).collect();
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
+    }
+    hits.into_iter().nth(n)
+}
+
+/// Run the full resolution chain against the Nth occurrence of `$var`
+/// in the snippet. `n=0` is the first (typically the first assignment's
+/// LHS); subsequent values target uses further into the function.
+fn resolve_at(src: &str, var: &str, n: usize) -> Option<String> {
+    let wrapped = format!("<?php\n{src}");
+    let tree = parse_php(&wrapped).expect("parse");
+    let bytes = wrapped.as_bytes();
+    let aliases = extract_use_aliases(&tree, &wrapped);
+    let node = find_nth_var(&tree, bytes, var, n)?;
+    resolve(node, bytes, var, &aliases)
+}
+
+// ---- Direct seeding -----------------------------------------------------
+
+#[test]
+fn flow_simple_seed_from_static_query() {
+    // `$q = User::query();` then `$q->where('|')` — flow tracks $q
+    // back to User. n=1 picks the use site (after the assignment LHS at
+    // n=0).
+    let src = r#"
+function search() {
+    $q = User::query();
+    $q->where('email', 'a@b.c');
+}
+"#;
+    assert_eq!(resolve_at(src, "q", 1).as_deref(), Some("User"));
+}
+
+#[test]
+fn flow_resolves_through_use_alias() {
+    // Same as above, but with a `use App\Models\User as Member;` alias.
+    // Flow tracking must run RHS through alias resolution.
+    let src = r#"
+use App\Models\User as Member;
+
+function search() {
+    $q = Member::query();
+    $q->where('email', 'a@b.c');
+}
+"#;
+    assert_eq!(
+        resolve_at(src, "q", 1).as_deref(),
+        Some("App\\Models\\User")
+    );
+}
+
+#[test]
+fn flow_simple_seed_from_static_where() {
+    // `User::where(...)` is also an Eloquent starter — flow tracks the
+    // same way regardless of which static method seeded the chain.
+    let src = r#"
+function search($email) {
+    $q = User::where('email', $email);
+    $q->orderBy('name');
+}
+"#;
+    assert_eq!(resolve_at(src, "q", 1).as_deref(), Some("User"));
+}
+
+#[test]
+fn flow_simple_seed_from_paren_new() {
+    // `(new User)->...` form — extract the class from the
+    // object_creation_expression. Common when starting a chain off a
+    // freshly-constructed model.
+    let src = r#"
+function search() {
+    $q = (new User)->newQuery();
+    $q->where('a', 1);
+}
+"#;
+    assert_eq!(resolve_at(src, "q", 1).as_deref(), Some("User"));
+}
+
+// ---- Reassignment chains ------------------------------------------------
+
+#[test]
+fn flow_reassignment_preserves_type() {
+    // `$q = User::query(); $q = $q->where(...); $q->orderBy('|')` —
+    // the second assignment's RHS is `$q->where(...)`, which recurses
+    // back to the first assignment and finds User. n=3 is the use after
+    // both reassignments (n=0 first LHS, n=1 second LHS, n=2 RHS receiver,
+    // n=3 final use).
+    let src = r#"
+function search() {
+    $q = User::query();
+    $q = $q->where('active', true);
+    $q->orderBy('name');
+}
+"#;
+    assert_eq!(resolve_at(src, "q", 3).as_deref(), Some("User"));
+}
+
+#[test]
+fn flow_reassignment_in_branch_preserves_type() {
+    // The motivating example from issue #23: build query in conditional
+    // branches. `$query` keeps its User type across `if` blocks because
+    // every reassignment to it is `$query->where(...)` which classifies
+    // back to User.
+    let src = r#"
+function search($activeOnly, $search) {
+    $query = User::query();
+
+    if ($activeOnly) {
+        $query = $query->where('active', true);
+    }
+
+    if ($search) {
+        $query = $query->where('name', 'like', '%foo%');
+    }
+
+    $query->orderBy('name');
+}
+"#;
+    // Last $query occurrence is the use site.
+    let wrapped = format!("<?php\n{src}");
+    let bytes = wrapped.as_bytes();
+    let tree = parse_php(&wrapped).expect("parse");
+    let aliases = extract_use_aliases(&tree, &wrapped);
+    // Find the final occurrence (largest n).
+    let mut last = None;
+    let mut n = 0;
+    while let Some(node) = find_nth_var(&tree, bytes, "query", n) {
+        last = Some(node);
+        n += 1;
+    }
+    let node = last.expect("at least one occurrence");
+    assert_eq!(
+        resolve(node, bytes, "query", &aliases).as_deref(),
+        Some("User")
+    );
+}
+
+// ---- Clearing behaviour -------------------------------------------------
+
+#[test]
+fn flow_clears_on_unknown_rhs() {
+    // AC #3: reassignment from a non-Builder type clears tracking. Once
+    // flow tracking is cleared, completion falls through to declared
+    // types (typed_param / docblock). When neither is present, the
+    // result is None — we don't carry forward the prior tracked type.
+    //
+    // Here: an earlier `$u = User::query()` would normally track $u as
+    // User, but the later reassignment to `wat()` (unclassifiable RHS)
+    // clears that tracking. No typed param, no docblock → None.
+    let src = r#"
+function show() {
+    $u = User::query();
+    $u = wat();
+    $u->where('email', 'a@b.c');
+}
+"#;
+    // n=2 is the use site (after both LHS positions at n=0, n=1).
+    assert_eq!(resolve_at(src, "u", 2), None);
+}
+
+#[test]
+fn flow_clears_keeps_typed_param_as_fallback() {
+    // When flow is cleared but a typed param exists, the typed param
+    // applies. The user declared intent at the function boundary; an
+    // unrecognised reassignment doesn't silently invalidate it.
+    //
+    // This is the "falls back to other resolution" part of AC #3 —
+    // the prior FLOW-tracked type is gone, but typed_param survives.
+    let src = r#"
+function show(User $u) {
+    $u = wat();
+    $u->where('email', 'a@b.c');
+}
+"#;
+    assert_eq!(resolve_at(src, "u", 2).as_deref(), Some("User"));
+}
+
+#[test]
+fn flow_clears_keeps_docblock_as_fallback() {
+    // Same as above with a docblock instead of a typed param. The
+    // docblock declares result-type intent and survives an
+    // unrecognised reassignment.
+    let src = r#"
+function show() {
+    /** @var User $u */
+    $u = SomeRepository::findOne(1);
+    $u->where('email', 'a@b.c');
+}
+"#;
+    assert_eq!(resolve_at(src, "u", 1).as_deref(), Some("User"));
+}
+
+#[test]
+fn flow_assignment_after_use_does_not_apply() {
+    // `$q->where('|')` runs BEFORE `$q = User::query()` in source
+    // order — so the assignment doesn't establish $q's type at the use
+    // site. Note: this is contrived; PHP would error at runtime, but
+    // we shouldn't crash or pretend the later assignment applies.
+    let src = r#"
+function show($q) {
+    $q->where('email', 'a@b.c');
+    $q = User::query();
+}
+"#;
+    // n=0 is the LHS of the param, n=1 is the use site (before
+    // the assignment).
+    assert_eq!(resolve_at(src, "q", 1), None);
+}
+
+// ---- Declared-type fallback ---------------------------------------------
+
+#[test]
+fn typed_param_wins_when_no_assignment() {
+    // No assignment in scope — typed param still works as before
+    // (regression check: we haven't broken the Phase 9 behaviour).
+    let src = r#"
+function show(User $user) {
+    $user->newQuery();
+}
+"#;
+    assert_eq!(resolve_at(src, "user", 0).as_deref(), Some("User"));
+}
+
+#[test]
+fn docblock_with_no_assignment_resolves() {
+    // Pure docblock case — variable used directly with only the
+    // docblock declaring its type. No assignment means flow doesn't
+    // fire and docblock wins.
+    let src = r#"
+function pull() {
+    /** @var User $user */
+    extract(['user' => fetch()]);
+    $user->newQuery();
+}
+"#;
+    assert_eq!(resolve_at(src, "user", 0).as_deref(), Some("User"));
+}
+
+// ---- `use ($var)` capture ----------------------------------------------
+
+#[test]
+fn use_clause_captures_typed_outer_param() {
+    // AC #4: closure `use ($query)` inherits the captured variable's
+    // tracked type. Outer scope has `User $query` typed param; the
+    // closure body's `$query->where(...)` should resolve to User by
+    // walking out of the closure scope.
+    let src = r#"
+function show(User $query) {
+    collect([])->each(function ($item) use ($query) {
+        $query->where('id', $item);
+    });
+}
+"#;
+    // Find the $query inside the closure (the LAST occurrence).
+    let wrapped = format!("<?php\n{src}");
+    let bytes = wrapped.as_bytes();
+    let tree = parse_php(&wrapped).expect("parse");
+    let aliases = extract_use_aliases(&tree, &wrapped);
+    let mut last = None;
+    let mut n = 0;
+    while let Some(node) = find_nth_var(&tree, bytes, "query", n) {
+        last = Some(node);
+        n += 1;
+    }
+    let node = last.expect("at least one $query");
+    assert_eq!(
+        resolve(node, bytes, "query", &aliases).as_deref(),
+        Some("User")
+    );
+}
+
+#[test]
+fn use_clause_captures_flow_tracked_outer_assignment() {
+    // The captured variable's type was established by a flow-tracked
+    // assignment in the outer scope, not a typed param. Walking out of
+    // the closure must re-run flow resolution in the outer scope.
+    let src = r#"
+function show() {
+    $query = User::query();
+
+    collect([])->each(function ($item) use ($query) {
+        $query->where('id', $item);
+    });
+}
+"#;
+    // Last $query is inside the closure.
+    let wrapped = format!("<?php\n{src}");
+    let bytes = wrapped.as_bytes();
+    let tree = parse_php(&wrapped).expect("parse");
+    let aliases = extract_use_aliases(&tree, &wrapped);
+    let mut last = None;
+    let mut n = 0;
+    while let Some(node) = find_nth_var(&tree, bytes, "query", n) {
+        last = Some(node);
+        n += 1;
+    }
+    let node = last.expect("at least one $query");
+    assert_eq!(
+        resolve(node, bytes, "query", &aliases).as_deref(),
+        Some("User")
+    );
+}
+
+#[test]
+fn arrow_function_auto_captures_outer_var() {
+    // Arrow functions auto-capture by value. `fn ($i) => $query->...`
+    // sees $query from the outer scope without an explicit use clause.
+    let src = r#"
+function show() {
+    $query = User::query();
+
+    collect([])->each(fn ($i) => $query->where('id', $i));
+}
+"#;
+    // The last $query is inside the arrow function.
+    let wrapped = format!("<?php\n{src}");
+    let bytes = wrapped.as_bytes();
+    let tree = parse_php(&wrapped).expect("parse");
+    let aliases = extract_use_aliases(&tree, &wrapped);
+    let mut last = None;
+    let mut n = 0;
+    while let Some(node) = find_nth_var(&tree, bytes, "query", n) {
+        last = Some(node);
+        n += 1;
+    }
+    let node = last.expect("at least one $query");
+    assert_eq!(
+        resolve(node, bytes, "query", &aliases).as_deref(),
+        Some("User")
+    );
+}
+
+#[test]
+fn closure_without_use_does_not_leak_outer_vars() {
+    // A plain anonymous function (no `use` clause) doesn't capture
+    // anything. If the closure body references `$query`, that's a
+    // PHP error — but for our purposes we should refuse to resolve.
+    let src = r#"
+function show() {
+    $query = User::query();
+
+    $cb = function ($item) {
+        $query->where('id', $item);
+    };
+}
+"#;
+    // Last $query — inside the closure body, no use clause.
+    let wrapped = format!("<?php\n{src}");
+    let bytes = wrapped.as_bytes();
+    let tree = parse_php(&wrapped).expect("parse");
+    let aliases = extract_use_aliases(&tree, &wrapped);
+    let mut last = None;
+    let mut n = 0;
+    while let Some(node) = find_nth_var(&tree, bytes, "query", n) {
+        last = Some(node);
+        n += 1;
+    }
+    let node = last.expect("at least one $query");
+    assert_eq!(resolve(node, bytes, "query", &aliases), None);
+}
+
+// ---- Scope isolation ----------------------------------------------------
+
+#[test]
+fn nested_closure_assignment_does_not_pollute_outer() {
+    // `$q = User::query()` in outer scope. A nested closure reassigns
+    // `$q = something()`. The outer use site after the closure must
+    // still see User — the inner reassignment is scoped to the closure
+    // and doesn't leak out (PHP closures capture by value unless
+    // `use (&$var)`, which we don't model).
+    let src = r#"
+function show() {
+    $q = User::query();
+
+    $cb = function ($i) {
+        $q = wat();
+        $q->where('a', 1);
+    };
+
+    $q->where('email', 'a@b.c');
+}
+"#;
+    // Final $q is the outermost use site.
+    let wrapped = format!("<?php\n{src}");
+    let bytes = wrapped.as_bytes();
+    let tree = parse_php(&wrapped).expect("parse");
+    let aliases = extract_use_aliases(&tree, &wrapped);
+    let mut last = None;
+    let mut n = 0;
+    while let Some(node) = find_nth_var(&tree, bytes, "q", n) {
+        last = Some(node);
+        n += 1;
+    }
+    let node = last.expect("at least one $q");
+    assert_eq!(resolve(node, bytes, "q", &aliases).as_deref(), Some("User"));
+}
+
+// ---- Recursion / cycle guards ------------------------------------------
+
+#[test]
+fn mutual_reassignment_does_not_loop() {
+    // Pathological: $a depends on $b, $b depends on $a. Without the
+    // visited guard, classify_rhs would recurse forever. With it, we
+    // bail and return None.
+    let src = r#"
+function show() {
+    $a = User::query();
+    $b = $a->where('x', 1);
+    $a = $b->where('y', 2);
+    $b = $a->where('z', 3);
+    $a->orderBy('id');
+}
+"#;
+    // The last $a is the use site.
+    let wrapped = format!("<?php\n{src}");
+    let bytes = wrapped.as_bytes();
+    let tree = parse_php(&wrapped).expect("parse");
+    let aliases = extract_use_aliases(&tree, &wrapped);
+    let mut last = None;
+    let mut n = 0;
+    while let Some(node) = find_nth_var(&tree, bytes, "a", n) {
+        last = Some(node);
+        n += 1;
+    }
+    let node = last.expect("at least one $a");
+    // The interesting property here is that we don't hang. The exact
+    // result depends on resolution order, but we should either resolve
+    // back to User (the original seed) or return None safely.
+    let _ = resolve(node, bytes, "a", &aliases);
+}

--- a/laravel-lsp/src/query_chain/var_type.rs
+++ b/laravel-lsp/src/query_chain/var_type.rs
@@ -2,70 +2,85 @@
 //!
 //! Used when a chain starts at an instance variable like `$user->newQuery()`.
 //! We need to know `$user` is a `User` to power column / relation completion
-//! against the right model. Two complementary strategies, tried in this order:
+//! against the right model. The resolution chain is layered:
 //!
-//! 1. **Typed function/method parameter.** `function show(User $user)` →
+//! 1. **Latest assignment in scope** (flow-tracked) — `$user = User::find($id);`
+//!    overrides any declared type for `$user`, because PHP allows free
+//!    reassignment. Lives in [`super::flow`].
+//!
+//! 2. **Typed function/method parameter.** `function show(User $user)` →
 //!    `$user`'s declared type is `User`. Covers the common case in
 //!    controllers and services where action methods take typed args.
 //!
-//! 2. **`@var` docblock.** PHPDoc allows `/** @var User $u */` immediately
+//! 3. **`@var` docblock.** PHPDoc allows `/** @var User $u */` immediately
 //!    above an assignment. Used in places where PHP's static type system
 //!    isn't sufficient (e.g. `$u = $repo->findOne(...);` whose return type
 //!    is too generic).
 //!
-//! Both strategies resolve the bare class name through the file's `use`
+//! All strategies resolve the bare class name through the file's `use`
 //! aliases via [`crate::query_chain::use_aliases::resolve_class_name`], so a
 //! parameter typed `Article` with `use App\Models\Post as Article;` returns
 //! `App\Models\Post` — ready to feed into Composer autoload.
+//!
+//! The actual scope-walking, flow analysis, and `use ($var)` capture
+//! traversal lives in [`super::flow`]. This module exposes the per-scope
+//! declared-type helpers (`typed_param_in`, `docblock_in`) that the flow
+//! resolver uses at each scope hop, plus the public `resolve` entry point
+//! which is now a thin wrapper around `flow::resolve`.
 //!
 //! Misses (no type info, ambiguous type, unresolvable name) return `None`
 //! rather than guessing. Better no completion than a wrong one.
 
 use tree_sitter::Node;
 
-use super::use_aliases::{resolve_class_name, UseAliases};
+use super::use_aliases::UseAliases;
 
-/// Return the resolved FQCN for `var_name` at `variable_node`'s position, or
-/// `None` if neither strategy yields a type. Caller stores the result in
+/// Return the resolved FQCN for `var_name` at `variable_node`'s position,
+/// or `None` if no strategy yields a type. Caller stores the result in
 /// `EloquentReceiver::InstanceVar::php_type` for later use by the cursor
 /// context resolver.
+///
+/// Delegates to [`super::flow::resolve`], which walks scope-by-scope
+/// applying flow > typed param > docblock, recursing into outer scopes
+/// via `use ($var)` capture.
 pub fn resolve(
     variable_node: Node,
     bytes: &[u8],
     var_name: &str,
     aliases: &UseAliases,
 ) -> Option<String> {
-    if let Some(raw_type) = typed_param_for(variable_node, bytes, var_name) {
-        return Some(resolve_class_name(&raw_type, aliases));
-    }
-    if let Some(raw_type) = var_docblock_for(variable_node, bytes, var_name) {
-        return Some(resolve_class_name(&raw_type, aliases));
-    }
-    None
+    super::flow::resolve(variable_node, bytes, var_name, aliases)
 }
 
-/// Walk up from `node` to the nearest function-like ancestor and scan its
-/// formal parameters for one named `var_name`. Returns the raw type string
-/// as written in source — caller handles use-alias resolution.
-fn typed_param_for(node: Node, bytes: &[u8], var_name: &str) -> Option<String> {
-    let mut cur = Some(node);
-    while let Some(n) = cur {
-        match n.kind() {
-            // Method on a class.
-            "method_declaration"
-            // Top-level function.
+/// Scan `scope`'s formal parameters for one named `var_name`. Returns the
+/// raw type string as written in source — caller handles use-alias
+/// resolution. `None` for untyped or missing parameters.
+///
+/// `scope` must be a function-like node (function_definition,
+/// method_declaration, anonymous_function, arrow_function). Caller is
+/// responsible for finding the right scope; this function does not walk
+/// up the tree.
+pub fn typed_param_in(scope: Node, bytes: &[u8], var_name: &str) -> Option<String> {
+    if !matches!(
+        scope.kind(),
+        "method_declaration"
             | "function_definition"
-            // `function () use (...) { ... }` — anonymous closure.
             | "anonymous_function_creation_expression"
             | "anonymous_function"
-            // `fn ($x) => ...` — short arrow.
-            | "arrow_function" => {
-                return scan_formal_parameters(n, bytes, var_name);
-            }
-            _ => cur = n.parent(),
-        }
+            | "arrow_function"
+    ) {
+        return None;
     }
-    None
+    scan_formal_parameters(scope, bytes, var_name)
+}
+
+/// Find a `@var $var_name <type>` (or `@var <type> $var_name`) docblock
+/// anywhere inside `scope`. `scope` is typically a function-like or
+/// `program` node. First match wins; we don't try to pick the "closest"
+/// docblock to a specific assignment — by convention PHP docblocks
+/// declare a variable once per scope.
+pub fn docblock_in(scope: Node, bytes: &[u8], var_name: &str) -> Option<String> {
+    scan_comments_for_var(scope, bytes, var_name)
 }
 
 /// Look at every direct child of the function's `parameters` (or
@@ -174,49 +189,6 @@ fn simplify_type(raw: String) -> Option<String> {
         return None;
     }
     Some(first.to_string())
-}
-
-/// Find a `@var` docblock declaring `var_name`'s type anywhere in the
-/// enclosing function-like scope. PHPDoc syntax:
-///
-/// ```php
-/// /** @var User $u */
-/// $u = $repo->findOne(...);
-/// $u->newQuery()->where('|');   // ← cursor here, docblock above the
-///                               //   assignment still applies.
-/// ```
-///
-/// We don't try to associate the docblock with a specific assignment —
-/// for Phase 9, any `@var Class $var` *in the same function* counts. PHP
-/// developers don't typically reassign the same variable to different
-/// types within one function; when they do, this picks the first
-/// declaration. Better than restricting to prev-sibling, which misses
-/// the common "docblock before assignment, var used several lines down"
-/// pattern.
-fn var_docblock_for(node: Node, bytes: &[u8], var_name: &str) -> Option<String> {
-    let scope = enclosing_scope(node)?;
-    scan_comments_for_var(scope, bytes, var_name)
-}
-
-/// Walk up to the closest function-like ancestor (or the file root if
-/// the variable lives at top level — rare but legal in scripts).
-fn enclosing_scope(node: Node) -> Option<Node> {
-    let mut cur = Some(node);
-    while let Some(n) = cur {
-        if matches!(
-            n.kind(),
-            "function_definition"
-                | "method_declaration"
-                | "anonymous_function"
-                | "anonymous_function_creation_expression"
-                | "arrow_function"
-                | "program"
-        ) {
-            return Some(n);
-        }
-        cur = n.parent();
-    }
-    None
 }
 
 /// DFS the scope's subtree for `comment` nodes containing a matching


### PR DESCRIPTION
## Summary

Closes #23 — Phase 2 of #11.

Adds intra-procedural flow-sensitive type tracking for chain-receiver variables. Chains rooted at `$var` now resolve to the right Eloquent model when the variable is established several statements earlier or rebuilt across conditional branches:

```php
$query = User::query();

if ($activeOnly) {
    $query = $query->where('active', true);
}

$query->orderBy('|');   // ← completes User's columns
```

Also handles `use ($var)` closure capture and arrow-function auto-capture, so this works:

```php
$query = User::query();
collect([])->each(fn ($i) => $query->where('id', $i));  // $query resolves to User
```

## Architecture

- New `query_chain/flow.rs` (~290 lines + module doc) — assignment tracking, RHS classifier, closure-capture traversal.
- `var_type::resolve` is now a thin wrapper that delegates to `flow::resolve`; per-scope helpers `typed_param_in` / `docblock_in` are exposed so flow can apply them at each scope hop.
- Cycles terminate naturally via a **monotonically-decreasing byte boundary** — when classifying an assignment's RHS, recursive lookups use that assignment's start byte as the new boundary, so \`\$q = \$q->where(...)\` walks back to the original seed rather than re-discovering itself. Simpler than a visited set, and avoids the subtle bug where re-entering a `(scope, var)` pair was incorrectly blocked during legitimate backward recursion.

## Resolution order

**Per scope:** latest classifiable assignment > typed param > docblock.

**Across scopes (`use ($var)` capture or arrow auto-capture):** if nothing resolves locally, step out one scope and try again with the closure's start as the new boundary.

When flow can't classify an assignment ("tracking cleared" per AC #3), we fall through to declared types within the same scope. Those are user-asserted intent and aren't invalidated by an unrecognised reassignment.

## Notable design choice — closure_scope ordering preserved

The issue AC states `typed param > docblock > flow-tracked > closure scope > unknown`. Implementing this literally would have regressed `whereHas('posts', function (Builder \$q) { \$q->where('|'); })` — today the closure_scope binding correctly resolves to Post; flipping the order would let the typed `Builder` param win and try to complete against a generic Builder class.

After discussion, the resolution model is **dataflow-closeness, walking backward from the use site**:

1. Latest assignment in current scope (overrides everything below — reassignment is a fresh write)
2. How `\$var` entered the scope:
   - Closure param → `closure_scope` binding > typed annotation > docblock
   - Function param → typed annotation > docblock
   - `use (\$var)` capture → recurse into outer scope, apply same rules

This preserves all existing `closure_scope` semantics. The cursor.rs dispatch is unchanged; only the *contents* of `php_type` are richer now (flow tracking + typed param + docblock).

## Acceptance criteria

- [x] `\$query = User::query();` followed by `\$query->where('|')` on a later line completes User's columns
- [x] `\$query = \$query->where(...)` keeps the type — subsequent `\$query->orderBy('|')` still completes columns
- [x] Reassignment from a non-Builder type clears tracking (\`\$query = something_unrelated();\` → falls back to typed param / docblock; None if neither exists)
- [x] Closure `use (\$query)` captures the variable's tracked type
- [x] `tap(fn (\$q) => \$q->where('|'))` resolves `\$q` to the chain's effective model (unchanged — handled by Phase 8 closure_scope SameModel binding; not regressed)
- [x] Receiver-resolution ordering documented and tested in module docs + tests

## Tests

- **18 unit tests** in [`flow/tests.rs`](laravel-lsp/src/query_chain/flow/tests.rs) covering: seed from static query / where / new, self-reassignment chains, branch reassignment (the motivating example), clearing on unknown RHS, fallback to typed param + docblock, `use ()` capture + auto-capture, scope isolation (nested closure assignments don't pollute outer), mutual-reassignment cycle guard.
- **4 integration tests** in [`extractor/tests.rs`](laravel-lsp/src/query_chain/extractor/tests.rs) verifying `InstanceVar.php_type` gets populated end-to-end on parsed files (not just at the var_type unit level).

**Full suite: 1108 passing, 0 failures, clippy clean.**

## Out of scope (per issue)

- Inter-procedural flow (across function boundaries)
- Method-name completion (#22)
- Joined tables

## Test plan

- [ ] In a Laravel project, open a controller with multi-statement query construction (e.g. `\$query = User::query(); if (...) { \$query = \$query->where(...); } \$query->where('|')`) — confirm column completion fires
- [ ] Confirm the original closure-carrier case still works: `whereHas('posts', fn (\$q) => \$q->where('|'))` → Post's columns
- [ ] Confirm `use (\$query)` capture in an anonymous function carries the type forward
- [ ] Confirm arrow function `fn (\$i) => \$query->where('|')` carries the type forward
- [ ] Sanity-check that reassigning a tracked var to something unclassifiable (e.g. `\$query = somethingElse();`) doesn't fire stale completions