### PR TITLE
docs: 📝 add Intelephense tuning section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,10 @@ What you trade:
 
 | Excluded | Intelephense loses | `laravel-lsp` covers |
 |---|---|---|
-| `_ide_helper*.php` | Eloquent dynamic attributes/methods (`$user->name`, `User::find()`), facade resolution (`Auth::user()`) | Eloquent completion from the actual DB schema (more accurate than ide-helper docblocks). **Facades not covered.** |
+| `_ide_helper*.php` | Eloquent dynamic attributes/methods (`$user->name`, `User::find()`), plus extra methods added to facades by third-party packages (e.g. Scout, Telescope, Spatie permissions) | Eloquent completion from the actual DB schema (more accurate than ide-helper docblocks). **Core framework facade resolution (`Auth::user()`, `Cache::get()`, `Route::get()`, etc.) keeps working without ide-helper** — Intelephense reads the `@method` PHPDoc tags directly off the facade source files at `vendor/laravel/framework/src/Illuminate/Support/Facades/*.php`. |
 | `.phpstorm.meta.php` | Container-binding type narrowing (`app('cache')` → `CacheManager`) | Container-binding goto via the `Binding` pattern. |
 
-If you lean heavily on Intelephense's facade method completion (`Auth::`, `Cache::`, `Route::`...), keep `_ide_helper*.php` in.
+If you use packages that extend Laravel facades with their own methods (Scout adds `Searchable` methods, Telescope extends `Gate`, etc.), keep `_ide_helper*.php` in to retain completion for those package-added methods. Core Laravel facades resolve fine without it.
 
 ### Per-project
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,77 @@ Zed defaults to tree-sitter outlines, which don't call any LSP — opt into LSP 
 
 > **Quirks worth knowing** — Zed colors outline labels by word-matching them against the source buffer's tree-sitter highlights, which produces slightly inconsistent colors on multi-segment URLs (e.g., `/cra-details` may color `cra` and `details` differently if they match different tokens elsewhere in the file). Route names appear in the LSP `detail` field, which Zed's outline panel doesn't currently render (VSCode and Sublime/LSP do). Both are tracked upstream: [zed#57576](https://github.com/zed-industries/zed/issues/57576).
 
+## 🔧 Tuning Intelephense
+
+If you use Intelephense as your PHP language server, goto-definition on a class name (e.g. `User`) can land you in a Zed multi-buffer with several unrelated files — the actual class, plus generated stubs from [barryvdh/laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper), `.phpstorm.meta.php`, and `class User` stub templates that packages like Jetstream ship under `vendor/*/stubs/`. Intelephense indexes all of them by default.
+
+Zed merges goto responses across every running LSP and only dedupes identical locations — distinct paths from the same logical click stay separate. So even though `laravel-lsp` returns nothing for bare class references (we don't claim that pattern), Intelephense's noisy results show through unfiltered.
+
+### Safe baseline
+
+Tell Intelephense to skip `vendor/*/stubs/` — those are scaffold templates (Jetstream, Filament, etc.), never loaded at runtime. Excluding them costs nothing.
+
+```json
+{
+  "lsp": {
+    "intelephense": {
+      "initialization_options": {
+        "licenceKey": "~/intelephense/licence.txt"
+      },
+      "settings": {
+        "files": {
+          "exclude": ["**/stubs/**"]
+        }
+      }
+    }
+  }
+}
+```
+
+Two things about this shape that catch people:
+
+- **`initialization_options` vs `settings` are siblings.** `initialization_options` is the right home for the four startup-only keys Intelephense accepts (`licenceKey`, `clearCache`, `storagePath`, `globalStoragePath`); drop the block entirely if you don't have a licence. Everything else (including `files.exclude`) belongs in `settings`. Nesting `settings` inside `initialization_options` makes Intelephense silently ignore it.
+- **No `intelephense` namespace inside `settings`.** Most VSCode-style Intelephense docs show keys nested under an `intelephense` object (e.g. `intelephense.files.exclude`). Don't do that here — Zed's PHP extension wraps your `settings` block inside `{ "intelephense": ... }` before sending it to the server. Adding your own `intelephense` key creates `intelephense.intelephense.files.exclude`, which the server silently ignores. Put `files.exclude` directly under `settings`.
+
+After saving, restart Intelephense (`Cmd+Shift+P → lsp: restart`). The stub-template results disappear from class-name goto.
+
+> ⚠️ **Cache caveat.** Intelephense keeps a persistent symbol index on disk, so already-indexed symbols can still surface after you add excludes. To force a rebuild, add `"clearCache": true` to `initialization_options` for one startup (then remove it — leaving it `true` re-indexes from scratch every launch). As a fallback, wipe `~/Library/Application Support/intelephense/` (macOS) while Zed isn't running.
+
+### More aggressive (with trade-offs)
+
+If `_ide_helper_models.php` and `.phpstorm.meta.php` still cluttering goto bothers you more than the Intelephense fidelity they enable, add them to the exclude array:
+
+```json
+"exclude": [
+  "**/stubs/**",
+  "**/_ide_helper*.php",
+  "**/.phpstorm.meta.php"
+]
+```
+
+What you trade:
+
+| Excluded | Intelephense loses | `laravel-lsp` covers |
+|---|---|---|
+| `_ide_helper*.php` | Eloquent dynamic attributes/methods (`$user->name`, `User::find()`), facade resolution (`Auth::user()`) | Eloquent completion from the actual DB schema (more accurate than ide-helper docblocks). **Facades not covered.** |
+| `.phpstorm.meta.php` | Container-binding type narrowing (`app('cache')` → `CacheManager`) | Container-binding goto via the `Binding` pattern. |
+
+If you lean heavily on Intelephense's facade method completion (`Auth::`, `Cache::`, `Route::`...), keep `_ide_helper*.php` in.
+
+### Per-project
+
+Drop the same exclude patterns into an `.intelephense.json` at your project root. Unlike the Zed `settings` block, this file is read directly by Intelephense, so it uses the standard namespaced shape:
+
+```json
+{
+  "files.exclude": [
+    "**/stubs/**",
+    "**/_ide_helper*.php",
+    "**/.phpstorm.meta.php"
+  ]
+}
+```
+
 ## ✨ Features
 
 ### 🔗 Go-to-Definition


### PR DESCRIPTION
Fixes #28 

## Summary

Adds a `🔧 Tuning Intelephense` section to the README that documents how to configure Intelephense's `files.exclude` to fix the noisy multi-buffer goto-definition results reported in #28.

The section walks through:

- **Why it happens** — Intelephense indexes `_ide_helper*.php`, `.phpstorm.meta.php`, and `vendor/*/stubs/**` by default. Zed merges goto across LSPs and only dedupes identical paths, so `laravel-lsp` returning `None` for bare class refs doesn't suppress them.
- **Safe baseline** — exclude `**/stubs/**` only (scaffold templates, never loaded at runtime → zero downside).
- **More aggressive** — also exclude `_ide_helper*.php` and `.phpstorm.meta.php`, with a trade-off table showing what `laravel-lsp` already covers (DB-schema Eloquent completion, container-binding goto) vs. what it does not (Intelephense facade resolution).
- **Per-project alternative** — `.intelephense.json` at project root, with the standard namespaced shape (since this file is read directly by Intelephense, not via Zed's wrapping).
- **Two Zed-specific config gotchas** that silently swallow the exclude:
  - `initialization_options` and `settings` are siblings — nesting one inside the other makes Intelephense ignore the inner block.
  - No inner `intelephense` namespace inside `settings` — Zed's PHP extension wraps the block automatically before sending to the server. Adding your own wrapper creates `intelephense.intelephense.files.exclude`, which Intelephense silently ignores.
- **Cache caveat** — Intelephense's persistent on-disk index needs `"clearCache": true` (or a manual storage wipe) to drop already-indexed symbols after adding excludes.

Validated end-to-end on a Jetstream-installed Laravel project: the multi-buffer collapses to a single result after applying the documented config.

#28 stays open as a parking lot for the optional class-ref goto implementation listed as item 3 in the issue body. That feature was discussed and deferred — Intelephense already handles bare class-name goto well, and `laravel-lsp` adding its own would be dedup'd away by Zed. Real laravel-specific class navigation (Eloquent relationships, facade resolution without ide-helper, factory chains) belongs in a separate issue with its own scope.

## Test plan

- [ ] Confirm README renders cleanly on GitHub
- [ ] Confirm the JSON code blocks copy-paste cleanly into a `settings.json`
- [ ] Sanity-check the per-project `.intelephense.json` example shape

Refs #28