### PR TITLE
feat: diagnostics + goto-definition for resolved columns/relations/tables (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ The extension works out of the box with zero configuration. It automatically dis
         "autoCompleteDebounce": 200,
         "blade": {
           "directiveSpacing": false
+        },
+        "diagnostics": {
+          "severity": "warning"
         }
       }
     }
@@ -61,6 +64,7 @@ The extension works out of the box with zero configuration. It automatically dis
 |---------|---------|-------------|
 | `autoCompleteDebounce` | `200` | Delay (ms) before autocomplete updates after typing. Lower values (50-100ms) give faster feedback. Higher values (300-500ms) reduce CPU usage. |
 | `blade.directiveSpacing` | `false` | Add space between directive name and parentheses. `false`: `@if($condition)` / `true`: `@if ($condition)` |
+| `diagnostics.severity` | `"warning"` | Severity for query-chain diagnostics (unknown column/relation/table in Eloquent & `DB::table()` chains). One of `"warning"`, `"error"`, `"info"`, or `"off"` to disable. Requires a working database connection — diagnostics stay silent when the schema can't be introspected. |
 
 **🗄️ Database autocomplete** (`exists:`, `unique:` rules, Eloquent properties) requires a working database connection. Configure in your `.env`:
 

--- a/README.md
+++ b/README.md
@@ -238,8 +238,19 @@ $message = __('auth.failed');
 //            ^^^^^^^^^^^^ → lang/en/auth.php
 ```
 
+Cmd+Click also works on **query-chain literals** — columns jump to the migration line that defines them, relations to the relation method on the model, and `DB::table()` names to the create-table migration:
+
+```php
+User::where('email', $value)->with('posts');
+//          ^^^^^ → database/migrations/..._create_users_table.php  ($table->string('email'))
+//                                ^^^^^ → app/Models/User.php  (public function posts())
+
+DB::table('users')->get();
+//        ^^^^^ → database/migrations/..._create_users_table.php  (Schema::create('users'))
+```
+
 **Supported patterns:**
-`view()` `View::make()` `@extends` `@include` `@component` `<x-*>` `</x-*>` `<livewire:*>` `</livewire:*>` `@livewire()` `route()` `to_route()` `config()` `Config::get()` `env()` `__()` `trans()` `@lang` `->middleware()` `app()` `resolve()` `asset()` `@vite` `app_path()` `base_path()` `storage_path()` `resource_path()` `public_path()` `Feature::active()` `Feature::inactive()` `Feature::value()` `@feature`
+`view()` `View::make()` `@extends` `@include` `@component` `<x-*>` `</x-*>` `<livewire:*>` `</livewire:*>` `@livewire()` `route()` `to_route()` `config()` `Config::get()` `env()` `__()` `trans()` `@lang` `->middleware()` `app()` `resolve()` `asset()` `@vite` `app_path()` `base_path()` `storage_path()` `resource_path()` `public_path()` `Feature::active()` `Feature::inactive()` `Feature::value()` `@feature` · query-chain columns / relations / tables
 
 ### 🔍 Find References
 

--- a/laravel-lsp/src/class_rename.rs
+++ b/laravel-lsp/src/class_rename.rs
@@ -1,0 +1,401 @@
+//! PHP class rename — locate every reference to a class FQCN within a file and
+//! rewrite it, so the LSP can rename an Eloquent model (or any project class)
+//! across the whole project: declaration, `use` imports, `User::` static calls,
+//! `new User`, type hints, `User::class`, `extends`/`implements`, `instanceof`,
+//! and `@var`/`@param`/`@return` docblocks.
+//!
+//! # How references are resolved
+//!
+//! For a target FQCN (`App\Models\User`, basename `User`) we walk the tree for
+//! tokens in **class-name positions** (an allowlist of tree-sitter contexts),
+//! resolve each token to an FQCN using the file's `use` aliases + namespace,
+//! and rewrite the basename segment **iff** it both resolves to the target AND
+//! its last segment equals the old basename. That two-part test is what makes
+//! aliases safe:
+//!
+//! - `use App\Models\User as U; U::find()` — the import's last segment `User`
+//!   is rewritten; the alias `U` (basename ≠ `User`) is left alone, so it keeps
+//!   pointing at the renamed class.
+//! - A method/property/function coincidentally named `User` sits in a context
+//!   that isn't on the allowlist, so it's never touched.
+//!
+//! Docblocks live in comments (tree-sitter doesn't descend them), so `@var` /
+//! `@param` / `@return` references are matched with a targeted scan.
+
+use crate::parser::parse_php;
+use crate::query_chain::use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};
+use std::path::{Path, PathBuf};
+use tree_sitter::Node;
+use walkdir::WalkDir;
+
+/// Directory names pruned when enumerating project PHP files for rename — we
+/// never rewrite dependencies or build artefacts.
+const SKIP_DIRS: &[&str] = &["vendor", "node_modules", ".git", "storage"];
+
+/// Every project (non-dependency) `*.php` file under `root`. Used to find class
+/// references for a project-wide rename. `vendor/`, `node_modules/`, `.git/`,
+/// and `storage/` are pruned.
+pub fn project_php_files(root: &Path) -> Vec<PathBuf> {
+    WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|entry| {
+            !(entry.file_type().is_dir()
+                && entry
+                    .file_name()
+                    .to_str()
+                    .map(|n| SKIP_DIRS.contains(&n))
+                    .unwrap_or(false))
+        })
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file() && e.path().extension().is_some_and(|x| x == "php"))
+        .map(|e| e.path().to_path_buf())
+        .collect()
+}
+
+/// Whether `path` is inside a pruned dependency dir (e.g. `vendor/`). We refuse
+/// to rename a class whose declaration lives there.
+pub fn is_dependency_path(path: &Path) -> bool {
+    path.components().any(|c| {
+        c.as_os_str()
+            .to_str()
+            .map(|s| SKIP_DIRS.contains(&s))
+            .unwrap_or(false)
+    })
+}
+
+/// A resolved class-name occurrence: the FQCN it refers to and the byte span of
+/// the **basename segment** to rewrite (just `User` in `App\Models\User`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ClassRef {
+    fqcn: String,
+    basename: String,
+    span: (usize, usize),
+}
+
+/// All byte spans in `content` that should be rewritten to the new basename
+/// when renaming `target_fqcn` (whose current basename is `old_basename`).
+/// Spans are sorted and de-duplicated; each covers exactly the old basename.
+pub fn reference_spans(
+    content: &str,
+    target_fqcn: &str,
+    old_basename: &str,
+) -> Vec<(usize, usize)> {
+    let Ok(tree) = parse_php(content) else {
+        return Vec::new();
+    };
+    let bytes = content.as_bytes();
+    let aliases = extract_use_aliases(&tree, content);
+    let namespace = namespace_in(&tree, bytes);
+
+    let mut spans: Vec<(usize, usize)> = refs_in(&tree, bytes, &aliases, namespace.as_deref())
+        .into_iter()
+        .filter(|r| r.fqcn == target_fqcn && r.basename == old_basename)
+        .map(|r| r.span)
+        .collect();
+    spans.extend(docblock_spans_in(
+        &tree,
+        bytes,
+        &aliases,
+        namespace.as_deref(),
+        target_fqcn,
+        old_basename,
+    ));
+    spans.sort_unstable();
+    spans.dedup();
+    spans
+}
+
+/// If `byte_offset` falls on a class-name token, return its resolved FQCN and
+/// the basename span. Returns `None` for aliases (cursor token ≠ basename) and
+/// for non-class positions — so the caller only offers rename on real class
+/// names.
+pub fn class_at_cursor(content: &str, byte_offset: usize) -> Option<(String, (usize, usize))> {
+    let tree = parse_php(content).ok()?;
+    let bytes = content.as_bytes();
+    let aliases = extract_use_aliases(&tree, content);
+    let namespace = namespace_in(&tree, bytes);
+    refs_in(&tree, bytes, &aliases, namespace.as_deref())
+        .into_iter()
+        .filter(|r| byte_offset >= r.span.0 && byte_offset <= r.span.1)
+        .find(|r| r.fqcn.rsplit('\\').next() == Some(r.basename.as_str()))
+        .map(|r| (r.fqcn, r.span))
+}
+
+/// Walk an already-parsed tree and resolve every class-name occurrence to a
+/// [`ClassRef`]. Parsing + alias/namespace extraction happen once in the caller
+/// — important on large projects where rename scans thousands of files.
+fn refs_in(
+    tree: &tree_sitter::Tree,
+    bytes: &[u8],
+    aliases: &UseAliases,
+    namespace: Option<&str>,
+) -> Vec<ClassRef> {
+    let mut out = Vec::new();
+    let mut stack = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        if (node.kind() == "name" || node.kind() == "qualified_name") && is_class_ref(node) {
+            if let Some(r) = resolve_ref(node, bytes, aliases, namespace) {
+                out.push(r);
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+    out
+}
+
+/// Resolve a class-name node to `(fqcn, basename, basename_span)`.
+fn resolve_ref(
+    node: Node,
+    bytes: &[u8],
+    aliases: &UseAliases,
+    namespace: Option<&str>,
+) -> Option<ClassRef> {
+    let text = node.utf8_text(bytes).ok()?;
+    // Basename segment + its span (the part we rewrite). For qualified names the
+    // basename is the trailing `\`-segment; identifiers are ASCII so byte
+    // arithmetic off the node end is exact.
+    let (basename, span) = if node.kind() == "qualified_name" {
+        let bn = text.rsplit('\\').next().unwrap_or(text);
+        let end = node.end_byte();
+        (bn.to_string(), (end - bn.len(), end))
+    } else {
+        (text.to_string(), (node.start_byte(), node.end_byte()))
+    };
+
+    let resolved = resolve_class_name(text, aliases);
+    let fqcn = if resolved.contains('\\') {
+        resolved
+    } else {
+        match namespace {
+            Some(ns) => format!("{ns}\\{resolved}"),
+            None => resolved,
+        }
+    };
+
+    Some(ClassRef {
+        fqcn,
+        basename,
+        span,
+    })
+}
+
+/// Whether a `name`/`qualified_name` node sits in a class-name position.
+/// Allowlist of tree-sitter contexts — anything else (member access, method /
+/// function names, the `class` of `::class`, namespace segments) is excluded.
+fn is_class_ref(node: Node) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    match parent.kind() {
+        // Segment of a larger qualified/namespace name — handled at the
+        // `qualified_name` level, not per segment.
+        "namespace_name" | "qualified_name" => false,
+        // Type hints (parameter / return / property), all wrap a `named_type`.
+        "named_type" => true,
+        // `new User`
+        "object_creation_expression" => true,
+        // `class X extends User`
+        "base_clause" => true,
+        // `class X implements User`
+        "class_interface_clause" => true,
+        // `use App\Models\User;` / `use ... as Alias;` — the basename filter
+        // sorts the import (rewrite) from the alias (skip).
+        "namespace_use_clause" => true,
+        // The class being declared (`class User { … }`).
+        "class_declaration" => is_field_child(parent, node, "name"),
+        // `User::method()` — only the scope, not the method.
+        "scoped_call_expression" => is_scope_child(parent, node),
+        // `User::class` / `User::CONST` — only the class, not the constant.
+        "class_constant_access_expression" => is_scope_child(parent, node),
+        // `User::$prop`
+        "scoped_property_access_expression" => is_scope_child(parent, node),
+        // `$x instanceof User`
+        "binary_expression" => is_instanceof_right(parent, node),
+        _ => false,
+    }
+}
+
+/// Whether `node` is the `field`-named child of `parent`.
+fn is_field_child(parent: Node, node: Node, field: &str) -> bool {
+    parent
+        .child_by_field_name(field)
+        .map(|c| c.id() == node.id())
+        .unwrap_or(false)
+}
+
+/// Whether `node` is the class/scope side of a `::` access. Prefers the `scope`
+/// field; falls back to "first named child" for grammars that don't field it.
+fn is_scope_child(parent: Node, node: Node) -> bool {
+    if let Some(scope) = parent.child_by_field_name("scope") {
+        return scope.id() == node.id();
+    }
+    let mut cursor = parent.walk();
+    let first = parent.named_children(&mut cursor).next();
+    first.map(|c| c.id() == node.id()).unwrap_or(false)
+}
+
+/// Whether `parent` is an `X instanceof Class` expression and `node` is the
+/// `Class` (right) operand.
+fn is_instanceof_right(parent: Node, node: Node) -> bool {
+    let mut cursor = parent.walk();
+    let has_instanceof = parent
+        .children(&mut cursor)
+        .any(|c| c.kind() == "instanceof");
+    if !has_instanceof {
+        return false;
+    }
+    // The class is the right operand; `right` field if present, else the last
+    // named child.
+    if let Some(right) = parent.child_by_field_name("right") {
+        return right.id() == node.id();
+    }
+    let mut cursor = parent.walk();
+    let last = parent.named_children(&mut cursor).last();
+    last.map(|c| c.id() == node.id()).unwrap_or(false)
+}
+
+/// The file's namespace (`namespace App\Models;`), if declared. Operates on an
+/// already-parsed tree.
+fn namespace_in(tree: &tree_sitter::Tree, bytes: &[u8]) -> Option<String> {
+    let mut stack = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "namespace_definition" {
+            // The name child holds the namespace path.
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if child.kind() == "namespace_name" {
+                    return child.utf8_text(bytes).ok().map(str::to_string);
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+    None
+}
+
+/// PHPDoc tags whose value starts with a type expression we should rewrite.
+const DOC_TYPE_TAGS: &[&str] = &[
+    "@param",
+    "@return",
+    "@var",
+    "@property",
+    "@property-read",
+    "@property-write",
+    "@throws",
+];
+
+/// Scan `/** … */` docblocks for class references in `@param`/`@return`/`@var`/…
+/// **type** positions only — not prose. For each tag we take the following type
+/// token (`User`, `User|null`, `\App\Models\User`, `User[]`) and rewrite
+/// basename words in it that resolve to the target. Comments aren't in the AST,
+/// so this is a targeted text scan; restricting to the type token keeps prose
+/// like `// named User` from matching.
+fn docblock_spans_in(
+    tree: &tree_sitter::Tree,
+    bytes: &[u8],
+    aliases: &UseAliases,
+    namespace: Option<&str>,
+    target_fqcn: &str,
+    old_basename: &str,
+) -> Vec<(usize, usize)> {
+    let resolves_to_target = |word: &str| -> bool {
+        let resolved = resolve_class_name(word, aliases);
+        let fqcn = if resolved.contains('\\') {
+            resolved
+        } else {
+            match namespace {
+                Some(ns) => format!("{ns}\\{resolved}"),
+                None => resolved,
+            }
+        };
+        fqcn == target_fqcn
+    };
+
+    let mut spans = Vec::new();
+    let mut stack = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "comment" {
+            if let Ok(text) = node.utf8_text(bytes) {
+                if text.starts_with("/**") {
+                    let base = node.start_byte();
+                    for (type_start, type_str) in doc_type_tokens(text) {
+                        for (woff, word) in word_spans(type_str) {
+                            if word == old_basename && resolves_to_target(word) {
+                                let at = base + type_start + woff;
+                                spans.push((at, at + word.len()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+    spans
+}
+
+/// Find each `@tag <type>` in a docblock and return `(byte offset of the type
+/// token within `text`, the type token)`. The type is the whitespace-delimited
+/// token immediately after a recognised tag.
+fn doc_type_tokens(text: &str) -> Vec<(usize, &str)> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    for tag in DOC_TYPE_TAGS {
+        let mut from = 0;
+        while let Some(rel) = text[from..].find(tag) {
+            let tag_at = from + rel;
+            from = tag_at + tag.len();
+            // The char right after the tag must be whitespace, so `@param`
+            // doesn't match inside `@parameters`.
+            match bytes.get(from) {
+                Some(b) if b.is_ascii_whitespace() => {}
+                _ => continue,
+            }
+            // Skip whitespace to the type token.
+            let mut i = from;
+            while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+                i += 1;
+            }
+            let type_start = i;
+            while i < bytes.len() && !bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            if i > type_start {
+                out.push((type_start, &text[type_start..i]));
+            }
+        }
+    }
+    out
+}
+
+/// Identifier-like words in a string, with their byte offsets. Splits on any
+/// non-identifier character so `User|null` yields `User`, `null`.
+fn word_spans(text: &str) -> Vec<(usize, &str)> {
+    let mut out = Vec::new();
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_alphabetic() || bytes[i] == b'_' {
+            let start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            out.push((start, &text[start..i]));
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/class_rename/tests.rs
+++ b/laravel-lsp/src/class_rename/tests.rs
@@ -1,0 +1,265 @@
+use super::{class_at_cursor, is_dependency_path, project_php_files, reference_spans};
+use std::path::Path;
+
+/// Replace every span (right-to-left so earlier offsets stay valid) — mimics
+/// what the rename WorkspaceEdit does, so we can assert on the rewritten source.
+fn apply(content: &str, spans: &[(usize, usize)], new: &str) -> String {
+    let mut out = content.to_string();
+    let mut spans = spans.to_vec();
+    spans.sort_unstable();
+    for (s, e) in spans.into_iter().rev() {
+        out.replace_range(s..e, new);
+    }
+    out
+}
+
+fn rename(content: &str, fqcn: &str, old: &str, new: &str) -> String {
+    apply(content, &reference_spans(content, fqcn, old), new)
+}
+
+// ---- declaration + same-file references -----------------------------------
+
+#[test]
+fn renames_declaration_and_self_references() {
+    let src = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model
+{
+    public function scopeRecent($q) { return $q; }
+}
+"#;
+    let out = rename(src, "App\\Models\\User", "User", "Customer");
+    assert!(out.contains("class Customer extends Model"));
+    // The base class `Model` is untouched.
+    assert!(out.contains("extends Model"));
+}
+
+// ---- use imports + static calls + new + type hints ------------------------
+
+const CONTROLLER: &str = r#"<?php
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Models\Post;
+
+class UserController extends Controller
+{
+    public function show(User $user): ?User
+    {
+        $u = new User();
+        $found = User::where('id', 1)->first();
+        $key = User::class;
+        if ($u instanceof User) {
+            return $u;
+        }
+        return $found;
+    }
+
+    public User $current;
+}
+"#;
+
+#[test]
+fn renames_all_reference_kinds_in_consumer_file() {
+    let out = rename(CONTROLLER, "App\\Models\\User", "User", "Member");
+    // use import
+    assert!(
+        out.contains("use App\\Models\\Member;"),
+        "use import\n{out}"
+    );
+    // param + return type
+    assert!(
+        out.contains("show(Member $user): ?Member"),
+        "type hints\n{out}"
+    );
+    // new
+    assert!(out.contains("new Member()"), "new\n{out}");
+    // static call
+    assert!(out.contains("Member::where("), "static call\n{out}");
+    // ::class
+    assert!(out.contains("Member::class"), "::class\n{out}");
+    // instanceof
+    assert!(out.contains("instanceof Member"), "instanceof\n{out}");
+    // property type
+    assert!(
+        out.contains("public Member $current"),
+        "property type\n{out}"
+    );
+    // unrelated import untouched
+    assert!(
+        out.contains("use App\\Models\\Post;"),
+        "Post untouched\n{out}"
+    );
+    // the controller class name itself is untouched
+    assert!(out.contains("class UserController extends Controller"));
+}
+
+// ---- alias safety ---------------------------------------------------------
+
+#[test]
+fn aliased_import_rewrites_only_the_class_segment() {
+    let src = r#"<?php
+namespace App\Http;
+use App\Models\User as Account;
+class C {
+    public function f(Account $a): Account { return new Account(); }
+}
+"#;
+    let out = rename(src, "App\\Models\\User", "User", "Member");
+    // The import's class segment changes; the alias `Account` stays everywhere.
+    assert!(out.contains("use App\\Models\\Member as Account;"), "{out}");
+    assert!(
+        out.contains("f(Account $a): Account"),
+        "alias usages unchanged\n{out}"
+    );
+    assert!(out.contains("new Account()"), "{out}");
+    assert!(!out.contains("Member as Member"));
+}
+
+// ---- fully-qualified references -------------------------------------------
+
+#[test]
+fn renames_fully_qualified_references() {
+    let src = r#"<?php
+namespace App\Jobs;
+class J {
+    public function f() {
+        return \App\Models\User::query()->get();
+    }
+}
+"#;
+    let out = rename(src, "App\\Models\\User", "User", "Member");
+    assert!(out.contains("\\App\\Models\\Member::query()"), "{out}");
+}
+
+// ---- precision: same-named member must NOT be touched ---------------------
+
+#[test]
+fn does_not_touch_method_or_property_named_like_class() {
+    let src = r#"<?php
+namespace App\Http;
+use App\Models\User;
+class C {
+    public function f($obj) {
+        $obj->User();       // method call named User
+        $x = $obj->User;    // property named User
+        return User::find(1); // real class ref
+    }
+}
+"#;
+    let spans = reference_spans(src, "App\\Models\\User", "User");
+    // Exactly two: the `use` import and the `User::find` static call.
+    assert_eq!(spans.len(), 2, "only real class refs: {spans:?}");
+    let out = apply(src, &spans, "Member");
+    assert!(out.contains("$obj->User()"), "method untouched\n{out}");
+    assert!(
+        out.contains("$x = $obj->User;"),
+        "property untouched\n{out}"
+    );
+    assert!(out.contains("Member::find(1)"), "{out}");
+}
+
+// ---- same-namespace bare references (no import needed) --------------------
+
+#[test]
+fn renames_same_namespace_bare_reference() {
+    let src = r#"<?php
+namespace App\Models;
+class Post extends Model {
+    public function author() { return $this->belongsTo(User::class); }
+    public function owner(): User { return new User(); }
+}
+"#;
+    let out = rename(src, "App\\Models\\User", "User", "Member");
+    assert!(out.contains("belongsTo(Member::class)"), "{out}");
+    assert!(out.contains("owner(): Member"), "{out}");
+    assert!(out.contains("new Member()"), "{out}");
+    // Post itself untouched.
+    assert!(out.contains("class Post extends Model"));
+}
+
+// ---- docblocks ------------------------------------------------------------
+
+#[test]
+fn renames_docblock_type_references() {
+    let src = r#"<?php
+namespace App\Http;
+use App\Models\User;
+class C {
+    /**
+     * @param User $user
+     * @return User|null
+     */
+    public function f($user) { return $user; }
+}
+"#;
+    let out = rename(src, "App\\Models\\User", "User", "Member");
+    assert!(out.contains("@param Member $user"), "docblock param\n{out}");
+    assert!(
+        out.contains("@return Member|null"),
+        "docblock return\n{out}"
+    );
+}
+
+// ---- class_at_cursor (prepare_rename) -------------------------------------
+
+#[test]
+fn cursor_on_static_call_resolves_class() {
+    let src = "<?php\nnamespace App\\Http;\nuse App\\Models\\User;\n$x = User::where('id', 1);\n";
+    let byte = src.find("User::").unwrap() + 1; // inside `User`
+    let (fqcn, span) = class_at_cursor(src, byte).expect("class at cursor");
+    assert_eq!(fqcn, "App\\Models\\User");
+    assert_eq!(&src[span.0..span.1], "User");
+}
+
+#[test]
+fn cursor_on_declaration_resolves_class() {
+    let src = "<?php\nnamespace App\\Models;\nclass User extends Model {}\n";
+    let byte = src.find("class User").unwrap() + "class U".len();
+    let (fqcn, _span) = class_at_cursor(src, byte).expect("class at cursor");
+    assert_eq!(fqcn, "App\\Models\\User");
+}
+
+#[test]
+fn cursor_on_alias_returns_none() {
+    // Cursor on the alias token `Account` — not a real class name, so no rename.
+    let src = "<?php\nuse App\\Models\\User as Account;\n$x = Account::find(1);\n";
+    let byte = src.find("Account::").unwrap() + 1;
+    assert!(class_at_cursor(src, byte).is_none());
+}
+
+#[test]
+fn cursor_off_any_class_returns_none() {
+    let src = "<?php\n$x = 1 + 2;\n";
+    assert!(class_at_cursor(src, 8).is_none());
+}
+
+// ---- project file enumeration ---------------------------------------------
+
+#[test]
+fn project_php_files_skips_vendor_and_finds_app() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("app/Models")).unwrap();
+    std::fs::create_dir_all(root.join("routes")).unwrap();
+    std::fs::create_dir_all(root.join("vendor/laravel/framework/src")).unwrap();
+    std::fs::write(root.join("app/Models/User.php"), "<?php").unwrap();
+    std::fs::write(root.join("routes/web.php"), "<?php").unwrap();
+    std::fs::write(root.join("vendor/laravel/framework/src/Model.php"), "<?php").unwrap();
+
+    let files = project_php_files(root);
+    assert!(files.iter().any(|p| p.ends_with("app/Models/User.php")));
+    assert!(
+        !files.iter().any(|p| p.to_string_lossy().contains("vendor")),
+        "vendor must be pruned: {files:?}"
+    );
+}
+
+#[test]
+fn is_dependency_path_flags_vendor() {
+    assert!(is_dependency_path(Path::new(
+        "/proj/vendor/laravel/framework/src/Model.php"
+    )));
+    assert!(!is_dependency_path(Path::new("/proj/app/Models/User.php")));
+}

--- a/laravel-lsp/src/file_watcher.rs
+++ b/laravel-lsp/src/file_watcher.rs
@@ -98,6 +98,16 @@ pub fn build_watchers(
         kind,
     });
 
+    // Migrations — feed the migration index (goto-definition for columns and
+    // tables). New/renamed/edited migrations change column definitions.
+    watchers.push(FileSystemWatcher {
+        glob_pattern: GlobPattern::String(format!(
+            "{}/database/migrations/**/*.php",
+            root.display()
+        )),
+        kind,
+    });
+
     // View paths. We watch `.blade.php` first as the primary case, then
     // bare `.php` for the rare anonymous-component-in-PHP-only style.
     // Some projects configure multiple view paths (e.g., themed apps);

--- a/laravel-lsp/src/file_watcher/tests.rs
+++ b/laravel-lsp/src/file_watcher/tests.rs
@@ -133,10 +133,10 @@ fn registration_options_round_trip_through_serde() {
     );
 
     // We constructed exactly 1 (controllers) + 1 (routes) + 2 (view
-    // blade + php) + 1 (livewire) + 2 (vendor php + blade) = 7
-    // watchers. If the construction changes, this assertion will
+    // blade + php) + 1 (livewire) + 2 (vendor php + blade) + 1 (migrations)
+    // = 8 watchers. If the construction changes, this assertion will
     // flag it for review.
-    assert_eq!(parsed.watchers.len(), 7);
+    assert_eq!(parsed.watchers.len(), 8);
 }
 
 #[test]

--- a/laravel-lsp/src/indexing_progress.rs
+++ b/laravel-lsp/src/indexing_progress.rs
@@ -24,9 +24,10 @@ use lsp_types::{
 };
 use tower_lsp::Client;
 
-/// Token identifier for our indexing progress. A constant string is fine —
-/// only one indexing progress is in flight at a time per LSP instance.
-const PROGRESS_TOKEN: &str = "laravel-lsp/indexing";
+/// Token identifier for the project-warming progress.
+pub const INDEXING_TOKEN: &str = "laravel-lsp/indexing";
+/// Token identifier for the class-rename progress.
+pub const RENAME_TOKEN: &str = "laravel-lsp/rename";
 
 /// Minimum interval between `$/progress` report notifications. Faster
 /// than this and we'd just be spamming the editor for sub-frame updates
@@ -36,9 +37,14 @@ const REPORT_THROTTLE: Duration = Duration::from_millis(150);
 /// Active progress handle. `report` is throttled so call sites don't
 /// need to be careful about update frequency. `end` consumes self; drop
 /// without ending also ends (with a fallback message) so a panic in the
-/// middle of warming doesn't leave a stale progress bar.
+/// middle of an operation doesn't leave a stale progress bar.
+///
+/// General-purpose despite the name — used for both project warming
+/// (determinate, with a filled bar) and class rename (indeterminate
+/// spinner). Each owner passes its own `token`.
 pub struct IndexingProgress {
     client: Client,
+    token: NumberOrString,
     /// Set to false after `end` runs so `Drop` doesn't double-end.
     active: bool,
     last_report: Instant,
@@ -46,29 +52,30 @@ pub struct IndexingProgress {
 
 impl IndexingProgress {
     /// Create the progress token on the client and emit the `Begin`
-    /// notification with both the persistent `title` and an initial
-    /// `message`. Returns `None` if the client doesn't honour the create
-    /// request — in that case the caller proceeds without UI.
+    /// notification with the persistent `title` and an initial `message`.
+    /// `percentage` is `Some(0)` for a determinate bar, or `None` for an
+    /// indeterminate spinner (use this when you can't report incremental
+    /// progress, e.g. a single blocking scan). Returns `None` if the client
+    /// doesn't honour the create request — the caller proceeds without UI.
     ///
-    /// Passing the initial message into `Begin` (rather than firing a
-    /// separate `Report` immediately after) matters: there's a real
-    /// observable gap between `Begin` and the first follow-up report
-    /// because intervening work (actor calls, config lookups) runs
-    /// between them. Without an initial message, the status-bar entry
-    /// shows just the title (e.g. "Laravel") for that gap, which looks
-    /// like the LSP is stuck.
+    /// Passing the initial message into `Begin` (rather than a separate
+    /// `Report`) matters: there's an observable gap between `Begin` and the
+    /// first follow-up report, and without an initial message the status-bar
+    /// entry shows just the title for that gap, looking stuck.
     pub async fn begin(
         client: Client,
+        token: impl Into<String>,
         title: impl Into<String>,
         initial_message: impl Into<String>,
+        percentage: Option<u32>,
     ) -> Option<Self> {
-        let token = NumberOrString::String(PROGRESS_TOKEN.to_string());
+        let token = NumberOrString::String(token.into());
         let title = title.into();
         let initial_message = initial_message.into();
 
         // Ask the client to allocate the progress token. Some clients
         // (older ones) don't support this; we'd rather skip the UI than
-        // fail warming.
+        // fail the operation.
         if client
             .send_request::<WorkDoneProgressCreate>(WorkDoneProgressCreateParams {
                 token: token.clone(),
@@ -81,20 +88,16 @@ impl IndexingProgress {
 
         client
             .send_notification::<ProgressNotification>(ProgressParams {
-                token,
+                token: token.clone(),
                 value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(
                     WorkDoneProgressBegin {
                         title,
                         cancellable: Some(false),
                         message: Some(initial_message),
-                        // Percentage is sent on the wire but the message
-                        // text is deliberately free of any "(X%)" suffix.
-                        // The LSP `percentage` field is a separate numeric
-                        // channel — clients that render a progress bar
-                        // use it for fill, clients that don't are free
-                        // to ignore it. Either way, the message stays
-                        // clean for the narrow status bar.
-                        percentage: Some(0),
+                        // The `percentage` field is a separate numeric channel
+                        // from the message: clients that render a bar use it for
+                        // fill, `None` yields an indeterminate spinner.
+                        percentage,
                     },
                 )),
             })
@@ -102,6 +105,7 @@ impl IndexingProgress {
 
         Some(Self {
             client,
+            token,
             active: true,
             last_report: Instant::now(),
         })
@@ -127,7 +131,7 @@ impl IndexingProgress {
 
         self.client
             .send_notification::<ProgressNotification>(ProgressParams {
-                token: NumberOrString::String(PROGRESS_TOKEN.to_string()),
+                token: self.token.clone(),
                 value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(
                     WorkDoneProgressReport {
                         cancellable: Some(false),
@@ -148,7 +152,7 @@ impl IndexingProgress {
         self.active = false;
         self.client
             .send_notification::<ProgressNotification>(ProgressParams {
-                token: NumberOrString::String(PROGRESS_TOKEN.to_string()),
+                token: self.token.clone(),
                 value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd {
                     message: Some(message.into()),
                 })),
@@ -166,13 +170,14 @@ impl Drop for IndexingProgress {
             return;
         }
         let client = self.client.clone();
+        let token = self.token.clone();
         tokio::spawn(async move {
             client
                 .send_notification::<ProgressNotification>(ProgressParams {
-                    token: NumberOrString::String(PROGRESS_TOKEN.to_string()),
+                    token,
                     value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(
                         WorkDoneProgressEnd {
-                            message: Some("Indexing interrupted.".into()),
+                            message: Some("Interrupted.".into()),
                         },
                     )),
                 })

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -16,6 +16,7 @@ pub mod blade_php_block;
 pub mod blade_props;
 pub mod cache_manager;
 pub mod class_locator;
+pub mod class_rename;
 pub mod completion_format;
 pub mod component_declaration_locator;
 pub mod composer_autoload;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -36,6 +36,7 @@ pub mod livewire_version;
 pub mod method_name_completion;
 pub mod middleware_binding_locator;
 pub mod middleware_parser;
+pub mod migration_index;
 // model_analyzer was consolidated into `laravel_introspector::model_metadata`.
 // Public API is re-exported as `laravel_introspector::ModelMetadata`.
 pub mod naming;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -1869,6 +1869,10 @@ struct LaravelLanguageServer {
     /// Add space between directive name and parentheses in completions
     /// false: @if($condition)  |  true: @if ($condition)
     directive_spacing: Arc<RwLock<bool>>,
+    /// Severity for query-chain diagnostics (unknown column/relation/table).
+    /// `None` disables them; defaults to `WARNING`. Set via the
+    /// `diagnostics.severity` LSP setting.
+    chain_diagnostic_severity: Arc<RwLock<Option<DiagnosticSeverity>>>,
     /// Whether we've shown the vendor missing diagnostic this session
     vendor_diagnostic_shown: Arc<RwLock<bool>>,
     /// Cached validation rule names (parsed from Laravel framework at startup)
@@ -1941,6 +1945,42 @@ struct BladeSettings {
     directive_spacing: bool,
 }
 
+/// Query-chain diagnostics settings (unknown column / relation / table).
+/// Configured via:
+/// `{ "lsp": { "laravel-lsp": { "settings": { "diagnostics": { "severity": "warning" } } } } }`
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticsSettings {
+    /// Severity for unknown column/relation/table diagnostics in query chains.
+    /// One of `"warning"` (default), `"error"`, `"info"`, or `"off"`.
+    #[serde(default = "default_diagnostics_severity")]
+    severity: String,
+}
+
+impl Default for DiagnosticsSettings {
+    fn default() -> Self {
+        Self {
+            severity: default_diagnostics_severity(),
+        }
+    }
+}
+
+fn default_diagnostics_severity() -> String {
+    "warning".to_string()
+}
+
+/// Parse the configured `diagnostics.severity` string into an LSP severity.
+/// `None` means the feature is turned off; an unrecognised value falls back to
+/// `WARNING` (the safe, visible-but-non-blocking default).
+fn parse_chain_diagnostic_severity(value: &str) -> Option<DiagnosticSeverity> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "off" | "none" | "false" => None,
+        "error" => Some(DiagnosticSeverity::ERROR),
+        "info" | "information" | "hint" => Some(DiagnosticSeverity::INFORMATION),
+        _ => Some(DiagnosticSeverity::WARNING),
+    }
+}
+
 fn default_auto_complete_debounce() -> u64 {
     DEFAULT_SALSA_DEBOUNCE_MS
 }
@@ -1957,6 +1997,8 @@ struct LspSettings {
     auto_complete_debounce: u64,
     #[serde(default)]
     blade: BladeSettings,
+    #[serde(default)]
+    diagnostics: DiagnosticsSettings,
 }
 
 // ============================================================================
@@ -3454,6 +3496,7 @@ impl LaravelLanguageServer {
             pending_salsa_updates: Arc::new(RwLock::new(HashMap::new())),
             auto_complete_debounce_ms: Arc::new(RwLock::new(DEFAULT_SALSA_DEBOUNCE_MS)),
             directive_spacing: Arc::new(RwLock::new(false)),
+            chain_diagnostic_severity: Arc::new(RwLock::new(Some(DiagnosticSeverity::WARNING))),
             vendor_diagnostic_shown: Arc::new(RwLock::new(false)),
             cached_validation_rule_names: Arc::new(RwLock::new(Vec::new())),
             database_schema: Arc::new(RwLock::new(None)),
@@ -3489,6 +3532,17 @@ impl LaravelLanguageServer {
                 old_spacing, new_spacing
             );
             *self.directive_spacing.write().await = new_spacing;
+        }
+
+        // Query-chain diagnostics severity
+        let new_severity = parse_chain_diagnostic_severity(&settings.diagnostics.severity);
+        let old_severity = *self.chain_diagnostic_severity.read().await;
+        if new_severity != old_severity {
+            info!(
+                "⚙️  Updating chain diagnostics severity: {:?} → {:?} (from {:?})",
+                old_severity, new_severity, settings.diagnostics.severity
+            );
+            *self.chain_diagnostic_severity.write().await = new_severity;
         }
     }
 
@@ -13101,6 +13155,7 @@ return [
             pending_salsa_updates: self.pending_salsa_updates.clone(),
             auto_complete_debounce_ms: self.auto_complete_debounce_ms.clone(),
             directive_spacing: self.directive_spacing.clone(),
+            chain_diagnostic_severity: self.chain_diagnostic_severity.clone(),
             vendor_diagnostic_shown: self.vendor_diagnostic_shown.clone(),
             cached_validation_rule_names: self.cached_validation_rule_names.clone(),
             database_schema: self.database_schema.clone(),
@@ -13185,6 +13240,81 @@ return [
             }
         };
         info!("   ⏱️  salsa.get_patterns: {:?}", t_patterns.elapsed());
+
+        // Query-chain diagnostics: unknown column / relation / table inside
+        // Eloquent & DB builder chains. Runs for both PHP and Blade (chains
+        // appear in `@php` blocks and `{{ }}`). Gated on the configured
+        // severity (None = feature off) and on the schema + project root being
+        // available — every guard inside `chain_diagnostics` errs toward
+        // staying quiet, so a cold DB or unresolved model yields no squiggles.
+        if is_php || is_blade {
+            if let Some(severity) = *self.chain_diagnostic_severity.read().await {
+                // CRITICAL: derive chains from the EXACT `source` we convert to
+                // ranges, not from `patterns.chains`. Salsa's cached chains can
+                // lag the live document (e.g. did_save without a prior debounce
+                // flush), and stale byte offsets produce squiggles in the wrong
+                // place AND that never clear. Completion re-extracts for the same
+                // reason. For PHP we re-parse here; Blade keeps the Salsa path,
+                // which already shifts embedded-PHP offsets back to Blade
+                // coordinates (re-parsing raw Blade as PHP wouldn't work).
+                let fresh_chains: Vec<Arc<laravel_lsp::query_chain::BuilderChain>> = if is_php {
+                    match laravel_lsp::parser::parse_php(source) {
+                        Ok(tree) => laravel_lsp::query_chain::extract_chains(&tree, source)
+                            .into_iter()
+                            .map(Arc::new)
+                            .collect(),
+                        Err(_) => Vec::new(),
+                    }
+                } else {
+                    patterns.chains.clone()
+                };
+                // Log the chain count unconditionally so the LSP log explains a
+                // "no diagnostics" outcome: 0 chains → nothing to lint (or
+                // unparsed); N chains but 0 found → schema/model didn't resolve
+                // (most often: DB not connected).
+                let n_chains = fresh_chains.len();
+                let root = self.initialized_root.read().await.clone();
+                match (n_chains, root) {
+                    (0, _) => {
+                        info!("🔗 chain_diagnostics: 0 chains in patterns for {}", uri);
+                    }
+                    (_, None) => {
+                        info!(
+                            "🔗 chain_diagnostics: {} chains but project root not initialised",
+                            n_chains
+                        );
+                    }
+                    (_, Some(root)) => {
+                        let db_guard = self.database_schema.read().await;
+                        match db_guard.as_ref() {
+                            None => info!(
+                                "🔗 chain_diagnostics: {} chains but DB schema provider not \
+                                 initialised — column/relation diagnostics need a DB connection",
+                                n_chains
+                            ),
+                            Some(db) => {
+                                let t_chain = std::time::Instant::now();
+                                let chain_diags = laravel_lsp::query_chain::chain_diagnostics(
+                                    &fresh_chains,
+                                    db,
+                                    &root,
+                                    source,
+                                    severity,
+                                )
+                                .await;
+                                info!(
+                                    "🔗 chain_diagnostics: {:?} — {} found over {} chains",
+                                    t_chain.elapsed(),
+                                    chain_diags.len(),
+                                    n_chains
+                                );
+                                diagnostics.extend(chain_diags);
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         // Validate PHP files with view() calls and env() calls
         if is_php {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -25,6 +25,7 @@ use laravel_lsp::cache_manager::{
 use laravel_lsp::completion_format::CompletionDoc;
 use laravel_lsp::config::find_project_root;
 use laravel_lsp::middleware_parser::{middleware_base_alias, resolve_class_to_file};
+use laravel_lsp::migration_index::{build_migration_index, MigrationIndex};
 use laravel_lsp::route_discovery::{build_route_index, discover_route_files, RouteIndex};
 
 // Salsa 0.25 database - integrated via actor pattern for async compatibility
@@ -1886,6 +1887,12 @@ struct LaravelLanguageServer {
     /// vendor PHP files. Replaces the legacy hard-coded route-file scan.
     route_index: Arc<RwLock<Option<RouteIndex>>>,
 
+    /// Project-wide index of column/table definitions parsed from
+    /// `database/migrations/*.php`. Powers goto-definition on chain literals
+    /// (column → migration line, table → create-table migration). Built at init
+    /// and refreshed when migration files change.
+    migration_index: Arc<RwLock<Option<MigrationIndex>>>,
+
     /// Cached map of translation `namespace → absolute lang directory` for
     /// unpublished vendor packages. Lazily populated on the first translation
     /// hover that needs it; subsequent hovers reuse the cached map. See
@@ -3502,6 +3509,7 @@ impl LaravelLanguageServer {
             database_schema: Arc::new(RwLock::new(None)),
             database_diagnostic_shown: Arc::new(RwLock::new(false)),
             route_index: Arc::new(RwLock::new(None)),
+            migration_index: Arc::new(RwLock::new(None)),
             vendor_translation_namespaces: Arc::new(RwLock::new(None)),
             builder_method_index_cache: Arc::new(RwLock::new(HashMap::new())),
             route_decl_cache: Arc::new(RwLock::new(HashMap::new())),
@@ -4478,6 +4486,7 @@ impl LaravelLanguageServer {
             let server = self.clone_for_spawn();
             tokio::spawn(async move {
                 server.rebuild_route_index(&route_root).await;
+                server.rebuild_migration_index(&route_root).await;
             });
         }
 
@@ -4841,6 +4850,7 @@ impl LaravelLanguageServer {
         // Rebuild the route name index so any route definition changes (added,
         // renamed, removed) are reflected on the next goto-definition request.
         self.rebuild_route_index(&root).await;
+        self.rebuild_migration_index(&root).await;
 
         // Populate cache with ALL parsed middleware/bindings AFTER all rescans complete
         // This ensures we capture middleware from both vendor and app sources
@@ -5083,6 +5093,7 @@ impl LaravelLanguageServer {
         info!("🛣️  Building route index from root: {:?}", discovered_root);
         info!("========================================");
         self.rebuild_route_index(&discovered_root).await;
+        self.rebuild_migration_index(&discovered_root).await;
 
         // Initialize environment variables with Salsa
         info!("========================================");
@@ -12962,6 +12973,230 @@ return [
         }
     }
 
+    /// Rebuild the migration index by parsing `database/migrations/*.php`.
+    /// Mirrors `rebuild_route_index` — runs the (blocking) walk + parse off the
+    /// async runtime, then swaps the index in.
+    async fn rebuild_migration_index(&self, root: &Path) {
+        let root = root.to_path_buf();
+        let index = tokio::task::spawn_blocking(move || build_migration_index(&root)).await;
+        match index {
+            Ok(index) => {
+                info!(
+                    "🗄️  Migration index built: {} columns, {} tables",
+                    index.column_count(),
+                    index.table_count()
+                );
+                *self.migration_index.write().await = Some(index);
+            }
+            Err(e) => {
+                tracing::warn!("Failed to build migration index: {}", e);
+            }
+        }
+    }
+
+    /// Goto-definition for a query-chain literal under the cursor. Re-extracts
+    /// chains from the LIVE document (Salsa's cached chains can lag, and we need
+    /// byte offsets that match `content`), resolves the literal, and routes it:
+    /// column → migration line, relation → model method, table → create
+    /// migration. Returns `None` when nothing resolves (no chain at cursor,
+    /// unresolved receiver, missing source) — goto then no-ops.
+    async fn chain_goto_definition(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<GotoDefinitionResponse> {
+        use laravel_lsp::query_chain::{
+            detect_chain_target_at, eloquent_completion, extract_chains, position_to_byte_offset,
+            ArgKind, BuilderChain, BuilderMode,
+        };
+
+        let content = self
+            .documents
+            .read()
+            .await
+            .get(uri)
+            .map(|(c, _)| c.clone())?;
+        let root = self.initialized_root.read().await.clone()?;
+
+        let tree = laravel_lsp::parser::parse_php(&content).ok()?;
+        let chains: Vec<Arc<BuilderChain>> = extract_chains(&tree, &content)
+            .into_iter()
+            .map(Arc::new)
+            .collect();
+        if chains.is_empty() {
+            return None;
+        }
+        let byte = position_to_byte_offset(&content, position.line, position.character)?;
+        let target = detect_chain_target_at(&chains, byte)?;
+        let mut ctx = target.ctx;
+
+        // Finalize the context the same way completion/diagnostics do: resolve a
+        // relation closure hop, then a post-`toBase()` table.
+        if let Some(rel) = ctx.closure_relation_hop.clone() {
+            let parent = ctx.effective_model.clone()?;
+            ctx.effective_model =
+                Some(eloquent_completion::resolve_related_model(&parent, &rel, &root).await?);
+            ctx.closure_relation_hop = None;
+        }
+        if ctx.mode == BuilderMode::BaseBuilder && ctx.effective_table.is_none() {
+            if let Some(model) = ctx.effective_model.clone() {
+                ctx.effective_table =
+                    eloquent_completion::resolve_table_for_model(&model, &root).await;
+            }
+        }
+
+        match ctx.expecting {
+            ArgKind::Column => {
+                self.goto_column_definition(&ctx, &target.value, &root)
+                    .await
+            }
+            ArgKind::Relation | ArgKind::ClosureCarrier => {
+                self.goto_relation_definition(&ctx, &target.value, &root)
+                    .await
+            }
+            ArgKind::Table => self.goto_table_definition(&target.value).await,
+            ArgKind::None => None,
+        }
+    }
+
+    /// Column literal → the migration line that defines it. A qualified literal
+    /// (`users.id`) carries its own table; otherwise the chain's effective table
+    /// is used (resolved from the model for Eloquent chains).
+    async fn goto_column_definition(
+        &self,
+        ctx: &laravel_lsp::query_chain::ChainContext,
+        value: &str,
+        root: &Path,
+    ) -> Option<GotoDefinitionResponse> {
+        use laravel_lsp::query_chain::{eloquent_completion, BuilderMode};
+
+        let (table, column) = match value.rsplit_once('.') {
+            Some((t, c)) => (t.to_string(), c.to_string()),
+            None => {
+                let table = match ctx.mode {
+                    BuilderMode::BaseBuilder => ctx.effective_table.clone()?,
+                    _ => {
+                        let model = ctx.effective_model.as_deref()?;
+                        eloquent_completion::resolve_table_for_model(model, root).await?
+                    }
+                };
+                (table, value.to_string())
+            }
+        };
+
+        let guard = self.migration_index.read().await;
+        let site = guard.as_ref()?.column(&table, &column)?.clone();
+        drop(guard);
+        Self::location_from_migration_site(&site)
+    }
+
+    /// Table literal (`DB::table('users')`) → the `Schema::create('users'` line.
+    async fn goto_table_definition(&self, table: &str) -> Option<GotoDefinitionResponse> {
+        let guard = self.migration_index.read().await;
+        let site = guard.as_ref()?.table(table)?.clone();
+        drop(guard);
+        Self::location_from_migration_site(&site)
+    }
+
+    /// Relation literal → the relation method on the model file. Walks any
+    /// dotted prefix (`posts.author`) to the final model, then locates the
+    /// last-segment method by name.
+    async fn goto_relation_definition(
+        &self,
+        ctx: &laravel_lsp::query_chain::ChainContext,
+        value: &str,
+        root: &Path,
+    ) -> Option<GotoDefinitionResponse> {
+        use laravel_lsp::query_chain::{eloquent_completion, BuilderMode};
+
+        if ctx.mode == BuilderMode::BaseBuilder {
+            return None; // base query builder has no relations
+        }
+        let starting = ctx.effective_model.as_deref()?;
+        let (model, method) = match value.rsplit_once('.') {
+            Some((prefix, last)) => {
+                let m = eloquent_completion::walk_dotted_hops(starting, prefix, root).await?;
+                (m, last.to_string())
+            }
+            None => (starting.to_string(), value.to_string()),
+        };
+
+        let path = laravel_lsp::class_locator::find_php_class_file(&model, root)?;
+        let path_for_blocking = path.clone();
+        let found = tokio::task::spawn_blocking(move || {
+            let content = std::fs::read_to_string(&path_for_blocking).ok()?;
+            let structure = laravel_lsp::laravel_introspector::extract_php_structure(&content);
+            structure
+                .structures
+                .iter()
+                .flat_map(|s| &s.methods)
+                .find(|m| m.name == method)
+                .map(|m| (m.start_line, m.start_column, m.end_line, m.end_column))
+        })
+        .await
+        .ok()
+        .flatten()?;
+
+        let uri = Url::from_file_path(&path).ok()?;
+        let (start_line, start_col, end_line, end_col) = found;
+        let target_range = Range {
+            start: Position {
+                line: start_line,
+                character: start_col,
+            },
+            end: Position {
+                line: end_line,
+                character: end_col,
+            },
+        };
+        Some(GotoDefinitionResponse::Link(vec![LocationLink {
+            origin_selection_range: None,
+            target_uri: uri,
+            target_range,
+            target_selection_range: Range {
+                start: Position {
+                    line: start_line,
+                    character: start_col,
+                },
+                end: Position {
+                    line: start_line,
+                    character: start_col,
+                },
+            },
+        }]))
+    }
+
+    /// Build a goto response pointing at a migration definition site.
+    fn location_from_migration_site(
+        site: &laravel_lsp::migration_index::MigrationSite,
+    ) -> Option<GotoDefinitionResponse> {
+        let uri = Url::from_file_path(&site.file).ok()?;
+        let range = Range {
+            start: Position {
+                line: site.line,
+                character: site.start_char,
+            },
+            end: Position {
+                line: site.line,
+                character: site.end_char,
+            },
+        };
+        // Land the caret at the column/table name WITHOUT selecting it. A
+        // selected `email` makes Zed highlight every `email` substring (incl.
+        // `email_verified_at`), which reads as "jumped to the wrong field". A
+        // zero-width selection reveals the line and places the caret cleanly.
+        let caret = Range {
+            start: range.start,
+            end: range.start,
+        };
+        Some(GotoDefinitionResponse::Link(vec![LocationLink {
+            origin_selection_range: None,
+            target_uri: uri,
+            target_range: range,
+            target_selection_range: caret,
+        }]))
+    }
+
     /// Create a goto location for a url('path') call
     /// Navigates to the file in public directory if it exists
     async fn create_url_location_from_salsa(
@@ -13161,6 +13396,7 @@ return [
             database_schema: self.database_schema.clone(),
             database_diagnostic_shown: self.database_diagnostic_shown.clone(),
             route_index: self.route_index.clone(),
+            migration_index: self.migration_index.clone(),
             vendor_translation_namespaces: self.vendor_translation_namespaces.clone(),
             builder_method_index_cache: self.builder_method_index_cache.clone(),
             route_decl_cache: self.route_decl_cache.clone(),
@@ -16101,6 +16337,7 @@ impl LanguageServer for LaravelLanguageServer {
         let mut created_or_changed = 0usize;
         let mut deleted = 0usize;
         let mut skipped_open = 0usize;
+        let mut migrations_changed = false;
 
         for change in params.changes {
             if open_docs.contains(&change.uri) {
@@ -16110,6 +16347,9 @@ impl LanguageServer for LaravelLanguageServer {
             let Ok(path) = change.uri.to_file_path() else {
                 continue;
             };
+            if !migrations_changed && path.to_string_lossy().contains("database/migrations") {
+                migrations_changed = true;
+            }
             match change.typ {
                 FileChangeType::CREATED => {
                     // Best-effort read. The file may already be gone
@@ -16188,6 +16428,14 @@ impl LanguageServer for LaravelLanguageServer {
                 "🛡️  watched files: {} updated, {} deleted, {} skipped (open in editor)",
                 created_or_changed, deleted, skipped_open
             );
+        }
+
+        // A migration changed on disk — rebuild the column/table index so
+        // goto-definition reflects the new schema. One rebuild per batch.
+        if migrations_changed {
+            if let Some(root) = self.initialized_root.read().await.clone() {
+                self.rebuild_migration_index(&root).await;
+            }
         }
     }
 
@@ -16291,6 +16539,15 @@ impl LanguageServer for LaravelLanguageServer {
                     if let Some(loc) = self.blade_variable_goto_definition(&uri, position).await {
                         return Ok(Some(loc));
                     }
+                }
+
+                // Query-chain literal fallback: cmd-click on a column / relation
+                // / table literal inside an Eloquent or DB::table() chain jumps
+                // to its definition (migration line / model method / create
+                // migration). Chains aren't position-indexed, so this lives in
+                // the no-pattern branch.
+                if let Some(loc) = self.chain_goto_definition(&uri, position).await {
+                    return Ok(Some(loc));
                 }
 
                 // Debug: show what middleware patterns exist on this line

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13197,6 +13197,217 @@ return [
         }]))
     }
 
+    /// prepare_rename fallback: if the cursor is on a PHP class name that
+    /// resolves to a *project* (non-dependency) class, return the basename range
+    /// so the editor offers a rename. Returns `None` for vendor classes, aliases,
+    /// and non-class positions.
+    async fn prepare_class_rename(&self, uri: &Url, position: Position) -> Option<Range> {
+        use laravel_lsp::query_chain::{byte_offset_to_position, position_to_byte_offset};
+        let content = self
+            .documents
+            .read()
+            .await
+            .get(uri)
+            .map(|(c, _)| c.clone())?;
+        let byte = position_to_byte_offset(&content, position.line, position.character)?;
+        let (fqcn, span) = laravel_lsp::class_rename::class_at_cursor(&content, byte)?;
+        let root = self.initialized_root.read().await.clone()?;
+        let decl = laravel_lsp::class_locator::find_php_class_file(&fqcn, &root)?;
+        if laravel_lsp::class_rename::is_dependency_path(&decl) {
+            return None; // don't rename vendor classes
+        }
+        Some(Range {
+            start: byte_offset_to_position(&content, span.0),
+            end: byte_offset_to_position(&content, span.1),
+        })
+    }
+
+    /// rename fallback for PHP class names: rewrite every project-wide reference
+    /// to the class (declaration, `use`, `::`, `new`, type hints, `::class`,
+    /// `instanceof`, docblocks) and rename the declaring file. Same-namespace
+    /// rename only — `new_name` must be a simple class identifier.
+    async fn class_rename_edit(
+        &self,
+        uri: &Url,
+        position: Position,
+        new_name: &str,
+    ) -> jsonrpc::Result<Option<WorkspaceEdit>> {
+        use laravel_lsp::query_chain::{byte_offset_to_position, position_to_byte_offset};
+
+        let content = match self.documents.read().await.get(uri) {
+            Some((c, _)) => c.clone(),
+            None => return Ok(None),
+        };
+        let Some(byte) = position_to_byte_offset(&content, position.line, position.character)
+        else {
+            return Ok(None);
+        };
+        let Some((fqcn, _span)) = laravel_lsp::class_rename::class_at_cursor(&content, byte) else {
+            return Ok(None);
+        };
+        let Some(root) = self.initialized_root.read().await.clone() else {
+            return Ok(None);
+        };
+        let Some(decl_path) = laravel_lsp::class_locator::find_php_class_file(&fqcn, &root) else {
+            return Ok(None);
+        };
+        if laravel_lsp::class_rename::is_dependency_path(&decl_path) {
+            return Ok(None);
+        }
+
+        // `new_name` must be a bare class identifier — renaming into a different
+        // namespace (a move) isn't supported.
+        let new_basename = new_name.trim();
+        let is_identifier = !new_basename.is_empty()
+            && new_basename
+                .chars()
+                .next()
+                .map(|c| c.is_ascii_alphabetic() || c == '_')
+                .unwrap_or(false)
+            && new_basename
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_');
+        if !is_identifier {
+            return Err(laravel_lsp::rename::rename_error(
+                "Rename a class to a simple name (moving it to another namespace isn't supported).",
+            ));
+        }
+        let old_basename = fqcn.rsplit('\\').next().unwrap_or(&fqcn).to_string();
+        if new_basename == old_basename {
+            return Ok(None);
+        }
+
+        // Find every reference across project PHP files. The expensive step is
+        // the per-file tree-sitter parse, so we read first (cheap) and only
+        // parse files whose text actually contains the old basename — on a large
+        // project that's a handful out of thousands. A size cap skips
+        // pathological generated files (e.g. giant `_ide_helper`).
+        const MAX_FILE_BYTES: usize = 2 * 1024 * 1024;
+
+        // Show a status-bar spinner — scanning a large project takes a few
+        // seconds and the rename would otherwise look frozen. Indeterminate
+        // (no percentage): the scan is one blocking pass we can't report inside.
+        // Best-effort; `None` if the client doesn't support progress.
+        let progress = laravel_lsp::indexing_progress::IndexingProgress::begin(
+            self.client.clone(),
+            laravel_lsp::indexing_progress::RENAME_TOKEN,
+            "Laravel",
+            format!("Renaming {old_basename} → {new_basename}…"),
+            None,
+        )
+        .await;
+
+        let root2 = root.clone();
+        let fqcn2 = fqcn.clone();
+        let old2 = old_basename.clone();
+        let t_scan = std::time::Instant::now();
+        let (per_file, scanned, parsed) = tokio::task::spawn_blocking(move || {
+            let files = laravel_lsp::class_rename::project_php_files(&root2);
+            let scanned = files.len();
+            let mut parsed = 0usize;
+            let per_file: Vec<_> = files
+                .into_iter()
+                .filter_map(|p| {
+                    let c = std::fs::read_to_string(&p).ok()?;
+                    // Cheap pre-filter: skip files that can't reference the class.
+                    if c.len() > MAX_FILE_BYTES || !c.contains(&old2) {
+                        return None;
+                    }
+                    parsed += 1;
+                    let spans = laravel_lsp::class_rename::reference_spans(&c, &fqcn2, &old2);
+                    if spans.is_empty() {
+                        None
+                    } else {
+                        Some((p, c, spans))
+                    }
+                })
+                .collect();
+            (per_file, scanned, parsed)
+        })
+        .await
+        .unwrap_or_default();
+
+        let edit_count: usize = per_file.iter().map(|(_, _, s)| s.len()).sum();
+        info!(
+            "✏️  class rename {} → {}: {} edits in {} files (scanned {}, parsed {}) in {:?}",
+            old_basename,
+            new_basename,
+            edit_count,
+            per_file.len(),
+            scanned,
+            parsed,
+            t_scan.elapsed()
+        );
+
+        // Scan done (the edit-building below is instant) — clear the spinner.
+        if let Some(p) = progress {
+            p.end(format!(
+                "Renamed {old_basename} → {new_basename} ({edit_count} edits, {} files)",
+                per_file.len()
+            ))
+            .await;
+        }
+
+        if per_file.is_empty() {
+            return Ok(None);
+        }
+
+        let new_basename = new_basename.to_string();
+        let mut ops: Vec<DocumentChangeOperation> = Vec::new();
+        for (path, file_content, spans) in &per_file {
+            let Ok(file_uri) = Url::from_file_path(path) else {
+                continue;
+            };
+            let edits: Vec<OneOf<TextEdit, AnnotatedTextEdit>> = spans
+                .iter()
+                .map(|(s, e)| {
+                    OneOf::Left(TextEdit {
+                        range: Range {
+                            start: byte_offset_to_position(file_content, *s),
+                            end: byte_offset_to_position(file_content, *e),
+                        },
+                        new_text: new_basename.clone(),
+                    })
+                })
+                .collect();
+            ops.push(DocumentChangeOperation::Edit(TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    uri: file_uri,
+                    version: None,
+                },
+                edits,
+            }));
+        }
+
+        // Rename the declaring file (same dir, new basename). Emitted AFTER the
+        // text edits so the `class User → class NewName` edit lands first.
+        let new_path = decl_path.with_file_name(format!("{new_basename}.php"));
+        if new_path != decl_path {
+            if let (Ok(old_uri), Ok(new_uri)) = (
+                Url::from_file_path(&decl_path),
+                Url::from_file_path(&new_path),
+            ) {
+                ops.push(DocumentChangeOperation::Op(ResourceOp::Rename(
+                    RenameFile {
+                        old_uri,
+                        new_uri,
+                        options: Some(RenameFileOptions {
+                            overwrite: Some(false),
+                            ignore_if_exists: Some(false),
+                        }),
+                        annotation_id: None,
+                    },
+                )));
+            }
+        }
+
+        Ok(Some(WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Operations(ops)),
+            change_annotations: None,
+        }))
+    }
+
     /// Create a goto location for a url('path') call
     /// Navigates to the file in public directory if it exists
     async fn create_url_location_from_salsa(
@@ -15993,8 +16204,10 @@ impl LanguageServer for LaravelLanguageServer {
             // editor chrome with.
             let mut progress = laravel_lsp::indexing_progress::IndexingProgress::begin(
                 client,
+                laravel_lsp::indexing_progress::INDEXING_TOKEN,
                 "Laravel",
                 "Starting indexer…",
+                Some(0),
             )
             .await;
 
@@ -16896,7 +17109,11 @@ impl LanguageServer for LaravelLanguageServer {
                     "prepare_rename: no classifier match at {}:{}",
                     position.line, position.character
                 );
-                return Ok(None);
+                // Fallback: a PHP class name (model, etc.) under the cursor.
+                return Ok(self
+                    .prepare_class_rename(uri, position)
+                    .await
+                    .map(PrepareRenameResponse::Range));
             }
         };
 
@@ -16967,7 +17184,8 @@ impl LanguageServer for LaravelLanguageServer {
                     "rename: classify returned None at {}:{}",
                     position.line, position.character
                 );
-                return Ok(None);
+                // Fallback: PHP class rename (model, etc.) across the project.
+                return self.class_rename_edit(uri, position, &new_name).await;
             }
         };
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -17503,6 +17503,31 @@ impl LanguageServer for LaravelLanguageServer {
 
         // Process each diagnostic to see if we can offer a fix
         for diagnostic in &context.diagnostics {
+            // Query-chain diagnostics (source: laravel-lsp) carry a structured
+            // `data` payload — offer rename + create-migration quick-fixes.
+            if diagnostic.source.as_deref() == Some("laravel-lsp") {
+                if let Some(action) =
+                    laravel_lsp::query_chain::code_actions::rename_action(diagnostic, uri)
+                {
+                    actions.push(action);
+                }
+                if let Some(root) = root {
+                    let timestamp =
+                        laravel_lsp::query_chain::code_actions::format_migration_timestamp(
+                            std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_secs())
+                                .unwrap_or(0),
+                        );
+                    if let Some(action) = laravel_lsp::query_chain::code_actions::migration_action(
+                        diagnostic, root, &timestamp,
+                    ) {
+                        actions.push(action);
+                    }
+                }
+                continue;
+            }
+
             // Check if this is our diagnostic (source: laravel)
             if diagnostic.source.as_deref() != Some("laravel") {
                 continue;

--- a/laravel-lsp/src/migration_index.rs
+++ b/laravel-lsp/src/migration_index.rs
@@ -1,0 +1,269 @@
+//! Eager, project-wide index of where columns and tables are *defined* in
+//! `database/migrations/*.php`. Powers goto-definition on query-chain literals:
+//! a column literal jumps to its `$table->string('col')` line, a table literal
+//! (`DB::table('users')`) to its `Schema::create('users'` line.
+//!
+//! Built once at init and refreshed when migration files change (mirrors the
+//! route index). Parsing is tree-sitter, not regex — migrations nest closures
+//! and span lines, and we need accurate positions for the jump target.
+//!
+//! Only column *definitions* are indexed: `Schema::create`/`Schema::table`
+//! closures, member calls whose method is a Blueprint column type
+//! ([`COLUMN_DEF_METHODS`]). Index/foreign/`dropColumn` calls reference columns
+//! but don't define them, so they're skipped — we never jump to the wrong line.
+//! First definition wins (the `create` migration over later `table` tweaks).
+
+use crate::parser::parse_php;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tree_sitter::Node;
+use walkdir::WalkDir;
+
+/// A definition site inside a migration file. Positions are 0-based and point
+/// at the *content* of the relevant string literal (inside the quotes).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationSite {
+    pub file: PathBuf,
+    pub line: u32,
+    pub start_char: u32,
+    pub end_char: u32,
+}
+
+/// Resolved column/table definition sites across all project migrations.
+#[derive(Debug, Clone, Default)]
+pub struct MigrationIndex {
+    /// `(table, column)` → where the column is defined.
+    columns: HashMap<(String, String), MigrationSite>,
+    /// `table` → where the table is created (`Schema::create`).
+    tables: HashMap<String, MigrationSite>,
+}
+
+impl MigrationIndex {
+    /// Definition site for `table`.`column`, if a migration defines it.
+    pub fn column(&self, table: &str, column: &str) -> Option<&MigrationSite> {
+        self.columns.get(&(table.to_string(), column.to_string()))
+    }
+
+    /// Creation site for `table`, if a migration creates it.
+    pub fn table(&self, table: &str) -> Option<&MigrationSite> {
+        self.tables.get(table)
+    }
+
+    pub fn column_count(&self) -> usize {
+        self.columns.len()
+    }
+
+    pub fn table_count(&self) -> usize {
+        self.tables.len()
+    }
+}
+
+/// Blueprint methods that *define* a column, taking the column name as their
+/// first string argument. Deliberately an allowlist: index/unique/foreign and
+/// drop*/rename* reference columns without defining them, and excluding them
+/// keeps goto from landing on the wrong line. `morphs`/`nullableMorphs` are
+/// omitted — their arg names a relation, not a single literal column.
+const COLUMN_DEF_METHODS: &[&str] = &[
+    "bigIncrements",
+    "bigInteger",
+    "binary",
+    "boolean",
+    "char",
+    "date",
+    "dateTime",
+    "dateTimeTz",
+    "decimal",
+    "double",
+    "enum",
+    "float",
+    "foreignId",
+    "foreignUlid",
+    "foreignUuid",
+    "geography",
+    "geometry",
+    "increments",
+    "integer",
+    "ipAddress",
+    "json",
+    "jsonb",
+    "longText",
+    "macAddress",
+    "mediumIncrements",
+    "mediumInteger",
+    "mediumText",
+    "set",
+    "smallIncrements",
+    "smallInteger",
+    "string",
+    "text",
+    "time",
+    "timeTz",
+    "timestamp",
+    "timestampTz",
+    "tinyIncrements",
+    "tinyInteger",
+    "tinyText",
+    "ulid",
+    "unsignedBigInteger",
+    "unsignedDecimal",
+    "unsignedInteger",
+    "unsignedMediumInteger",
+    "unsignedSmallInteger",
+    "unsignedTinyInteger",
+    "uuid",
+    "year",
+];
+
+/// Build the index by parsing every `*.php` under `<root>/database/migrations`.
+/// Missing directory yields an empty index (non-Laravel project / no DB).
+pub fn build_migration_index(root: &Path) -> MigrationIndex {
+    let mut index = MigrationIndex::default();
+    let dir = root.join("database").join("migrations");
+    if !dir.exists() {
+        return index;
+    }
+    for entry in WalkDir::new(&dir)
+        .max_depth(4)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if path.is_file() && path.extension().is_some_and(|ext| ext == "php") {
+            if let Ok(content) = std::fs::read_to_string(path) {
+                index_migration_file(&mut index, path, &content);
+            }
+        }
+    }
+    index
+}
+
+/// Index a single migration file's `Schema::create`/`Schema::table` blocks.
+/// Exposed for unit tests; `build_migration_index` is the production entry.
+pub fn index_migration_file(index: &mut MigrationIndex, path: &Path, content: &str) {
+    let Ok(tree) = parse_php(content) else {
+        return;
+    };
+    let bytes = content.as_bytes();
+    let mut stack = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "scoped_call_expression" {
+            if let Some((table, table_node, method)) = schema_call(node, bytes) {
+                if method == "create" {
+                    index
+                        .tables
+                        .entry(table.clone())
+                        .or_insert_with(|| site_from_string_node(path, table_node));
+                }
+                if let Some(args) = node.child_by_field_name("arguments") {
+                    collect_columns(index, path, &table, args, bytes);
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+}
+
+/// If `node` is a `Schema::create('t', …)` / `Schema::table('t', …)` call,
+/// return `(table, table_name_string_node, method)`.
+fn schema_call<'a>(node: Node<'a>, bytes: &[u8]) -> Option<(String, Node<'a>, &'static str)> {
+    let scope = node.child_by_field_name("scope")?;
+    let scope_text = scope.utf8_text(bytes).ok()?;
+    // PHP class names are case-insensitive; match the `Schema` facade by its
+    // basename so `\Illuminate\Support\Facades\Schema` also matches.
+    let basename = scope_text.rsplit('\\').next().unwrap_or(scope_text);
+    if !basename.eq_ignore_ascii_case("Schema") {
+        return None;
+    }
+    let name = node.child_by_field_name("name")?.utf8_text(bytes).ok()?;
+    let method = match name {
+        "create" => "create",
+        "table" => "table",
+        _ => return None,
+    };
+    let args = node.child_by_field_name("arguments")?;
+    let (table, table_node) = first_string_arg(args, bytes)?;
+    Some((table, table_node, method))
+}
+
+/// Walk an arguments subtree for `$table->method('col')` column definitions,
+/// mapping each to `(table, col)`. First definition wins.
+fn collect_columns(index: &mut MigrationIndex, path: &Path, table: &str, args: Node, bytes: &[u8]) {
+    let mut stack = vec![args];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "member_call_expression" {
+            if let Some(name) = node
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(bytes).ok())
+            {
+                if COLUMN_DEF_METHODS.contains(&name) {
+                    if let Some(call_args) = node.child_by_field_name("arguments") {
+                        if let Some((column, col_node)) = first_string_arg(call_args, bytes) {
+                            index
+                                .columns
+                                .entry((table.to_string(), column))
+                                .or_insert_with(|| site_from_string_node(path, col_node));
+                        }
+                    }
+                }
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+}
+
+/// First string-literal argument of an `arguments` node, as `(value, node)`.
+fn first_string_arg<'a>(args: Node<'a>, bytes: &[u8]) -> Option<(String, Node<'a>)> {
+    let mut cursor = args.walk();
+    for child in args.children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        if let Some(inner) = child.named_child(0) {
+            if inner.kind() == "string" {
+                if let Some(value) = string_literal_value(inner, bytes) {
+                    return Some((value, inner));
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Decode a tree-sitter `string` node to its unquoted content.
+fn string_literal_value(node: Node, bytes: &[u8]) -> Option<String> {
+    let raw = node.utf8_text(bytes).ok()?;
+    let trimmed = raw
+        .strip_prefix(['\'', '"'])
+        .and_then(|s| s.strip_suffix(['\'', '"']))
+        .unwrap_or(raw);
+    Some(trimmed.to_string())
+}
+
+/// Build a `MigrationSite` pointing at the *content* of a string literal node
+/// (inside the quotes). Assumes a single-line, single-byte-quoted literal —
+/// always true for table/column names.
+fn site_from_string_node(path: &Path, node: Node) -> MigrationSite {
+    let start = node.start_position();
+    let end = node.end_position();
+    // Inside the quotes: +1 past the opener, -1 before the closer.
+    let (start_char, end_char) = if start.row == end.row && end.column > start.column + 1 {
+        (start.column as u32 + 1, end.column as u32 - 1)
+    } else {
+        (start.column as u32, end.column as u32)
+    };
+    MigrationSite {
+        file: path.to_path_buf(),
+        line: start.row as u32,
+        start_char,
+        end_char,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/migration_index/tests.rs
+++ b/laravel-lsp/src/migration_index/tests.rs
@@ -1,0 +1,162 @@
+use super::*;
+use std::path::Path;
+use tempfile::TempDir;
+
+/// Extract the source text a `MigrationSite` points at, to assert the jump
+/// target lands exactly on the column/table name.
+fn text_at<'a>(content: &'a str, site: &MigrationSite) -> &'a str {
+    let line = content.lines().nth(site.line as usize).unwrap();
+    &line[site.start_char as usize..site.end_char as usize]
+}
+
+const CREATE_USERS: &str = r#"<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->unique();
+            $table->string('name');
+            $table->boolean('is_active')->default(true);
+            $table->index('email');
+            $table->timestamps();
+        });
+    }
+};
+"#;
+
+#[test]
+fn indexes_create_table_columns() {
+    let mut index = MigrationIndex::default();
+    index_migration_file(&mut index, Path::new("/m/create_users.php"), CREATE_USERS);
+
+    // Table create site points at `users`.
+    let table = index.table("users").expect("users table indexed");
+    assert_eq!(text_at(CREATE_USERS, table), "users");
+
+    // Columns from `$table->string(...)` / `boolean(...)`.
+    let email = index.column("users", "email").expect("email column");
+    assert_eq!(text_at(CREATE_USERS, email), "email");
+    let name = index.column("users", "name").expect("name column");
+    assert_eq!(text_at(CREATE_USERS, name), "name");
+    assert!(index.column("users", "is_active").is_some());
+}
+
+#[test]
+fn email_column_points_at_string_definition_not_the_index_call() {
+    // Both `$table->string('email')` and `$table->index('email')` mention
+    // email. The definition (string) wins — it's first AND `index` is not an
+    // allowlisted column method.
+    let mut index = MigrationIndex::default();
+    index_migration_file(&mut index, Path::new("/m/create_users.php"), CREATE_USERS);
+    let site = index.column("users", "email").unwrap();
+    // Line 11 (0-based) is the `$table->string('email')` line.
+    let line = CREATE_USERS.lines().nth(site.line as usize).unwrap();
+    assert!(line.contains("string('email')"), "wrong line: {line}");
+}
+
+#[test]
+fn email_and_email_prefixed_columns_are_distinct() {
+    // Regression: clicking `email` must resolve to the `email` column, not the
+    // prefix-sharing `email_verified_at`. Exact key match, distinct sites.
+    let src = "<?php\nSchema::create('users', function ($table) {\n    $table->string('email', 64)->nullable();\n    $table->timestamp('email_verified_at')->nullable();\n});\n";
+    let mut index = MigrationIndex::default();
+    index_migration_file(&mut index, Path::new("/m/users.php"), src);
+    let email = index.column("users", "email").expect("email column");
+    let verified = index
+        .column("users", "email_verified_at")
+        .expect("email_verified_at column");
+    assert_eq!(text_at(src, email), "email");
+    assert_eq!(text_at(src, verified), "email_verified_at");
+    assert_ne!(email.line, verified.line, "must resolve to distinct lines");
+}
+
+#[test]
+fn does_not_index_reference_or_drop_methods() {
+    let src = r#"<?php
+Schema::table('users', function (Blueprint $table) {
+    $table->dropColumn('legacy');
+    $table->renameColumn('old', 'new');
+    $table->index('email');
+});
+"#;
+    let mut index = MigrationIndex::default();
+    index_migration_file(&mut index, Path::new("/m/x.php"), src);
+    assert!(index.column("users", "legacy").is_none());
+    assert!(index.column("users", "old").is_none());
+    // `index('email')` is a reference, not a definition.
+    assert!(index.column("users", "email").is_none());
+}
+
+#[test]
+fn indexes_add_column_via_schema_table() {
+    let src = r#"<?php
+Schema::table('posts', function (Blueprint $table) {
+    $table->string('slug');
+});
+"#;
+    let mut index = MigrationIndex::default();
+    index_migration_file(&mut index, Path::new("/m/add_slug.php"), src);
+    let slug = index.column("posts", "slug").expect("slug column");
+    assert_eq!(text_at(src, slug), "slug");
+    // Schema::table does NOT create the table, so no table create site.
+    assert!(index.table("posts").is_none());
+}
+
+#[test]
+fn matches_fully_qualified_schema_facade() {
+    let src = r#"<?php
+\Illuminate\Support\Facades\Schema::create('flags', function ($table) {
+    $table->boolean('enabled');
+});
+"#;
+    let mut index = MigrationIndex::default();
+    index_migration_file(&mut index, Path::new("/m/flags.php"), src);
+    assert!(index.table("flags").is_some());
+    assert!(index.column("flags", "enabled").is_some());
+}
+
+#[test]
+fn first_definition_wins() {
+    // A later migration re-touching the column shouldn't overwrite the create
+    // migration's definition site.
+    let create = "<?php\nSchema::create('t', function ($table) {\n    $table->string('c');\n});\n";
+    let modify =
+        "<?php\nSchema::table('t', function ($table) {\n    $table->text('c')->change();\n});\n";
+    let mut index = MigrationIndex::default();
+    index_migration_file(&mut index, Path::new("/m/1_create.php"), create);
+    index_migration_file(&mut index, Path::new("/m/2_modify.php"), modify);
+    let site = index.column("t", "c").unwrap();
+    assert_eq!(site.file, Path::new("/m/1_create.php"));
+}
+
+#[test]
+fn build_index_reads_migrations_dir() {
+    let dir = TempDir::new().unwrap();
+    let migrations = dir.path().join("database").join("migrations");
+    std::fs::create_dir_all(&migrations).unwrap();
+    std::fs::write(
+        migrations.join("2024_01_01_000000_create_users_table.php"),
+        CREATE_USERS,
+    )
+    .unwrap();
+
+    let index = build_migration_index(dir.path());
+    assert!(index.table("users").is_some());
+    assert!(index.column("users", "email").is_some());
+    assert!(index.column_count() >= 3);
+}
+
+#[test]
+fn build_index_empty_without_migrations_dir() {
+    let dir = TempDir::new().unwrap();
+    let index = build_migration_index(dir.path());
+    assert_eq!(index.table_count(), 0);
+    assert_eq!(index.column_count(), 0);
+}

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -18,6 +18,7 @@
 //!   valid alongside DB columns.
 
 pub mod chain;
+pub mod code_actions;
 pub mod cursor;
 pub mod diagnostics;
 pub mod eloquent_completion;

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -19,6 +19,7 @@
 
 pub mod chain;
 pub mod cursor;
+pub mod diagnostics;
 pub mod eloquent_completion;
 pub mod extractor;
 pub mod flow;
@@ -28,8 +29,10 @@ pub mod var_type;
 
 pub use chain::*;
 pub use cursor::{
-    detect_chain_context_at, detect_chain_context_at_diagnostic, fixup_for_completion,
-    position_to_byte_offset, ChainResolveFailure, CompletionPrep,
+    byte_offset_to_position, chain_context_for_link, detect_chain_context_at,
+    detect_chain_context_at_diagnostic, fixup_for_completion, position_to_byte_offset,
+    ChainResolveFailure, CompletionPrep,
 };
+pub use diagnostics::chain_diagnostics;
 pub use extractor::extract_chains;
 pub use use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -31,8 +31,8 @@ pub mod var_type;
 pub use chain::*;
 pub use cursor::{
     byte_offset_to_position, chain_context_for_link, detect_chain_context_at,
-    detect_chain_context_at_diagnostic, fixup_for_completion, position_to_byte_offset,
-    ChainResolveFailure, CompletionPrep,
+    detect_chain_context_at_diagnostic, detect_chain_target_at, fixup_for_completion,
+    position_to_byte_offset, ChainResolveFailure, ChainTarget, CompletionPrep,
 };
 pub use diagnostics::chain_diagnostics;
 pub use extractor::extract_chains;

--- a/laravel-lsp/src/query_chain/code_actions.rs
+++ b/laravel-lsp/src/query_chain/code_actions.rs
@@ -1,0 +1,297 @@
+//! Code actions (quick-fixes) for query-chain diagnostics.
+//!
+//! Two actions, driven entirely by the structured `data` payload on the
+//! diagnostics produced by [`super::diagnostics`] — so this layer never
+//! re-parses messages or re-resolves schema:
+//!
+//! - **Rename to `<suggestion>`** — a `TextEdit` over the diagnostic's range.
+//!   For a plain column/relation/table the edit inserts the corrected
+//!   identifier; for a dynamic `where{Column}` finder the range covers just
+//!   the studly column portion of the method, so inserting `Email` turns
+//!   `whereEmaaaail` into `whereEmail`.
+//! - **Create migration to add column `<col>`** (columns only) — a `CreateFile`
+//!   workspace edit writing a timestamped `database/migrations/*.php`. The body
+//!   comes from the project's `migration.update.stub` (custom → vendor →
+//!   built-in fallback, same as `php artisan make:migration`), so any custom
+//!   format is honoured; we fill Laravel's `{{ table }}` placeholder and inject
+//!   the column into the `up()`/`down()` bodies (`string()` default).
+//!
+//! The timestamp helper is pure (takes Unix seconds) so it can be tested
+//! deterministically; the call site passes `SystemTime::now()`-derived seconds.
+
+use std::collections::HashMap;
+use std::path::Path;
+use tower_lsp::lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, CreateFile, CreateFileOptions, Diagnostic,
+    DocumentChangeOperation, DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier,
+    Position, Range, ResourceOp, TextDocumentEdit, TextEdit, Url, WorkspaceEdit,
+};
+
+/// The fields the code-action layer reads from a chain diagnostic's `data`.
+struct ChainDiagData {
+    kind: String,
+    name: String,
+    replacement: Option<String>,
+    replacement_label: Option<String>,
+    table: Option<String>,
+}
+
+/// Pull the `data` payload off a chain diagnostic. Returns `None` for any
+/// diagnostic that isn't one of ours (wrong source, missing/foreign data).
+fn parse(diagnostic: &Diagnostic) -> Option<ChainDiagData> {
+    if diagnostic.source.as_deref() != Some("laravel-lsp") {
+        return None;
+    }
+    let data = diagnostic.data.as_ref()?;
+    let str_field = |key: &str| data.get(key).and_then(|v| v.as_str()).map(str::to_string);
+    Some(ChainDiagData {
+        kind: str_field("kind")?,
+        name: str_field("name")?,
+        replacement: str_field("replacement"),
+        replacement_label: str_field("replacementLabel"),
+        table: str_field("table"),
+    })
+}
+
+/// Build the "Rename to `<suggestion>`" quick-fix for a chain diagnostic, if it
+/// carries a replacement. The edit targets the diagnostic's own range.
+pub fn rename_action(diagnostic: &Diagnostic, doc_uri: &Url) -> Option<CodeActionOrCommand> {
+    let data = parse(diagnostic)?;
+    let replacement = data.replacement?;
+    let label = data
+        .replacement_label
+        .unwrap_or_else(|| replacement.clone());
+
+    let mut changes = HashMap::new();
+    changes.insert(
+        doc_uri.clone(),
+        vec![TextEdit {
+            range: diagnostic.range,
+            new_text: replacement,
+        }],
+    );
+
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Rename to `{label}`"),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        is_preferred: Some(true),
+        ..Default::default()
+    }))
+}
+
+/// Build the "Create migration to add column …" quick-fix for a column
+/// diagnostic. `project_root` locates `database/migrations/`; `timestamp` is
+/// the `YYYY_MM_DD_HHMMSS` filename prefix (see [`format_migration_timestamp`]).
+/// Returns `None` for non-column diagnostics or when the table is unknown.
+pub fn migration_action(
+    diagnostic: &Diagnostic,
+    project_root: &Path,
+    timestamp: &str,
+) -> Option<CodeActionOrCommand> {
+    let data = parse(diagnostic)?;
+    if data.kind != "column" {
+        return None;
+    }
+    let table = data.table?;
+    let column = data.name;
+
+    let filename = format!("{timestamp}_add_{column}_to_{table}_table.php");
+    let path = project_root
+        .join("database")
+        .join("migrations")
+        .join(&filename);
+    let uri = Url::from_file_path(&path).ok()?;
+    let content = migration_content(project_root, &table, &column);
+
+    let edit = WorkspaceEdit {
+        changes: None,
+        document_changes: Some(DocumentChanges::Operations(vec![
+            DocumentChangeOperation::Op(ResourceOp::Create(CreateFile {
+                uri: uri.clone(),
+                options: Some(CreateFileOptions {
+                    overwrite: Some(false),
+                    ignore_if_exists: Some(true),
+                }),
+                annotation_id: None,
+            })),
+            DocumentChangeOperation::Edit(TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier { uri, version: None },
+                edits: vec![OneOf::Left(TextEdit {
+                    range: Range {
+                        start: Position {
+                            line: 0,
+                            character: 0,
+                        },
+                        end: Position {
+                            line: 0,
+                            character: 0,
+                        },
+                    },
+                    new_text: content,
+                })],
+            }),
+        ])),
+        change_annotations: None,
+    };
+
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Create migration: add column `{column}` to `{table}`"),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(edit),
+        // Not preferred — the rename is the likely intent for a typo.
+        is_preferred: Some(false),
+        ..Default::default()
+    }))
+}
+
+/// Laravel's `migration.update.stub` (10.x/11.x). Used as the fallback when the
+/// project hasn't published a stub and vendor can't be located, so generated
+/// migrations match `php artisan make:migration --table=` byte-for-byte.
+const FALLBACK_UPDATE_STUB: &str = r#"<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+};
+"#;
+
+/// Resolve the `migration.update.stub`, honouring project customisation the
+/// same way `php artisan make:migration` does (and the same priority the rest
+/// of this extension's stub-backed code actions use):
+///
+/// 1. `stubs/migration.update.stub` — published & customised by the project.
+/// 2. `vendor/laravel/framework/.../migrations/stubs/migration.update.stub`.
+///
+/// Returns `None` when neither exists; the caller falls back to
+/// [`FALLBACK_UPDATE_STUB`] so output stays consistent regardless.
+fn resolve_migration_stub(project_root: &Path) -> Option<String> {
+    let custom = project_root.join("stubs").join("migration.update.stub");
+    if let Ok(content) = std::fs::read_to_string(&custom) {
+        return Some(content);
+    }
+    let framework = project_root.join(
+        "vendor/laravel/framework/src/Illuminate/Database/Migrations/stubs/migration.update.stub",
+    );
+    std::fs::read_to_string(&framework).ok()
+}
+
+/// Build the "add column" migration from the resolved stub: honour the
+/// project's format, fill Laravel's placeholders, and inject the column into
+/// the `up()` / `down()` bodies. Column type defaults to `string()`.
+fn migration_content(project_root: &Path, table: &str, column: &str) -> String {
+    let stub =
+        resolve_migration_stub(project_root).unwrap_or_else(|| FALLBACK_UPDATE_STUB.to_string());
+    render_migration(&stub, table, column)
+}
+
+/// Apply Laravel's stub substitutions to `stub` and inject the column. Pure —
+/// the stub text is supplied by the caller, so this is fully testable against
+/// both the default stub and arbitrary custom formats.
+fn render_migration(stub: &str, table: &str, column: &str) -> String {
+    // Old (≤7.x) named-class stubs carry a class placeholder; modern
+    // anonymous-class stubs don't. Fill it when present.
+    let class_name = format!(
+        "Add{}To{}Table",
+        crate::laravel_introspector::snake_to_studly(column),
+        crate::laravel_introspector::snake_to_studly(table),
+    );
+    let substituted = stub
+        .replace("{{ table }}", table)
+        .replace("{{table}}", table)
+        .replace("DummyTable", table)
+        .replace("{{ class }}", &class_name)
+        .replace("{{class}}", &class_name)
+        .replace("DummyClass", &class_name);
+    inject_columns(&substituted, column)
+}
+
+/// Replace the first two standalone `//` body placeholders (Laravel's empty
+/// closure markers — `up()` then `down()`) with the column add / drop,
+/// preserving each line's indentation. Only whole-line `//` markers are
+/// touched, so inline `// comments` in a custom stub are left alone. If the
+/// stub has fewer than two such markers, whatever's present is filled and the
+/// rest left as-is (the stub is still honoured).
+fn inject_columns(content: &str, column: &str) -> String {
+    let inserts = [
+        format!("$table->string('{column}');"),
+        format!("$table->dropColumn('{column}');"),
+    ];
+    let mut next = 0;
+    let trailing_newline = content.ends_with('\n');
+    let body: Vec<String> = content
+        .lines()
+        .map(|line| {
+            if next < inserts.len() && line.trim() == "//" {
+                let indent_len = line.len() - line.trim_start().len();
+                let rendered = format!("{}{}", &line[..indent_len], inserts[next]);
+                next += 1;
+                rendered
+            } else {
+                line.to_string()
+            }
+        })
+        .collect();
+    let mut out = body.join("\n");
+    if trailing_newline {
+        out.push('\n');
+    }
+    out
+}
+
+/// Format Unix epoch seconds as Laravel's migration filename prefix
+/// `YYYY_MM_DD_HHMMSS` (UTC). Pure — the caller supplies the seconds.
+pub fn format_migration_timestamp(unix_secs: u64) -> String {
+    let days = (unix_secs / 86_400) as i64;
+    let tod = unix_secs % 86_400;
+    let (hh, mm, ss) = (tod / 3600, (tod % 3600) / 60, tod % 60);
+    let (y, m, d) = civil_from_days(days);
+    format!("{y:04}_{m:02}_{d:02}_{hh:02}{mm:02}{ss:02}")
+}
+
+/// Convert days-since-Unix-epoch to a `(year, month, day)` civil date.
+/// Howard Hinnant's `civil_from_days` algorithm — proleptic Gregorian, exact,
+/// no leap-second handling needed (migration ordering only needs monotonicity).
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32; // [1, 12]
+    (y + if m <= 2 { 1 } else { 0 }, m, d)
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/query_chain/code_actions/tests.rs
+++ b/laravel-lsp/src/query_chain/code_actions/tests.rs
@@ -1,0 +1,303 @@
+use super::*;
+use serde_json::json;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::{CodeActionOrCommand, Diagnostic, NumberOrString, Range};
+
+fn diag(code: &str, data: serde_json::Value) -> Diagnostic {
+    Diagnostic {
+        range: Range {
+            start: Position {
+                line: 2,
+                character: 12,
+            },
+            end: Position {
+                line: 2,
+                character: 18,
+            },
+        },
+        source: Some("laravel-lsp".to_string()),
+        code: Some(NumberOrString::String(code.to_string())),
+        data: Some(data),
+        ..Default::default()
+    }
+}
+
+fn uri() -> Url {
+    Url::parse("file:///app/Http/Controllers/UserController.php").unwrap()
+}
+
+// ---- format_migration_timestamp / civil_from_days -------------------------
+
+#[test]
+fn timestamp_epoch_zero() {
+    assert_eq!(format_migration_timestamp(0), "1970_01_01_000000");
+}
+
+#[test]
+fn timestamp_end_of_first_day() {
+    assert_eq!(format_migration_timestamp(86_399), "1970_01_01_235959");
+    assert_eq!(format_migration_timestamp(86_400), "1970_01_02_000000");
+}
+
+#[test]
+fn timestamp_known_modern_date() {
+    // 2020-01-01 00:00:00 UTC
+    assert_eq!(
+        format_migration_timestamp(1_577_836_800),
+        "2020_01_01_000000"
+    );
+}
+
+#[test]
+fn timestamp_handles_leap_day() {
+    // 2020-02-29 00:00:00 UTC (2020 is a leap year)
+    assert_eq!(
+        format_migration_timestamp(1_582_934_400),
+        "2020_02_29_000000"
+    );
+}
+
+// ---- render_migration / stub handling -------------------------------------
+
+const STD_STUB: &str = r#"<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+};
+"#;
+
+#[test]
+fn render_fills_table_and_injects_column_with_indentation() {
+    let c = render_migration(STD_STUB, "users", "phone");
+    // `{{ table }}` substituted in both closures.
+    assert!(!c.contains("{{ table }}"));
+    assert_eq!(c.matches("Schema::table('users'").count(), 2);
+    // Column injected at the placeholder's own indentation (12 spaces), and the
+    // `//` markers are gone.
+    assert!(
+        c.contains("\n            $table->string('phone');\n"),
+        "up column at 12 spaces; got:\n{c}"
+    );
+    assert!(
+        c.contains("\n            $table->dropColumn('phone');\n"),
+        "down column at 12 spaces"
+    );
+    assert!(!c.contains("//"), "placeholders consumed");
+    assert!(c.contains("\n    public function up(): void\n"));
+}
+
+#[test]
+fn render_honours_custom_stub_and_skips_inline_comments() {
+    // A custom stub with a license header (inline `//`) and an extra comment.
+    // The inline comments must survive; only the standalone `//` body markers
+    // get the column injected.
+    let custom = "<?php\n// Acme Corp — proprietary.\n\nreturn new class extends Migration\n{\n    public function up(): void\n    {\n        Schema::table('{{ table }}', function (Blueprint $table) {\n            //\n        });\n    }\n    public function down(): void\n    {\n        Schema::table('{{ table }}', function (Blueprint $table) {\n            //\n        });\n    }\n};\n";
+    let c = render_migration(custom, "orders", "ref");
+    assert!(
+        c.contains("// Acme Corp — proprietary."),
+        "inline comment kept"
+    );
+    assert!(c.contains("$table->string('ref');"));
+    assert!(c.contains("$table->dropColumn('ref');"));
+    assert_eq!(c.matches("Schema::table('orders'").count(), 2);
+}
+
+#[test]
+fn render_fills_legacy_named_class_placeholder() {
+    let legacy = "<?php\nclass {{ class }} extends Migration {\n    public function up() { Schema::table('DummyTable', function ($t) { // }); }\n}\n";
+    let c = render_migration(legacy, "users", "phone");
+    assert!(c.contains("class AddPhoneToUsersTable extends Migration"));
+    assert!(c.contains("Schema::table('users'"));
+    assert!(!c.contains("DummyTable"));
+}
+
+#[test]
+fn inject_columns_only_touches_standalone_markers() {
+    let src = "// header\n    //\n  not // a marker\n        //\n";
+    let out = inject_columns(src, "x");
+    assert!(out.starts_with("// header\n")); // inline header untouched
+    assert!(out.contains("\n    $table->string('x');\n")); // first standalone marker
+    assert!(out.contains("not // a marker")); // inline `//` untouched
+    assert!(out.contains("\n        $table->dropColumn('x');\n")); // second marker
+}
+
+#[test]
+fn migration_content_prefers_published_project_stub() {
+    let dir = TempDir::new().unwrap();
+    let stubs = dir.path().join("stubs");
+    std::fs::create_dir_all(&stubs).unwrap();
+    std::fs::write(
+        stubs.join("migration.update.stub"),
+        "<?php // CUSTOM STUB\nSchema::table('{{ table }}', function ($t) {\n    //\n});\n",
+    )
+    .unwrap();
+    let c = migration_content(dir.path(), "users", "phone");
+    assert!(
+        c.contains("// CUSTOM STUB"),
+        "should use the project's stub"
+    );
+    assert!(c.contains("Schema::table('users'"));
+    assert!(c.contains("$table->string('phone');"));
+}
+
+#[test]
+fn migration_content_falls_back_without_stub() {
+    let dir = TempDir::new().unwrap(); // no stubs/, no vendor/
+    let c = migration_content(dir.path(), "users", "phone");
+    assert!(c.contains("return new class extends Migration"));
+    assert!(c.contains("Schema::table('users'"));
+    assert!(c.contains("$table->string('phone');"));
+    assert!(c.contains("$table->dropColumn('phone');"));
+    assert!(!c.contains("{{ table }}"));
+}
+
+// ---- rename_action --------------------------------------------------------
+
+fn into_action(a: CodeActionOrCommand) -> tower_lsp::lsp_types::CodeAction {
+    match a {
+        CodeActionOrCommand::CodeAction(ca) => ca,
+        CodeActionOrCommand::Command(_) => panic!("expected a CodeAction, got a Command"),
+    }
+}
+
+#[test]
+fn rename_action_replaces_diagnostic_range() {
+    let d = diag(
+        "laravel-lsp.unknown-column",
+        json!({"kind": "column", "name": "emial", "replacement": "email", "replacementLabel": "email", "table": "users"}),
+    );
+    let action = into_action(rename_action(&d, &uri()).expect("a rename action"));
+    assert_eq!(action.title, "Rename to `email`");
+    assert_eq!(action.kind, Some(CodeActionKind::QUICKFIX));
+    assert_eq!(action.is_preferred, Some(true));
+
+    let changes = action.edit.unwrap().changes.unwrap();
+    let edits = &changes[&uri()];
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].new_text, "email");
+    assert_eq!(edits[0].range, d.range);
+}
+
+#[test]
+fn rename_action_for_dynamic_uses_studly_replacement_and_method_label() {
+    // Dynamic where{Column}: the range covers the studly portion, so the edit
+    // inserts `Email`, but the title shows the whole corrected method.
+    let d = diag(
+        "laravel-lsp.unknown-column",
+        json!({"kind": "column", "name": "emaaaail", "dynamic": true,
+               "replacement": "Email", "replacementLabel": "whereEmail", "table": "users"}),
+    );
+    let action = into_action(rename_action(&d, &uri()).expect("a rename action"));
+    assert_eq!(action.title, "Rename to `whereEmail`");
+    let changes = action.edit.unwrap().changes.unwrap();
+    assert_eq!(changes[&uri()][0].new_text, "Email");
+}
+
+#[test]
+fn rename_action_none_without_replacement() {
+    // No suggestion was close enough → no replacement → no rename action.
+    let d = diag(
+        "laravel-lsp.unknown-column",
+        json!({"kind": "column", "name": "zzzzz", "replacement": null, "table": "users"}),
+    );
+    assert!(rename_action(&d, &uri()).is_none());
+}
+
+#[test]
+fn rename_action_none_for_foreign_source() {
+    let mut d = diag(
+        "laravel-lsp.unknown-column",
+        json!({"kind": "column", "name": "emial", "replacement": "email"}),
+    );
+    d.source = Some("intelephense".to_string());
+    assert!(rename_action(&d, &uri()).is_none());
+}
+
+// ---- migration_action -----------------------------------------------------
+
+fn create_file_uri(action: &tower_lsp::lsp_types::CodeAction) -> Url {
+    match &action.edit.as_ref().unwrap().document_changes {
+        Some(DocumentChanges::Operations(ops)) => match &ops[0] {
+            DocumentChangeOperation::Op(ResourceOp::Create(cf)) => cf.uri.clone(),
+            _ => panic!("first op should be a CreateFile"),
+        },
+        _ => panic!("expected document_changes operations"),
+    }
+}
+
+fn create_file_content(action: &tower_lsp::lsp_types::CodeAction) -> String {
+    match &action.edit.as_ref().unwrap().document_changes {
+        Some(DocumentChanges::Operations(ops)) => match &ops[1] {
+            DocumentChangeOperation::Edit(te) => match &te.edits[0] {
+                OneOf::Left(edit) => edit.new_text.clone(),
+                _ => panic!("expected a plain TextEdit"),
+            },
+            _ => panic!("second op should be the content edit"),
+        },
+        _ => panic!("expected document_changes operations"),
+    }
+}
+
+#[test]
+fn migration_action_creates_timestamped_file_with_stub() {
+    let d = diag(
+        "laravel-lsp.unknown-column",
+        json!({"kind": "column", "name": "phone", "table": "users"}),
+    );
+    let root = Path::new("/srv/app");
+    let action =
+        into_action(migration_action(&d, root, "2026_05_29_120000").expect("a migration action"));
+    assert_eq!(
+        action.title,
+        "Create migration: add column `phone` to `users`"
+    );
+    assert_eq!(action.is_preferred, Some(false));
+
+    let file_uri = create_file_uri(&action);
+    assert!(
+        file_uri
+            .path()
+            .ends_with("/database/migrations/2026_05_29_120000_add_phone_to_users_table.php"),
+        "got: {}",
+        file_uri.path()
+    );
+
+    let content = create_file_content(&action);
+    assert!(content.contains("$table->string('phone');"));
+    assert!(content.contains("Schema::table('users'"));
+}
+
+#[test]
+fn migration_action_none_for_relation() {
+    let d = diag(
+        "laravel-lsp.unknown-relation",
+        json!({"kind": "relation", "name": "postss", "replacement": "posts"}),
+    );
+    assert!(migration_action(&d, Path::new("/srv/app"), "2026_05_29_120000").is_none());
+}
+
+#[test]
+fn migration_action_none_without_table() {
+    let d = diag(
+        "laravel-lsp.unknown-column",
+        json!({"kind": "column", "name": "phone"}), // no table
+    );
+    assert!(migration_action(&d, Path::new("/srv/app"), "2026_05_29_120000").is_none());
+}

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -413,11 +413,32 @@ pub fn chain_context_for_link(
     })
 }
 
+/// The string literal the cursor sits in, plus the resolved [`ChainContext`].
+/// Goto-definition needs the literal's value (which column/relation/table) and
+/// its span — neither of which `ChainContext` carries — so the cursor resolver
+/// surfaces them here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainTarget {
+    pub ctx: ChainContext,
+    /// The unquoted literal under the cursor (`"posts.author"`, `"email"`, …).
+    pub value: String,
+    /// Byte span of the string literal *including* its quotes.
+    pub value_span: (usize, usize),
+}
+
 fn detect_in_chain(
     chains: &[Arc<BuilderChain>],
     chain: &BuilderChain,
     byte_offset: usize,
 ) -> Option<ChainContext> {
+    detect_target_in_chain(chains, chain, byte_offset).map(|t| t.ctx)
+}
+
+fn detect_target_in_chain(
+    chains: &[Arc<BuilderChain>],
+    chain: &BuilderChain,
+    byte_offset: usize,
+) -> Option<ChainTarget> {
     let (mut mode, effective_table, effective_model, closure_relation_hop) =
         initial_receiver_context(chains, chain)?;
 
@@ -451,7 +472,7 @@ fn detect_in_chain(
     // The cursor must be inside a string-literal arg of the cursor link.
     // `pluck` is `ArgKind::Column` even though it terminates the chain —
     // we still complete inside its first arg.
-    let (quote, string_value) = string_arg_at(cursor_link, byte_offset)?;
+    let (quote, string_value, value_span) = string_arg_at(cursor_link, byte_offset)?;
 
     if !matches!(
         cursor_link.arg,
@@ -479,15 +500,30 @@ fn detect_in_chain(
         None
     };
 
-    Some(ChainContext {
-        mode,
-        effective_table,
-        effective_model,
-        expecting: cursor_link.arg,
-        dotted_prefix,
-        closure_relation_hop,
-        quote,
+    Some(ChainTarget {
+        ctx: ChainContext {
+            mode,
+            effective_table,
+            effective_model,
+            expecting: cursor_link.arg,
+            dotted_prefix,
+            closure_relation_hop,
+            quote,
+        },
+        value: string_value,
+        value_span,
     })
+}
+
+/// Resolve a cursor to the chain literal under it plus its [`ChainContext`].
+/// Like [`detect_chain_context_at`], but also returns the literal's value and
+/// span — used by goto-definition to route the literal to its source.
+pub fn detect_chain_target_at(
+    chains: &[Arc<BuilderChain>],
+    byte_offset: usize,
+) -> Option<ChainTarget> {
+    let chain = find_chain_containing(chains, byte_offset)?;
+    detect_target_in_chain(chains, chain, byte_offset)
 }
 
 /// Phase 8 helper: find the smallest chain in `chains` whose span strictly
@@ -533,14 +569,14 @@ fn parent_chain_eloquent_model(
 }
 
 /// Find the string-literal arg of `link` that contains the cursor, returning
-/// its quote character and value. Walks both top-level `StringLit` args and
-/// string literals nested inside an `Array` arg, so `with(['posts'|, 'comments'])`
-/// resolves the same as `with('posts'|)`. Returns `None` if no string arg
-/// covers the cursor.
-fn string_arg_at(link: &ChainLink, byte_offset: usize) -> Option<(char, String)> {
+/// its quote character, value, and byte span (incl. quotes). Walks both
+/// top-level `StringLit` args and string literals nested inside an `Array` arg,
+/// so `with(['posts'|, 'comments'])` resolves the same as `with('posts'|)`.
+/// Returns `None` if no string arg covers the cursor.
+fn string_arg_at(link: &ChainLink, byte_offset: usize) -> Option<(char, String, (usize, usize))> {
     for arg in &link.args {
-        if let Some((quote, value)) = string_arg_in(arg, byte_offset) {
-            return Some((quote, value));
+        if let Some(found) = string_arg_in(arg, byte_offset) {
+            return Some(found);
         }
     }
     None
@@ -548,9 +584,10 @@ fn string_arg_at(link: &ChainLink, byte_offset: usize) -> Option<(char, String)>
 
 /// Check whether a single arg (or any of its nested string elements, for
 /// `Array` args) contains the cursor and is a string literal. Returns the
-/// quote character + literal value on hit. Pulled out as a separate helper
-/// so `Array` can recurse into its elements without duplicating the span check.
-fn string_arg_in(arg: &ChainArg, byte_offset: usize) -> Option<(char, String)> {
+/// quote character, literal value, and byte span on hit. Pulled out as a
+/// separate helper so `Array` can recurse into its elements without
+/// duplicating the span check.
+fn string_arg_in(arg: &ChainArg, byte_offset: usize) -> Option<(char, String, (usize, usize))> {
     match arg {
         ChainArg::StringLit {
             quote,
@@ -559,7 +596,7 @@ fn string_arg_in(arg: &ChainArg, byte_offset: usize) -> Option<(char, String)> {
         } => {
             let (start, end) = *span_byte_range;
             if byte_offset >= start && byte_offset <= end {
-                Some((*quote, value.clone()))
+                Some((*quote, value.clone(), *span_byte_range))
             } else {
                 None
             }

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -11,6 +11,7 @@
 
 use super::chain::*;
 use std::sync::Arc;
+use tower_lsp::lsp_types::Position;
 
 /// Result of preparing source content for chain-completion at the cursor.
 /// Carries the (possibly fixed) content to parse PLUS metadata the items
@@ -216,6 +217,36 @@ pub fn position_to_byte_offset(content: &str, line: u32, character: u32) -> Opti
     Some(line_start + byte_in_line)
 }
 
+/// Inverse of [`position_to_byte_offset`]: translate a byte offset inside
+/// `content` into an LSP `Position` (0-based line + character). Characters are
+/// counted as Unicode code points, matching `position_to_byte_offset` — so a
+/// round-trip through both functions is stable for ASCII Laravel source. A
+/// `byte_offset` past the end of `content` clamps to the final position; an
+/// offset that lands mid-codepoint (only possible from a buggy caller) falls
+/// back to column 0 on its line rather than panicking.
+///
+/// Used by the diagnostics path, which carries byte spans out of the chain
+/// extractor and needs LSP `Range`s to attach squiggles.
+pub fn byte_offset_to_position(content: &str, byte_offset: usize) -> Position {
+    let clamped = byte_offset.min(content.len());
+    let mut line: u32 = 0;
+    let mut line_start = 0usize;
+    for (idx, b) in content.bytes().enumerate() {
+        if idx >= clamped {
+            break;
+        }
+        if b == b'\n' {
+            line += 1;
+            line_start = idx + 1;
+        }
+    }
+    let character = content
+        .get(line_start..clamped)
+        .map(|slice| slice.chars().count() as u32)
+        .unwrap_or(0);
+    Position { line, character }
+}
+
 /// Resolve a cursor inside a parsed file to a `ChainContext`. Returns `None`
 /// when no chain contains the cursor, when the chain's receiver can't be
 /// resolved without async I/O (Eloquent — handled by later phases), or when
@@ -279,23 +310,24 @@ fn find_chain_containing(
     best
 }
 
-fn detect_in_chain(
+/// Resolve the initial chain context from the receiver alone, before any links
+/// are walked. Returns `(mode, effective_table, effective_model,
+/// closure_relation_hop)`, or `None` when the receiver can't be resolved
+/// synchronously (unknown receiver, or an instance var with no declared type
+/// and no enclosing closure binding).
+///
+/// - DbTable carries the table directly; no model lookup needed.
+/// - Eloquent static receivers (`User::where(...)`) carry the class FQCN; the
+///   handler resolves it to a model/table async (file I/O). `effective_table`
+///   stays `None` here.
+/// - Eloquent instance receivers (`$user->newQuery()`) resolve via an
+///   enclosing relation/same-model closure binding, or a declared `@var` /
+///   typed-param type captured at extraction time.
+fn initial_receiver_context(
     chains: &[Arc<BuilderChain>],
     chain: &BuilderChain,
-    byte_offset: usize,
-) -> Option<ChainContext> {
-    // Initial mode + table + model from the receiver.
-    //
-    // - DbTable carries the table directly; no model lookup needed.
-    // - Eloquent static receivers (`User::where(...)`) carry the class FQCN;
-    //   the handler will resolve it to a `ModelMetadata` async (file I/O).
-    //   `effective_table` stays `None` here — the handler fills it in.
-    // - Eloquent instance receivers (`$user->newQuery()`) need `@var`
-    //   docblock + typed-param scanning to resolve the class; that lands in
-    //   Phase 9. Phase 8 handles the special case of `$q` bound by an
-    //   enclosing relation closure: the parent chain's model + the closure's
-    //   relation name resolve via one async hop in the handler.
-    let (mut mode, effective_table, effective_model, closure_relation_hop) = match &chain.receiver {
+) -> Option<(BuilderMode, Option<String>, Option<String>, Option<String>)> {
+    let resolved = match &chain.receiver {
         ChainReceiver::DbTable { table, .. } => {
             (BuilderMode::BaseBuilder, Some(table.clone()), None, None)
         }
@@ -306,23 +338,11 @@ fn detect_in_chain(
             None,
         ),
         ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, php_type }) => {
-            // Phase 8: if the chain's receiver var is bound by an enclosing
-            // closure carrier, inherit the parent chain's effective model.
-            // Two flavors:
-            //
-            // - RelationHop (`whereHas('rel', closure)` / `with(['rel' =>
-            //   closure])`): closure binds to a *related* model's builder.
-            //   The handler walks one hop on the parent's model.
-            // - SameModel (`where(closure)`, `when($cond, closure)`,
-            //   `having(closure)`, etc.): closure binds to the *same* model
-            //   as the parent. Inherit `effective_model` directly; no hop.
-            //
-            // Phase 9 (fallback): no closure scope match? Try the resolved
-            // `php_type` captured at extraction time from a typed function
-            // parameter (`function show(User $user)`) or a `@var` docblock
-            // (`/** @var User $u */`). This is what makes the idiomatic
-            // controller-style `public function show(User $user) {
-            // $user->newQuery()->where('|'); }` work end-to-end.
+            // Phase 8: a `$q` receiver bound by an enclosing closure carrier
+            // inherits the parent chain's model — RelationHop (`whereHas('rel',
+            // closure)`) walks one relation hop; SameModel (`where(closure)`,
+            // `when(...)`, …) inherits directly. Phase 9 fallback: the resolved
+            // `php_type` from a typed param / `@var` docblock.
             match chain.closure_scope.as_ref() {
                 Some(binding) if &binding.param_var == var => {
                     let parent_model = parent_chain_eloquent_model(chains, chain)?;
@@ -351,6 +371,55 @@ fn detect_in_chain(
         }
         ChainReceiver::Unknown => return None,
     };
+    Some(resolved)
+}
+
+/// Resolve the chain context at a specific link index, applying the effects of
+/// all links *before* `link_idx` to the running mode. Unlike
+/// [`detect_chain_context_at`], this does NOT require the link to expose a
+/// recognised string argument — it's for diagnostics on dynamic
+/// `where{Column}` finders, whose column lives in the method name rather than
+/// an argument. `expecting` is set to the target link's `ArgKind` (often
+/// `None` for dynamic finders). Returns `None` if a prior link terminated the
+/// chain or the receiver can't be resolved synchronously.
+pub fn chain_context_for_link(
+    chains: &[Arc<BuilderChain>],
+    chain: &BuilderChain,
+    link_idx: usize,
+) -> Option<ChainContext> {
+    let (mut mode, effective_table, effective_model, closure_relation_hop) =
+        initial_receiver_context(chains, chain)?;
+    for link in chain.links.iter().take(link_idx) {
+        match link.effect {
+            ChainEffect::FlipToBase => mode = BuilderMode::BaseBuilder,
+            ChainEffect::FlipToCollection => {
+                if mode == BuilderMode::EloquentBuilder {
+                    mode = BuilderMode::EloquentCollection;
+                }
+            }
+            ChainEffect::Terminate => return None,
+            ChainEffect::None => {}
+        }
+    }
+    let arg = chain.links.get(link_idx)?.arg;
+    Some(ChainContext {
+        mode,
+        effective_table,
+        effective_model,
+        expecting: arg,
+        dotted_prefix: None,
+        closure_relation_hop,
+        quote: '\'',
+    })
+}
+
+fn detect_in_chain(
+    chains: &[Arc<BuilderChain>],
+    chain: &BuilderChain,
+    byte_offset: usize,
+) -> Option<ChainContext> {
+    let (mut mode, effective_table, effective_model, closure_relation_hop) =
+        initial_receiver_context(chains, chain)?;
 
     // Walk links in source order. For each link, decide: (a) does the cursor
     // sit inside this link? (b) if not, apply this link's effect and move on.

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -34,6 +34,41 @@ fn detect(src_with_cursor: &str) -> Option<ChainContext> {
     detect_chain_context_at(&chains, byte_offset)
 }
 
+fn detect_target(src_with_cursor: &str) -> Option<ChainTarget> {
+    let (wrapped, byte_offset) = cursor_at(src_with_cursor);
+    let tree = parse_php(&wrapped).expect("parse");
+    let chains: Vec<Arc<BuilderChain>> = extract_chains(&tree, &wrapped)
+        .into_iter()
+        .map(Arc::new)
+        .collect();
+    detect_chain_target_at(&chains, byte_offset).inspect(|t| {
+        // Verify the span maps back to the literal in the source.
+        let span_text = &wrapped[t.value_span.0..t.value_span.1];
+        assert_eq!(
+            span_text,
+            format!("'{}'", t.value),
+            "span should cover the quoted literal"
+        );
+    })
+}
+
+#[test]
+fn target_returns_column_value_and_kind() {
+    let t = detect_target("DB::table('users')->where('emai|l', 1);").expect("target");
+    assert_eq!(t.value, "email");
+    assert_eq!(t.ctx.expecting, ArgKind::Column);
+}
+
+#[test]
+fn target_returns_dotted_relation_value() {
+    let t = detect_target("User::with('posts.auth|or');").expect("target");
+    assert_eq!(t.value, "posts.author");
+    assert!(matches!(
+        t.ctx.expecting,
+        ArgKind::Relation | ArgKind::ClosureCarrier
+    ));
+}
+
 // ---- fixup_for_completion ---------------------------------------------
 
 #[test]

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -768,3 +768,68 @@ fn find_chain_containing_picks_innermost() {
         other => panic!("expected $q's chain, got {other:?}"),
     }
 }
+
+// ---- byte_offset_to_position ----------------------------------------------
+
+#[test]
+fn byte_offset_to_position_first_line() {
+    let content = "abc\ndef";
+    assert_eq!(
+        byte_offset_to_position(content, 0),
+        tower_lsp::lsp_types::Position {
+            line: 0,
+            character: 0
+        }
+    );
+    assert_eq!(
+        byte_offset_to_position(content, 2),
+        tower_lsp::lsp_types::Position {
+            line: 0,
+            character: 2
+        }
+    );
+}
+
+#[test]
+fn byte_offset_to_position_after_newline() {
+    let content = "abc\ndef";
+    // Byte 4 is 'd' on line 1, column 0.
+    assert_eq!(
+        byte_offset_to_position(content, 4),
+        tower_lsp::lsp_types::Position {
+            line: 1,
+            character: 0
+        }
+    );
+    // Byte 6 is 'f' → line 1, column 2.
+    assert_eq!(
+        byte_offset_to_position(content, 6),
+        tower_lsp::lsp_types::Position {
+            line: 1,
+            character: 2
+        }
+    );
+}
+
+#[test]
+fn byte_offset_to_position_clamps_past_end() {
+    let content = "ab\ncd";
+    assert_eq!(
+        byte_offset_to_position(content, 999),
+        tower_lsp::lsp_types::Position {
+            line: 1,
+            character: 2
+        }
+    );
+}
+
+#[test]
+fn position_byte_round_trip_is_stable() {
+    let content = "<?php\nUser::where('email');\n$x = 1;\n";
+    for byte in [0usize, 6, 12, 20, 27] {
+        let pos = byte_offset_to_position(content, byte);
+        let back =
+            position_to_byte_offset(content, pos.line, pos.character).expect("round-trip offset");
+        assert_eq!(back, byte, "round-trip failed for byte {byte}");
+    }
+}

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -69,6 +69,18 @@ fn target_returns_dotted_relation_value() {
     ));
 }
 
+#[test]
+fn target_resolves_array_element_under_cursor() {
+    // Goto on an element inside an array arg resolves that element (the cursor
+    // resolver recurses into arrays).
+    let t = detect_target("User::with(['posts', 'comm|ents']);").expect("target");
+    assert_eq!(t.value, "comments");
+    assert!(matches!(
+        t.ctx.expecting,
+        ArgKind::Relation | ArgKind::ClosureCarrier
+    ));
+}
+
 // ---- fixup_for_completion ---------------------------------------------
 
 #[test]

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -269,7 +269,9 @@ async fn legal_names(
             }
             names.extend(casts);
             names.extend(accessors);
-            Some((names, format!("table \"{table}\"")))
+            // Subject = the raw table name; `make_diagnostic` formats the
+            // message and the code-action layer reads it from `data.table`.
+            Some((names, table))
         }
         DiagKind::Relation => {
             // Relations only exist on Eloquent builders/collections. A relation
@@ -593,6 +595,11 @@ fn make_dynamic_where_diagnostic(
         message.push_str(&format!(" Did you mean `{fixed}`?"));
     }
 
+    // For the rename quick-fix: `range` covers the studly column portion of
+    // the method name, so the replacement is the studly form of the suggested
+    // column (`email` → `Email`), which turns `whereEmaaaail` into `whereEmail`.
+    // `replacementLabel` shows the whole corrected method in the action title.
+    let replacement = suggestion.as_ref().map(|s| snake_to_studly(s));
     let data = serde_json::json!({
         "kind": "column",
         "name": column,
@@ -601,6 +608,9 @@ fn make_dynamic_where_diagnostic(
         "prefix": prefix,
         "suggestion": suggestion,
         "suggestedMethod": fixed_method,
+        "replacement": replacement,
+        "replacementLabel": fixed_method,
+        "table": table,
     });
 
     Diagnostic {
@@ -726,26 +736,34 @@ fn make_diagnostic(
         end: byte_offset_to_position(content, content_end),
     };
 
-    let (code, kind_word, data_kind) = match kind {
-        DiagKind::Column => (CODE_UNKNOWN_COLUMN, "Column", "column"),
-        DiagKind::Relation => (CODE_UNKNOWN_RELATION, "Relation", "relation"),
-        DiagKind::Table => (CODE_UNKNOWN_TABLE, "Table", "table"),
+    let (code, data_kind) = match kind {
+        DiagKind::Column => (CODE_UNKNOWN_COLUMN, "column"),
+        DiagKind::Relation => (CODE_UNKNOWN_RELATION, "relation"),
+        DiagKind::Table => (CODE_UNKNOWN_TABLE, "table"),
     };
 
+    // `subject` is the raw table name (Column), the model FQCN (Relation), or
+    // unused (Table).
     let mut message = match kind {
-        DiagKind::Table => format!("{kind_word} \"{needle}\" does not exist."),
-        // subject = `table "users"` or the model FQCN.
-        _ => format!("{kind_word} \"{needle}\" does not exist on {subject}."),
+        DiagKind::Table => format!("Table \"{needle}\" does not exist."),
+        DiagKind::Column => format!("Column \"{needle}\" does not exist on table \"{subject}\"."),
+        DiagKind::Relation => format!("Relation \"{needle}\" does not exist on {subject}."),
     };
     if let Some(ref s) = suggestion {
         message.push_str(&format!(" Did you mean \"{s}\"?"));
     }
 
+    // `replacement` is the exact text the rename quick-fix puts in `range`
+    // (identical to the suggestion for these non-dynamic cases). `table` is
+    // present only for columns — it drives the create-migration action.
     let data = serde_json::json!({
         "kind": data_kind,
         "name": needle,
         "value": full_value,
         "suggestion": suggestion,
+        "replacement": suggestion,
+        "replacementLabel": suggestion,
+        "table": if kind == DiagKind::Column { Some(subject) } else { None },
     });
 
     Diagnostic {

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -56,11 +56,16 @@ use std::path::Path;
 use std::sync::Arc;
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Range};
 
-/// Column methods whose first string arg we deliberately DON'T validate,
-/// because it's frequently an alias or raw fragment rather than a bare column:
-/// `select`/`addSelect` define aliases (`'votes as score'`), `having` filters
-/// on them. These would surface false positives on valid queries.
-const COLUMN_DIAG_DENY: &[&str] = &["select", "addSelect", "having"];
+/// Column methods whose first string arg we deliberately DON'T validate.
+/// `having` filters on aggregate *aliases* (`having('total', '>', 5)` after a
+/// `selectRaw('count(*) as total')`), where a bare simple identifier is
+/// routinely not a real column — validating it would false-positive.
+///
+/// `select`/`addSelect` are NOT denied: their alias/qualified/expression forms
+/// (`'votes as score'`, `'users.id'`, `'count(*)'`) are already skipped by the
+/// [`is_simple_identifier`] guard, so only a bare typo like `select('emial')`
+/// is flagged — which is exactly what we want.
+const COLUMN_DIAG_DENY: &[&str] = &["having"];
 
 /// Diagnostic codes — stable strings the code-action handler keys off to offer
 /// the matching quick-fix. Kept here so the producer and the consumer share a

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -20,13 +20,13 @@
 //! - **Non-identifier literals** — qualified columns (`users.id`), expressions
 //!   (`count(*)`), aliases (`name as n`), wildcards (`*`) — are skipped via the
 //!   [`is_simple_identifier`] guard. A bare typo like `emial` is what we catch.
-//! - **Alias-defining methods** (`select`, `addSelect`, `having`) are not
-//!   diagnosed: their string args are routinely aliases or raw fragments.
-//! - **Array-form args** (`with(['a', 'b'])`, `select(['x'])`) are not yet
-//!   diagnosed — only the first *top-level* string literal of a call is
-//!   checked. Catching the canonical `with('postss')` / `where('emial')` forms
-//!   without risking the keyed-array `where(['col' => 'val'])` false-positive.
-//!   Array coverage is a deliberate follow-up.
+//! - **`having`** is not diagnosed: it filters on aggregate aliases where a
+//!   bare identifier is routinely not a real column. (`select`/`addSelect` ARE
+//!   diagnosed — the identifier guard skips their alias/qualified forms.)
+//! - **Array-form args** are diagnosed for list methods: `with(['a', 'b'])`,
+//!   `select(['x', 'y'])`, and keyed relations `with(['rel' => $closure])`. But
+//!   `where`-family arrays are NOT descended — they hold values / `col => value`
+//!   pairs, and validating the value side would false-positive.
 //!
 //! Raw-SQL methods (`whereRaw`, `selectRaw`, …) never reach here: the method
 //! classifier assigns them [`ArgKind::None`], so their links carry no
@@ -136,22 +136,13 @@ pub async fn chain_diagnostics(
                 ArgKind::None => continue,
             };
 
-            // The literal under inspection: the FIRST top-level string arg.
-            // (Operators / values in `where('col', '=', 'x')` are 2nd+ args and
-            // never validated; array args are skipped entirely.)
-            let Some((value, lit_span)) = first_string_arg(link) else {
-                continue;
-            };
-
-            // The segment we actually validate. Relations may be dotted
-            // (`posts.author`): the prefix is walked as hops, the LAST segment
-            // is the name to check.
-            let needle = match kind {
-                DiagKind::Relation => value.rsplit('.').next().unwrap_or(&value),
-                DiagKind::Column | DiagKind::Table => value.as_str(),
-            };
-            if !is_simple_identifier(needle) {
-                // Qualified / expression / aliased / wildcard — stay quiet.
+            // The literal(s) to validate. Most methods validate a single
+            // leading string; list methods (`select`, `with(['a','b'])`, …)
+            // validate every array element too. `where`-family arrays are
+            // values/`col => value` pairs, so they're never descended (the
+            // value side would false-positive).
+            let targets = collect_targets(link, kind);
+            if targets.is_empty() {
                 continue;
             }
 
@@ -159,39 +150,67 @@ pub async fn chain_diagnostics(
             // the effects of preceding links. This lints each method call on
             // its own; it does NOT depend on the chain being "finished" (a
             // terminator like `->get()`), nor on cursor/completion semantics.
-            let Some(ctx) = chain_context_for_link(chains, chain, idx) else {
+            let Some(base_ctx) = chain_context_for_link(chains, chain, idx) else {
                 continue;
             };
-            let Some(mut ctx) = finalize_context(ctx, project_root).await else {
+            let Some(base_ctx) = finalize_context(base_ctx, project_root).await else {
                 continue;
             };
-            // For dotted relations, the prefix is the hops to walk before
-            // listing the final model's relations (`chain_context_for_link`
-            // doesn't compute this — it's derived from the literal here).
-            if kind == DiagKind::Relation {
-                ctx.dotted_prefix = value.rfind('.').map(|i| value[..i].to_string());
-            }
 
-            // The legal set to check against, plus the message subject
-            // ("table \"users\"" or the model FQCN).
-            let Some((legal, subject)) = legal_names(kind, &ctx, db, project_root).await else {
-                continue; // resolution gap / schema not loaded — stay quiet
-            };
-            if legal.iter().any(|name| name == needle) {
-                continue; // valid — no diagnostic
+            match kind {
+                // Columns/tables share one legal set across all targets (no
+                // per-element hop), so resolve it once.
+                DiagKind::Column | DiagKind::Table => {
+                    let Some((legal, subject)) =
+                        legal_names(kind, &base_ctx, db, project_root).await
+                    else {
+                        continue; // resolution gap / schema not loaded — stay quiet
+                    };
+                    for (value, span) in targets {
+                        if !is_simple_identifier(&value) {
+                            continue; // qualified / expression / aliased / wildcard
+                        }
+                        if legal.iter().any(|name| name == &value) {
+                            continue; // valid
+                        }
+                        let suggestion = best_suggestion(&value, &legal);
+                        out.push(make_diagnostic(
+                            kind, &value, &subject, suggestion, span, &value, content, severity,
+                        ));
+                    }
+                }
+                // Relations can be dotted per element (`with(['posts.author',
+                // 'comments'])`), so the legal set is resolved per target.
+                DiagKind::Relation => {
+                    for (value, span) in targets {
+                        let needle = value.rsplit('.').next().unwrap_or(&value);
+                        if !is_simple_identifier(needle) {
+                            continue;
+                        }
+                        let mut ctx = base_ctx.clone();
+                        ctx.dotted_prefix = value.rfind('.').map(|i| value[..i].to_string());
+                        let Some((legal, subject)) =
+                            legal_names(DiagKind::Relation, &ctx, db, project_root).await
+                        else {
+                            continue;
+                        };
+                        if legal.iter().any(|name| name == needle) {
+                            continue;
+                        }
+                        let suggestion = best_suggestion(needle, &legal);
+                        out.push(make_diagnostic(
+                            DiagKind::Relation,
+                            needle,
+                            &subject,
+                            suggestion,
+                            span,
+                            &value,
+                            content,
+                            severity,
+                        ));
+                    }
+                }
             }
-
-            let suggestion = best_suggestion(needle, &legal);
-            out.push(make_diagnostic(
-                kind,
-                needle,
-                &subject,
-                suggestion,
-                lit_span,
-                value.as_str(),
-                content,
-                severity,
-            ));
         }
     }
 
@@ -626,6 +645,86 @@ fn make_dynamic_where_diagnostic(
         message,
         data: Some(data),
         ..Default::default()
+    }
+}
+
+/// Column methods that take a *list* of columns rather than a single column
+/// followed by operator/value args. Their positional string args AND array
+/// elements are all columns. `where`-family methods are excluded: their arrays
+/// are values or `col => value` pairs, and their 2nd+ args are operators/values.
+const COLUMN_LIST_METHODS: &[&str] = &["select", "addSelect", "groupBy"];
+
+/// The literal(s) to validate for a link, as `(value, span)` (span includes
+/// quotes). Method-aware so we never validate a `where(...)` value or a
+/// `whereHas(...)` operator:
+///
+/// - **Table** / **where-family column**: the first top-level string only.
+/// - **Column list methods** (`select`/`addSelect`/`groupBy`): every top-level
+///   string AND every string element of array args.
+/// - **Relation**: the first argument only (a string, or the string elements of
+///   an array like `with(['a', 'b'])` / `with(['rel' => $closure])`) — never the
+///   2nd+ args, which are closures/operators.
+fn collect_targets(link: &ChainLink, kind: DiagKind) -> Vec<(String, (usize, usize))> {
+    match kind {
+        DiagKind::Table => first_string_arg(link).into_iter().collect(),
+        DiagKind::Relation => relation_targets(link),
+        DiagKind::Column => {
+            if COLUMN_LIST_METHODS.contains(&link.method.as_str()) {
+                column_list_targets(link)
+            } else {
+                first_string_arg(link).into_iter().collect()
+            }
+        }
+    }
+}
+
+/// Relation targets: the first arg only. A `StringLit` → that one; an `Array`
+/// → its string elements (plain `'rel'` entries and keyed `'rel' => …` keys).
+fn relation_targets(link: &ChainLink) -> Vec<(String, (usize, usize))> {
+    match link.args.first() {
+        Some(ChainArg::StringLit {
+            value,
+            span_byte_range,
+            ..
+        }) => vec![(value.clone(), *span_byte_range)],
+        Some(arr @ ChainArg::Array { .. }) => array_string_elements(arr),
+        _ => Vec::new(),
+    }
+}
+
+/// Column-list targets: every top-level string arg plus every string element of
+/// any array arg (`select('a', 'b')`, `select(['a', 'b'])`).
+fn column_list_targets(link: &ChainLink) -> Vec<(String, (usize, usize))> {
+    let mut out = Vec::new();
+    for arg in &link.args {
+        match arg {
+            ChainArg::StringLit {
+                value,
+                span_byte_range,
+                ..
+            } => out.push((value.clone(), *span_byte_range)),
+            ChainArg::Array { .. } => out.extend(array_string_elements(arg)),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// The top-level string elements of an `Array` arg, as `(value, span)`.
+fn array_string_elements(arg: &ChainArg) -> Vec<(String, (usize, usize))> {
+    match arg {
+        ChainArg::Array { elements, .. } => elements
+            .iter()
+            .filter_map(|e| match e {
+                ChainArg::StringLit {
+                    value,
+                    span_byte_range,
+                    ..
+                } => Some((value.clone(), *span_byte_range)),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -1,0 +1,763 @@
+//! Whole-file validation of Eloquent / DB query-builder chains.
+//!
+//! Completion answers "what is valid at the cursor"; diagnostics answer the
+//! mirror question — "is what's already written valid?". We reuse the exact
+//! same resolution pipeline as completion ([`detect_chain_context_at`] plus
+//! the async model/relation hops) so the two features can never disagree: if
+//! completion would have offered an identifier, diagnostics won't flag it.
+//!
+//! # Guiding principle: under-warn, never over-warn
+//!
+//! A false positive (squiggle on valid code) is worse than a false negative
+//! (missed typo) — it trains users to ignore the LSP. Every ambiguity resolves
+//! toward *staying quiet*:
+//!
+//! - **Schema not loaded** (no DB connection, table absent) → the legal set is
+//!   empty → skip. We only flag when we have a confident, non-empty set to
+//!   check against.
+//! - **Receiver unresolved** (`$x->where(...)` with no known type) → the
+//!   resolver returns `None` → skip.
+//! - **Non-identifier literals** — qualified columns (`users.id`), expressions
+//!   (`count(*)`), aliases (`name as n`), wildcards (`*`) — are skipped via the
+//!   [`is_simple_identifier`] guard. A bare typo like `emial` is what we catch.
+//! - **Alias-defining methods** (`select`, `addSelect`, `having`) are not
+//!   diagnosed: their string args are routinely aliases or raw fragments.
+//! - **Array-form args** (`with(['a', 'b'])`, `select(['x'])`) are not yet
+//!   diagnosed — only the first *top-level* string literal of a call is
+//!   checked. Catching the canonical `with('postss')` / `where('emial')` forms
+//!   without risking the keyed-array `where(['col' => 'val'])` false-positive.
+//!   Array coverage is a deliberate follow-up.
+//!
+//! Raw-SQL methods (`whereRaw`, `selectRaw`, …) never reach here: the method
+//! classifier assigns them [`ArgKind::None`], so their links carry no
+//! diagnosable arg.
+//!
+//! # Dynamic `where{Column}` finders
+//!
+//! Eloquent's magic `whereEmail($v)` / `orWhereName($v)` (and `And`/`Or`
+//! composites like `whereFirstNameAndEmail`) carry their column in the *method
+//! name*, not an argument. These are validated too — but only after ruling out
+//! real builder methods ([`KNOWN_WHERE_METHODS`]) and the model's local
+//! `scope{Name}` methods (a `scopeWhereActive` makes `whereActive()` a scope
+//! call, not a column probe). Collections are skipped — they have no dynamic
+//! `where{Column}`.
+
+use super::chain::*;
+use super::cursor::{byte_offset_to_position, chain_context_for_link};
+use super::eloquent_completion::{
+    resolve_related_model, resolve_table_for_model, snake_pluralize, walk_dotted_hops,
+};
+use crate::class_locator::find_php_class_file;
+use crate::database::DatabaseSchemaProvider;
+use crate::laravel_introspector::{
+    analyze, pascal_to_snake, snake_to_studly, ClassView, ModelMetadata,
+};
+use std::path::Path;
+use std::sync::Arc;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Range};
+
+/// Column methods whose first string arg we deliberately DON'T validate,
+/// because it's frequently an alias or raw fragment rather than a bare column:
+/// `select`/`addSelect` define aliases (`'votes as score'`), `having` filters
+/// on them. These would surface false positives on valid queries.
+const COLUMN_DIAG_DENY: &[&str] = &["select", "addSelect", "having"];
+
+/// Diagnostic codes — stable strings the code-action handler keys off to offer
+/// the matching quick-fix. Kept here so the producer and the consumer share a
+/// single source of truth.
+pub const CODE_UNKNOWN_COLUMN: &str = "laravel-lsp.unknown-column";
+pub const CODE_UNKNOWN_RELATION: &str = "laravel-lsp.unknown-relation";
+pub const CODE_UNKNOWN_TABLE: &str = "laravel-lsp.unknown-table";
+
+/// What kind of identifier a link's first string arg names. Derived from the
+/// link's `ArgKind`, collapsed to the three things we can validate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiagKind {
+    Column,
+    Relation,
+    Table,
+}
+
+/// Validate every diagnosable chain in `chains` against the resolved schema,
+/// returning one [`Diagnostic`] per unknown column / relation / table.
+///
+/// `content` is the file source the chains' byte spans index into (used to
+/// turn byte spans into LSP `Range`s). `severity` is the configured severity
+/// for these diagnostics — the caller skips the call entirely when the feature
+/// is turned off.
+pub async fn chain_diagnostics(
+    chains: &[Arc<BuilderChain>],
+    db: &DatabaseSchemaProvider,
+    project_root: &Path,
+    content: &str,
+    severity: DiagnosticSeverity,
+) -> Vec<Diagnostic> {
+    let mut out = Vec::new();
+
+    for chain in chains {
+        for (idx, link) in chain.links.iter().enumerate() {
+            // Dynamic `where{Column}` / `orWhere{Column}` finders carry their
+            // column in the METHOD NAME, not a string arg — handle them first.
+            // A finder link has no diagnosable string arg, so on a hit we move
+            // straight to the next link.
+            if let Some(diag) = dynamic_where_diagnostic(
+                chains,
+                chain,
+                idx,
+                link,
+                db,
+                project_root,
+                content,
+                severity,
+            )
+            .await
+            {
+                out.push(diag);
+                continue;
+            }
+
+            // Which kind of identifier (if any) does this link's first string
+            // arg name? `ArgKind::None` links (terminators, raw SQL, …) and
+            // alias-defining column methods are skipped here.
+            let kind = match link.arg {
+                ArgKind::Column => {
+                    if COLUMN_DIAG_DENY.contains(&link.method.as_str()) {
+                        continue;
+                    }
+                    DiagKind::Column
+                }
+                ArgKind::Relation | ArgKind::ClosureCarrier => DiagKind::Relation,
+                ArgKind::Table => DiagKind::Table,
+                ArgKind::None => continue,
+            };
+
+            // The literal under inspection: the FIRST top-level string arg.
+            // (Operators / values in `where('col', '=', 'x')` are 2nd+ args and
+            // never validated; array args are skipped entirely.)
+            let Some((value, lit_span)) = first_string_arg(link) else {
+                continue;
+            };
+
+            // The segment we actually validate. Relations may be dotted
+            // (`posts.author`): the prefix is walked as hops, the LAST segment
+            // is the name to check.
+            let needle = match kind {
+                DiagKind::Relation => value.rsplit('.').next().unwrap_or(&value),
+                DiagKind::Column | DiagKind::Table => value.as_str(),
+            };
+            if !is_simple_identifier(needle) {
+                // Qualified / expression / aliased / wildcard — stay quiet.
+                continue;
+            }
+
+            // Resolve the context for THIS link by index — receiver type plus
+            // the effects of preceding links. This lints each method call on
+            // its own; it does NOT depend on the chain being "finished" (a
+            // terminator like `->get()`), nor on cursor/completion semantics.
+            let Some(ctx) = chain_context_for_link(chains, chain, idx) else {
+                continue;
+            };
+            let Some(mut ctx) = finalize_context(ctx, project_root).await else {
+                continue;
+            };
+            // For dotted relations, the prefix is the hops to walk before
+            // listing the final model's relations (`chain_context_for_link`
+            // doesn't compute this — it's derived from the literal here).
+            if kind == DiagKind::Relation {
+                ctx.dotted_prefix = value.rfind('.').map(|i| value[..i].to_string());
+            }
+
+            // The legal set to check against, plus the message subject
+            // ("table \"users\"" or the model FQCN).
+            let Some((legal, subject)) = legal_names(kind, &ctx, db, project_root).await else {
+                continue; // resolution gap / schema not loaded — stay quiet
+            };
+            if legal.iter().any(|name| name == needle) {
+                continue; // valid — no diagnostic
+            }
+
+            let suggestion = best_suggestion(needle, &legal);
+            out.push(make_diagnostic(
+                kind,
+                needle,
+                &subject,
+                suggestion,
+                lit_span,
+                value.as_str(),
+                content,
+                severity,
+            ));
+        }
+    }
+
+    out
+}
+
+/// Apply the async resolution hops completion does before dispatch: a relation
+/// closure hop (`whereHas('rel', fn ($q) => $q->where('|'))` resolves `$q` to
+/// the related model) and post-`toBase()` table resolution. Returns `None`
+/// when a required hop can't be resolved — the caller then stays quiet.
+async fn finalize_context(mut ctx: ChainContext, root: &Path) -> Option<ChainContext> {
+    if let Some(rel) = ctx.closure_relation_hop.take() {
+        let parent = ctx.effective_model.clone()?;
+        let related = resolve_related_model(&parent, &rel, root).await?;
+        ctx.effective_model = Some(related);
+    }
+    if ctx.mode == BuilderMode::BaseBuilder && ctx.effective_table.is_none() {
+        if let Some(model) = ctx.effective_model.clone() {
+            ctx.effective_table = resolve_table_for_model(&model, root).await;
+        }
+    }
+    Some(ctx)
+}
+
+/// Build the set of legal names for `kind` in `ctx`, plus the human-readable
+/// subject for the diagnostic message. Returns `None` whenever the set can't be
+/// computed confidently (no table/model, schema not loaded, model has no
+/// relations) — every such case means "don't flag".
+async fn legal_names(
+    kind: DiagKind,
+    ctx: &ChainContext,
+    db: &DatabaseSchemaProvider,
+    root: &Path,
+) -> Option<(Vec<String>, String)> {
+    match kind {
+        DiagKind::Table => {
+            let tables = db.get_tables().await;
+            if tables.is_empty() {
+                return None; // schema not introspected — stay quiet
+            }
+            Some((tables, String::new()))
+        }
+        DiagKind::Column => {
+            let (table, casts, accessors) = match ctx.mode {
+                BuilderMode::BaseBuilder => (ctx.effective_table.clone()?, Vec::new(), Vec::new()),
+                BuilderMode::EloquentBuilder | BuilderMode::EloquentCollection => {
+                    let model = ctx.effective_model.as_deref()?;
+                    let meta = load_metadata(model, root).await?;
+                    let simple = model.rsplit('\\').next().unwrap_or(model);
+                    let table = meta
+                        .table_name
+                        .clone()
+                        .unwrap_or_else(|| snake_pluralize(simple));
+                    let casts: Vec<String> = meta.casts.keys().cloned().collect();
+                    // Accessors are valid `where` args only post-execution, when
+                    // filtering happens in memory on a hydrated collection.
+                    let accessors: Vec<String> = if ctx.mode == BuilderMode::EloquentCollection {
+                        meta.accessors
+                            .iter()
+                            .map(|a| a.property_name.clone())
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
+                    (table, casts, accessors)
+                }
+            };
+
+            let mut names: Vec<String> = db
+                .get_columns_with_types(&table)
+                .await
+                .into_iter()
+                .map(|(name, _)| name)
+                .collect();
+            if names.is_empty() {
+                // Table not in the introspected schema — can't validate. Note
+                // this fires BEFORE folding in casts/accessors, so a model with
+                // casts but an unreachable table still stays quiet.
+                return None;
+            }
+            names.extend(casts);
+            names.extend(accessors);
+            Some((names, format!("table \"{table}\"")))
+        }
+        DiagKind::Relation => {
+            // Relations only exist on Eloquent builders/collections. A relation
+            // method on a `DB::table()` base builder is user error, but flagging
+            // it is out of scope — stay quiet.
+            if ctx.mode == BuilderMode::BaseBuilder {
+                return None;
+            }
+            let starting = ctx.effective_model.as_deref()?;
+            // Walk any dotted prefix to the final model whose relations we list.
+            let model = match ctx.dotted_prefix.as_deref() {
+                Some(prefix) => walk_dotted_hops(starting, prefix, root).await?,
+                None => starting.to_string(),
+            };
+            let meta = load_metadata(&model, root).await?;
+            let names: Vec<String> = meta
+                .relationships
+                .into_iter()
+                .map(|rel| rel.method_name)
+                .collect();
+            if names.is_empty() {
+                // No relations extracted — can't confidently flag a typo.
+                return None;
+            }
+            Some((names, model))
+        }
+    }
+}
+
+/// Read + parse a model class to [`ModelMetadata`], walking its `extends`
+/// chain. Mirrors the blocking-pool pattern the completion helpers use so the
+/// LSP runtime stays responsive on slow disks / deep inheritance.
+async fn load_metadata(class: &str, root: &Path) -> Option<ModelMetadata> {
+    let path = find_php_class_file(class, root)?;
+    let path_c = path.clone();
+    let root_c = root.to_path_buf();
+    tokio::task::spawn_blocking(move || ModelMetadata::from_file_with_inheritance(&path_c, &root_c))
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Read + parse a model class to a [`ClassView`] (inheritance- and
+/// trait-aware). Used by the dynamic-where path, which needs the model's local
+/// `scopes` (to avoid flagging a scope call) alongside its table.
+async fn load_class_view(class: &str, root: &Path) -> Option<ClassView> {
+    let path = find_php_class_file(class, root)?;
+    let path_c = path.clone();
+    let root_c = root.to_path_buf();
+    tokio::task::spawn_blocking(move || analyze(&path_c, &root_c))
+        .await
+        .ok()
+        .flatten()
+}
+
+// ---- Dynamic `where{Column}` finders --------------------------------------
+
+/// Real `where*` builder methods — NOT dynamic finders. A `where`/`orWhere`-
+/// prefixed method that isn't in this set (and isn't a local scope) is treated
+/// as a dynamic `where{Column}` finder. Kept deliberately broad: a real method
+/// mistaken for a finder would be a false positive, which we never want.
+const KNOWN_WHERE_METHODS: &[&str] = &[
+    "where",
+    "orWhere",
+    "whereIn",
+    "orWhereIn",
+    "whereNotIn",
+    "orWhereNotIn",
+    "whereNull",
+    "orWhereNull",
+    "whereNotNull",
+    "orWhereNotNull",
+    "whereBetween",
+    "orWhereBetween",
+    "whereNotBetween",
+    "orWhereNotBetween",
+    "whereBetweenColumns",
+    "whereNotBetweenColumns",
+    "whereColumn",
+    "orWhereColumn",
+    "whereDate",
+    "orWhereDate",
+    "whereMonth",
+    "orWhereMonth",
+    "whereDay",
+    "orWhereDay",
+    "whereYear",
+    "orWhereYear",
+    "whereTime",
+    "orWhereTime",
+    "whereExists",
+    "orWhereExists",
+    "whereNotExists",
+    "orWhereNotExists",
+    "whereHas",
+    "orWhereHas",
+    "whereDoesntHave",
+    "orWhereDoesntHave",
+    "whereHasMorph",
+    "orWhereHasMorph",
+    "whereDoesntHaveMorph",
+    "whereRaw",
+    "orWhereRaw",
+    "whereJsonContains",
+    "orWhereJsonContains",
+    "whereJsonDoesntContain",
+    "whereJsonContainsKey",
+    "whereJsonDoesntContainKey",
+    "whereJsonLength",
+    "orWhereJsonLength",
+    "whereFullText",
+    "orWhereFullText",
+    "whereBelongsTo",
+    "orWhereBelongsTo",
+    "whereRelation",
+    "orWhereRelation",
+    "whereMorphRelation",
+    "orWhereMorphRelation",
+    "whereKey",
+    "whereKeyNot",
+    "whereNot",
+    "orWhereNot",
+    "whereInRaw",
+    "orWhereInRaw",
+    "whereIntegerInRaw",
+    "whereIntegerNotInRaw",
+    "whereNotInRaw",
+    "orWhereNotInRaw",
+    "whereMorphedTo",
+    "orWhereMorphedTo",
+    "whereDescendantOf",
+    "whereAncestorOf",
+    "whereAll",
+    "orWhereAll",
+    "whereAny",
+    "orWhereAny",
+    "whereNone",
+    "orWhereNone",
+    "wherePivot",
+    "wherePivotIn",
+    "wherePivotNotIn",
+    "wherePivotBetween",
+    "wherePivotNotBetween",
+    "wherePivotNull",
+    "wherePivotNotNull",
+];
+
+/// If `method` is a dynamic `where{Column}` / `orWhere{Column}` finder, return
+/// `(prefix, finder)` where `prefix` is `"where"` or `"orWhere"` and `finder`
+/// is the studly column portion. Returns `None` for real builder methods and
+/// for `where`/`orWhere` themselves (no studly suffix).
+fn dynamic_where_finder(method: &str) -> Option<(&'static str, &str)> {
+    if KNOWN_WHERE_METHODS.contains(&method) {
+        return None;
+    }
+    // Try the longer prefix first so `orWhereName` strips to `Name`, not
+    // `eName` via a `where` mismatch (it doesn't start with `where` anyway,
+    // but explicit ordering keeps the intent clear).
+    for prefix in ["orWhere", "where"] {
+        if let Some(rest) = method.strip_prefix(prefix) {
+            // A real finder has an uppercase studly column right after the
+            // prefix (`whereEmail`). `whereabouts` (lowercase) isn't a finder.
+            if rest
+                .chars()
+                .next()
+                .map(|c| c.is_ascii_uppercase())
+                .unwrap_or(false)
+            {
+                return Some((prefix, rest));
+            }
+        }
+    }
+    None
+}
+
+/// Split a dynamic finder's studly portion into column segments, mirroring
+/// Laravel's `Builder::dynamicWhere` (`preg_split('/(And|Or)(?=[A-Z])/')`):
+/// split on `And`/`Or` only when immediately followed by an uppercase letter,
+/// so `FirstNameAndEmail` → `["FirstName", "Email"]` while `Brand` stays whole
+/// (lowercase `and`) — and a leading separator never splits.
+fn split_dynamic_segments(finder: &str) -> Vec<&str> {
+    let bytes = finder.as_bytes();
+    let mut segments = Vec::new();
+    let mut seg_start = 0usize;
+    let mut i = 0usize;
+    while i < finder.len() {
+        let kw_len = if finder[i..].starts_with("And") {
+            Some(3)
+        } else if finder[i..].starts_with("Or") {
+            Some(2)
+        } else {
+            None
+        };
+        if let Some(klen) = kw_len {
+            let next_is_upper = bytes
+                .get(i + klen)
+                .map(u8::is_ascii_uppercase)
+                .unwrap_or(false);
+            if i > seg_start && next_is_upper {
+                segments.push(&finder[seg_start..i]);
+                seg_start = i + klen;
+                i = seg_start;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    if seg_start < finder.len() {
+        segments.push(&finder[seg_start..]);
+    }
+    segments
+}
+
+/// Validate a dynamic `where{Column}` finder link, returning a diagnostic for
+/// the first segment that doesn't resolve to a real column. Returns `None` for
+/// non-finders, local scopes, collection chains, unresolved receivers, and a
+/// cold/absent schema — every ambiguity stays quiet.
+#[allow(clippy::too_many_arguments)]
+async fn dynamic_where_diagnostic(
+    chains: &[Arc<BuilderChain>],
+    chain: &BuilderChain,
+    link_idx: usize,
+    link: &ChainLink,
+    db: &DatabaseSchemaProvider,
+    root: &Path,
+    content: &str,
+    severity: DiagnosticSeverity,
+) -> Option<Diagnostic> {
+    let (prefix, finder) = dynamic_where_finder(&link.method)?;
+
+    let ctx = chain_context_for_link(chains, chain, link_idx)?;
+    let ctx = finalize_context(ctx, root).await?;
+
+    // Resolve the table to validate against. For Eloquent we also load the
+    // model's scopes: a scope whose callable name equals the method (e.g.
+    // `scopeWhereActive` → `whereActive`) means this is a scope call, not a
+    // dynamic column finder — stay quiet.
+    let table = match ctx.mode {
+        BuilderMode::BaseBuilder => ctx.effective_table.clone()?,
+        // Collections don't have dynamic `where{Column}` — `whereEmail` on a
+        // hydrated collection is just an undefined method, not a column probe.
+        BuilderMode::EloquentCollection => return None,
+        BuilderMode::EloquentBuilder => {
+            let model = ctx.effective_model.as_deref()?;
+            let view = load_class_view(model, root).await?;
+            if view.scopes.iter().any(|scope| scope.name == link.method) {
+                return None; // it's a local scope, not a dynamic finder
+            }
+            let simple = model.rsplit('\\').next().unwrap_or(model);
+            view.table_name
+                .clone()
+                .unwrap_or_else(|| snake_pluralize(simple))
+        }
+    };
+
+    let columns: Vec<String> = db
+        .get_columns_with_types(&table)
+        .await
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    if columns.is_empty() {
+        return None; // schema not loaded — stay quiet
+    }
+
+    for segment in split_dynamic_segments(finder) {
+        let column = pascal_to_snake(segment);
+        if !is_simple_identifier(&column) {
+            return None; // defensive — give up rather than risk a bad squiggle
+        }
+        if !columns.iter().any(|c| c == &column) {
+            let suggestion = best_suggestion(&column, &columns);
+            return Some(make_dynamic_where_diagnostic(
+                &link.method,
+                prefix,
+                &column,
+                &table,
+                suggestion,
+                link.span_byte_range,
+                content,
+                severity,
+            ));
+        }
+    }
+    None
+}
+
+/// Build the diagnostic for a dynamic-where finder. The squiggle covers the
+/// studly column portion of the method name (`Emaaail` in `whereEmaaail`), and
+/// the suggestion is the corrected *method* name (`whereEmail`).
+#[allow(clippy::too_many_arguments)]
+fn make_dynamic_where_diagnostic(
+    method: &str,
+    prefix: &str,
+    column: &str,
+    table: &str,
+    suggestion: Option<String>,
+    link_span: (usize, usize),
+    content: &str,
+    severity: DiagnosticSeverity,
+) -> Diagnostic {
+    // Locate the method name within the link's span to target the squiggle.
+    // (Same dynamic finder called twice in one chain is the only ambiguity;
+    // `find` lands on the first, still a correctly-named token.)
+    let span_text = content.get(link_span.0..link_span.1).unwrap_or("");
+    let method_rel = span_text.find(method).unwrap_or(0);
+    let method_start = link_span.0 + method_rel;
+    let studly_start = method_start + prefix.len();
+    let method_end = method_start + method.len();
+    let range = Range {
+        start: byte_offset_to_position(content, studly_start),
+        end: byte_offset_to_position(content, method_end),
+    };
+
+    let mut message =
+        format!("Column \"{column}\" does not exist on table \"{table}\" (dynamic `{method}`).");
+    let fixed_method = suggestion
+        .as_ref()
+        .map(|s| format!("{prefix}{}", snake_to_studly(s)));
+    if let Some(ref fixed) = fixed_method {
+        message.push_str(&format!(" Did you mean `{fixed}`?"));
+    }
+
+    let data = serde_json::json!({
+        "kind": "column",
+        "name": column,
+        "dynamic": true,
+        "method": method,
+        "prefix": prefix,
+        "suggestion": suggestion,
+        "suggestedMethod": fixed_method,
+    });
+
+    Diagnostic {
+        range,
+        severity: Some(severity),
+        code: Some(NumberOrString::String(CODE_UNKNOWN_COLUMN.to_string())),
+        source: Some("laravel-lsp".to_string()),
+        message,
+        data: Some(data),
+        ..Default::default()
+    }
+}
+
+/// The first top-level [`ChainArg::StringLit`] of a link, as `(value, span)`.
+/// Span includes the surrounding quotes (as the extractor records it). Array
+/// args and 2nd+ positional args are intentionally ignored.
+fn first_string_arg(link: &ChainLink) -> Option<(String, (usize, usize))> {
+    link.args.iter().find_map(|arg| match arg {
+        ChainArg::StringLit {
+            value,
+            span_byte_range,
+            ..
+        } => Some((value.clone(), *span_byte_range)),
+        _ => None,
+    })
+}
+
+/// A bare PHP identifier: `[A-Za-z_][A-Za-z0-9_]*`. Rejects qualified names
+/// (`users.id`), expressions (`count(*)`), aliases (`x as y`), and wildcards
+/// (`*`) — none of which we validate.
+fn is_simple_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Pick the closest candidate to `needle` as a "did you mean" suggestion.
+/// Accepts a candidate within Levenshtein distance 2; failing that, the closest
+/// candidate that shares a ≥3-character case-insensitive prefix. Returns `None`
+/// when nothing is close enough — better no suggestion than a misleading one.
+fn best_suggestion(needle: &str, candidates: &[String]) -> Option<String> {
+    let needle_lower = needle.to_ascii_lowercase();
+    let mut best_edit: Option<(usize, &str)> = None;
+    let mut best_prefix: Option<(usize, &str)> = None;
+
+    for candidate in candidates {
+        let cand_lower = candidate.to_ascii_lowercase();
+        let dist = levenshtein(&needle_lower, &cand_lower);
+        if dist <= 2 {
+            match best_edit {
+                Some((d, _)) if d <= dist => {}
+                _ => best_edit = Some((dist, candidate)),
+            }
+        }
+        if common_prefix_len(&needle_lower, &cand_lower) >= 3 {
+            match best_prefix {
+                Some((d, _)) if d <= dist => {}
+                _ => best_prefix = Some((dist, candidate)),
+            }
+        }
+    }
+
+    best_edit.or(best_prefix).map(|(_, c)| c.to_string())
+}
+
+/// Length of the shared leading run of two strings, in characters.
+fn common_prefix_len(a: &str, b: &str) -> usize {
+    a.chars().zip(b.chars()).take_while(|(x, y)| x == y).count()
+}
+
+/// Classic two-row Levenshtein edit distance. Small inputs (identifier names),
+/// so the allocation-light two-row form is plenty — no need for a crate.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr: Vec<usize> = vec![0; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = if ca == cb { 0 } else { 1 };
+            curr[j + 1] = (prev[j + 1] + 1) // deletion
+                .min(curr[j] + 1) // insertion
+                .min(prev[j] + cost); // substitution
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+/// Build the LSP `Diagnostic` for one unknown identifier. The squiggle is
+/// narrowed to the offending segment (e.g. just `authorr` in `posts.authorr`).
+/// A structured `data` payload carries everything the code-action handler needs
+/// without re-parsing the message string.
+#[allow(clippy::too_many_arguments)]
+fn make_diagnostic(
+    kind: DiagKind,
+    needle: &str,
+    subject: &str,
+    suggestion: Option<String>,
+    lit_span: (usize, usize),
+    full_value: &str,
+    content: &str,
+    severity: DiagnosticSeverity,
+) -> Diagnostic {
+    // Content lives between the quotes: span includes them, so the closing
+    // quote sits one byte before the literal's end (quotes are single-byte
+    // ASCII). `content_end` is the position just past the last content char.
+    let content_end = lit_span.1.saturating_sub(1);
+    // Narrow to the needle: for dotted relations it's the tail segment.
+    let needle_start = content_end.saturating_sub(needle.len());
+    let range = Range {
+        start: byte_offset_to_position(content, needle_start),
+        end: byte_offset_to_position(content, content_end),
+    };
+
+    let (code, kind_word, data_kind) = match kind {
+        DiagKind::Column => (CODE_UNKNOWN_COLUMN, "Column", "column"),
+        DiagKind::Relation => (CODE_UNKNOWN_RELATION, "Relation", "relation"),
+        DiagKind::Table => (CODE_UNKNOWN_TABLE, "Table", "table"),
+    };
+
+    let mut message = match kind {
+        DiagKind::Table => format!("{kind_word} \"{needle}\" does not exist."),
+        // subject = `table "users"` or the model FQCN.
+        _ => format!("{kind_word} \"{needle}\" does not exist on {subject}."),
+    };
+    if let Some(ref s) = suggestion {
+        message.push_str(&format!(" Did you mean \"{s}\"?"));
+    }
+
+    let data = serde_json::json!({
+        "kind": data_kind,
+        "name": needle,
+        "value": full_value,
+        "suggestion": suggestion,
+    });
+
+    Diagnostic {
+        range,
+        severity: Some(severity),
+        code: Some(NumberOrString::String(code.to_string())),
+        source: Some("laravel-lsp".to_string()),
+        message,
+        data: Some(data),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -735,3 +735,40 @@ async fn lints_each_method_call_independently() {
     let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
     assert_eq!(diags.len(), 2, "each bad call should flag: {diags:?}");
 }
+
+// ---- data payload contract (consumed by code_actions) ---------------------
+
+#[tokio::test]
+async fn column_diagnostic_data_carries_replacement_and_table() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::where('emaaail');\n";
+    let chains = chains_of(source);
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    let data = diags[0].data.as_ref().expect("data payload");
+    assert_eq!(data["kind"], "column");
+    assert_eq!(data["name"], "emaaail");
+    assert_eq!(data["replacement"], "email");
+    assert_eq!(data["table"], "users");
+}
+
+#[tokio::test]
+async fn dynamic_where_data_carries_studly_replacement_and_method_label() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::whereEmaaail('x');\n";
+    let chains = chains_of(source);
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    let data = diags[0].data.as_ref().expect("data payload");
+    assert_eq!(data["replacement"], "Email"); // studly, inserted into the method
+    assert_eq!(data["replacementLabel"], "whereEmail"); // shown in the action title
+    assert_eq!(data["table"], "users");
+}

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -311,18 +311,53 @@ async fn qualified_column_is_skipped() {
 }
 
 #[tokio::test]
-async fn select_alias_method_is_not_diagnosed() {
-    // `select` defines aliases; its args are deny-listed for diagnostics.
+async fn select_flags_bare_typo() {
+    // A bare typo in `select` IS diagnosed (AC names `select`). Alias/qualified
+    // forms are handled separately by the identifier guard (below).
     let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
-    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
     let source = "<?php\nuse App\\Models\\User;\nUser::select('emial')->get();\n";
     let chains = chains_of(source);
 
     let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
-    assert!(
-        diags.is_empty(),
-        "select args must not be diagnosed: {diags:?}"
-    );
+    assert_eq!(diags.len(), 1, "bare select typo should flag: {diags:?}");
+    assert!(diags[0].message.contains("emial"));
+}
+
+#[tokio::test]
+async fn select_alias_and_qualified_forms_are_skipped() {
+    // `'votes as score'` (alias) and `'users.id'` (qualified) are not simple
+    // identifiers → skipped, so un-denying `select` doesn't add false positives.
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let alias = "<?php\nuse App\\Models\\User;\nUser::select('votes as score')->get();\n";
+    let qualified = "<?php\nuse App\\Models\\User;\nUser::select('users.id')->get();\n";
+    for source in [alias, qualified] {
+        let chains = chains_of(source);
+        let diags =
+            chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+        assert!(
+            diags.is_empty(),
+            "alias/qualified select must not flag: {source:?} → {diags:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn having_is_not_diagnosed() {
+    // `having` filters on aggregate aliases — a bare identifier there is often
+    // not a real column, so it stays deny-listed.
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::having('total', '>', 5)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(diags.is_empty(), "having must not be diagnosed: {diags:?}");
 }
 
 #[tokio::test]

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -220,6 +220,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 class User extends Model {
     public function posts() { return $this->hasMany(Post::class); }
+    public function comments() { return $this->hasMany(Comment::class); }
     public function scopeWhereActive($query) { return $query->where('status', 'active'); }
 }
 "#;
@@ -806,4 +807,90 @@ async fn dynamic_where_data_carries_studly_replacement_and_method_label() {
     assert_eq!(data["replacement"], "Email"); // studly, inserted into the method
     assert_eq!(data["replacementLabel"], "whereEmail"); // shown in the action title
     assert_eq!(data["table"], "users");
+}
+
+// ---- array-form args ------------------------------------------------------
+
+#[tokio::test]
+async fn array_relation_flags_unknown_element() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    // posts + comments exist; postss is a typo.
+    let source =
+        "<?php\nuse App\\Models\\User;\nUser::with(['posts', 'postss', 'comments'])->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(diags.len(), 1, "only the typo should flag: {diags:?}");
+    assert!(diags[0].message.contains("postss"));
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_RELATION);
+}
+
+#[tokio::test]
+async fn keyed_relation_array_validates_the_key() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    // `with(['rel' => closure])` — the key is the relation name.
+    let source = "<?php\nuse App\\Models\\User;\nUser::with(['postss' => function ($q) { return $q; }])->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(diags.len(), 1, "keyed relation key should flag: {diags:?}");
+    assert!(diags[0].message.contains("postss"));
+}
+
+#[tokio::test]
+async fn array_select_flags_unknown_column() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::select(['id', 'emial', 'email'])->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "only the typo column should flag: {diags:?}"
+    );
+    assert!(diags[0].message.contains("emial"));
+}
+
+#[tokio::test]
+async fn array_select_skips_aliased_and_qualified_elements() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source =
+        "<?php\nuse App\\Models\\User;\nUser::select(['id', 'name as n', 'users.id'])->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "aliased/qualified elements must be skipped: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn where_array_values_are_not_flagged() {
+    // `where(['email' => 'somevalue'])` — the array holds a `col => value`
+    // pair. We don't descend `where`-family arrays, so neither the key nor the
+    // value is validated (the value side would otherwise false-positive).
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::where(['email' => 'somevalue'])->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "where-array values must not be flagged: {diags:?}"
+    );
 }

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -1,0 +1,737 @@
+//! Tests for query-chain diagnostics.
+//!
+//! Split in two: pure-helper unit tests (Levenshtein, identifier guard,
+//! suggestion picking, arg selection) that need no I/O, and fixture-backed
+//! end-to-end tests that parse real PHP, seed a schema, and assert which
+//! literals get flagged — with heavy emphasis on the false-positive guards.
+
+use super::{
+    best_suggestion, chain_diagnostics, common_prefix_len, dynamic_where_finder, first_string_arg,
+    is_simple_identifier, levenshtein, split_dynamic_segments,
+};
+use crate::database::{DatabaseSchema, DatabaseSchemaProvider};
+use crate::parser::parse_php;
+use crate::query_chain::{extract_chains, ArgKind, ChainArg, ChainEffect, ChainLink};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString};
+
+// ---- levenshtein ----------------------------------------------------------
+
+#[test]
+fn levenshtein_identical_is_zero() {
+    assert_eq!(levenshtein("email", "email"), 0);
+}
+
+#[test]
+fn levenshtein_canonical_typos() {
+    // The issue's worked examples.
+    assert_eq!(levenshtein("emial", "email"), 2); // transposition = 2 substitutions
+    assert_eq!(levenshtein("postss", "posts"), 1); // one deletion
+    assert_eq!(levenshtein("user", "users"), 1); // one insertion
+    assert_eq!(levenshtein("authorr", "author"), 1);
+}
+
+#[test]
+fn levenshtein_empty_operands() {
+    assert_eq!(levenshtein("", "abc"), 3);
+    assert_eq!(levenshtein("abc", ""), 3);
+    assert_eq!(levenshtein("", ""), 0);
+}
+
+// ---- is_simple_identifier -------------------------------------------------
+
+#[test]
+fn simple_identifier_accepts_bare_names() {
+    assert!(is_simple_identifier("email"));
+    assert!(is_simple_identifier("created_at"));
+    assert!(is_simple_identifier("_private"));
+    assert!(is_simple_identifier("col9"));
+}
+
+#[test]
+fn simple_identifier_rejects_qualified_and_expressions() {
+    assert!(!is_simple_identifier("users.id")); // qualified column
+    assert!(!is_simple_identifier("count(*)")); // aggregate expression
+    assert!(!is_simple_identifier("name as n")); // alias (space)
+    assert!(!is_simple_identifier("*")); // wildcard
+    assert!(!is_simple_identifier("")); // empty
+    assert!(!is_simple_identifier("9col")); // leading digit
+}
+
+// ---- best_suggestion ------------------------------------------------------
+
+#[test]
+fn suggestion_picks_closest_within_edit_distance_two() {
+    let candidates = vec!["email".to_string(), "name".to_string(), "id".to_string()];
+    assert_eq!(
+        best_suggestion("emial", &candidates),
+        Some("email".to_string())
+    );
+}
+
+#[test]
+fn suggestion_none_when_nothing_close() {
+    let candidates = vec!["email".to_string(), "name".to_string()];
+    assert_eq!(best_suggestion("xyzzyx", &candidates), None);
+}
+
+#[test]
+fn suggestion_falls_back_to_prefix_match() {
+    // "descr" is edit-distance 6 from "description" but shares a long prefix.
+    let candidates = vec!["description".to_string()];
+    assert_eq!(
+        best_suggestion("descr", &candidates),
+        Some("description".to_string())
+    );
+}
+
+#[test]
+fn suggestion_is_case_insensitive() {
+    let candidates = vec!["Email".to_string()];
+    assert_eq!(
+        best_suggestion("emial", &candidates),
+        Some("Email".to_string())
+    );
+}
+
+// ---- common_prefix_len ----------------------------------------------------
+
+#[test]
+fn common_prefix_len_counts_shared_run() {
+    assert_eq!(common_prefix_len("status", "stat"), 4);
+    assert_eq!(common_prefix_len("abc", "xyz"), 0);
+    assert_eq!(common_prefix_len("same", "same"), 4);
+}
+
+// ---- first_string_arg -----------------------------------------------------
+
+fn lit(value: &str, start: usize, end: usize) -> ChainArg {
+    ChainArg::StringLit {
+        value: value.to_string(),
+        quote: '\'',
+        span_byte_range: (start, end),
+    }
+}
+
+fn link(method: &str, arg: ArgKind, args: Vec<ChainArg>) -> ChainLink {
+    ChainLink {
+        method: method.to_string(),
+        arg,
+        effect: ChainEffect::None,
+        span_byte_range: (0, 0),
+        args,
+    }
+}
+
+#[test]
+fn first_string_arg_returns_leading_literal_only() {
+    // `where('email', '=', 'active')` — only the column position is returned.
+    let l = link(
+        "where",
+        ArgKind::Column,
+        vec![
+            lit("email", 10, 17),
+            lit("=", 19, 22),
+            lit("active", 24, 32),
+        ],
+    );
+    let got = first_string_arg(&l).expect("a leading string arg");
+    assert_eq!(got.0, "email");
+    assert_eq!(got.1, (10, 17));
+}
+
+#[test]
+fn first_string_arg_skips_array_and_nonstring_args() {
+    // First arg is an array → no top-level string literal → None.
+    let array_arg = ChainArg::Array {
+        elements: vec![lit("posts", 1, 8)],
+        span_byte_range: (0, 10),
+    };
+    let l = link("with", ArgKind::Relation, vec![array_arg]);
+    assert!(first_string_arg(&l).is_none());
+
+    // No args at all → None.
+    let empty = link("get", ArgKind::None, vec![]);
+    assert!(first_string_arg(&empty).is_none());
+}
+
+// ---- end-to-end fixtures --------------------------------------------------
+
+/// Parse PHP and extract its query chains.
+fn chains_of(source: &str) -> Vec<Arc<crate::query_chain::BuilderChain>> {
+    let tree = parse_php(source).expect("parse php");
+    extract_chains(&tree, source)
+        .into_iter()
+        .map(Arc::new)
+        .collect()
+}
+
+/// Tempdir with one or more model files under `app/Models/`. Returns the
+/// tempdir (hold it to keep the dir alive) and the project root.
+fn project_with_models(models: &[(&str, &str)]) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let models_dir = dir.path().join("app").join("Models");
+    std::fs::create_dir_all(&models_dir).expect("create models dir");
+    for (name, body) in models {
+        std::fs::write(models_dir.join(format!("{name}.php")), body).expect("write model");
+    }
+    let root = dir.path().to_path_buf();
+    (dir, root)
+}
+
+/// Seed a `DatabaseSchemaProvider` directly from fixtures — no live DB.
+async fn provider_with(
+    root: PathBuf,
+    tables: &[(&str, &[(&str, &str)])],
+) -> DatabaseSchemaProvider {
+    let mut columns = HashMap::new();
+    let mut columns_with_types = HashMap::new();
+    let mut table_names = Vec::new();
+    for (table, cols) in tables {
+        table_names.push(table.to_string());
+        columns.insert(
+            table.to_string(),
+            cols.iter().map(|(n, _)| n.to_string()).collect(),
+        );
+        columns_with_types.insert(
+            table.to_string(),
+            cols.iter()
+                .map(|(n, t)| (n.to_string(), t.to_string()))
+                .collect(),
+        );
+    }
+    let schema = DatabaseSchema {
+        tables: table_names,
+        columns,
+        columns_with_types,
+        cached_at: Instant::now(),
+    };
+    let provider = DatabaseSchemaProvider::new(root);
+    provider.set_test_schema(schema).await;
+    provider
+}
+
+const USER_MODEL: &str = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() { return $this->hasMany(Post::class); }
+    public function scopeWhereActive($query) { return $query->where('status', 'active'); }
+}
+"#;
+
+fn code_of(diag: &tower_lsp::lsp_types::Diagnostic) -> &str {
+    match &diag.code {
+        Some(NumberOrString::String(s)) => s.as_str(),
+        _ => "",
+    }
+}
+
+#[tokio::test]
+async fn flags_unknown_column_with_suggestion() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::where('emial', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+
+    assert_eq!(diags.len(), 1, "exactly one unknown-column diagnostic");
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_COLUMN);
+    assert!(diags[0].message.contains("emial"));
+    assert!(diags[0].message.contains("table \"users\""));
+    assert!(
+        diags[0].message.contains("Did you mean \"email\"?"),
+        "got: {}",
+        diags[0].message
+    );
+    assert_eq!(diags[0].severity, Some(DiagnosticSeverity::WARNING));
+}
+
+#[tokio::test]
+async fn valid_column_produces_no_diagnostic() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::where('email', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "valid column should not be flagged: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn operator_and_value_args_are_not_flagged() {
+    // `where('email', '=', 'emial')` — only the column arg is validated. The
+    // operator `=` and the VALUE `emial` must never be treated as columns.
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::where('email', '=', 'emial')->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "operator/value must not be flagged: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn qualified_column_is_skipped() {
+    // `where('users.id', 1)` is valid (qualified column for joins) — the
+    // identifier guard skips it rather than flagging "users.id" as missing.
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::where('users.id', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "qualified column must be skipped: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn select_alias_method_is_not_diagnosed() {
+    // `select` defines aliases; its args are deny-listed for diagnostics.
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::select('emial')->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "select args must not be diagnosed: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn no_diagnostic_when_schema_not_loaded() {
+    // Provider has no `users` table → legal set is empty → stay quiet, even
+    // though `emial` is "wrong". False positives are worse than nothing.
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[]).await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::where('emial', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(diags.is_empty(), "cold schema must not flag: {diags:?}");
+}
+
+#[tokio::test]
+async fn flags_unknown_relation() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::with('postss')->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(diags.len(), 1, "one unknown-relation diagnostic: {diags:?}");
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_RELATION);
+    assert!(diags[0].message.contains("postss"));
+    assert!(diags[0].message.contains("App\\Models\\User"));
+    assert!(diags[0].message.contains("Did you mean \"posts\"?"));
+}
+
+#[tokio::test]
+async fn valid_relation_produces_no_diagnostic() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::with('posts')->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "valid relation must not be flagged: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn flags_unknown_table_in_db_table() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nDB::table('user')->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(diags.len(), 1, "one unknown-table diagnostic: {diags:?}");
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_TABLE);
+    assert!(diags[0].message.contains("Table \"user\" does not exist"));
+    assert!(diags[0].message.contains("Did you mean \"users\"?"));
+}
+
+#[tokio::test]
+async fn valid_table_produces_no_diagnostic() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nDB::table('users')->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "valid table must not be flagged: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn diagnostic_range_targets_the_column_text_not_the_quotes() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    // Line 2 (0-based): `User::where('emial', 1)->get();`
+    let source = "<?php\nUse App\\Models\\User;\nUser::where('emial', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(diags.len(), 1);
+    let range = diags[0].range;
+    // Squiggle covers exactly `emial` (5 chars), inside the quotes.
+    assert_eq!(range.start.line, 2);
+    assert_eq!(range.end.line, 2);
+    let line = source.lines().nth(2).unwrap();
+    let start = range.start.character as usize;
+    let end = range.end.character as usize;
+    assert_eq!(&line[start..end], "emial");
+}
+
+#[tokio::test]
+async fn severity_is_propagated() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::where('emial', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::ERROR).await;
+    assert_eq!(diags.len(), 1);
+    assert_eq!(diags[0].severity, Some(DiagnosticSeverity::ERROR));
+}
+
+#[tokio::test]
+async fn flags_bare_single_arg_where_statement() {
+    // Repro of `User::where('emaaail');` — single string arg, no second arg,
+    // no terminator, bare expression statement. Must still flag.
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::where('emaaail');\n";
+    let chains = chains_of(source);
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "bare single-arg where should flag: {diags:?}"
+    );
+    assert!(diags[0].message.contains("emaaail"));
+}
+
+#[tokio::test]
+async fn flags_bare_where_without_use_import() {
+    // Same, but the file does NOT `use App\Models\User` — the receiver stays
+    // the bare name "User". This exercises whether class resolution finds the
+    // model from a bare classname (common when testing in scratch files).
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nUser::where('emaaail');\n";
+    let chains = chains_of(source);
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "bare classname should still resolve: {diags:?}"
+    );
+}
+
+// ---- dynamic where{Column} : pure helpers ---------------------------------
+
+#[test]
+fn dynamic_where_finder_recognizes_finders() {
+    assert_eq!(dynamic_where_finder("whereEmail"), Some(("where", "Email")));
+    assert_eq!(
+        dynamic_where_finder("orWhereName"),
+        Some(("orWhere", "Name"))
+    );
+    assert_eq!(
+        dynamic_where_finder("whereFirstNameAndEmail"),
+        Some(("where", "FirstNameAndEmail"))
+    );
+}
+
+#[test]
+fn dynamic_where_finder_rejects_real_methods_and_non_finders() {
+    assert_eq!(dynamic_where_finder("where"), None); // no studly suffix
+    assert_eq!(dynamic_where_finder("orWhere"), None);
+    assert_eq!(dynamic_where_finder("whereNull"), None); // real method
+    assert_eq!(dynamic_where_finder("whereHas"), None); // real method
+    assert_eq!(dynamic_where_finder("whereBetween"), None); // real method
+    assert_eq!(dynamic_where_finder("whereabouts"), None); // lowercase → not a finder
+    assert_eq!(dynamic_where_finder("orderBy"), None); // not where-prefixed
+}
+
+#[test]
+fn split_dynamic_segments_handles_and_or_and_traps() {
+    assert_eq!(split_dynamic_segments("Email"), vec!["Email"]);
+    assert_eq!(
+        split_dynamic_segments("FirstNameAndEmail"),
+        vec!["FirstName", "Email"]
+    );
+    assert_eq!(split_dynamic_segments("NameOrEmail"), vec!["Name", "Email"]);
+    // `Brand` has lowercase "and" — must NOT split.
+    assert_eq!(split_dynamic_segments("Brand"), vec!["Brand"]);
+    // `Order` starts with "Or" but it's the segment start — must NOT split.
+    assert_eq!(split_dynamic_segments("Order"), vec!["Order"]);
+}
+
+// ---- dynamic where{Column} : end-to-end -----------------------------------
+
+#[tokio::test]
+async fn flags_dynamic_where_unknown_column() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[(
+            "users",
+            &[("id", "int"), ("email", "string"), ("name", "string")],
+        )],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::whereEmaaail('x');\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(diags.len(), 1, "dynamic where typo should flag: {diags:?}");
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_COLUMN);
+    assert!(
+        diags[0].message.contains("emaaail"),
+        "msg: {}",
+        diags[0].message
+    );
+    assert!(
+        diags[0].message.contains("whereEmail"),
+        "should suggest corrected method name; msg: {}",
+        diags[0].message
+    );
+    // Squiggle targets the studly column portion of the method name.
+    let line = source.lines().nth(2).unwrap();
+    let r = diags[0].range;
+    let (s, e) = (r.start.character as usize, r.end.character as usize);
+    assert_eq!(&line[s..e], "Emaaail");
+}
+
+#[tokio::test]
+async fn valid_dynamic_where_no_diagnostic() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::whereEmail('x');\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "valid dynamic finder must not flag: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn dynamic_where_matching_scope_is_not_flagged() {
+    // `whereActive` would map to a column `active` (absent from the schema),
+    // but the model defines `scopeWhereActive` → callable `whereActive`. It's a
+    // scope call, not a dynamic column finder. Must stay quiet.
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])], // no `active` column
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::whereActive();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "scope call must not be flagged: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn dynamic_where_multi_column_flags_bad_segment() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[(
+            "users",
+            &[("id", "int"), ("email", "string"), ("name", "string")],
+        )],
+    )
+    .await;
+    // `whereEmailAndNaame` → segments email (ok), naame (typo of name).
+    let source = "<?php\nuse App\\Models\\User;\nUser::whereEmailAndNaame('a', 'b');\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(diags.len(), 1, "bad segment should flag: {diags:?}");
+    assert!(diags[0].message.contains("naame"));
+}
+
+#[tokio::test]
+async fn dynamic_where_on_base_builder_flags() {
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let source = "<?php\nDB::table('users')->whereEmaaail('x');\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "dynamic where on DB::table should flag: {diags:?}"
+    );
+    assert!(diags[0].message.contains("emaaail"));
+}
+
+#[tokio::test]
+async fn dynamic_where_on_collection_is_not_flagged() {
+    // `User::all()` flips to a hydrated Collection — which has no dynamic
+    // `where{Column}`. Don't flag `whereEmaaail` there (it'd be a plain
+    // undefined-method, not a column probe).
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::all()->whereEmaaail('x');\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "collection dynamic where must not flag: {diags:?}"
+    );
+}
+
+// ---- incomplete / mid-typing chains ---------------------------------------
+// The linter must not require a "finished" query (a terminator like ->get()).
+// Each method call in the chain should be linted on its own.
+
+async fn user_db_root() -> (TempDir, PathBuf, DatabaseSchemaProvider) {
+    let (dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[("users", &[("id", "int"), ("email", "string")])],
+    )
+    .await;
+    (dir, root, db)
+}
+
+#[tokio::test]
+async fn incomplete_chain_no_semicolon_still_flags() {
+    let (_d, root, db) = user_db_root().await;
+    let source = "<?php\nUser::where('emaaail')\n";
+    let chains = chains_of(source);
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(diags.len(), 1, "no-semicolon should still flag: {diags:?}");
+}
+
+#[tokio::test]
+async fn incomplete_chain_trailing_arrow_still_flags() {
+    let (_d, root, db) = user_db_root().await;
+    let source = "<?php\nUser::where('emaaail')->\n";
+    let chains = chains_of(source);
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "trailing-arrow should still flag: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn incomplete_chain_partial_next_method_still_flags() {
+    // `->wher` is a half-typed next call — the completed `where('emaaail')`
+    // before it must still be linted.
+    let (_d, root, db) = user_db_root().await;
+    let source = "<?php\nUser::where('emaaail')->wher\n";
+    let chains = chains_of(source);
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "partial next method should still flag the where: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn unterminated_chain_assigned_still_flags() {
+    // No terminator (`->get()`), just assigned — must lint the `where`.
+    let (_d, root, db) = user_db_root().await;
+    let source = "<?php\n$q = User::where('emaaail');\n";
+    let chains = chains_of(source);
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "assigned chain should still flag: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn dynamic_where_range_is_correct_deep_in_file() {
+    // Mirror a real controller file: the call is indented, several lines in.
+    // The squiggle must cover exactly the studly column portion of the method.
+    let (_d, root, db) = user_db_root().await;
+    let source = "<?php\n\nnamespace App\\Http\\Controllers;\n\nuse App\\Models\\User;\n\nclass C {\n    public function i() {\n        User::whereEmaaaail('1');\n    }\n}\n";
+    let chains = chains_of(source);
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(diags.len(), 1, "should flag once: {diags:?}");
+    let r = diags[0].range;
+    let line = source.lines().nth(r.start.line as usize).unwrap();
+    let (s, e) = (r.start.character as usize, r.end.character as usize);
+    assert_eq!(
+        &line[s..e],
+        "Emaaaail",
+        "squiggle must cover the studly column"
+    );
+}
+
+#[tokio::test]
+async fn lints_each_method_call_independently() {
+    // Two bad columns in one unterminated chain → two diagnostics. Proves we
+    // lint per method call, not once per "finished" query.
+    let (_d, root, db) = user_db_root().await;
+    let source = "<?php\nUser::where('emaaail')->orderBy('naaame')\n";
+    let chains = chains_of(source);
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(diags.len(), 2, "each bad call should flag: {diags:?}");
+}


### PR DESCRIPTION
Implements #25 — diagnostics, code actions, and goto-definition for query-chain columns / relations / tables — **plus** the cross-file model-class rename that #25 originally split out and that's been deferred across the last two PRs. Built incrementally, each part manually verified in Zed (incl. a 34k-file project).

## Phase 1 — Diagnostics
Warns on unknown identifiers in Eloquent & `DB::table()` chains with a Levenshtein "did you mean". Covers `where`/`orderBy`/`select`/`pluck`/…, relations (`with`/`whereHas`/`load`/…), tables, dynamic `where{Column}` finders (`whereEmial` → `whereEmail`, scope-safe), and **array-form args** (`with(['posts','postss'])`, `select(['id','emial'])`, keyed `with(['rel' => $closure])`). Under-warns by design: silent on cold/absent schema, unresolved receivers, qualified/aliased/expression literals, `having`, scopes, collections, and `where`-array values.

## Phase 2 — Code actions
- **Rename to `<suggestion>`** quick-fix on each diagnostic.
- **Create migration to add column** — `CreateFile` from the project's `migration.update.stub` (custom → vendor → fallback, like `make:migration`); honors custom stub formats.

## Phase 3 — Goto-definition
Cmd-click a chain literal → its source: **column** → migration definition line, **relation** → relation method on the model, **table** → create-table migration. Backed by a tree-sitter `migration_index` (eager, file-watcher-refreshed). DB-independent.

## Phase 4 — Model-class rename (completes #25's deferred cross-file refactoring)
F2 / Rename Symbol on a model class → rewrites the class **everywhere** (declaration, `use` imports, `User::`, `new`, type hints, `::class`, `extends`/`implements`, `instanceof`, `@param`/`@return`/`@var` docblocks) and renames the file. New `class_rename` module resolves each token per-file via use-aliases + namespace; aliases are preserved, members coincidentally named like the class are untouched. Same-namespace rename (simple identifier). Scales to large projects via single-parse + a substring pre-filter (only parse files that mention the name) and shows a status-bar spinner during the scan.

## Acceptance criteria
**Diagnostics:** [x] column · [x] relation · [x] table · [x] did-you-mean · [x] `diagnostics.severity` setting · [x] no false positives when unresolved/cold · [x] no raw-arg diagnostics
**Code actions:** [x] rename-to-suggestion · [x] create-migration (file, stub-resolved)
**Goto-definition:** [x] column→migration · [x] relation→method · [x] table→migration · [x] no-op fallback
**Cross-file rename** (deferred by the original issue, now included): [x] rename a model class + all references + the file

## Out of scope
Literal-value validation; namespace *moves* via rename (simple-name rename only — a move returns a status message, not a half-move).

## Known limitations (deliberate)
- Goto/diagnostics resolve in `.php` (Blade-embedded chains use the cached path).
- Migration goto covers Blueprint column-type methods (allowlist); exotic types no-op.
- Rename scan is ~5s on very large projects (dominated by reading thousands of files); a spinner covers it. Parallel reads are a possible follow-up.

## Test plan
`cargo test` — **1049 passing**, `cargo clippy` + `cargo fmt --check` clean. Coverage: false-positive guards, dynamic-where + scope guard, array args, code-action rename + stub migration, migration-index exactness (`email` vs `email_verified_at`), goto target resolution, and the rename detector (every reference kind, alias safety, member-name precision, docblocks, file enumeration).

Fixes #25.