### PR TITLE
feat: joined-table column resolution (joins + from/fromSub) (#24)

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13074,13 +13074,15 @@ return [
         }
     }
 
-    /// Column literal → the migration line that defines it, resolved across
+    /// Column literal → the migration line(s) that define it, resolved across
     /// every table the chain can reference (root + joined tables, issue #24).
     ///
     /// - A **qualified** literal (`orders.status`, `o.status`) resolves its
-    ///   qualifier (alias or name) to a real table.
-    /// - A **bare** literal (`status`) is probed against each accessible table
-    ///   in order (root first); the first table that defines it wins.
+    ///   qualifier (alias or name) to a real table — a single target.
+    /// - A **bare** literal (`status`) is probed against every accessible
+    ///   table. If exactly one defines it, jump there; if several do (an
+    ///   ambiguous column), return them ALL so the editor lets the user pick
+    ///   (the ambiguity diagnostic flags it separately).
     async fn goto_column_definition(
         &self,
         ctx: &laravel_lsp::query_chain::ChainContext,
@@ -13094,12 +13096,17 @@ return [
 
         let guard = self.migration_index.read().await;
         let index = guard.as_ref()?;
-        let site = candidates
+        let links: Vec<LocationLink> = candidates
             .iter()
-            .find_map(|(table, column)| index.column(table, column))?
-            .clone();
+            .filter_map(|(table, column)| index.column(table, column))
+            .filter_map(Self::location_link_from_migration_site)
+            .collect();
         drop(guard);
-        Self::location_from_migration_site(&site)
+        if links.is_empty() {
+            None
+        } else {
+            Some(GotoDefinitionResponse::Link(links))
+        }
     }
 
     /// Build the tables a chain can reference columns from, for goto
@@ -13217,6 +13224,16 @@ return [
     fn location_from_migration_site(
         site: &laravel_lsp::migration_index::MigrationSite,
     ) -> Option<GotoDefinitionResponse> {
+        Self::location_link_from_migration_site(site)
+            .map(|link| GotoDefinitionResponse::Link(vec![link]))
+    }
+
+    /// Build a single `LocationLink` for a migration site. Shared by
+    /// single-target goto and the multi-target ambiguous-column case (issue
+    /// #24), which returns several links so the editor lets the user pick.
+    fn location_link_from_migration_site(
+        site: &laravel_lsp::migration_index::MigrationSite,
+    ) -> Option<LocationLink> {
         let uri = Url::from_file_path(&site.file).ok()?;
         let range = Range {
             start: Position {
@@ -13236,12 +13253,12 @@ return [
             start: range.start,
             end: range.start,
         };
-        Some(GotoDefinitionResponse::Link(vec![LocationLink {
+        Some(LocationLink {
             origin_selection_range: None,
             target_uri: uri,
             target_range: range,
             target_selection_range: caret,
-        }]))
+        })
     }
 
     /// prepare_rename fallback: if the cursor is on a PHP class name that
@@ -18033,6 +18050,11 @@ impl LanguageServer for LaravelLanguageServer {
                 {
                     actions.push(action);
                 }
+                // Ambiguous-column diagnostics offer one "Qualify as `t.col`"
+                // fix per candidate table (issue #24).
+                actions.extend(
+                    laravel_lsp::query_chain::code_actions::qualify_actions(diagnostic, uri),
+                );
                 if let Some(root) = root {
                     let timestamp =
                         laravel_lsp::query_chain::code_actions::format_migration_timestamp(

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13059,35 +13059,67 @@ return [
         }
     }
 
-    /// Column literal → the migration line that defines it. A qualified literal
-    /// (`users.id`) carries its own table; otherwise the chain's effective table
-    /// is used (resolved from the model for Eloquent chains).
+    /// Column literal → the migration line that defines it, resolved across
+    /// every table the chain can reference (root + joined tables, issue #24).
+    ///
+    /// - A **qualified** literal (`orders.status`, `o.status`) resolves its
+    ///   qualifier (alias or name) to a real table.
+    /// - A **bare** literal (`status`) is probed against each accessible table
+    ///   in order (root first); the first table that defines it wins.
     async fn goto_column_definition(
         &self,
         ctx: &laravel_lsp::query_chain::ChainContext,
         value: &str,
         root: &Path,
     ) -> Option<GotoDefinitionResponse> {
-        use laravel_lsp::query_chain::{eloquent_completion, BuilderMode};
+        use laravel_lsp::query_chain::eloquent_completion;
 
-        let (table, column) = match value.rsplit_once('.') {
-            Some((t, c)) => (t.to_string(), c.to_string()),
-            None => {
-                let table = match ctx.mode {
-                    BuilderMode::BaseBuilder => ctx.effective_table.clone()?,
-                    _ => {
-                        let model = ctx.effective_model.as_deref()?;
-                        eloquent_completion::resolve_table_for_model(model, root).await?
-                    }
-                };
-                (table, value.to_string())
-            }
-        };
+        let accessible = Self::accessible_tables_for_goto(ctx, root).await;
+        let candidates = eloquent_completion::goto_column_candidates(&accessible, value);
 
         let guard = self.migration_index.read().await;
-        let site = guard.as_ref()?.column(&table, &column)?.clone();
+        let index = guard.as_ref()?;
+        let site = candidates
+            .iter()
+            .find_map(|(table, column)| index.column(table, column))?
+            .clone();
         drop(guard);
         Self::location_from_migration_site(&site)
+    }
+
+    /// Build the tables a chain can reference columns from, for goto
+    /// resolution: the root (honoring a `from()` override, or the model's
+    /// table for Eloquent chains) plus any joined tables. Mirrors the
+    /// accessible-table model `eloquent_completion` uses for completion.
+    async fn accessible_tables_for_goto(
+        ctx: &laravel_lsp::query_chain::ChainContext,
+        root: &Path,
+    ) -> Vec<laravel_lsp::query_chain::AccessibleTable> {
+        use laravel_lsp::query_chain::{
+            eloquent_completion, AccessibleTable, BuilderMode, FromClause,
+        };
+
+        let mut tables = Vec::new();
+        match &ctx.from_clause {
+            FromClause::Replace(table) => tables.push(table.clone()),
+            FromClause::Opaque => {}
+            FromClause::Inherit => {
+                let root_table = match ctx.mode {
+                    BuilderMode::BaseBuilder => ctx.effective_table.clone(),
+                    _ => match ctx.effective_model.as_deref() {
+                        Some(model) => {
+                            eloquent_completion::resolve_table_for_model(model, root).await
+                        }
+                        None => None,
+                    },
+                };
+                if let Some(table) = root_table {
+                    tables.push(AccessibleTable::bare(table));
+                }
+            }
+        }
+        tables.extend(ctx.joined_tables.iter().cloned());
+        tables
     }
 
     /// Table literal (`DB::table('users')`) → the `Schema::create('users'` line.

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18052,9 +18052,9 @@ impl LanguageServer for LaravelLanguageServer {
                 }
                 // Ambiguous-column diagnostics offer one "Qualify as `t.col`"
                 // fix per candidate table (issue #24).
-                actions.extend(
-                    laravel_lsp::query_chain::code_actions::qualify_actions(diagnostic, uri),
-                );
+                actions.extend(laravel_lsp::query_chain::code_actions::qualify_actions(
+                    diagnostic, uri,
+                ));
                 if let Some(root) = root {
                     let timestamp =
                         laravel_lsp::query_chain::code_actions::format_migration_timestamp(

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3135,6 +3135,17 @@ impl LaravelLanguageServer {
             _ => ctx,
         };
 
+        // Join-closure parent table (issue #24): inside `User::query()->join(
+        // 'orders', fn ($join) => …)`, fold the parent model's table into the
+        // accessible set so the parent side of the ON clause completes. No-op
+        // unless `join_parent_model` is set.
+        let mut ctx = ctx;
+        if ctx.join_parent_model.is_some() {
+            if let Some(root) = self.initialized_root.read().await.clone() {
+                eloquent_completion::enrich_join_parent_tables(&mut ctx, &root).await;
+            }
+        }
+
         let items = match (ctx.mode, ctx.expecting) {
             (BuilderMode::BaseBuilder, ArgKind::Column) => {
                 eloquent_completion::columns_raw(&ctx, db, wrap_with_quote).await
@@ -13044,6 +13055,10 @@ return [
                     eloquent_completion::resolve_table_for_model(&model, &root).await;
             }
         }
+        // Join-closure parent table (issue #24): fold an Eloquent parent's
+        // table into the accessible set so goto on the parent side of an ON
+        // clause resolves.
+        eloquent_completion::enrich_join_parent_tables(&mut ctx, &root).await;
 
         match ctx.expecting {
             ArgKind::Column => {

--- a/laravel-lsp/src/query_chain/chain.rs
+++ b/laravel-lsp/src/query_chain/chain.rs
@@ -52,6 +52,13 @@ pub enum ClosureScopeKind {
     /// `where(closure)` / `when($cond, closure)` / `having(closure)` /
     /// `tap(closure)` etc. — bind to the same model as the outer chain.
     SameModel,
+    /// `join('orders', fn ($join) => …)` — `$join` is a `JoinClause` builder
+    /// rooted at the joined table (issue #24). `table_ref` is the raw
+    /// first-arg string (`"orders"`, `"orders as o"`, `"mydb.orders"`); the
+    /// cursor resolver parses it to an [`AccessibleTable`] and models it as a
+    /// `from()` override so column completion inside the closure resolves
+    /// against that table (alias included).
+    JoinTable { table_ref: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -281,10 +288,22 @@ pub struct ChainContext {
     /// query regardless of textual order, so a join anywhere in the chain
     /// makes its table referenceable everywhere. Columns from these are
     /// offered as `qualifier.column`.
+    ///
+    /// Inside a join closure (`join('orders', fn ($join) => …)`) this also
+    /// carries the *parent* query's accessible tables that resolve
+    /// synchronously (a `DB::table()` / `from()` root and the parent's other
+    /// joins), so both sides of an ON clause complete.
     pub joined_tables: Vec<AccessibleTable>,
     /// Whether a `from*()` call replaced or obscured the chain's root table.
     /// `Inherit` for the common case (no `from()` override).
     pub from_clause: FromClause,
+    /// Inside a join closure whose *parent* query is rooted at an Eloquent
+    /// model (`User::query()->join('orders', fn ($join) => …)`), the parent
+    /// model's FQCN. Its table needs async model→table resolution, so the
+    /// cursor resolver can't add it to `joined_tables` synchronously —
+    /// consumers resolve it and fold it into the accessible set (mirrors how
+    /// `closure_relation_hop` defers a relation hop). `None` otherwise.
+    pub join_parent_model: Option<String>,
     /// Set when the chain is inside a recognized relation closure
     /// (`whereHas('posts', fn ($q) => $q->where('|'))` or
     /// `with(['posts' => fn ($q) => $q->where('|')])`). When `Some(rel)`,

--- a/laravel-lsp/src/query_chain/chain.rs
+++ b/laravel-lsp/src/query_chain/chain.rs
@@ -98,6 +98,14 @@ pub struct ChainLink {
     pub effect: ChainEffect,
     pub span_byte_range: (usize, usize),
     pub args: Vec<ChainArg>,
+    /// For subquery methods (`fromSub`/`joinSub`/lateral, issue #24): the
+    /// column names the subquery's SELECT list exposes, extracted from the
+    /// first argument's AST at parse time (the cursor resolver only sees
+    /// [`ChainArg`]s, which don't carry the nested selects). `None` for every
+    /// other method; `Some(empty)` when the subquery has no resolvable SELECT
+    /// (e.g. `select('*')`), meaning the virtual table is opaque.
+    #[serde(default)]
+    pub subquery_columns: Option<Vec<String>>,
 }
 
 /// What kind of argument the cursor's link expects. Used at the cursor only —
@@ -186,26 +194,45 @@ pub struct ClosureParam {
 pub struct AccessibleTable {
     /// Real table name as it appears in the database. May be schema-qualified
     /// (`mydb.orders`) for cross-database joins; column lookup passes it
-    /// through to the schema provider, which resolves it best-effort.
+    /// through to the schema provider, which resolves it best-effort. For a
+    /// virtual (subquery) table this holds the alias — there's no real table,
+    /// so [`virtual_columns`](Self::virtual_columns) supplies the columns.
     pub table: String,
     /// Alias the user references columns by — `u` from `users as u`, or a
     /// subquery alias. `None` for a plain `join('orders', …)`, where the
     /// qualifier IS the table name.
     pub alias: Option<String>,
+    /// For virtual tables synthesized from a subquery (`fromSub`/`joinSub`,
+    /// issue #24): the columns the subquery's SELECT list exposes. `Some` →
+    /// completion/validation use these instead of a DB schema lookup. `None`
+    /// for ordinary tables backed by the database.
+    pub virtual_columns: Option<Vec<String>>,
 }
 
 impl AccessibleTable {
-    /// Construct an unaliased accessible table from a bare name.
+    /// Construct an unaliased, database-backed accessible table from a bare
+    /// name.
     pub fn bare(table: impl Into<String>) -> Self {
         Self {
             table: table.into(),
             alias: None,
+            virtual_columns: None,
+        }
+    }
+
+    /// Construct a virtual (subquery) table: the `alias` is both the qualifier
+    /// and the stored name, and `columns` are the subquery's SELECT list.
+    pub fn virtual_table(alias: impl Into<String>, columns: Vec<String>) -> Self {
+        Self {
+            table: alias.into(),
+            alias: None,
+            virtual_columns: Some(columns),
         }
     }
 
     /// The qualifier the user types before a column: the alias if present,
     /// else the table name. For a schema-qualified table with no alias this
-    /// is the full `mydb.orders`.
+    /// is the full `mydb.orders`; for a virtual table it's the subquery alias.
     pub fn qualifier(&self) -> &str {
         self.alias.as_deref().unwrap_or(&self.table)
     }
@@ -229,11 +256,13 @@ pub fn parse_table_ref(raw: &str) -> AccessibleTable {
         [table, kw, alias] if kw.eq_ignore_ascii_case("as") => AccessibleTable {
             table: (*table).to_string(),
             alias: Some((*alias).to_string()),
+            virtual_columns: None,
         },
         // `table alias` (implicit alias)
         [table, alias] => AccessibleTable {
             table: (*table).to_string(),
             alias: Some((*alias).to_string()),
+            virtual_columns: None,
         },
         // `table` (no alias) — also the fallback for any unexpected shape,
         // where keeping the whole trimmed string as the table name is the

--- a/laravel-lsp/src/query_chain/chain.rs
+++ b/laravel-lsp/src/query_chain/chain.rs
@@ -170,6 +170,88 @@ pub struct ClosureParam {
     pub php_type: Option<String>,
 }
 
+/// A table reachable for column references within a chain — either the root
+/// (the receiver, or a `from()` replacement) or one made available by a
+/// join. Carries the real schema name (used to fetch columns) separately
+/// from the alias the user types, so `join('users as u', …)` offers `u.*`
+/// while looking columns up under `users`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccessibleTable {
+    /// Real table name as it appears in the database. May be schema-qualified
+    /// (`mydb.orders`) for cross-database joins; column lookup passes it
+    /// through to the schema provider, which resolves it best-effort.
+    pub table: String,
+    /// Alias the user references columns by — `u` from `users as u`, or a
+    /// subquery alias. `None` for a plain `join('orders', …)`, where the
+    /// qualifier IS the table name.
+    pub alias: Option<String>,
+}
+
+impl AccessibleTable {
+    /// Construct an unaliased accessible table from a bare name.
+    pub fn bare(table: impl Into<String>) -> Self {
+        Self {
+            table: table.into(),
+            alias: None,
+        }
+    }
+
+    /// The qualifier the user types before a column: the alias if present,
+    /// else the table name. For a schema-qualified table with no alias this
+    /// is the full `mydb.orders`.
+    pub fn qualifier(&self) -> &str {
+        self.alias.as_deref().unwrap_or(&self.table)
+    }
+}
+
+/// Parse a Laravel table reference string into an [`AccessibleTable`].
+///
+/// Handles the three shapes that appear in `join()` / `from()` arguments:
+/// - `'orders'` → table `orders`, no alias
+/// - `'mydb.orders'` → schema-qualified table `mydb.orders`, no alias
+/// - `'users as u'` / `'users AS u'` → table `users`, alias `u`
+/// - `'users u'` → implicit alias (MySQL-style), table `users`, alias `u`
+///
+/// The `as` keyword is matched case-insensitively. The table portion is kept
+/// verbatim (dots and all) so schema qualifiers survive to the column lookup.
+pub fn parse_table_ref(raw: &str) -> AccessibleTable {
+    let trimmed = raw.trim();
+    let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+    match tokens.as_slice() {
+        // `table as alias`
+        [table, kw, alias] if kw.eq_ignore_ascii_case("as") => AccessibleTable {
+            table: (*table).to_string(),
+            alias: Some((*alias).to_string()),
+        },
+        // `table alias` (implicit alias)
+        [table, alias] => AccessibleTable {
+            table: (*table).to_string(),
+            alias: Some((*alias).to_string()),
+        },
+        // `table` (no alias) — also the fallback for any unexpected shape,
+        // where keeping the whole trimmed string as the table name is the
+        // least-surprising behavior.
+        _ => AccessibleTable::bare(trimmed.to_string()),
+    }
+}
+
+/// How the chain's root (FROM) table is determined, after accounting for any
+/// receiver-replacing `from*()` call in the chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FromClause {
+    /// No `from*()` override — the root is the receiver's table (`DB::table`)
+    /// or the model's table (Eloquent).
+    Inherit,
+    /// `from('admins')` / `from('admins as a')` replaced the root with a
+    /// concrete table. Columns come from the schema only (no model casts —
+    /// the model→table mapping no longer applies once `from()` redirects it).
+    Replace(AccessibleTable),
+    /// `fromRaw(...)` (and, until Phase 4, `fromSub(...)`) made the root an
+    /// opaque expression — no bare root columns can be offered, though any
+    /// joined tables remain valid.
+    Opaque,
+}
+
 /// Completion-time context produced fresh from a `BuilderChain` plus a cursor
 /// position. Not stored — recomputed on each completion request.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -186,10 +268,23 @@ pub struct ChainContext {
     /// completion; `ClosureCarrier` is handled by closure-scope descent;
     /// `None` means no completion.
     pub expecting: ArgKind,
-    /// For dotted relation paths like `with('posts.author.|')`, the prefix the
-    /// user has already typed after the last dot. Completion items filter
-    /// against this and `insert_text` is just the current segment.
+    /// Everything the user has typed before the last dot of the literal under
+    /// the cursor. Two meanings depending on `expecting`:
+    /// - **Relation** (`with('posts.author.|')`) — the relation segments to
+    ///   walk; the final model's relations are then offered.
+    /// - **Column** (`where('orders.|')`) — the table qualifier (alias or
+    ///   table name) the column belongs to; completion narrows to that one
+    ///   table's columns.
     pub dotted_prefix: Option<String>,
+    /// Tables made accessible by `join()`-family calls, in source order.
+    /// Global to the chain — Laravel compiles the whole chain into one SQL
+    /// query regardless of textual order, so a join anywhere in the chain
+    /// makes its table referenceable everywhere. Columns from these are
+    /// offered as `qualifier.column`.
+    pub joined_tables: Vec<AccessibleTable>,
+    /// Whether a `from*()` call replaced or obscured the chain's root table.
+    /// `Inherit` for the common case (no `from()` override).
+    pub from_clause: FromClause,
     /// Set when the chain is inside a recognized relation closure
     /// (`whereHas('posts', fn ($q) => $q->where('|'))` or
     /// `with(['posts' => fn ($q) => $q->where('|')])`). When `Some(rel)`,
@@ -215,3 +310,6 @@ pub enum BuilderMode {
     /// via `load()`.
     EloquentCollection,
 }
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/query_chain/chain/tests.rs
+++ b/laravel-lsp/src/query_chain/chain/tests.rs
@@ -1,0 +1,69 @@
+use super::*;
+
+// ---- parse_table_ref: Laravel `join`/`from` table reference strings ----
+
+#[test]
+fn parse_plain_table() {
+    let at = parse_table_ref("orders");
+    assert_eq!(at.table, "orders");
+    assert_eq!(at.alias, None);
+    // With no alias the qualifier IS the table name.
+    assert_eq!(at.qualifier(), "orders");
+}
+
+#[test]
+fn parse_aliased_table_lowercase_as() {
+    let at = parse_table_ref("users as u");
+    assert_eq!(at.table, "users");
+    assert_eq!(at.alias.as_deref(), Some("u"));
+    assert_eq!(at.qualifier(), "u");
+}
+
+#[test]
+fn parse_aliased_table_uppercase_as() {
+    // The `as` keyword is matched case-insensitively.
+    let at = parse_table_ref("users AS u");
+    assert_eq!(at.table, "users");
+    assert_eq!(at.alias.as_deref(), Some("u"));
+}
+
+#[test]
+fn parse_implicit_alias() {
+    // MySQL-style implicit alias (`table alias`, no `as`).
+    let at = parse_table_ref("orders o");
+    assert_eq!(at.table, "orders");
+    assert_eq!(at.alias.as_deref(), Some("o"));
+}
+
+#[test]
+fn parse_schema_qualified_table() {
+    // Cross-database / schema-qualified name: the dotted table survives whole
+    // so column lookup can pass it through; the qualifier is the full name.
+    let at = parse_table_ref("mydb.orders");
+    assert_eq!(at.table, "mydb.orders");
+    assert_eq!(at.alias, None);
+    assert_eq!(at.qualifier(), "mydb.orders");
+}
+
+#[test]
+fn parse_schema_qualified_with_alias() {
+    let at = parse_table_ref("mydb.orders as o");
+    assert_eq!(at.table, "mydb.orders");
+    assert_eq!(at.alias.as_deref(), Some("o"));
+    assert_eq!(at.qualifier(), "o");
+}
+
+#[test]
+fn parse_trims_and_collapses_whitespace() {
+    let at = parse_table_ref("  users   as   u  ");
+    assert_eq!(at.table, "users");
+    assert_eq!(at.alias.as_deref(), Some("u"));
+}
+
+#[test]
+fn bare_constructor_has_no_alias() {
+    let at = AccessibleTable::bare("posts");
+    assert_eq!(at.table, "posts");
+    assert_eq!(at.alias, None);
+    assert_eq!(at.qualifier(), "posts");
+}

--- a/laravel-lsp/src/query_chain/code_actions.rs
+++ b/laravel-lsp/src/query_chain/code_actions.rs
@@ -34,6 +34,9 @@ struct ChainDiagData {
     replacement: Option<String>,
     replacement_label: Option<String>,
     table: Option<String>,
+    /// For an ambiguous-column diagnostic: the candidate tables (qualifiers)
+    /// the column could belong to, driving one "Qualify as …" fix each.
+    tables: Vec<String>,
 }
 
 /// Pull the `data` payload off a chain diagnostic. Returns `None` for any
@@ -44,13 +47,61 @@ fn parse(diagnostic: &Diagnostic) -> Option<ChainDiagData> {
     }
     let data = diagnostic.data.as_ref()?;
     let str_field = |key: &str| data.get(key).and_then(|v| v.as_str()).map(str::to_string);
+    let tables = data
+        .get("tables")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
     Some(ChainDiagData {
         kind: str_field("kind")?,
         name: str_field("name")?,
         replacement: str_field("replacement"),
         replacement_label: str_field("replacementLabel"),
         table: str_field("table"),
+        tables,
     })
+}
+
+/// Build "Qualify as `<table>.<col>`" quick-fixes for an ambiguous-column
+/// diagnostic (issue #24) — one per candidate table. Each replaces the bare
+/// column (the diagnostic's range) with a qualified reference, resolving the
+/// ambiguity. Empty for any non-ambiguity diagnostic.
+pub fn qualify_actions(diagnostic: &Diagnostic, doc_uri: &Url) -> Vec<CodeActionOrCommand> {
+    let Some(data) = parse(diagnostic) else {
+        return Vec::new();
+    };
+    if data.kind != "ambiguous-column" {
+        return Vec::new();
+    }
+    data.tables
+        .iter()
+        .map(|table| {
+            let qualified = format!("{table}.{}", data.name);
+            let mut changes = HashMap::new();
+            changes.insert(
+                doc_uri.clone(),
+                vec![TextEdit {
+                    range: diagnostic.range,
+                    new_text: qualified.clone(),
+                }],
+            );
+            CodeActionOrCommand::CodeAction(CodeAction {
+                title: format!("Qualify as `{qualified}`"),
+                kind: Some(CodeActionKind::QUICKFIX),
+                diagnostics: Some(vec![diagnostic.clone()]),
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    document_changes: None,
+                    change_annotations: None,
+                }),
+                ..Default::default()
+            })
+        })
+        .collect()
 }
 
 /// Build the "Rename to `<suggestion>`" quick-fix for a chain diagnostic, if it

--- a/laravel-lsp/src/query_chain/code_actions/tests.rs
+++ b/laravel-lsp/src/query_chain/code_actions/tests.rs
@@ -301,3 +301,49 @@ fn migration_action_none_without_table() {
     );
     assert!(migration_action(&d, Path::new("/srv/app"), "2026_05_29_120000").is_none());
 }
+
+// ---- qualify_actions (ambiguous columns, issue #24) ------------------------
+
+#[test]
+fn qualify_actions_one_per_candidate_table() {
+    let d = diag(
+        "laravel-lsp.ambiguous-column",
+        json!({"kind": "ambiguous-column", "name": "id", "tables": ["users", "orders"]}),
+    );
+    let actions: Vec<_> = qualify_actions(&d, &uri())
+        .into_iter()
+        .map(into_action)
+        .collect();
+    assert_eq!(actions.len(), 2);
+    assert_eq!(actions[0].title, "Qualify as `users.id`");
+    assert_eq!(actions[1].title, "Qualify as `orders.id`");
+    // Each replaces the diagnostic range with the qualified column.
+    let edits = actions[0].edit.as_ref().unwrap().changes.as_ref().unwrap();
+    assert_eq!(edits[&uri()][0].new_text, "users.id");
+    assert_eq!(edits[&uri()][0].range, d.range);
+    assert_eq!(actions[0].kind, Some(CodeActionKind::QUICKFIX));
+}
+
+#[test]
+fn qualify_actions_uses_alias_qualifier() {
+    // For an aliased join the candidate is the alias the user must type.
+    let d = diag(
+        "laravel-lsp.ambiguous-column",
+        json!({"kind": "ambiguous-column", "name": "id", "tables": ["u", "o"]}),
+    );
+    let actions: Vec<_> = qualify_actions(&d, &uri())
+        .into_iter()
+        .map(into_action)
+        .collect();
+    assert_eq!(actions[0].title, "Qualify as `u.id`");
+    assert_eq!(actions[1].title, "Qualify as `o.id`");
+}
+
+#[test]
+fn qualify_actions_empty_for_non_ambiguity_diagnostic() {
+    let d = diag(
+        "laravel-lsp.unknown-column",
+        json!({"kind": "column", "name": "emial", "replacement": "email", "table": "users"}),
+    );
+    assert!(qualify_actions(&d, &uri()).is_empty());
+}

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -10,7 +10,9 @@
 //! later phases.
 
 use super::chain::*;
-use super::methods::{is_from_opaque, is_from_replace, is_table_join};
+use super::methods::{
+    is_from_opaque, is_from_replace, is_from_sub, is_subquery_join, is_table_join,
+};
 use std::sync::Arc;
 use tower_lsp::lsp_types::Position;
 
@@ -696,6 +698,25 @@ fn scan_accessible_tables(chain: &BuilderChain) -> (Vec<AccessibleTable>, FromCl
             }
         } else if is_from_opaque(method) {
             from_clause = FromClause::Opaque;
+        } else if is_from_sub(method) {
+            // `fromSub($query, 'alias')` — virtual root from the subquery's
+            // SELECT list. Unknown columns (no usable SELECT) → opaque root.
+            from_clause = match (first_string_arg_value(link), &link.subquery_columns) {
+                (Some(alias), Some(cols)) if !cols.is_empty() => {
+                    FromClause::Replace(AccessibleTable::virtual_table(alias, cols.clone()))
+                }
+                _ => FromClause::Opaque,
+            };
+        } else if is_subquery_join(method) {
+            // `joinSub($query, 'alias', …)` — virtual joined table. Skip when
+            // the subquery's columns are unknown (offer nothing for it).
+            if let (Some(alias), Some(cols)) =
+                (first_string_arg_value(link), &link.subquery_columns)
+            {
+                if !cols.is_empty() {
+                    joined.push(AccessibleTable::virtual_table(alias, cols.clone()));
+                }
+            }
         }
     }
     (joined, from_clause)

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -345,20 +345,29 @@ fn initial_receiver_context(
             // `when(...)`, …) inherits directly. Phase 9 fallback: the resolved
             // `php_type` from a typed param / `@var` docblock.
             match chain.closure_scope.as_ref() {
-                Some(binding) if &binding.param_var == var => {
-                    let parent_model = parent_chain_eloquent_model(chains, chain)?;
-                    match &binding.kind {
-                        ClosureScopeKind::RelationHop { relation_name } => (
+                Some(binding) if &binding.param_var == var => match &binding.kind {
+                    ClosureScopeKind::RelationHop { relation_name } => {
+                        let parent_model = parent_chain_eloquent_model(chains, chain)?;
+                        (
                             BuilderMode::EloquentBuilder,
                             None,
                             Some(parent_model),
                             Some(relation_name.clone()),
-                        ),
-                        ClosureScopeKind::SameModel => {
-                            (BuilderMode::EloquentBuilder, None, Some(parent_model), None)
-                        }
+                        )
                     }
-                }
+                    ClosureScopeKind::SameModel => {
+                        let parent_model = parent_chain_eloquent_model(chains, chain)?;
+                        (BuilderMode::EloquentBuilder, None, Some(parent_model), None)
+                    }
+                    // `$join` is a base query builder rooted at the joined
+                    // table. The table itself is supplied via the from_clause
+                    // override ([`closure_join_from_override`]); here we only
+                    // set the mode (and don't need the parent model, so a
+                    // `DB::table()` parent works too).
+                    ClosureScopeKind::JoinTable { .. } => {
+                        (BuilderMode::BaseBuilder, None, None, None)
+                    }
+                },
                 _ => match php_type {
                     Some(class) => (
                         BuilderMode::EloquentBuilder,
@@ -403,7 +412,19 @@ pub fn chain_context_for_link(
         }
     }
     let arg = chain.links.get(link_idx)?.arg;
-    let (joined_tables, from_clause) = scan_accessible_tables(chain);
+    let (mut joined_tables, mut from_clause) = scan_accessible_tables(chain);
+    let mut join_parent_model = None;
+    if let Some(override_clause) = closure_join_from_override(chain) {
+        let own_qualifier = match &override_clause {
+            FromClause::Replace(t) => t.qualifier().to_string(),
+            _ => String::new(),
+        };
+        from_clause = override_clause;
+        let (parent_tables, parent_model) =
+            join_closure_parent_tables(chains, chain, &own_qualifier);
+        joined_tables.extend(parent_tables);
+        join_parent_model = parent_model;
+    }
     Some(ChainContext {
         mode,
         effective_table,
@@ -414,6 +435,7 @@ pub fn chain_context_for_link(
         quote: '\'',
         joined_tables,
         from_clause,
+        join_parent_model,
     })
 }
 
@@ -481,8 +503,9 @@ fn detect_target_in_chain(
     // Position-aware classification: most methods carry one ArgKind for the
     // whole link, but join/`from` methods name a TABLE in their first string
     // arg (`crossJoin('|')`, `from('|')`) — so we offer table completion there,
-    // just like `DB::table('|')`.
-    let expecting = expecting_at(cursor_link, byte_offset);
+    // just like `DB::table('|')`. Inside a join closure, `$join->on(...)` takes
+    // columns (`in_join_clause`).
+    let expecting = expecting_at(cursor_link, byte_offset, is_join_clause_chain(chain));
 
     if !matches!(
         expecting,
@@ -511,7 +534,21 @@ fn detect_target_in_chain(
         None
     };
 
-    let (joined_tables, from_clause) = scan_accessible_tables(chain);
+    let (mut joined_tables, mut from_clause) = scan_accessible_tables(chain);
+    let mut join_parent_model = None;
+    if let Some(override_clause) = closure_join_from_override(chain) {
+        let own_qualifier = match &override_clause {
+            FromClause::Replace(t) => t.qualifier().to_string(),
+            _ => String::new(),
+        };
+        from_clause = override_clause;
+        // Inside a join closure, the parent query's tables are also
+        // referenceable (both sides of the ON clause).
+        let (parent_tables, parent_model) =
+            join_closure_parent_tables(chains, chain, &own_qualifier);
+        joined_tables.extend(parent_tables);
+        join_parent_model = parent_model;
+    }
 
     Some(ChainTarget {
         ctx: ChainContext {
@@ -524,6 +561,7 @@ fn detect_target_in_chain(
             quote,
             joined_tables,
             from_clause,
+            join_parent_model,
         },
         value: string_value,
         value_span,
@@ -541,46 +579,95 @@ pub fn detect_chain_target_at(
     detect_target_in_chain(chains, chain, byte_offset)
 }
 
-/// Phase 8 helper: find the smallest chain in `chains` whose span strictly
-/// contains `child`'s span and whose receiver is an Eloquent static model.
-/// Returns the model's class name (FQCN if it was resolved through
-/// use-aliases at extraction time).
-///
-/// Used when a child chain's receiver is `$q` bound by an enclosing
-/// `whereHas` / `with` closure — the parent's model is the starting point
-/// for the relation hop the handler will perform.
-fn parent_chain_eloquent_model(
-    chains: &[Arc<BuilderChain>],
+/// Find the smallest chain in `chains` whose span *strictly* contains
+/// `child`'s span — the innermost enclosing chain (the one whose method
+/// invoked the closure `child`'s receiver is bound by).
+fn parent_chain<'a>(
+    chains: &'a [Arc<BuilderChain>],
     child: &BuilderChain,
-) -> Option<String> {
+) -> Option<&'a BuilderChain> {
     let (cs, ce) = child.span_byte_range;
     let mut best: Option<&BuilderChain> = None;
     for chain in chains {
         let (ps, pe) = chain.span_byte_range;
         // Strictly contains (not equal — that'd be the child itself).
         if ps <= cs && pe >= ce && (ps, pe) != (cs, ce) {
-            // Pick the SMALLEST containing chain — that's the innermost
-            // parent, the one whose method invoked the closure.
             let new_size = pe - ps;
             let pick = match best {
                 None => true,
-                Some(b) => {
-                    let cur_size = b.span_byte_range.1 - b.span_byte_range.0;
-                    new_size < cur_size
-                }
+                Some(b) => new_size < (b.span_byte_range.1 - b.span_byte_range.0),
             };
             if pick {
                 best = Some(chain.as_ref());
             }
         }
     }
-    let parent = best?;
-    match &parent.receiver {
+    best
+}
+
+/// Phase 8 helper: the Eloquent model class of the innermost chain enclosing
+/// `child`. Used when a child chain's receiver is `$q` bound by an enclosing
+/// `whereHas` / `with` closure — the parent's model is the starting point for
+/// the relation hop the handler will perform.
+fn parent_chain_eloquent_model(
+    chains: &[Arc<BuilderChain>],
+    child: &BuilderChain,
+) -> Option<String> {
+    match &parent_chain(chains, child)?.receiver {
         ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class)) => Some(class.clone()),
         // Future: also support `(new self)` receivers etc. — already
         // produce StaticModel via Phase 5.1.
         _ => None,
     }
+}
+
+/// The tables the *parent* query contributes inside a join closure (issue
+/// #24), so `$join->on('orders.id', '=', 'users.|')` completes the `users`
+/// side. Returns `(sync_tables, parent_model)`:
+///
+/// - `sync_tables` — the parent's root when it's a `DB::table()` / `from()`
+///   table, plus the parent's other joins. These resolve without I/O.
+/// - `parent_model` — set when the parent is rooted at an Eloquent model whose
+///   table needs async resolution; consumers fold it in (see
+///   `ChainContext::join_parent_model`).
+///
+/// The join's *own* table (`own_qualifier`) is excluded — it's already the
+/// inner chain's root.
+fn join_closure_parent_tables(
+    chains: &[Arc<BuilderChain>],
+    chain: &BuilderChain,
+    own_qualifier: &str,
+) -> (Vec<AccessibleTable>, Option<String>) {
+    let Some(parent) = parent_chain(chains, chain) else {
+        return (Vec::new(), None);
+    };
+    let (parent_joins, parent_from) = scan_accessible_tables(parent);
+
+    let mut tables = Vec::new();
+    let mut parent_model = None;
+    match &parent_from {
+        FromClause::Replace(table) => tables.push(table.clone()),
+        FromClause::Opaque => {}
+        FromClause::Inherit => match &parent.receiver {
+            ChainReceiver::DbTable { table, .. } => {
+                tables.push(AccessibleTable::bare(table.clone()));
+            }
+            ChainReceiver::Eloquent(EloquentReceiver::StaticModel(class)) => {
+                parent_model = Some(class.clone());
+            }
+            ChainReceiver::Eloquent(EloquentReceiver::InstanceVar {
+                php_type: Some(class),
+                ..
+            }) => {
+                parent_model = Some(class.clone());
+            }
+            _ => {}
+        },
+    }
+    tables.extend(parent_joins);
+    // Drop the join's own table — it's the inner root, not a sibling.
+    tables.retain(|t| t.qualifier() != own_qualifier);
+    (tables, parent_model)
 }
 
 /// Scan ALL links in the chain and collect the tables made accessible by
@@ -614,6 +701,28 @@ fn scan_accessible_tables(chain: &BuilderChain) -> (Vec<AccessibleTable>, FromCl
     (joined, from_clause)
 }
 
+/// If this chain's receiver `$var` is bound by an enclosing join closure
+/// (`join('orders', fn ($var) => $var->where(…))`), the `$var` `JoinClause`
+/// builder is rooted at the joined table — model it as a `from(orders)`
+/// override so column completion/narrowing inside the closure resolves
+/// against that table (alias included). Returns `None` for any other chain.
+fn closure_join_from_override(chain: &BuilderChain) -> Option<FromClause> {
+    let var = match &chain.receiver {
+        ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) => var,
+        _ => return None,
+    };
+    let binding = chain.closure_scope.as_ref()?;
+    if &binding.param_var != var {
+        return None;
+    }
+    match &binding.kind {
+        ClosureScopeKind::JoinTable { table_ref } => {
+            Some(FromClause::Replace(parse_table_ref(table_ref)))
+        }
+        _ => None,
+    }
+}
+
 /// The value of a link's first `StringLit` argument, if any. Used to read the
 /// table name out of a `join('orders', …)` / `from('admins')` call. Closures
 /// and other arg shapes are skipped — `join('orders', fn ($j) => …)` still
@@ -639,9 +748,15 @@ fn first_string_arg_value(link: &ChainLink) -> Option<String> {
 /// - **`from('admins')`**: the first arg names the new root table →
 ///   [`ArgKind::Table`]; any later arg (e.g. a connection name) →
 ///   [`ArgKind::None`].
+/// - **`on`/`orOn` on a JoinClause** (`$join->on('orders.id', '=', 'users.id')`
+///   inside a join closure, `in_join_clause = true`): the ON-condition args
+///   are columns → [`ArgKind::Column`]. This is disambiguated by receiver: a
+///   *member* call on the query builder takes columns, whereas the *static*
+///   `Model::on('mysql')` connection-setter (`in_join_clause = false`) is left
+///   as [`ArgKind::None`] — not a column.
 ///
 /// Non-join/from links fall through to the link's own `arg` classification.
-fn expecting_at(link: &ChainLink, byte_offset: usize) -> ArgKind {
+fn expecting_at(link: &ChainLink, byte_offset: usize, in_join_clause: bool) -> ArgKind {
     if is_table_join(&link.method) {
         return if cursor_in_first_string_arg(link, byte_offset) {
             ArgKind::Table
@@ -656,7 +771,21 @@ fn expecting_at(link: &ChainLink, byte_offset: usize) -> ArgKind {
             ArgKind::None
         };
     }
+    if in_join_clause && matches!(link.method.as_str(), "on" | "orOn") {
+        return ArgKind::Column;
+    }
     link.arg
+}
+
+/// Whether this chain is the body of a join closure — its receiver `$join` is
+/// bound by an enclosing `join('orders', fn ($join) => …)`. Inside it, the
+/// builder is a `JoinClause`, so `on`/`orOn` take columns (see
+/// [`expecting_at`]).
+fn is_join_clause_chain(chain: &BuilderChain) -> bool {
+    matches!(
+        chain.closure_scope.as_ref().map(|b| &b.kind),
+        Some(ClosureScopeKind::JoinTable { .. })
+    )
 }
 
 /// Whether `byte_offset` falls inside the link's FIRST string-literal arg —

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -10,6 +10,7 @@
 //! later phases.
 
 use super::chain::*;
+use super::methods::{is_from_opaque, is_from_replace, is_table_join};
 use std::sync::Arc;
 use tower_lsp::lsp_types::Position;
 
@@ -402,6 +403,7 @@ pub fn chain_context_for_link(
         }
     }
     let arg = chain.links.get(link_idx)?.arg;
+    let (joined_tables, from_clause) = scan_accessible_tables(chain);
     Some(ChainContext {
         mode,
         effective_table,
@@ -410,6 +412,8 @@ pub fn chain_context_for_link(
         dotted_prefix: None,
         closure_relation_hop,
         quote: '\'',
+        joined_tables,
+        from_clause,
     })
 }
 
@@ -474,25 +478,32 @@ fn detect_target_in_chain(
     // we still complete inside its first arg.
     let (quote, string_value, value_span) = string_arg_at(cursor_link, byte_offset)?;
 
+    // Position-aware classification: most methods carry one ArgKind for the
+    // whole link, but join/`from` methods name a TABLE in their first string
+    // arg (`crossJoin('|')`, `from('|')`) — so we offer table completion there,
+    // just like `DB::table('|')`.
+    let expecting = expecting_at(cursor_link, byte_offset);
+
     if !matches!(
-        cursor_link.arg,
+        expecting,
         ArgKind::Column | ArgKind::Relation | ArgKind::ClosureCarrier | ArgKind::Table
     ) {
         return None;
     }
 
-    // Phase 7: dotted-relation paths in relation positions. For
-    // `with('posts.author.|')` the value is "posts.author." — everything
-    // before the LAST dot is the relation chain to walk
-    // ("posts" → Post, then "author" on Post → Author), and the portion
-    // after is the typing prefix that the editor uses for fuzzy
-    // filtering. Only meaningful for Relation / ClosureCarrier args
-    // — Column args don't follow dotted hops (`where('a.b')` isn't a
-    // thing) and Table args are single-segment.
-    let dotted_prefix = if matches!(cursor_link.arg, ArgKind::Relation | ArgKind::ClosureCarrier) {
-        // Find the last `.` in the string value. If present, return the
-        // substring up to (not including) that dot — those are the
-        // segments we walk.
+    // Dotted prefixes — everything before the LAST dot of the literal.
+    // - Relation / ClosureCarrier (`with('posts.author.|')`): the relation
+    //   chain to walk ("posts" → Post, then "author" on Post → Author).
+    // - Column (`where('orders.|')`): the table qualifier (alias or table
+    //   name) the column belongs to, so completion narrows to that one
+    //   table. Joins make qualified columns meaningful (`orders.status`);
+    //   without joins it's still harmless (the qualifier just matches the
+    //   root table or nothing).
+    // Table args stay single-segment.
+    let dotted_prefix = if matches!(
+        expecting,
+        ArgKind::Relation | ArgKind::ClosureCarrier | ArgKind::Column
+    ) {
         string_value
             .rfind('.')
             .map(|idx| string_value[..idx].to_string())
@@ -500,15 +511,19 @@ fn detect_target_in_chain(
         None
     };
 
+    let (joined_tables, from_clause) = scan_accessible_tables(chain);
+
     Some(ChainTarget {
         ctx: ChainContext {
             mode,
             effective_table,
             effective_model,
-            expecting: cursor_link.arg,
+            expecting,
             dotted_prefix,
             closure_relation_hop,
             quote,
+            joined_tables,
+            from_clause,
         },
         value: string_value,
         value_span,
@@ -566,6 +581,98 @@ fn parent_chain_eloquent_model(
         // produce StaticModel via Phase 5.1.
         _ => None,
     }
+}
+
+/// Scan ALL links in the chain and collect the tables made accessible by
+/// `join()`-family calls, plus any `from*()` root override.
+///
+/// Visibility is **global**: Laravel compiles the entire chain into one SQL
+/// query, so a join appearing anywhere in the chain makes its table
+/// referenceable from every column position — we don't gate on whether the
+/// join textually precedes the cursor. (Mode flips like `toBase()` stay
+/// positional; that's a separate concern handled by the link walk.)
+///
+/// The last `from*()` wins, mirroring Laravel's runtime where a later
+/// `from()` overrides an earlier FROM clause.
+fn scan_accessible_tables(chain: &BuilderChain) -> (Vec<AccessibleTable>, FromClause) {
+    let mut joined = Vec::new();
+    let mut from_clause = FromClause::Inherit;
+    for link in &chain.links {
+        let method = link.method.as_str();
+        if is_table_join(method) {
+            if let Some(table_ref) = first_string_arg_value(link) {
+                joined.push(parse_table_ref(&table_ref));
+            }
+        } else if is_from_replace(method) {
+            if let Some(table_ref) = first_string_arg_value(link) {
+                from_clause = FromClause::Replace(parse_table_ref(&table_ref));
+            }
+        } else if is_from_opaque(method) {
+            from_clause = FromClause::Opaque;
+        }
+    }
+    (joined, from_clause)
+}
+
+/// The value of a link's first `StringLit` argument, if any. Used to read the
+/// table name out of a `join('orders', …)` / `from('admins')` call. Closures
+/// and other arg shapes are skipped — `join('orders', fn ($j) => …)` still
+/// returns `"orders"` because the closure is a later arg.
+fn first_string_arg_value(link: &ChainLink) -> Option<String> {
+    link.args.iter().find_map(|arg| match arg {
+        ChainArg::StringLit { value, .. } => Some(value.clone()),
+        _ => None,
+    })
+}
+
+/// What the cursor's link expects at this byte position. Most links carry a
+/// single `ArgKind` for the whole call, but join/`from` methods are
+/// position-sensitive:
+///
+/// - **Join methods** (`join('orders', 'orders.user_id', '=', 'users.id')`):
+///   the FIRST string arg names a table → [`ArgKind::Table`] (table-name
+///   completion, like `DB::table('|')`). Every later arg is part of the ON
+///   condition, which references the accessible tables → [`ArgKind::Column`]
+///   (`join('orders', 'orders.|')` offers `orders` columns). The operator /
+///   value slots over-offer harmlessly, exactly as `where('x', '=', '|')`
+///   already does — the editor filters them out.
+/// - **`from('admins')`**: the first arg names the new root table →
+///   [`ArgKind::Table`]; any later arg (e.g. a connection name) →
+///   [`ArgKind::None`].
+///
+/// Non-join/from links fall through to the link's own `arg` classification.
+fn expecting_at(link: &ChainLink, byte_offset: usize) -> ArgKind {
+    if is_table_join(&link.method) {
+        return if cursor_in_first_string_arg(link, byte_offset) {
+            ArgKind::Table
+        } else {
+            ArgKind::Column
+        };
+    }
+    if is_from_replace(&link.method) {
+        return if cursor_in_first_string_arg(link, byte_offset) {
+            ArgKind::Table
+        } else {
+            ArgKind::None
+        };
+    }
+    link.arg
+}
+
+/// Whether `byte_offset` falls inside the link's FIRST string-literal arg —
+/// the table-name slot of a join/`from` call. A cursor in a later string arg
+/// (the join condition) returns `false`.
+fn cursor_in_first_string_arg(link: &ChainLink, byte_offset: usize) -> bool {
+    for arg in &link.args {
+        if let ChainArg::StringLit {
+            span_byte_range, ..
+        } = arg
+        {
+            let (start, end) = *span_byte_range;
+            return byte_offset >= start && byte_offset <= end;
+        }
+    }
+    false
 }
 
 /// Find the string-literal arg of `link` that contains the cursor, returning

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -1052,3 +1052,126 @@ fn db_table_still_expects_table() {
     let ctx = detect("DB::table('|');").expect("ctx");
     assert_eq!(ctx.expecting, ArgKind::Table);
 }
+
+// ---- closure-form joins (issue #24, Phase 3) --------------------------
+
+#[test]
+fn join_closure_binds_receiver_to_joined_table() {
+    // Inside `join('orders', fn ($join) => $join->where('|'))`, `$join` is a
+    // builder rooted at orders — modeled as a from() override.
+    let ctx =
+        detect("DB::table('users')->join('orders', function ($join) { $join->where('|'); });")
+            .expect("ctx");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(
+        ctx.from_clause,
+        FromClause::Replace(AccessibleTable::bare("orders"))
+    );
+}
+
+#[test]
+fn join_closure_arrow_fn_form() {
+    let ctx = detect("DB::table('users')->join('orders', fn ($join) => $join->where('|'));")
+        .expect("ctx");
+    assert_eq!(
+        ctx.from_clause,
+        FromClause::Replace(AccessibleTable::bare("orders"))
+    );
+}
+
+#[test]
+fn join_closure_aliased_table_narrows_on_alias() {
+    let ctx = detect(
+        "DB::table('users')->join('orders as o', function ($join) { $join->where('o.sta|'); });",
+    )
+    .expect("ctx");
+    assert_eq!(
+        ctx.from_clause,
+        FromClause::Replace(AccessibleTable {
+            table: "orders".to_string(),
+            alias: Some("o".to_string()),
+        })
+    );
+    assert_eq!(ctx.dotted_prefix.as_deref(), Some("o"));
+}
+
+#[test]
+fn join_closure_on_eloquent_parent_resolves_joined_table() {
+    // The parent is an Eloquent chain; the join closure still resolves to the
+    // joined table without needing the parent model.
+    let ctx = detect("User::query()->join('orders', function ($join) { $join->where('|'); });")
+        .expect("ctx");
+    assert_eq!(ctx.mode, BuilderMode::BaseBuilder);
+    assert_eq!(
+        ctx.from_clause,
+        FromClause::Replace(AccessibleTable::bare("orders"))
+    );
+}
+
+#[test]
+fn join_clause_on_method_completes_columns() {
+    // `$join->on('orders.id', '=', 'users.id')` — `on` on the query builder
+    // takes columns. The first ON arg narrows on its qualifier.
+    let ctx = detect(
+        "DB::table('users')->join('orders', function ($join) { $join->on('orders.us|', '=', 'users.id'); });",
+    )
+    .expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(ctx.dotted_prefix.as_deref(), Some("orders"));
+}
+
+#[test]
+fn model_static_on_is_connection_not_column() {
+    // `User::on('mysql')` is the connection setter, called directly on the
+    // model (static) — it must NOT offer column completion.
+    let ctx = detect("User::on('mys|ql');");
+    assert!(
+        ctx.is_none(),
+        "Model::on(connection) must not be column completion: {ctx:?}"
+    );
+}
+
+#[test]
+fn join_closure_includes_parent_dbtable_root() {
+    // Inside the join closure, the parent's `users` table is accessible (the
+    // other side of the ON clause).
+    let ctx =
+        detect("DB::table('users')->join('orders', function ($join) { $join->where('|'); });")
+            .expect("ctx");
+    let tables: Vec<&str> = ctx.joined_tables.iter().map(|t| t.table.as_str()).collect();
+    assert!(
+        tables.contains(&"users"),
+        "parent root should be accessible inside the join closure; got {tables:?}"
+    );
+    assert_eq!(
+        ctx.from_clause,
+        FromClause::Replace(AccessibleTable::bare("orders"))
+    );
+    assert!(ctx.join_parent_model.is_none());
+}
+
+#[test]
+fn join_closure_eloquent_parent_sets_pending_model() {
+    // The parent root is an Eloquent model — its table needs async
+    // resolution, so it's deferred via join_parent_model.
+    let ctx = detect("User::query()->join('orders', function ($join) { $join->where('|'); });")
+        .expect("ctx");
+    assert_eq!(ctx.join_parent_model.as_deref(), Some("User"));
+}
+
+#[test]
+fn join_closure_includes_sibling_joins_excludes_own() {
+    let ctx = detect(
+        "DB::table('users')->join('orders', function ($join) { $join->where('|'); })\
+         ->join('roles', 'roles.id', '=', 'users.role_id');",
+    )
+    .expect("ctx");
+    let tables: Vec<&str> = ctx.joined_tables.iter().map(|t| t.table.as_str()).collect();
+    assert!(tables.contains(&"users"), "parent root; got {tables:?}");
+    assert!(tables.contains(&"roles"), "sibling join; got {tables:?}");
+    assert!(
+        !tables.contains(&"orders"),
+        "the join's own table is the root, not a sibling; got {tables:?}"
+    );
+}

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -664,14 +664,16 @@ fn dotted_relation_path_no_dot_means_no_prefix() {
 }
 
 #[test]
-fn dotted_path_only_applies_to_relation_args_not_columns() {
-    // `User::where('a.b|', 1)` — column args don't have dotted-path
-    // semantics. We should NOT set dotted_prefix here.
+fn dotted_column_sets_qualifier_prefix() {
+    // `User::where('a.b|', 1)` — issue #24: a dotted column carries a table
+    // qualifier ("a"), so completion can narrow to that one table. The
+    // segment after the last dot is the typing prefix the editor filters on.
     let ctx = detect("User::where('a.b|', 1);").expect("ctx");
     assert_eq!(ctx.expecting, ArgKind::Column);
-    assert!(
-        ctx.dotted_prefix.is_none(),
-        "dotted prefix should only fire for Relation/ClosureCarrier args"
+    assert_eq!(
+        ctx.dotted_prefix.as_deref(),
+        Some("a"),
+        "dotted column should expose its table qualifier as the dotted prefix"
     );
 }
 
@@ -879,4 +881,174 @@ fn position_byte_round_trip_is_stable() {
             position_to_byte_offset(content, pos.line, pos.character).expect("round-trip offset");
         assert_eq!(back, byte, "round-trip failed for byte {byte}");
     }
+}
+
+// ---- accessible-table scan: joins + from*() (issue #24) ----------------
+
+#[test]
+fn join_adds_accessible_table() {
+    let ctx = detect(
+        "DB::table('users')->join('orders', 'orders.user_id', '=', 'users.id')->where('emai|l');",
+    )
+    .expect("ctx");
+    assert_eq!(ctx.joined_tables.len(), 1);
+    assert_eq!(ctx.joined_tables[0].table, "orders");
+    assert_eq!(ctx.joined_tables[0].alias, None);
+    assert_eq!(ctx.from_clause, FromClause::Inherit);
+}
+
+#[test]
+fn multiple_joins_compose() {
+    let ctx = detect(
+        "DB::table('users')\
+         ->join('orders', 'orders.user_id', '=', 'users.id')\
+         ->leftJoin('roles', 'roles.id', '=', 'users.role_id')\
+         ->where('|');",
+    )
+    .expect("ctx");
+    let tables: Vec<&str> = ctx.joined_tables.iter().map(|t| t.table.as_str()).collect();
+    assert_eq!(tables, vec!["orders", "roles"]);
+}
+
+#[test]
+fn join_visibility_is_global_even_before_the_join() {
+    // The cursor sits in a `where` that textually PRECEDES the join. Global
+    // visibility means the joined table is still accessible.
+    let ctx = detect(
+        "DB::table('users')->where('|')->join('orders', 'orders.user_id', '=', 'users.id');",
+    )
+    .expect("ctx");
+    let tables: Vec<&str> = ctx.joined_tables.iter().map(|t| t.table.as_str()).collect();
+    assert_eq!(tables, vec!["orders"]);
+}
+
+#[test]
+fn aliased_join_captures_table_and_alias() {
+    let ctx = detect(
+        "DB::table('users')->join('orders as o', 'o.user_id', '=', 'users.id')->where('|');",
+    )
+    .expect("ctx");
+    assert_eq!(ctx.joined_tables[0].table, "orders");
+    assert_eq!(ctx.joined_tables[0].alias.as_deref(), Some("o"));
+    assert_eq!(ctx.joined_tables[0].qualifier(), "o");
+}
+
+#[test]
+fn cross_join_is_tracked() {
+    let ctx = detect("DB::table('users')->crossJoin('roles')->where('|');").expect("ctx");
+    assert_eq!(ctx.joined_tables[0].table, "roles");
+}
+
+#[test]
+fn closure_form_join_still_captures_table_from_first_arg() {
+    // The closure is the 2nd arg; the table name is still the first string.
+    let ctx = detect(
+        "DB::table('users')->join('orders', function ($join) { $join->on('a', '=', 'b'); })->where('|');",
+    )
+    .expect("ctx");
+    assert_eq!(ctx.joined_tables[0].table, "orders");
+}
+
+#[test]
+fn from_replace_sets_from_clause() {
+    let ctx = detect("DB::table('users')->from('admins')->where('|');").expect("ctx");
+    assert_eq!(
+        ctx.from_clause,
+        FromClause::Replace(AccessibleTable::bare("admins"))
+    );
+}
+
+#[test]
+fn from_raw_is_opaque() {
+    let ctx = detect("DB::table('users')->fromRaw('(select 1)')->where('|');").expect("ctx");
+    assert_eq!(ctx.from_clause, FromClause::Opaque);
+}
+
+#[test]
+fn last_from_wins() {
+    let ctx =
+        detect("DB::table('users')->from('admins')->from('managers')->where('|');").expect("ctx");
+    assert_eq!(
+        ctx.from_clause,
+        FromClause::Replace(AccessibleTable::bare("managers"))
+    );
+}
+
+#[test]
+fn column_qualifier_populates_dotted_prefix() {
+    // `where('orders.|')` — the table qualifier becomes the dotted prefix so
+    // completion can narrow to that one table.
+    let ctx = detect("DB::table('users')->join('orders', 'a', '=', 'b')->where('orders.sta|');")
+        .expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(ctx.dotted_prefix.as_deref(), Some("orders"));
+}
+
+#[test]
+fn unqualified_column_has_no_dotted_prefix() {
+    let ctx = detect("DB::table('users')->where('emai|l');").expect("ctx");
+    assert_eq!(ctx.dotted_prefix, None);
+}
+
+#[test]
+fn plain_chain_has_no_accessible_extras() {
+    let ctx = detect("DB::table('users')->where('|');").expect("ctx");
+    assert!(ctx.joined_tables.is_empty());
+    assert_eq!(ctx.from_clause, FromClause::Inherit);
+}
+
+// ---- table-name completion inside join/from args (issue #24) -----------
+
+#[test]
+fn cross_join_first_arg_expects_table() {
+    // `crossJoin('|')` should offer table names, same as `DB::table('|')`.
+    let ctx = detect("DB::table('users')->crossJoin('|');").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Table);
+}
+
+#[test]
+fn join_first_arg_expects_table() {
+    let ctx = detect("DB::table('users')->join('|', 'a', '=', 'b');").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Table);
+}
+
+#[test]
+fn from_first_arg_expects_table() {
+    let ctx = detect("DB::table('users')->from('|');").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Table);
+}
+
+#[test]
+fn join_condition_arg_expects_column_not_table() {
+    // The 2nd arg of join is an ON column — column completion, not table.
+    let ctx = detect("DB::table('users')->join('orders', 'col|', '=', 'b');").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Column);
+}
+
+#[test]
+fn join_condition_qualified_column_narrows_to_that_table() {
+    // `join('orders', 'orders.|', …)` — the ON column references `orders`, so
+    // the qualifier becomes the dotted prefix and completion narrows to it.
+    let ctx =
+        detect("DB::table('users')->join('orders', 'orders.us|', '=', 'users.id');").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(ctx.dotted_prefix.as_deref(), Some("orders"));
+    // The joined table is accessible from inside its own ON clause.
+    assert!(ctx.joined_tables.iter().any(|t| t.table == "orders"));
+}
+
+#[test]
+fn join_second_condition_column_also_completes() {
+    // The 4th arg (second ON column) references the root table.
+    let ctx = detect("DB::table('users')->join('orders', 'orders.user_id', '=', 'users.i|');")
+        .expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(ctx.dotted_prefix.as_deref(), Some("users"));
+}
+
+#[test]
+fn db_table_still_expects_table() {
+    // Regression guard: the original `DB::table('|')` path is unaffected.
+    let ctx = detect("DB::table('|');").expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Table);
 }

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -1091,6 +1091,7 @@ fn join_closure_aliased_table_narrows_on_alias() {
         FromClause::Replace(AccessibleTable {
             table: "orders".to_string(),
             alias: Some("o".to_string()),
+            virtual_columns: None,
         })
     );
     assert_eq!(ctx.dotted_prefix.as_deref(), Some("o"));
@@ -1158,6 +1159,62 @@ fn join_closure_eloquent_parent_sets_pending_model() {
     let ctx = detect("User::query()->join('orders', function ($join) { $join->where('|'); });")
         .expect("ctx");
     assert_eq!(ctx.join_parent_model.as_deref(), Some("User"));
+}
+
+// ---- subquery virtual tables (issue #24, Phase 4) ---------------------
+
+#[test]
+fn from_sub_creates_virtual_root_table() {
+    let ctx = detect(
+        "DB::table('orders')->fromSub(function ($q) { $q->select('id', 'name'); }, 'u')->where('|');",
+    )
+    .expect("ctx");
+    match &ctx.from_clause {
+        FromClause::Replace(t) => {
+            assert_eq!(t.qualifier(), "u");
+            assert_eq!(
+                t.virtual_columns.as_deref(),
+                Some(["id".to_string(), "name".to_string()].as_slice())
+            );
+        }
+        other => panic!("expected Replace(virtual table), got {other:?}"),
+    }
+}
+
+#[test]
+fn from_sub_without_select_is_opaque() {
+    let ctx = detect(
+        "DB::table('orders')->fromSub(function ($q) { $q->where('x', 1); }, 'u')->where('|');",
+    )
+    .expect("ctx");
+    assert_eq!(ctx.from_clause, FromClause::Opaque);
+}
+
+#[test]
+fn join_sub_creates_virtual_joined_table() {
+    let ctx = detect(
+        "DB::table('users')->joinSub(function ($q) { $q->select('total'); }, 'agg', 'agg.user_id', '=', 'users.id')->where('|');",
+    )
+    .expect("ctx");
+    let virt = ctx
+        .joined_tables
+        .iter()
+        .find(|t| t.qualifier() == "agg")
+        .expect("virtual joined table 'agg'");
+    assert_eq!(
+        virt.virtual_columns.as_deref(),
+        Some(["total".to_string()].as_slice())
+    );
+}
+
+#[test]
+fn from_sub_narrows_on_alias() {
+    let ctx = detect(
+        "DB::table('orders')->fromSub(function ($q) { $q->select('id', 'name'); }, 'u')->where('u.|');",
+    )
+    .expect("ctx");
+    assert_eq!(ctx.expecting, ArgKind::Column);
+    assert_eq!(ctx.dotted_prefix.as_deref(), Some("u"));
 }
 
 #[test]

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -45,7 +45,8 @@
 use super::chain::*;
 use super::cursor::{byte_offset_to_position, chain_context_for_link};
 use super::eloquent_completion::{
-    resolve_related_model, resolve_table_for_model, snake_pluralize, walk_dotted_hops,
+    enrich_join_parent_tables, resolve_related_model, resolve_table_for_model, snake_pluralize,
+    walk_dotted_hops,
 };
 use crate::class_locator::find_php_class_file;
 use crate::database::DatabaseSchemaProvider;
@@ -232,6 +233,10 @@ async fn finalize_context(mut ctx: ChainContext, root: &Path) -> Option<ChainCon
             ctx.effective_table = resolve_table_for_model(&model, root).await;
         }
     }
+    // Join-closure parent table (issue #24): fold an Eloquent parent's table
+    // into the accessible set so a bare parent column inside the closure isn't
+    // false-flagged.
+    enrich_join_parent_tables(&mut ctx, root).await;
     Some(ctx)
 }
 

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -939,11 +939,6 @@ fn levenshtein(a: &str, b: &str) -> usize {
     prev[b.len()]
 }
 
-/// Build the LSP `Diagnostic` for one unknown identifier. The squiggle is
-/// narrowed to the offending segment (e.g. just `authorr` in `posts.authorr`).
-/// A structured `data` payload carries everything the code-action handler needs
-/// without re-parsing the message string.
-#[allow(clippy::too_many_arguments)]
 /// LSP `Range` covering just the `needle` at the end of a string literal's
 /// content. The literal span includes its quotes (single-byte ASCII), so the
 /// closing quote is one byte before the span end; the needle is the trailing
@@ -991,6 +986,11 @@ fn ambiguous_column_diagnostic(
     }
 }
 
+/// Build the LSP `Diagnostic` for one unknown identifier. The squiggle is
+/// narrowed to the offending segment (e.g. just `authorr` in `posts.authorr`).
+/// A structured `data` payload carries everything the code-action handler needs
+/// without re-parsing the message string.
+#[allow(clippy::too_many_arguments)]
 fn make_diagnostic(
     kind: DiagKind,
     needle: &str,

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -259,6 +259,19 @@ async fn legal_names(
             Some((tables, String::new()))
         }
         DiagKind::Column => {
+            // Virtual (subquery) tables carry best-effort SELECT columns — a
+            // bare column might be legitimately exposed by the subquery even
+            // if our extraction missed it. Stay quiet (under-warn) whenever a
+            // virtual table is in scope, rather than risk a false positive.
+            let has_virtual = matches!(&ctx.from_clause, FromClause::Replace(t) if t.virtual_columns.is_some())
+                || ctx
+                    .joined_tables
+                    .iter()
+                    .any(|t| t.virtual_columns.is_some());
+            if has_virtual {
+                return None;
+            }
+
             // Resolve the root (FROM) table plus, for Eloquent chains, the
             // model's casts/accessors. A `from()` override redirects the root
             // to a plain schema-only table (no model casts apply once the table

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -74,6 +74,9 @@ const COLUMN_DIAG_DENY: &[&str] = &["having"];
 pub const CODE_UNKNOWN_COLUMN: &str = "laravel-lsp.unknown-column";
 pub const CODE_UNKNOWN_RELATION: &str = "laravel-lsp.unknown-relation";
 pub const CODE_UNKNOWN_TABLE: &str = "laravel-lsp.unknown-table";
+/// A bare column that exists on more than one accessible table (issue #24) —
+/// the query would be ambiguous at runtime, so the user must qualify it.
+pub const CODE_AMBIGUOUS_COLUMN: &str = "laravel-lsp.ambiguous-column";
 
 /// What kind of identifier a link's first string arg names. Derived from the
 /// link's `ArgKind`, collapsed to the three things we can validate.
@@ -159,24 +162,85 @@ pub async fn chain_diagnostics(
             };
 
             match kind {
-                // Columns/tables share one legal set across all targets (no
-                // per-element hop), so resolve it once.
-                DiagKind::Column | DiagKind::Table => {
-                    let Some((legal, subject)) =
-                        legal_names(kind, &base_ctx, db, project_root).await
+                // Columns: validate against the per-table column sets of every
+                // accessible table, so we can tell unknown (on none) from
+                // ambiguous (on more than one, issue #24) apart.
+                DiagKind::Column => {
+                    let Some((tables, extras)) =
+                        accessible_column_sets(&base_ctx, db, project_root).await
                     else {
-                        continue; // resolution gap / schema not loaded — stay quiet
+                        continue; // resolution gap / schema not loaded / virtual — stay quiet
                     };
                     for (value, span) in targets {
                         if !is_simple_identifier(&value) {
                             continue; // qualified / expression / aliased / wildcard
                         }
+                        let hits: Vec<&str> = tables
+                            .iter()
+                            .filter(|(_, cols)| cols.iter().any(|c| c == &value))
+                            .map(|(name, _)| name.as_str())
+                            .collect();
+                        match hits.len() {
+                            // On exactly one table — unambiguous, valid.
+                            1 => {}
+                            // On more than one — ambiguous; must be qualified.
+                            n if n > 1 => out.push(ambiguous_column_diagnostic(
+                                &value, &hits, span, content, severity,
+                            )),
+                            // On none — valid only if it's a model accessor;
+                            // otherwise an unknown column.
+                            _ => {
+                                if extras.iter().any(|e| e == &value) {
+                                    continue;
+                                }
+                                let union: Vec<String> = tables
+                                    .iter()
+                                    .flat_map(|(_, cols)| cols.iter().cloned())
+                                    .chain(extras.iter().cloned())
+                                    .collect();
+                                let subject = tables
+                                    .first()
+                                    .map(|(name, _)| name.clone())
+                                    .unwrap_or_default();
+                                let suggestion = best_suggestion(&value, &union);
+                                out.push(make_diagnostic(
+                                    DiagKind::Column,
+                                    &value,
+                                    &subject,
+                                    suggestion,
+                                    span,
+                                    &value,
+                                    content,
+                                    severity,
+                                ));
+                            }
+                        }
+                    }
+                }
+                // Tables resolve a single legal set across all targets.
+                DiagKind::Table => {
+                    let Some((legal, subject)) =
+                        legal_names(DiagKind::Table, &base_ctx, db, project_root).await
+                    else {
+                        continue; // resolution gap / schema not loaded — stay quiet
+                    };
+                    for (value, span) in targets {
+                        if !is_simple_identifier(&value) {
+                            continue;
+                        }
                         if legal.iter().any(|name| name == &value) {
-                            continue; // valid
+                            continue;
                         }
                         let suggestion = best_suggestion(&value, &legal);
                         out.push(make_diagnostic(
-                            kind, &value, &subject, suggestion, span, &value, content, severity,
+                            DiagKind::Table,
+                            &value,
+                            &subject,
+                            suggestion,
+                            span,
+                            &value,
+                            content,
+                            severity,
                         ));
                     }
                 }
@@ -258,99 +322,9 @@ async fn legal_names(
             }
             Some((tables, String::new()))
         }
-        DiagKind::Column => {
-            // Virtual (subquery) tables carry best-effort SELECT columns — a
-            // bare column might be legitimately exposed by the subquery even
-            // if our extraction missed it. Stay quiet (under-warn) whenever a
-            // virtual table is in scope, rather than risk a false positive.
-            let has_virtual = matches!(&ctx.from_clause, FromClause::Replace(t) if t.virtual_columns.is_some())
-                || ctx
-                    .joined_tables
-                    .iter()
-                    .any(|t| t.virtual_columns.is_some());
-            if has_virtual {
-                return None;
-            }
-
-            // Resolve the root (FROM) table plus, for Eloquent chains, the
-            // model's casts/accessors. A `from()` override redirects the root
-            // to a plain schema-only table (no model casts apply once the table
-            // is redirected); `fromRaw`/`fromSub` (Opaque) leaves no root.
-            // This mirrors `eloquent_completion::resolve_eloquent_root`.
-            let (root_table, casts, accessors): (Option<String>, Vec<String>, Vec<String>) =
-                match &ctx.from_clause {
-                    FromClause::Replace(at) => (Some(at.table.clone()), Vec::new(), Vec::new()),
-                    FromClause::Opaque => (None, Vec::new(), Vec::new()),
-                    FromClause::Inherit => match ctx.mode {
-                        BuilderMode::BaseBuilder => {
-                            (ctx.effective_table.clone(), Vec::new(), Vec::new())
-                        }
-                        BuilderMode::EloquentBuilder | BuilderMode::EloquentCollection => {
-                            let model = ctx.effective_model.as_deref()?;
-                            let meta = load_metadata(model, root).await?;
-                            let simple = model.rsplit('\\').next().unwrap_or(model);
-                            let table = meta
-                                .table_name
-                                .clone()
-                                .unwrap_or_else(|| snake_pluralize(simple));
-                            let casts: Vec<String> = meta.casts.keys().cloned().collect();
-                            // Accessors are valid `where` args only
-                            // post-execution, when filtering happens in memory
-                            // on a hydrated collection.
-                            let accessors: Vec<String> =
-                                if ctx.mode == BuilderMode::EloquentCollection {
-                                    meta.accessors
-                                        .iter()
-                                        .map(|a| a.property_name.clone())
-                                        .collect()
-                                } else {
-                                    Vec::new()
-                                };
-                            (Some(table), casts, accessors)
-                        }
-                    },
-                };
-
-            // Union columns across every accessible table — the root plus any
-            // joined tables (issue #24). A bare column is legal if it exists on
-            // ANY of them, so a joined-table column doesn't false-positive.
-            // (Qualified columns like `orders.status` are skipped upstream by
-            // the `is_simple_identifier` guard.)
-            let mut names: Vec<String> = Vec::new();
-            let mut subject = String::new();
-            let mut found_columns = false;
-
-            if let Some(table) = &root_table {
-                let cols = db.get_columns_with_types(table).await;
-                if !cols.is_empty() {
-                    found_columns = true;
-                    names.extend(cols.into_iter().map(|(name, _)| name));
-                    subject = table.clone();
-                }
-            }
-            for jt in &ctx.joined_tables {
-                let cols = db.get_columns_with_types(&jt.table).await;
-                if !cols.is_empty() {
-                    found_columns = true;
-                    names.extend(cols.into_iter().map(|(name, _)| name));
-                    if subject.is_empty() {
-                        subject = jt.table.clone();
-                    }
-                }
-            }
-
-            if !found_columns {
-                // No accessible table resolved any columns — can't validate.
-                // Fires BEFORE folding in casts/accessors, so a model with
-                // casts but an unreachable table still stays quiet.
-                return None;
-            }
-            names.extend(casts);
-            names.extend(accessors);
-            // Subject = the raw table name; `make_diagnostic` formats the
-            // message and the code-action layer reads it from `data.table`.
-            Some((names, subject))
-        }
+        // Columns are validated via `accessible_column_sets` (it needs
+        // per-table sets to distinguish ambiguous from unknown), never here.
+        DiagKind::Column => unreachable!("columns use accessible_column_sets"),
         DiagKind::Relation => {
             // Relations only exist on Eloquent builders/collections. A relation
             // method on a `DB::table()` base builder is user error, but flagging
@@ -377,6 +351,103 @@ async fn legal_names(
             Some((names, model))
         }
     }
+}
+
+/// Per-table DB column sets for every table a chain can reference, plus
+/// root-bound extras (model accessors). Used for ambiguity-aware column
+/// validation: a bare column on >1 table is ambiguous, on exactly 1 is valid,
+/// on 0 (and not an accessor) is unknown (issue #24).
+///
+/// Returns `None` — stay quiet — when nothing resolves confidently: no
+/// accessible table has columns, the schema isn't loaded, or a virtual
+/// (subquery) table is in scope (its best-effort columns shouldn't drive
+/// ambiguity). Each entry is `(table_name, db_column_names)`; the root entry's
+/// columns include the model's cast keys (which are columns of the root).
+async fn accessible_column_sets(
+    ctx: &ChainContext,
+    db: &DatabaseSchemaProvider,
+    root: &Path,
+) -> Option<(Vec<(String, Vec<String>)>, Vec<String>)> {
+    // Virtual (subquery) tables carry best-effort SELECT columns — don't let
+    // them drive ambiguity/unknown decisions; stay quiet entirely.
+    let has_virtual = matches!(&ctx.from_clause, FromClause::Replace(t) if t.virtual_columns.is_some())
+        || ctx
+            .joined_tables
+            .iter()
+            .any(|t| t.virtual_columns.is_some());
+    if has_virtual {
+        return None;
+    }
+
+    // Resolve the root (FROM) table plus, for Eloquent chains, the model's
+    // casts (columns whose type is overridden) and accessors. Mirrors
+    // `eloquent_completion::resolve_eloquent_root`. The root is an
+    // `AccessibleTable` so its DB lookup uses the real name while the reported
+    // identifier (and qualify-fix) uses the qualifier (alias if aliased).
+    let (root_at, casts, accessors): (Option<AccessibleTable>, Vec<String>, Vec<String>) =
+        match &ctx.from_clause {
+            FromClause::Replace(at) => (Some(at.clone()), Vec::new(), Vec::new()),
+            FromClause::Opaque => (None, Vec::new(), Vec::new()),
+            FromClause::Inherit => match ctx.mode {
+                BuilderMode::BaseBuilder => (
+                    ctx.effective_table.clone().map(AccessibleTable::bare),
+                    Vec::new(),
+                    Vec::new(),
+                ),
+                BuilderMode::EloquentBuilder | BuilderMode::EloquentCollection => {
+                    let model = ctx.effective_model.as_deref()?;
+                    let meta = load_metadata(model, root).await?;
+                    let simple = model.rsplit('\\').next().unwrap_or(model);
+                    let table = meta
+                        .table_name
+                        .clone()
+                        .unwrap_or_else(|| snake_pluralize(simple));
+                    let casts: Vec<String> = meta.casts.keys().cloned().collect();
+                    let accessors: Vec<String> = if ctx.mode == BuilderMode::EloquentCollection {
+                        meta.accessors
+                            .iter()
+                            .map(|a| a.property_name.clone())
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
+                    (Some(AccessibleTable::bare(table)), casts, accessors)
+                }
+            },
+        };
+
+    // Each entry's identifier is the qualifier the user references (alias if
+    // present), used for the ambiguity message and the qualify quick-fix; the
+    // DB lookup uses the real table name.
+    let mut tables: Vec<(String, Vec<String>)> = Vec::new();
+    if let Some(at) = root_at {
+        let mut cols: Vec<String> = db
+            .get_columns_with_types(&at.table)
+            .await
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        if !cols.is_empty() {
+            cols.extend(casts); // cast keys are columns of the root table
+            tables.push((at.qualifier().to_string(), cols));
+        }
+    }
+    for jt in &ctx.joined_tables {
+        let cols: Vec<String> = db
+            .get_columns_with_types(&jt.table)
+            .await
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        if !cols.is_empty() {
+            tables.push((jt.qualifier().to_string(), cols));
+        }
+    }
+
+    if tables.is_empty() {
+        return None; // no accessible table resolved any columns — can't validate
+    }
+    Some((tables, accessors))
 }
 
 /// Read + parse a model class to [`ModelMetadata`], walking its `extends`
@@ -873,6 +944,53 @@ fn levenshtein(a: &str, b: &str) -> usize {
 /// A structured `data` payload carries everything the code-action handler needs
 /// without re-parsing the message string.
 #[allow(clippy::too_many_arguments)]
+/// LSP `Range` covering just the `needle` at the end of a string literal's
+/// content. The literal span includes its quotes (single-byte ASCII), so the
+/// closing quote is one byte before the span end; the needle is the trailing
+/// `needle.len()` content bytes (for dotted relations, the tail segment).
+fn needle_range(lit_span: (usize, usize), needle: &str, content: &str) -> Range {
+    let content_end = lit_span.1.saturating_sub(1);
+    let needle_start = content_end.saturating_sub(needle.len());
+    Range {
+        start: byte_offset_to_position(content, needle_start),
+        end: byte_offset_to_position(content, content_end),
+    }
+}
+
+/// Build the `laravel-lsp.ambiguous-column` diagnostic for a bare column that
+/// exists on more than one accessible table (issue #24). `tables` are the
+/// tables that define it; the message suggests qualifying with the first.
+fn ambiguous_column_diagnostic(
+    needle: &str,
+    tables: &[&str],
+    lit_span: (usize, usize),
+    content: &str,
+    severity: DiagnosticSeverity,
+) -> Diagnostic {
+    let range = needle_range(lit_span, needle, content);
+    let table_list = tables.join("`, `");
+    let qualify_hint = tables
+        .first()
+        .map(|t| format!(" Qualify it, e.g. `{t}.{needle}`."))
+        .unwrap_or_default();
+    let message =
+        format!("Column \"{needle}\" is ambiguous — it exists on `{table_list}`.{qualify_hint}");
+    let data = serde_json::json!({
+        "kind": "ambiguous-column",
+        "name": needle,
+        "tables": tables,
+    });
+    Diagnostic {
+        range,
+        severity: Some(severity),
+        code: Some(NumberOrString::String(CODE_AMBIGUOUS_COLUMN.to_string())),
+        source: Some("laravel-lsp".to_string()),
+        message,
+        data: Some(data),
+        ..Default::default()
+    }
+}
+
 fn make_diagnostic(
     kind: DiagKind,
     needle: &str,
@@ -883,16 +1001,7 @@ fn make_diagnostic(
     content: &str,
     severity: DiagnosticSeverity,
 ) -> Diagnostic {
-    // Content lives between the quotes: span includes them, so the closing
-    // quote sits one byte before the literal's end (quotes are single-byte
-    // ASCII). `content_end` is the position just past the last content char.
-    let content_end = lit_span.1.saturating_sub(1);
-    // Narrow to the needle: for dotted relations it's the tail segment.
-    let needle_start = content_end.saturating_sub(needle.len());
-    let range = Range {
-        start: byte_offset_to_position(content, needle_start),
-        end: byte_offset_to_position(content, content_end),
-    };
+    let range = needle_range(lit_span, needle, content);
 
     let (code, data_kind) = match kind {
         DiagKind::Column => (CODE_UNKNOWN_COLUMN, "column"),

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -256,40 +256,41 @@ async fn legal_names(
         DiagKind::Column => {
             // Resolve the root (FROM) table plus, for Eloquent chains, the
             // model's casts/accessors. A `from()` override redirects the root
-            // to a plain table; `fromRaw`/`fromSub` (Opaque) leaves no root.
+            // to a plain schema-only table (no model casts apply once the table
+            // is redirected); `fromRaw`/`fromSub` (Opaque) leaves no root.
+            // This mirrors `eloquent_completion::resolve_eloquent_root`.
             let (root_table, casts, accessors): (Option<String>, Vec<String>, Vec<String>) =
-                match ctx.mode {
-                    BuilderMode::BaseBuilder => {
-                        let table = match &ctx.from_clause {
-                            FromClause::Replace(at) => Some(at.table.clone()),
-                            FromClause::Opaque => None,
-                            FromClause::Inherit => ctx.effective_table.clone(),
-                        };
-                        (table, Vec::new(), Vec::new())
-                    }
-                    BuilderMode::EloquentBuilder | BuilderMode::EloquentCollection => {
-                        let model = ctx.effective_model.as_deref()?;
-                        let meta = load_metadata(model, root).await?;
-                        let simple = model.rsplit('\\').next().unwrap_or(model);
-                        let table = meta
-                            .table_name
-                            .clone()
-                            .unwrap_or_else(|| snake_pluralize(simple));
-                        let casts: Vec<String> = meta.casts.keys().cloned().collect();
-                        // Accessors are valid `where` args only post-execution,
-                        // when filtering happens in memory on a hydrated
-                        // collection.
-                        let accessors: Vec<String> = if ctx.mode == BuilderMode::EloquentCollection
-                        {
-                            meta.accessors
-                                .iter()
-                                .map(|a| a.property_name.clone())
-                                .collect()
-                        } else {
-                            Vec::new()
-                        };
-                        (Some(table), casts, accessors)
-                    }
+                match &ctx.from_clause {
+                    FromClause::Replace(at) => (Some(at.table.clone()), Vec::new(), Vec::new()),
+                    FromClause::Opaque => (None, Vec::new(), Vec::new()),
+                    FromClause::Inherit => match ctx.mode {
+                        BuilderMode::BaseBuilder => {
+                            (ctx.effective_table.clone(), Vec::new(), Vec::new())
+                        }
+                        BuilderMode::EloquentBuilder | BuilderMode::EloquentCollection => {
+                            let model = ctx.effective_model.as_deref()?;
+                            let meta = load_metadata(model, root).await?;
+                            let simple = model.rsplit('\\').next().unwrap_or(model);
+                            let table = meta
+                                .table_name
+                                .clone()
+                                .unwrap_or_else(|| snake_pluralize(simple));
+                            let casts: Vec<String> = meta.casts.keys().cloned().collect();
+                            // Accessors are valid `where` args only
+                            // post-execution, when filtering happens in memory
+                            // on a hydrated collection.
+                            let accessors: Vec<String> =
+                                if ctx.mode == BuilderMode::EloquentCollection {
+                                    meta.accessors
+                                        .iter()
+                                        .map(|a| a.property_name.clone())
+                                        .collect()
+                                } else {
+                                    Vec::new()
+                                };
+                            (Some(table), casts, accessors)
+                        }
+                    },
                 };
 
             // Union columns across every accessible table — the root plus any

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -254,40 +254,75 @@ async fn legal_names(
             Some((tables, String::new()))
         }
         DiagKind::Column => {
-            let (table, casts, accessors) = match ctx.mode {
-                BuilderMode::BaseBuilder => (ctx.effective_table.clone()?, Vec::new(), Vec::new()),
-                BuilderMode::EloquentBuilder | BuilderMode::EloquentCollection => {
-                    let model = ctx.effective_model.as_deref()?;
-                    let meta = load_metadata(model, root).await?;
-                    let simple = model.rsplit('\\').next().unwrap_or(model);
-                    let table = meta
-                        .table_name
-                        .clone()
-                        .unwrap_or_else(|| snake_pluralize(simple));
-                    let casts: Vec<String> = meta.casts.keys().cloned().collect();
-                    // Accessors are valid `where` args only post-execution, when
-                    // filtering happens in memory on a hydrated collection.
-                    let accessors: Vec<String> = if ctx.mode == BuilderMode::EloquentCollection {
-                        meta.accessors
-                            .iter()
-                            .map(|a| a.property_name.clone())
-                            .collect()
-                    } else {
-                        Vec::new()
-                    };
-                    (table, casts, accessors)
-                }
-            };
+            // Resolve the root (FROM) table plus, for Eloquent chains, the
+            // model's casts/accessors. A `from()` override redirects the root
+            // to a plain table; `fromRaw`/`fromSub` (Opaque) leaves no root.
+            let (root_table, casts, accessors): (Option<String>, Vec<String>, Vec<String>) =
+                match ctx.mode {
+                    BuilderMode::BaseBuilder => {
+                        let table = match &ctx.from_clause {
+                            FromClause::Replace(at) => Some(at.table.clone()),
+                            FromClause::Opaque => None,
+                            FromClause::Inherit => ctx.effective_table.clone(),
+                        };
+                        (table, Vec::new(), Vec::new())
+                    }
+                    BuilderMode::EloquentBuilder | BuilderMode::EloquentCollection => {
+                        let model = ctx.effective_model.as_deref()?;
+                        let meta = load_metadata(model, root).await?;
+                        let simple = model.rsplit('\\').next().unwrap_or(model);
+                        let table = meta
+                            .table_name
+                            .clone()
+                            .unwrap_or_else(|| snake_pluralize(simple));
+                        let casts: Vec<String> = meta.casts.keys().cloned().collect();
+                        // Accessors are valid `where` args only post-execution,
+                        // when filtering happens in memory on a hydrated
+                        // collection.
+                        let accessors: Vec<String> = if ctx.mode == BuilderMode::EloquentCollection
+                        {
+                            meta.accessors
+                                .iter()
+                                .map(|a| a.property_name.clone())
+                                .collect()
+                        } else {
+                            Vec::new()
+                        };
+                        (Some(table), casts, accessors)
+                    }
+                };
 
-            let mut names: Vec<String> = db
-                .get_columns_with_types(&table)
-                .await
-                .into_iter()
-                .map(|(name, _)| name)
-                .collect();
-            if names.is_empty() {
-                // Table not in the introspected schema — can't validate. Note
-                // this fires BEFORE folding in casts/accessors, so a model with
+            // Union columns across every accessible table — the root plus any
+            // joined tables (issue #24). A bare column is legal if it exists on
+            // ANY of them, so a joined-table column doesn't false-positive.
+            // (Qualified columns like `orders.status` are skipped upstream by
+            // the `is_simple_identifier` guard.)
+            let mut names: Vec<String> = Vec::new();
+            let mut subject = String::new();
+            let mut found_columns = false;
+
+            if let Some(table) = &root_table {
+                let cols = db.get_columns_with_types(table).await;
+                if !cols.is_empty() {
+                    found_columns = true;
+                    names.extend(cols.into_iter().map(|(name, _)| name));
+                    subject = table.clone();
+                }
+            }
+            for jt in &ctx.joined_tables {
+                let cols = db.get_columns_with_types(&jt.table).await;
+                if !cols.is_empty() {
+                    found_columns = true;
+                    names.extend(cols.into_iter().map(|(name, _)| name));
+                    if subject.is_empty() {
+                        subject = jt.table.clone();
+                    }
+                }
+            }
+
+            if !found_columns {
+                // No accessible table resolved any columns — can't validate.
+                // Fires BEFORE folding in casts/accessors, so a model with
                 // casts but an unreachable table still stays quiet.
                 return None;
             }
@@ -295,7 +330,7 @@ async fn legal_names(
             names.extend(accessors);
             // Subject = the raw table name; `make_diagnostic` formats the
             // message and the code-action layer reads it from `data.table`.
-            Some((names, table))
+            Some((names, subject))
         }
         DiagKind::Relation => {
             // Relations only exist on Eloquent builders/collections. A relation

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -124,6 +124,7 @@ fn link(method: &str, arg: ArgKind, args: Vec<ChainArg>) -> ChainLink {
         effect: ChainEffect::None,
         span_byte_range: (0, 0),
         args,
+        subquery_columns: None,
     }
 }
 
@@ -1001,5 +1002,22 @@ async fn eloquent_from_replace_validates_against_new_table() {
         diags.len(),
         1,
         "column from the replaced table should be flagged: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn virtual_table_in_scope_suppresses_column_diagnostics() {
+    // A `fromSub` virtual table exposes best-effort columns; diagnostics stay
+    // quiet rather than risk a false positive on a column the subquery might
+    // legitimately expose.
+    let (_dir, root) = project_with_models(&[]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nDB::table('users')->fromSub(function ($q) { $q->select('id', 'total'); }, 'u')->where('whatever', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "virtual table in scope should suppress column diagnostics: {diags:?}"
     );
 }

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -1006,6 +1006,77 @@ async fn eloquent_from_replace_validates_against_new_table() {
 }
 
 #[tokio::test]
+async fn ambiguous_bare_column_is_flagged() {
+    // `id` exists on BOTH users and the joined orders — bare `id` is
+    // ambiguous and must be qualified.
+    let (_dir, root) = project_with_models(&[]);
+    let db = provider_with(
+        root.clone(),
+        &[
+            ("users", &[("id", "int"), ("name", "string")]),
+            ("orders", &[("id", "int"), ("status", "string")]),
+        ],
+    )
+    .await;
+    let source = "<?php\nDB::table('users')->join('orders', 'orders.user_id', '=', 'users.id')->where('id', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "ambiguous column should be flagged: {diags:?}"
+    );
+    assert_eq!(code_of(&diags[0]), super::CODE_AMBIGUOUS_COLUMN);
+    assert!(
+        diags[0].message.contains("ambiguous"),
+        "{}",
+        diags[0].message
+    );
+    assert!(diags[0].message.contains("users"));
+    assert!(diags[0].message.contains("orders"));
+}
+
+#[tokio::test]
+async fn column_on_a_single_accessible_table_is_valid() {
+    // `name` lives only on users — unambiguous, so no diagnostic (and not
+    // flagged unknown either).
+    let (_dir, root) = project_with_models(&[]);
+    let db = provider_with(
+        root.clone(),
+        &[
+            ("users", &[("id", "int"), ("name", "string")]),
+            ("orders", &[("id", "int"), ("status", "string")]),
+        ],
+    )
+    .await;
+    let source =
+        "<?php\nDB::table('users')->join('orders', 'a', '=', 'b')->where('name', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "column on exactly one table is valid: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn ambiguous_check_does_not_fire_without_joins() {
+    // A single-table query can't be ambiguous — `id` is just valid.
+    let (_dir, root) = project_with_models(&[]);
+    let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;
+    let source = "<?php\nDB::table('users')->where('id', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "single-table column is unambiguous: {diags:?}"
+    );
+}
+
+#[tokio::test]
 async fn virtual_table_in_scope_suppresses_column_diagnostics() {
     // A `fromSub` virtual table exposes best-effort columns; diagnostics stay
     // quiet rather than risk a false positive on a column the subquery might

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -943,3 +943,63 @@ async fn typo_still_flagged_with_joins_present() {
     );
     assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_COLUMN);
 }
+
+#[tokio::test]
+async fn eloquent_bare_joined_column_not_flagged() {
+    // `status` is on `orders`, joined onto a `User::query()` chain — must not
+    // be flagged as missing on the model's `users` table.
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[
+            ("users", &[("id", "int"), ("name", "string")]),
+            ("orders", &[("id", "int"), ("status", "string")]),
+        ],
+    )
+    .await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::query()->join('orders', 'orders.user_id', '=', 'users.id')->where('status', 'active')->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "Eloquent joined-table column must not be flagged: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn eloquent_from_replace_validates_against_new_table() {
+    // `User::query()->from('admins')` redirects the root — a column on
+    // `admins` is valid; one only on the replaced `users` table is flagged.
+    let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
+    let db = provider_with(
+        root.clone(),
+        &[
+            ("users", &[("id", "int"), ("name", "string")]),
+            ("admins", &[("admin_id", "int"), ("level", "int")]),
+        ],
+    )
+    .await;
+
+    let ok =
+        "<?php\nuse App\\Models\\User;\nUser::query()->from('admins')->where('level', 1)->get();\n";
+    let diags =
+        chain_diagnostics(&chains_of(ok), &db, &root, ok, DiagnosticSeverity::WARNING).await;
+    assert!(diags.is_empty(), "admins column must be valid: {diags:?}");
+
+    let bad =
+        "<?php\nuse App\\Models\\User;\nUser::query()->from('admins')->where('name', 1)->get();\n";
+    let diags = chain_diagnostics(
+        &chains_of(bad),
+        &db,
+        &root,
+        bad,
+        DiagnosticSeverity::WARNING,
+    )
+    .await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "column from the replaced table should be flagged: {diags:?}"
+    );
+}

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -894,3 +894,52 @@ async fn where_array_values_are_not_flagged() {
         "where-array values must not be flagged: {diags:?}"
     );
 }
+
+// ---- joined-table columns (issue #24) ---------------------------------
+
+#[tokio::test]
+async fn bare_column_from_joined_table_is_not_flagged() {
+    // `status` lives only on `orders`, but the join makes it a legal bare
+    // column — diagnostics must not flag it as missing on `users`.
+    let (_dir, root) = project_with_models(&[]);
+    let db = provider_with(
+        root.clone(),
+        &[
+            ("users", &[("id", "int"), ("name", "string")]),
+            ("orders", &[("id", "int"), ("status", "string")]),
+        ],
+    )
+    .await;
+    let source = "<?php\nDB::table('users')->join('orders', 'orders.user_id', '=', 'users.id')->where('status', 'active')->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "bare joined-table column must not be flagged: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn typo_still_flagged_with_joins_present() {
+    // A genuine typo absent from EVERY accessible table is still caught.
+    let (_dir, root) = project_with_models(&[]);
+    let db = provider_with(
+        root.clone(),
+        &[
+            ("users", &[("id", "int"), ("name", "string")]),
+            ("orders", &[("id", "int"), ("status", "string")]),
+        ],
+    )
+    .await;
+    let source = "<?php\nDB::table('users')->join('orders', 'a', '=', 'b')->where('stattus', 'active')->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "real typo should still be flagged: {diags:?}"
+    );
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_COLUMN);
+}

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -758,6 +758,27 @@ pub async fn resolve_table_for_model(class: &str, project_root: &Path) -> Option
     )
 }
 
+/// Fold a join closure's Eloquent *parent* table into the accessible set
+/// (issue #24). When the cursor is inside `User::query()->join('orders',
+/// fn ($join) => …)`, the parent model's table can't be resolved
+/// synchronously, so the cursor resolver leaves it in `ctx.join_parent_model`.
+/// Consumers (completion, diagnostics, goto) call this to resolve it (async)
+/// and append it to `joined_tables`, so the parent side of an ON clause
+/// (`$join->on('orders.id', '=', 'users.|')`) completes. No-op when the field
+/// is unset.
+pub async fn enrich_join_parent_tables(ctx: &mut ChainContext, project_root: &Path) {
+    let Some(model) = ctx.join_parent_model.take() else {
+        return;
+    };
+    let Some(table) = resolve_table_for_model(&model, project_root).await else {
+        return;
+    };
+    // Dedup by qualifier — don't double-list a table already accessible.
+    if ctx.joined_tables.iter().all(|t| t.qualifier() != table) {
+        ctx.joined_tables.push(AccessibleTable::bare(table));
+    }
+}
+
 /// Phase 6: column completion for an `EloquentCollection` chain — a
 /// chain that's been executed via `->get()` / `->all()` / `->pluck()` /
 /// `->cursor()` etc. After execution, the result is a hydrated

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -75,9 +75,16 @@ pub async fn tables(
 /// Build column completions for a `BaseBuilder` chain. Reads the schema
 /// directly — no model lookup, no casts, no accessors.
 ///
+/// Handles joined tables (issue #24): when the chain has joins, columns are
+/// offered both bare (root table) and `qualifier.column`-qualified (every
+/// accessible table, including the root). A `from()` override replaces the
+/// root; `fromRaw`/`fromSub` make it opaque (no bare root columns, but joined
+/// tables still resolve). When the user has already typed a `qualifier.`
+/// prefix (`where('orders.|')`), completion narrows to that one table.
+///
 /// Returns an empty `Vec` when:
-/// - The context has no `effective_table` (shouldn't happen for Base chains
-///   coming out of the cursor resolver, but guarded for safety)
+/// - No table is accessible (no root and no joins, or an opaque root with no
+///   joins)
 /// - The database schema isn't introspected yet (cold start, no DB connection,
 ///   or the table doesn't exist in the introspected schema)
 pub async fn columns_raw(
@@ -85,56 +92,162 @@ pub async fn columns_raw(
     db: &DatabaseSchemaProvider,
     wrap_with_quote: Option<char>,
 ) -> Vec<CompletionItem> {
-    let Some(table) = &ctx.effective_table else {
-        info!("🔗 columns_raw: ctx.effective_table is None — returning 0 items");
+    let root = base_root_table(ctx);
+
+    // The user already typed a `qualifier.` — narrow to that one table.
+    if let Some(qualifier) = ctx.dotted_prefix.as_deref() {
+        return narrowed_columns(ctx, db, wrap_with_quote, root.as_ref(), qualifier).await;
+    }
+
+    let has_joins = !ctx.joined_tables.is_empty();
+    let mut items = Vec::new();
+
+    // Root table: bare columns always; qualified forms too once joins make
+    // qualification meaningful (so a plain single-table query keeps offering
+    // only bare names — no `users.name` noise).
+    if let Some(r) = &root {
+        let columns = db.get_columns_with_types(&r.table).await;
+        if columns.is_empty() {
+            info!(
+                "🔗 columns_raw: get_columns_with_types({:?}) returned 0 columns \
+                 (schema cache may not have this table, or DB not yet warmed)",
+                r.table
+            );
+        }
+        for (name, php_type) in &columns {
+            items.push(raw_column_item(
+                name,
+                php_type,
+                &r.table,
+                None,
+                wrap_with_quote,
+                1,
+            ));
+            if has_joins {
+                items.push(raw_column_item(
+                    name,
+                    php_type,
+                    &r.table,
+                    Some(r.qualifier()),
+                    wrap_with_quote,
+                    2,
+                ));
+            }
+        }
+    }
+
+    // Joined tables: always offered as `qualifier.column`.
+    for jt in &ctx.joined_tables {
+        let columns = db.get_columns_with_types(&jt.table).await;
+        for (name, php_type) in &columns {
+            items.push(raw_column_item(
+                name,
+                php_type,
+                &jt.table,
+                Some(jt.qualifier()),
+                wrap_with_quote,
+                2,
+            ));
+        }
+    }
+
+    if items.is_empty() {
+        info!("🔗 columns_raw: no accessible tables/columns resolved — returning 0 items");
+    }
+    items
+}
+
+/// Resolve the root (FROM) table for a base-builder chain, honoring any
+/// `from*()` override. `None` means no bare root columns should be offered
+/// (an opaque `fromRaw`/`fromSub`, or no resolvable table at all).
+fn base_root_table(ctx: &ChainContext) -> Option<AccessibleTable> {
+    match &ctx.from_clause {
+        FromClause::Replace(table) => Some(table.clone()),
+        FromClause::Opaque => None,
+        FromClause::Inherit => ctx.effective_table.clone().map(AccessibleTable::bare),
+    }
+}
+
+/// Narrow completion to a single table when the user has typed its
+/// `qualifier.` prefix (`where('orders.|')`). The qualifier matches an
+/// accessible table's alias or name; columns are inserted **bare** because
+/// the `qualifier.` is already in the source.
+async fn narrowed_columns(
+    ctx: &ChainContext,
+    db: &DatabaseSchemaProvider,
+    wrap_with_quote: Option<char>,
+    root: Option<&AccessibleTable>,
+    qualifier: &str,
+) -> Vec<CompletionItem> {
+    let target = root
+        .into_iter()
+        .chain(ctx.joined_tables.iter())
+        .find(|t| t.qualifier() == qualifier);
+    let Some(at) = target else {
+        info!(
+            "🔗 columns_raw: qualifier {:?} matches no accessible table — returning 0 items",
+            qualifier
+        );
         return Vec::new();
     };
-
-    let columns = db.get_columns_with_types(table).await;
-    if columns.is_empty() {
-        info!(
-            "🔗 columns_raw: get_columns_with_types({:?}) returned 0 columns \
-             (schema cache may not have this table, or DB not yet warmed)",
-            table
-        );
-    }
-    columns
+    db.get_columns_with_types(&at.table)
+        .await
         .into_iter()
         .map(|(name, php_type)| {
-            let insert_text = match wrap_with_quote {
-                Some(q) => format!("{q}{name}{q}"),
-                None => name.clone(),
-            };
-            CompletionItem {
-                label: name.clone(),
-                kind: Some(CompletionItemKind::FIELD),
-                // Use `label_details` (LSP 3.17) so the type renders right
-                // next to the column name (e.g., "email   string") and the
-                // source table renders as a dimmer suffix on the right
-                // ("from users"). Editors that support it (Zed, VS Code)
-                // render each piece distinctly; older clients fall back to
-                // `detail` below, which we still set as a single-string
-                // approximation.
-                label_details: Some(CompletionItemLabelDetails {
-                    detail: Some(format!("  {php_type}")),
-                    description: Some(table.clone()),
-                }),
-                detail: Some(format!("{php_type} ({table})")),
-                documentation: Some(
-                    CompletionDoc::new()
-                        .header(format!("{}.{}", table, name))
-                        .summary(format!("Database column of type `{}`.", php_type))
-                        .into_documentation(),
-                ),
-                // DB columns rank first; later modes will add accessors at
-                // sort_text = "2_…" so columns still rank above them.
-                sort_text: Some(format!("1_{name}")),
-                filter_text: Some(name.clone()),
-                insert_text: Some(insert_text),
-                ..Default::default()
-            }
+            raw_column_item(&name, &php_type, &at.table, None, wrap_with_quote, 1)
         })
         .collect()
+}
+
+/// Build a schema-only column completion item (no casts/accessors).
+///
+/// - `qualifier = None` → bare item (`label`/`insert` = `name`).
+/// - `qualifier = Some(q)` → qualified item (`label`/`insert` = `q.name`).
+///
+/// `source_table` is the real table name shown in the popup's right-hand
+/// description. `sort_rank` groups items (1 = bare root, 2 = qualified) so
+/// bare columns surface first. Shared by base-builder completion here and (in
+/// later phases) the joined-table portion of Eloquent completion.
+fn raw_column_item(
+    name: &str,
+    php_type: &str,
+    source_table: &str,
+    qualifier: Option<&str>,
+    wrap_with_quote: Option<char>,
+    sort_rank: u8,
+) -> CompletionItem {
+    let text = match qualifier {
+        Some(q) => format!("{q}.{name}"),
+        None => name.to_string(),
+    };
+    let insert_text = match wrap_with_quote {
+        Some(quote) => format!("{quote}{text}{quote}"),
+        None => text.clone(),
+    };
+    CompletionItem {
+        label: text.clone(),
+        kind: Some(CompletionItemKind::FIELD),
+        // Use `label_details` (LSP 3.17) so the type renders right next to the
+        // column name (e.g., "email   string") and the source table renders
+        // as a dimmer suffix on the right. Editors that support it (Zed, VS
+        // Code) render each piece distinctly; older clients fall back to
+        // `detail` below.
+        label_details: Some(CompletionItemLabelDetails {
+            detail: Some(format!("  {php_type}")),
+            description: Some(source_table.to_string()),
+        }),
+        detail: Some(format!("{php_type} ({source_table})")),
+        documentation: Some(
+            CompletionDoc::new()
+                .header(format!("{source_table}.{name}"))
+                .summary(format!("Database column of type `{php_type}`."))
+                .into_documentation(),
+        ),
+        sort_text: Some(format!("{sort_rank}_{text}")),
+        filter_text: Some(text.clone()),
+        insert_text: Some(insert_text),
+        ..Default::default()
+    }
 }
 
 /// Build column completions for an `EloquentBuilder` chain — a chain rooted

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -333,7 +333,15 @@ async fn build_table_items(
     meta: &RootMeta,
     emit: ColEmit,
 ) -> Vec<CompletionItem> {
-    let columns = db.get_columns_with_types(&table.table).await;
+    // Virtual (subquery) tables carry their columns directly — the SELECT
+    // list, with no DB types known (so `mixed`). Real tables hit the schema.
+    let columns: Vec<(String, String)> = match &table.virtual_columns {
+        Some(cols) => cols
+            .iter()
+            .map(|c| (c.clone(), "mixed".to_string()))
+            .collect(),
+        None => db.get_columns_with_types(&table.table).await,
+    };
     if columns.is_empty() {
         info!(
             "🔗 build_table_items: get_columns_with_types({:?}) returned 0 columns \

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -1,20 +1,21 @@
 //! Build LSP `CompletionItem`s from a resolved [`ChainContext`].
 //!
-//! Three column-completion helpers, picked by `BuilderMode`:
+//! Three column-completion entry points, picked by `BuilderMode`, all funnel
+//! through the shared [`assemble_columns`] multi-table assembler — they differ
+//! only in how the ROOT table and its cast/accessor metadata are resolved:
 //!
-//! - [`columns_raw`] — DB schema only. Used by `BaseBuilder` chains
-//!   (`DB::table(...)` and post-`toBase()` Eloquent chains). No casts, no
-//!   accessors, no relations.
-//! - `columns_for_builder` (Phase 4) — DB columns with cast-aware PHP types
-//!   in `detail`. Eloquent builder pre-execution.
-//! - `columns_for_collection` (Phase 6) — DB columns + accessors + cast
-//!   property names. Eloquent collection post-execution.
+//! - [`columns_raw`] — `BaseBuilder` chains (`DB::table(...)` / post-`toBase()`).
+//!   Schema-only root, no casts, no accessors.
+//! - [`columns_for_builder`] — Eloquent builder pre-execution. Root from the
+//!   model with cast-aware PHP types.
+//! - [`columns_for_collection`] — Eloquent collection post-execution. Adds the
+//!   model's accessors to the root's columns.
 //!
-//! `relations` (Phase 5) — Eloquent-only relation list for `with()` /
-//! `whereHas()` / `load()` etc.
+//! Joined tables (issue #24) are offered as `qualifier.column` in every mode;
+//! a `from()` override replaces the root, `fromRaw`/`fromSub` makes it opaque.
 //!
-//! Phase 3 ships only `columns_raw`. The other functions are stubbed so
-//! their wiring sites can compile against the same module surface.
+//! [`relations`] — Eloquent-only relation list for `with()` / `whereHas()` /
+//! `load()` etc.
 
 use super::chain::*;
 use crate::class_locator::find_php_class_file;
@@ -72,89 +73,39 @@ pub async fn tables(
         .collect()
 }
 
-/// Build column completions for a `BaseBuilder` chain. Reads the schema
-/// directly — no model lookup, no casts, no accessors.
+/// Per-table cast/accessor metadata for building the ROOT table's items.
+/// Base-builder roots (and `from()`-replaced roots) use the empty default —
+/// schema-only, no casts, no accessors. Eloquent roots fill `casts` (column →
+/// raw cast name) and, in collection mode, `accessors`.
+#[derive(Default)]
+struct RootMeta {
+    /// column name → raw cast (e.g. `"array"`), mapped to a PHP type at build.
+    casts: std::collections::HashMap<String, String>,
+    /// (property name, PHP return type) accessor entries — collection mode only.
+    accessors: Vec<(String, String)>,
+}
+
+/// Build column completions for a `BaseBuilder` chain (`DB::table(...)` or a
+/// post-`toBase()` Eloquent chain). Schema-only — no casts, no accessors.
 ///
-/// Handles joined tables (issue #24): when the chain has joins, columns are
-/// offered both bare (root table) and `qualifier.column`-qualified (every
-/// accessible table, including the root). A `from()` override replaces the
-/// root; `fromRaw`/`fromSub` make it opaque (no bare root columns, but joined
-/// tables still resolve). When the user has already typed a `qualifier.`
-/// prefix (`where('orders.|')`), completion narrows to that one table.
-///
-/// Returns an empty `Vec` when:
-/// - No table is accessible (no root and no joins, or an opaque root with no
-///   joins)
-/// - The database schema isn't introspected yet (cold start, no DB connection,
-///   or the table doesn't exist in the introspected schema)
+/// Joined tables (issue #24) are offered as `qualifier.column`; `from()`
+/// replaces the root; `fromRaw`/`fromSub` make it opaque. See
+/// [`assemble_columns`] for the full multi-table behavior.
 pub async fn columns_raw(
     ctx: &ChainContext,
     db: &DatabaseSchemaProvider,
     wrap_with_quote: Option<char>,
 ) -> Vec<CompletionItem> {
     let root = base_root_table(ctx);
-
-    // The user already typed a `qualifier.` — narrow to that one table.
-    if let Some(qualifier) = ctx.dotted_prefix.as_deref() {
-        return narrowed_columns(ctx, db, wrap_with_quote, root.as_ref(), qualifier).await;
-    }
-
-    let has_joins = !ctx.joined_tables.is_empty();
-    let mut items = Vec::new();
-
-    // Root table: bare columns always; qualified forms too once joins make
-    // qualification meaningful (so a plain single-table query keeps offering
-    // only bare names — no `users.name` noise).
-    if let Some(r) = &root {
-        let columns = db.get_columns_with_types(&r.table).await;
-        if columns.is_empty() {
-            info!(
-                "🔗 columns_raw: get_columns_with_types({:?}) returned 0 columns \
-                 (schema cache may not have this table, or DB not yet warmed)",
-                r.table
-            );
-        }
-        for (name, php_type) in &columns {
-            items.push(raw_column_item(
-                name,
-                php_type,
-                &r.table,
-                None,
-                wrap_with_quote,
-                1,
-            ));
-            if has_joins {
-                items.push(raw_column_item(
-                    name,
-                    php_type,
-                    &r.table,
-                    Some(r.qualifier()),
-                    wrap_with_quote,
-                    2,
-                ));
-            }
-        }
-    }
-
-    // Joined tables: always offered as `qualifier.column`.
-    for jt in &ctx.joined_tables {
-        let columns = db.get_columns_with_types(&jt.table).await;
-        for (name, php_type) in &columns {
-            items.push(raw_column_item(
-                name,
-                php_type,
-                &jt.table,
-                Some(jt.qualifier()),
-                wrap_with_quote,
-                2,
-            ));
-        }
-    }
-
-    if items.is_empty() {
-        info!("🔗 columns_raw: no accessible tables/columns resolved — returning 0 items");
-    }
-    items
+    assemble_columns(
+        db,
+        wrap_with_quote,
+        ctx.dotted_prefix.as_deref(),
+        root.as_ref(),
+        &RootMeta::default(),
+        &ctx.joined_tables,
+    )
+    .await
 }
 
 /// Resolve the root (FROM) table for a base-builder chain, honoring any
@@ -168,51 +119,305 @@ fn base_root_table(ctx: &ChainContext) -> Option<AccessibleTable> {
     }
 }
 
-/// Narrow completion to a single table when the user has typed its
-/// `qualifier.` prefix (`where('orders.|')`). The qualifier matches an
-/// accessible table's alias or name; columns are inserted **bare** because
-/// the `qualifier.` is already in the source.
-async fn narrowed_columns(
+/// Given a chain's accessible tables and a column literal under the cursor,
+/// produce the ordered `(real_table, column)` candidates to probe for
+/// goto-definition (issue #24).
+///
+/// - **Qualified** (`orders.status`, `o.status`): resolve the qualifier
+///   (alias or table name) through `accessible` to its real table; if nothing
+///   matches, fall back to treating the qualifier as a literal table name
+///   (covers schema-qualified or untracked tables). One candidate.
+/// - **Bare** (`status`): one candidate per accessible table, in order (root
+///   first), so the lookup returns the first table that defines the column.
+///
+/// Pure (no I/O) so the resolution order is unit-testable; the caller probes
+/// each candidate against the migration index and takes the first hit.
+pub fn goto_column_candidates(
+    accessible: &[AccessibleTable],
+    value: &str,
+) -> Vec<(String, String)> {
+    match value.rsplit_once('.') {
+        Some((qualifier, column)) => {
+            let table = accessible
+                .iter()
+                .find(|t| t.qualifier() == qualifier)
+                .map(|t| t.table.clone())
+                .unwrap_or_else(|| qualifier.to_string());
+            vec![(table, column.to_string())]
+        }
+        None => accessible
+            .iter()
+            .map(|t| (t.table.clone(), value.to_string()))
+            .collect(),
+    }
+}
+
+/// Resolve the root table + cast/accessor metadata for an Eloquent chain,
+/// honoring any `from*()` override (issue #24):
+/// - `from('admins')` redirects to a plain schema-only table — the model→table
+///   mapping no longer applies, so casts/accessors are dropped.
+/// - `fromRaw(...)` / `fromSub(...)` (Opaque) leave no root (joined tables
+///   still resolve in [`assemble_columns`]).
+/// - Otherwise the root is the model's table (from `$table` or the
+///   snake-pluralize convention) with its casts, plus accessors when
+///   `want_accessors` (collection mode).
+///
+/// Returns `(None, default)` on any model-resolution failure — the caller then
+/// offers only joined-table columns (or nothing), logging the cause at INFO.
+async fn resolve_eloquent_root(
     ctx: &ChainContext,
+    project_root: &Path,
+    want_accessors: bool,
+) -> (Option<AccessibleTable>, RootMeta) {
+    match &ctx.from_clause {
+        FromClause::Replace(table) => (Some(table.clone()), RootMeta::default()),
+        FromClause::Opaque => (None, RootMeta::default()),
+        FromClause::Inherit => {
+            let Some(class) = &ctx.effective_model else {
+                info!("🔗 resolve_eloquent_root: ctx.effective_model is None");
+                return (None, RootMeta::default());
+            };
+            let Some(path) = find_php_class_file(class, project_root) else {
+                info!(
+                    "🔗 resolve_eloquent_root: no PHP file found for class {:?} under {:?}",
+                    class, project_root
+                );
+                return (None, RootMeta::default());
+            };
+            // Walk `extends` chains so a child inherits its parent's
+            // `$table`/casts/accessors. Runs the sync walker on a blocking
+            // thread so the LSP runtime stays responsive on slow disks.
+            let path_for_blocking = path.clone();
+            let root_for_blocking = project_root.to_path_buf();
+            let metadata = match tokio::task::spawn_blocking(move || {
+                ModelMetadata::from_file_with_inheritance(&path_for_blocking, &root_for_blocking)
+            })
+            .await
+            {
+                Ok(Some(m)) => m,
+                Ok(None) => {
+                    info!(
+                        "🔗 resolve_eloquent_root: failed to read/parse {:?} (or no inheritable parent)",
+                        path
+                    );
+                    return (None, RootMeta::default());
+                }
+                Err(err) => {
+                    info!("🔗 resolve_eloquent_root: blocking task panicked: {}", err);
+                    return (None, RootMeta::default());
+                }
+            };
+            let simple_class = class.rsplit('\\').next().unwrap_or(class);
+            let table = metadata
+                .table_name
+                .clone()
+                .unwrap_or_else(|| snake_pluralize(simple_class));
+            let accessors = if want_accessors {
+                metadata
+                    .accessors
+                    .iter()
+                    .map(|a| {
+                        (
+                            a.property_name.clone(),
+                            a.return_type.clone().unwrap_or_else(|| "mixed".to_string()),
+                        )
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            (
+                Some(AccessibleTable::bare(table)),
+                RootMeta {
+                    casts: metadata.casts,
+                    accessors,
+                },
+            )
+        }
+    }
+}
+
+/// Assemble multi-table column completions, shared by every builder mode.
+///
+/// - **No `dotted_prefix`**: bare columns for the root table, plus
+///   `qualifier.column` for every accessible table (root + joined) once joins
+///   make qualification meaningful — so a join-free query stays bare-only.
+///   Root accessors (collection mode) are appended bare.
+/// - **`dotted_prefix = Some(qual)`** (`where('orders.|')`): narrow to the one
+///   accessible table whose qualifier (alias or name) matches `qual`; columns
+///   insert bare because the `qualifier.` is already typed.
+///
+/// `root_meta` carries cast/accessor info for the root; joined tables are
+/// always schema-only (there's no model behind them).
+async fn assemble_columns(
     db: &DatabaseSchemaProvider,
     wrap_with_quote: Option<char>,
+    dotted_prefix: Option<&str>,
     root: Option<&AccessibleTable>,
-    qualifier: &str,
+    root_meta: &RootMeta,
+    joined: &[AccessibleTable],
 ) -> Vec<CompletionItem> {
-    let target = root
-        .into_iter()
-        .chain(ctx.joined_tables.iter())
-        .find(|t| t.qualifier() == qualifier);
-    let Some(at) = target else {
+    // Narrowing: the user typed `qualifier.` — resolve it to one table.
+    if let Some(qualifier) = dotted_prefix {
+        if let Some(r) = root {
+            if r.qualifier() == qualifier {
+                return build_table_items(db, wrap_with_quote, r, root_meta, ColEmit::Narrow).await;
+            }
+        }
+        if let Some(jt) = joined.iter().find(|t| t.qualifier() == qualifier) {
+            return build_table_items(
+                db,
+                wrap_with_quote,
+                jt,
+                &RootMeta::default(),
+                ColEmit::Narrow,
+            )
+            .await;
+        }
         info!(
-            "🔗 columns_raw: qualifier {:?} matches no accessible table — returning 0 items",
+            "🔗 assemble_columns: qualifier {:?} matches no accessible table — returning 0 items",
             qualifier
         );
         return Vec::new();
-    };
-    db.get_columns_with_types(&at.table)
-        .await
-        .into_iter()
-        .map(|(name, php_type)| {
-            raw_column_item(&name, &php_type, &at.table, None, wrap_with_quote, 1)
-        })
-        .collect()
+    }
+
+    let has_joins = !joined.is_empty();
+    let mut items = Vec::new();
+    if let Some(r) = root {
+        let emit = if has_joins {
+            ColEmit::BareAndQualified
+        } else {
+            ColEmit::BareOnly
+        };
+        items.extend(build_table_items(db, wrap_with_quote, r, root_meta, emit).await);
+    }
+    for jt in joined {
+        items.extend(
+            build_table_items(
+                db,
+                wrap_with_quote,
+                jt,
+                &RootMeta::default(),
+                ColEmit::QualifiedOnly,
+            )
+            .await,
+        );
+    }
+    if items.is_empty() {
+        info!("🔗 assemble_columns: no accessible tables/columns resolved — returning 0 items");
+    }
+    items
 }
 
-/// Build a schema-only column completion item (no casts/accessors).
+/// Which item variants [`build_table_items`] emits for one table.
+#[derive(Clone, Copy)]
+enum ColEmit {
+    /// Bare columns only — the narrowed `qualifier.|` case (the qualifier is
+    /// already typed). Accessors are NOT included (they're not table-qualified).
+    Narrow,
+    /// Bare columns + accessors — the root of a join-free query.
+    BareOnly,
+    /// Bare + `qualifier.column` columns + accessors — the root when joins are
+    /// present.
+    BareAndQualified,
+    /// `qualifier.column` only, no accessors — a joined table.
+    QualifiedOnly,
+}
+
+/// Fetch one table's columns and emit completion items per `emit`, applying
+/// `meta`'s casts (and accessors, when listing the root fully).
+async fn build_table_items(
+    db: &DatabaseSchemaProvider,
+    wrap_with_quote: Option<char>,
+    table: &AccessibleTable,
+    meta: &RootMeta,
+    emit: ColEmit,
+) -> Vec<CompletionItem> {
+    let columns = db.get_columns_with_types(&table.table).await;
+    if columns.is_empty() {
+        info!(
+            "🔗 build_table_items: get_columns_with_types({:?}) returned 0 columns \
+             (schema cache may not have this table, or DB not yet warmed)",
+            table.table
+        );
+    }
+    let mut items = Vec::new();
+    for (name, sql_php_type) in &columns {
+        // Cast override: if the model declares a cast for this column, its PHP
+        // type wins (a JSON column with `'options' => 'array'` shows `array`).
+        let (php_type, has_cast) = match meta.casts.get(name) {
+            Some(cast) => (map_cast_to_php_type(cast), true),
+            None => (sql_php_type.clone(), false),
+        };
+        match emit {
+            ColEmit::Narrow | ColEmit::BareOnly => {
+                items.push(col_item(
+                    name,
+                    &php_type,
+                    &table.table,
+                    None,
+                    has_cast,
+                    wrap_with_quote,
+                    1,
+                ));
+            }
+            ColEmit::QualifiedOnly => {
+                items.push(col_item(
+                    name,
+                    &php_type,
+                    &table.table,
+                    Some(table.qualifier()),
+                    has_cast,
+                    wrap_with_quote,
+                    2,
+                ));
+            }
+            ColEmit::BareAndQualified => {
+                items.push(col_item(
+                    name,
+                    &php_type,
+                    &table.table,
+                    None,
+                    has_cast,
+                    wrap_with_quote,
+                    1,
+                ));
+                items.push(col_item(
+                    name,
+                    &php_type,
+                    &table.table,
+                    Some(table.qualifier()),
+                    has_cast,
+                    wrap_with_quote,
+                    2,
+                ));
+            }
+        }
+    }
+    // Accessors only when listing the root fully — never narrowed (not
+    // table-qualified) and never for joined tables (no model behind them).
+    if matches!(emit, ColEmit::BareOnly | ColEmit::BareAndQualified) {
+        for (name, php_type) in &meta.accessors {
+            items.push(accessor_item(name, php_type, wrap_with_quote));
+        }
+    }
+    items
+}
+
+/// Build a column completion item.
 ///
 /// - `qualifier = None` → bare item (`label`/`insert` = `name`).
 /// - `qualifier = Some(q)` → qualified item (`label`/`insert` = `q.name`).
 ///
-/// `source_table` is the real table name shown in the popup's right-hand
-/// description. `sort_rank` groups items (1 = bare root, 2 = qualified) so
-/// bare columns surface first. Shared by base-builder completion here and (in
-/// later phases) the joined-table portion of Eloquent completion.
-fn raw_column_item(
+/// `has_cast` annotates the type with `· cast` when a model cast overrode the
+/// raw SQL type. `sort_rank` groups items (1 = bare, 2 = qualified) so bare
+/// columns surface first.
+fn col_item(
     name: &str,
     php_type: &str,
     source_table: &str,
     qualifier: Option<&str>,
+    has_cast: bool,
     wrap_with_quote: Option<char>,
     sort_rank: u8,
 ) -> CompletionItem {
@@ -224,23 +429,27 @@ fn raw_column_item(
         Some(quote) => format!("{quote}{text}{quote}"),
         None => text.clone(),
     };
+    let detail_suffix = if has_cast { " · cast" } else { "" };
+    let summary = if has_cast {
+        format!("Database column of type `{php_type}` (overridden by model cast).")
+    } else {
+        format!("Database column of type `{php_type}`.")
+    };
     CompletionItem {
         label: text.clone(),
         kind: Some(CompletionItemKind::FIELD),
         // Use `label_details` (LSP 3.17) so the type renders right next to the
-        // column name (e.g., "email   string") and the source table renders
-        // as a dimmer suffix on the right. Editors that support it (Zed, VS
-        // Code) render each piece distinctly; older clients fall back to
-        // `detail` below.
+        // column name and the source table renders as a dimmer suffix on the
+        // right. Older clients fall back to `detail`.
         label_details: Some(CompletionItemLabelDetails {
-            detail: Some(format!("  {php_type}")),
+            detail: Some(format!("  {php_type}{detail_suffix}")),
             description: Some(source_table.to_string()),
         }),
-        detail: Some(format!("{php_type} ({source_table})")),
+        detail: Some(format!("{php_type}{detail_suffix} ({source_table})")),
         documentation: Some(
             CompletionDoc::new()
                 .header(format!("{source_table}.{name}"))
-                .summary(format!("Database column of type `{php_type}`."))
+                .summary(summary)
                 .into_documentation(),
         ),
         sort_text: Some(format!("{sort_rank}_{text}")),
@@ -250,143 +459,64 @@ fn raw_column_item(
     }
 }
 
+/// Build a model-accessor completion item (collection mode). Accessors are
+/// in-memory computed properties, so they're kinded `PROPERTY` and ranked
+/// after DB columns (`2_`).
+fn accessor_item(name: &str, php_type: &str, wrap_with_quote: Option<char>) -> CompletionItem {
+    let insert_text = match wrap_with_quote {
+        Some(quote) => format!("{quote}{name}{quote}"),
+        None => name.to_string(),
+    };
+    CompletionItem {
+        label: name.to_string(),
+        kind: Some(CompletionItemKind::PROPERTY),
+        label_details: Some(CompletionItemLabelDetails {
+            detail: Some(format!("  {php_type}")),
+            description: Some("accessor".to_string()),
+        }),
+        detail: Some(format!("{php_type} (accessor)")),
+        documentation: Some(
+            CompletionDoc::new()
+                .header(name)
+                .summary(format!("Model accessor returning `{php_type}`."))
+                .into_documentation(),
+        ),
+        sort_text: Some(format!("2_{name}")),
+        filter_text: Some(name.to_string()),
+        insert_text: Some(insert_text),
+        ..Default::default()
+    }
+}
+
 /// Build column completions for an `EloquentBuilder` chain — a chain rooted
 /// at a static call on a model class (`User::where('|')`, `User::query()->
 /// where('|')`, `User::firstWhere('|')`, etc.).
 ///
-/// Two extra hops compared to [`columns_raw`]:
-/// 1. Resolve the class FQCN in `ctx.effective_model` to a model file path
-///    (uses [`find_php_class_file`]) and parse it to a [`ModelMetadata`].
-/// 2. Determine the table: prefer the model's `$table` property, else
-///    snake-pluralize the class basename (Laravel convention).
+/// The root table comes from the model (`$table` or the snake-pluralize
+/// convention) with cast-aware PHP types — a column's model cast wins over the
+/// raw SQL→PHP mapping and is annotated `· cast`. Joined tables (issue #24)
+/// are offered as `qualifier.column` (schema-only), and a `from()` override
+/// redirects the root; see [`resolve_eloquent_root`] and [`assemble_columns`].
 ///
-/// Once the table is known, fetch DB columns and apply cast-aware PHP types
-/// — if the model has a cast for a column, the cast's PHP type wins over
-/// the raw SQL → PHP mapping. The cast is also surfaced in `label_details`
-/// so the user can tell at a glance which columns are auto-cast.
-///
-/// Returns an empty `Vec` for any of the failure modes (model not found,
-/// not actually an Eloquent model, table missing from DB schema, etc.) and
-/// logs the cause at INFO so the LSP log is the source of truth for "why
-/// did completion produce nothing here?"
+/// Returns an empty `Vec` for failure modes (model not found, table missing
+/// from the DB schema, …) when there are no joined tables to fall back on;
+/// the cause is logged at INFO.
 pub async fn columns_for_builder(
     ctx: &ChainContext,
     db: &DatabaseSchemaProvider,
     wrap_with_quote: Option<char>,
     project_root: &Path,
 ) -> Vec<CompletionItem> {
-    let Some(class) = &ctx.effective_model else {
-        info!("🔗 columns_for_builder: ctx.effective_model is None — returning 0 items");
-        return Vec::new();
-    };
-
-    // Resolve class FQCN → file path.
-    let Some(path) = find_php_class_file(class, project_root) else {
-        info!(
-            "🔗 columns_for_builder: no PHP file found for class {:?} under {:?}",
-            class, project_root
-        );
-        return Vec::new();
-    };
-
-    // Read + parse to ModelMetadata, walking `extends` chains so the
-    // child inherits its parent's `$table` / casts / accessors /
-    // relationships when it doesn't declare them itself. Runs the sync
-    // walker on a blocking thread so the LSP runtime stays responsive
-    // even for deep inheritance trees on slow disks.
-    let path_for_blocking = path.clone();
-    let root_for_blocking = project_root.to_path_buf();
-    let metadata = match tokio::task::spawn_blocking(move || {
-        ModelMetadata::from_file_with_inheritance(&path_for_blocking, &root_for_blocking)
-    })
+    let (root, meta) = resolve_eloquent_root(ctx, project_root, false).await;
+    assemble_columns(
+        db,
+        wrap_with_quote,
+        ctx.dotted_prefix.as_deref(),
+        root.as_ref(),
+        &meta,
+        &ctx.joined_tables,
+    )
     .await
-    {
-        Ok(Some(m)) => m,
-        Ok(None) => {
-            info!(
-                "🔗 columns_for_builder: failed to read/parse {:?} (or no inheritable parent found)",
-                path
-            );
-            return Vec::new();
-        }
-        Err(err) => {
-            info!("🔗 columns_for_builder: blocking task panicked: {}", err);
-            return Vec::new();
-        }
-    };
-
-    // Resolve the table: prefer `$table`, fall back to Laravel's
-    // snake_case + pluralize convention on the class basename. Naive plural
-    // rules — covers >95% of real models. Custom-pluralized models declare
-    // `$table` explicitly.
-    let simple_class = class.rsplit('\\').next().unwrap_or(class);
-    let table = metadata
-        .table_name
-        .clone()
-        .unwrap_or_else(|| snake_pluralize(simple_class));
-
-    let columns = db.get_columns_with_types(&table).await;
-    if columns.is_empty() {
-        info!(
-            "🔗 columns_for_builder: get_columns_with_types({:?}) returned 0 columns \
-             (model class {:?}, resolved file {:?}, table derived from {})",
-            table,
-            class,
-            path,
-            if metadata.table_name.is_some() {
-                "$table property"
-            } else {
-                "snake_pluralize convention"
-            }
-        );
-    }
-
-    columns
-        .into_iter()
-        .map(|(name, sql_php_type)| {
-            // Cast override: if the model declares a cast for this column,
-            // its PHP type wins. Example: a JSON column with
-            // `'options' => 'array'` cast surfaces as `array`, not `string`.
-            let (php_type, has_cast) = match metadata.casts.get(&name) {
-                Some(cast) => (map_cast_to_php_type(cast), true),
-                None => (sql_php_type, false),
-            };
-            let insert_text = match wrap_with_quote {
-                Some(q) => format!("{q}{name}{q}"),
-                None => name.clone(),
-            };
-            // Annotate cast-overridden types so the user can tell at a
-            // glance which columns are model-cast vs raw DB-typed.
-            let detail_suffix = if has_cast { " · cast" } else { "" };
-            let summary = if has_cast {
-                format!(
-                    "Database column of type `{}` (overridden by model cast).",
-                    php_type
-                )
-            } else {
-                format!("Database column of type `{}`.", php_type)
-            };
-            CompletionItem {
-                label: name.clone(),
-                kind: Some(CompletionItemKind::FIELD),
-                label_details: Some(CompletionItemLabelDetails {
-                    detail: Some(format!("  {php_type}{detail_suffix}")),
-                    description: Some(table.clone()),
-                }),
-                detail: Some(format!("{php_type}{detail_suffix} ({table})")),
-                documentation: Some(
-                    CompletionDoc::new()
-                        .header(format!("{}.{}", table, name))
-                        .summary(summary)
-                        .into_documentation(),
-                ),
-                sort_text: Some(format!("1_{name}")),
-                filter_text: Some(name.clone()),
-                insert_text: Some(insert_text),
-                ..Default::default()
-            }
-        })
-        .collect()
 }
 
 /// Build relation completions for an `EloquentBuilder` chain — the first
@@ -637,72 +767,26 @@ pub async fn resolve_table_for_model(class: &str, project_root: &Path) -> Option
 /// args even though they don't exist as DB columns.
 ///
 /// Returns DB columns (with cast-aware types) FIRST, then accessor items
-/// after them via sort_text ordering. Accessors are kinded as `PROPERTY`
-/// to visually distinguish them from `FIELD` DB columns.
+/// after them via sort_text ordering (`1_` vs `2_`). Joined-table columns
+/// (issue #24) are offered as `qualifier.column`, same as builder mode.
 pub async fn columns_for_collection(
     ctx: &ChainContext,
     db: &DatabaseSchemaProvider,
     wrap_with_quote: Option<char>,
     project_root: &Path,
 ) -> Vec<CompletionItem> {
-    // Start with DB columns + cast-aware types — same set the builder
-    // mode returns. Collection adds to this; doesn't replace.
-    let mut items = columns_for_builder(ctx, db, wrap_with_quote, project_root).await;
-
-    // Add accessors. Read metadata again (cheap: OS cache + tokio
-    // blocking pool); we don't plumb metadata through columns_for_builder's
-    // return since the helper's signature is shaped for the pre-execution
-    // case where accessors don't apply.
-    let Some(class) = &ctx.effective_model else {
-        return items;
-    };
-    let Some(path) = find_php_class_file(class, project_root) else {
-        return items;
-    };
-    let path_clone = path.clone();
-    let root_clone = project_root.to_path_buf();
-    let metadata = match tokio::task::spawn_blocking(move || {
-        ModelMetadata::from_file_with_inheritance(&path_clone, &root_clone)
-    })
+    // `want_accessors = true`: the root's accessors join its DB columns in the
+    // assembled set (they're valid in-memory `where()` args post-execution).
+    let (root, meta) = resolve_eloquent_root(ctx, project_root, true).await;
+    assemble_columns(
+        db,
+        wrap_with_quote,
+        ctx.dotted_prefix.as_deref(),
+        root.as_ref(),
+        &meta,
+        &ctx.joined_tables,
+    )
     .await
-    {
-        Ok(Some(m)) => m,
-        _ => return items,
-    };
-
-    for accessor in metadata.accessors {
-        let name = accessor.property_name;
-        let php_type = accessor.return_type.unwrap_or_else(|| "mixed".to_string());
-        let insert_text = match wrap_with_quote {
-            Some(q) => format!("{q}{name}{q}"),
-            None => name.clone(),
-        };
-        items.push(CompletionItem {
-            label: name.clone(),
-            // PROPERTY kind — semantically "computed property of the
-            // hydrated model", distinct from FIELD (DB column).
-            kind: Some(CompletionItemKind::PROPERTY),
-            label_details: Some(CompletionItemLabelDetails {
-                detail: Some(format!("  {php_type}")),
-                description: Some("accessor".to_string()),
-            }),
-            detail: Some(format!("{php_type} (accessor)")),
-            documentation: Some(
-                CompletionDoc::new()
-                    .header(&name)
-                    .summary(format!("Model accessor returning `{}`.", php_type))
-                    .into_documentation(),
-            ),
-            // Sort AFTER DB columns (which use "1_…"). When the popup
-            // is fuzzy-filtered the explicit DB columns rank first.
-            sort_text: Some(format!("2_{name}")),
-            filter_text: Some(name.clone()),
-            insert_text: Some(insert_text),
-            ..Default::default()
-        });
-    }
-
-    items
 }
 
 /// Convert a PascalCase class basename to Laravel's default table name:

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -1017,3 +1017,292 @@ async fn columns_raw_wraps_qualified_insert_text() {
         .expect("qualified item");
     assert_eq!(qualified.insert_text.as_deref(), Some("'orders.status'"));
 }
+
+// ---- Eloquent joins + from() (issue #24, Phase 2) ---------------------
+
+/// Build an Eloquent `ChainContext` for column-completion tests.
+fn eloquent_ctx(
+    class: &str,
+    mode: BuilderMode,
+    joined_tables: Vec<AccessibleTable>,
+    from_clause: FromClause,
+    dotted_prefix: Option<&str>,
+) -> ChainContext {
+    ChainContext {
+        mode,
+        effective_table: None,
+        effective_model: Some(class.to_string()),
+        expecting: ArgKind::Column,
+        dotted_prefix: dotted_prefix.map(|s| s.to_string()),
+        closure_relation_hop: None,
+        quote: '\'',
+        joined_tables,
+        from_clause,
+    }
+}
+
+const PLAIN_USER: &str = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {}
+"#;
+
+#[tokio::test]
+async fn eloquent_builder_offers_joined_columns() {
+    let (_dir, root) = project_with_model("User", PLAIN_USER);
+    let db = provider_with_tables(
+        root.clone(),
+        vec![
+            ("users", vec![("id", "int"), ("name", "string")]),
+            ("orders", vec![("status", "string")]),
+        ],
+    )
+    .await;
+    let ctx = eloquent_ctx(
+        "App\\Models\\User",
+        BuilderMode::EloquentBuilder,
+        vec![AccessibleTable::bare("orders")],
+        FromClause::Inherit,
+        None,
+    );
+    let got = labels(&columns_for_builder(&ctx, &db, None, &root).await);
+    assert!(got.contains(&"name".to_string()), "bare root; got {got:?}");
+    assert!(got.contains(&"users.name".to_string()), "qualified root");
+    assert!(
+        got.contains(&"orders.status".to_string()),
+        "qualified joined"
+    );
+}
+
+#[tokio::test]
+async fn eloquent_builder_narrows_to_joined_table() {
+    let (_dir, root) = project_with_model("User", PLAIN_USER);
+    let db = provider_with_tables(
+        root.clone(),
+        vec![
+            ("users", vec![("id", "int")]),
+            ("orders", vec![("status", "string"), ("total", "int")]),
+        ],
+    )
+    .await;
+    let ctx = eloquent_ctx(
+        "App\\Models\\User",
+        BuilderMode::EloquentBuilder,
+        vec![AccessibleTable::bare("orders")],
+        FromClause::Inherit,
+        Some("orders"),
+    );
+    let got = labels(&columns_for_builder(&ctx, &db, None, &root).await);
+    assert_eq!(got.len(), 2, "only orders columns; got {got:?}");
+    assert!(got.contains(&"status".to_string()));
+    assert!(got.contains(&"total".to_string()));
+}
+
+#[tokio::test]
+async fn eloquent_narrow_to_root_model_table_keeps_casts() {
+    // `User::query()->join(...)->where('users.|')` narrows to the model's
+    // table (qualifier = "users") and still applies the model cast.
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    protected $casts = ['options' => 'array'];
+}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let db = provider_with_tables(
+        root.clone(),
+        vec![
+            ("users", vec![("id", "int"), ("options", "string")]),
+            ("orders", vec![("status", "string")]),
+        ],
+    )
+    .await;
+    let ctx = eloquent_ctx(
+        "App\\Models\\User",
+        BuilderMode::EloquentBuilder,
+        vec![AccessibleTable::bare("orders")],
+        FromClause::Inherit,
+        Some("users"),
+    );
+    let items = columns_for_builder(&ctx, &db, None, &root).await;
+    let options = items
+        .iter()
+        .find(|i| i.label == "options")
+        .expect("options column narrowed to users");
+    assert!(
+        options.detail.as_deref().unwrap_or("").contains("array"),
+        "cast should still apply when narrowing to the model table; got {:?}",
+        options.detail
+    );
+}
+
+#[tokio::test]
+async fn eloquent_from_replace_uses_schema_table() {
+    // `User::query()->from('admins')` redirects the root to admins
+    // (schema-only — the User model's casts no longer apply).
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    protected $casts = ['options' => 'array'];
+}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let db = provider_with_tables(
+        root.clone(),
+        vec![
+            ("users", vec![("id", "int"), ("options", "string")]),
+            ("admins", vec![("admin_id", "int"), ("level", "int")]),
+        ],
+    )
+    .await;
+    let ctx = eloquent_ctx(
+        "App\\Models\\User",
+        BuilderMode::EloquentBuilder,
+        Vec::new(),
+        FromClause::Replace(AccessibleTable::bare("admins")),
+        None,
+    );
+    let got = labels(&columns_for_builder(&ctx, &db, None, &root).await);
+    assert!(got.contains(&"admin_id".to_string()), "got {got:?}");
+    assert!(got.contains(&"level".to_string()));
+    assert!(!got.contains(&"id".to_string()), "users table is replaced");
+    assert!(!got.contains(&"options".to_string()));
+}
+
+#[tokio::test]
+async fn eloquent_opaque_from_suppresses_root_keeps_joins() {
+    let (_dir, root) = project_with_model("User", PLAIN_USER);
+    let db = provider_with_tables(
+        root.clone(),
+        vec![
+            ("users", vec![("id", "int")]),
+            ("orders", vec![("status", "string")]),
+        ],
+    )
+    .await;
+    let ctx = eloquent_ctx(
+        "App\\Models\\User",
+        BuilderMode::EloquentBuilder,
+        vec![AccessibleTable::bare("orders")],
+        FromClause::Opaque,
+        None,
+    );
+    let got = labels(&columns_for_builder(&ctx, &db, None, &root).await);
+    assert!(got.contains(&"orders.status".to_string()));
+    assert!(
+        !got.contains(&"id".to_string()),
+        "opaque root suppressed; got {got:?}"
+    );
+}
+
+#[tokio::test]
+async fn eloquent_collection_offers_joined_columns_and_accessors() {
+    let body = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function getFullNameAttribute(): string { return ''; }
+}
+"#;
+    let (_dir, root) = project_with_model("User", body);
+    let db = provider_with_tables(
+        root.clone(),
+        vec![
+            ("users", vec![("id", "int"), ("name", "string")]),
+            ("orders", vec![("status", "string")]),
+        ],
+    )
+    .await;
+    let ctx = eloquent_ctx(
+        "App\\Models\\User",
+        BuilderMode::EloquentCollection,
+        vec![AccessibleTable::bare("orders")],
+        FromClause::Inherit,
+        None,
+    );
+    let got = labels(&columns_for_collection(&ctx, &db, None, &root).await);
+    assert!(got.contains(&"name".to_string()), "bare root col");
+    assert!(got.contains(&"orders.status".to_string()), "joined col");
+    assert!(
+        got.contains(&"full_name".to_string()),
+        "accessor; got {got:?}"
+    );
+    // Accessors are in-memory props — never offered table-qualified.
+    assert!(!got.contains(&"users.full_name".to_string()));
+}
+
+// ---- goto_column_candidates (issue #24) -------------------------------
+
+#[test]
+fn goto_candidates_bare_single_table() {
+    let accessible = vec![AccessibleTable::bare("users")];
+    assert_eq!(
+        goto_column_candidates(&accessible, "email"),
+        vec![("users".to_string(), "email".to_string())]
+    );
+}
+
+#[test]
+fn goto_candidates_bare_searches_all_tables_root_first() {
+    let accessible = vec![
+        AccessibleTable::bare("users"),
+        AccessibleTable::bare("orders"),
+    ];
+    assert_eq!(
+        goto_column_candidates(&accessible, "status"),
+        vec![
+            ("users".to_string(), "status".to_string()),
+            ("orders".to_string(), "status".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn goto_candidates_qualified_resolves_alias_to_real_table() {
+    let accessible = vec![
+        AccessibleTable::bare("users"),
+        AccessibleTable {
+            table: "orders".to_string(),
+            alias: Some("o".to_string()),
+        },
+    ];
+    assert_eq!(
+        goto_column_candidates(&accessible, "o.status"),
+        vec![("orders".to_string(), "status".to_string())]
+    );
+}
+
+#[test]
+fn goto_candidates_qualified_by_table_name() {
+    let accessible = vec![
+        AccessibleTable::bare("users"),
+        AccessibleTable::bare("orders"),
+    ];
+    assert_eq!(
+        goto_column_candidates(&accessible, "orders.status"),
+        vec![("orders".to_string(), "status".to_string())]
+    );
+}
+
+#[test]
+fn goto_candidates_unknown_qualifier_falls_back_to_literal() {
+    // A qualifier that matches no accessible table is treated as a literal
+    // table name (covers schema-qualified / untracked tables).
+    let accessible = vec![AccessibleTable::bare("users")];
+    assert_eq!(
+        goto_column_candidates(&accessible, "posts.id"),
+        vec![("posts".to_string(), "id".to_string())]
+    );
+}
+
+#[test]
+fn goto_candidates_schema_qualified() {
+    // `mydb.orders.status` — qualifier is everything before the last dot.
+    let accessible = vec![AccessibleTable::bare("mydb.orders")];
+    assert_eq!(
+        goto_column_candidates(&accessible, "mydb.orders.status"),
+        vec![("mydb.orders".to_string(), "status".to_string())]
+    );
+}

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -115,6 +115,7 @@ fn make_ctx(class: &str) -> ChainContext {
         quote: '\'',
         joined_tables: Vec::new(),
         from_clause: FromClause::Inherit,
+        join_parent_model: None,
     }
 }
 
@@ -701,6 +702,7 @@ class Post extends Model {
         quote: '\'',
         joined_tables: Vec::new(),
         from_clause: FromClause::Inherit,
+        join_parent_model: None,
     };
     let items = relations(&ctx, None, &root).await;
     let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
@@ -737,6 +739,7 @@ class User extends Model {
         quote: '\'',
         joined_tables: Vec::new(),
         from_clause: FromClause::Inherit,
+        join_parent_model: None,
     };
     let items = relations(&ctx, None, &root).await;
     assert!(items.is_empty(), "unresolvable hop should yield no items");
@@ -798,6 +801,7 @@ fn base_ctx(
         quote: '\'',
         joined_tables,
         from_clause,
+        join_parent_model: None,
     }
 }
 
@@ -1038,6 +1042,7 @@ fn eloquent_ctx(
         quote: '\'',
         joined_tables,
         from_clause,
+        join_parent_model: None,
     }
 }
 
@@ -1305,4 +1310,44 @@ fn goto_candidates_schema_qualified() {
         goto_column_candidates(&accessible, "mydb.orders.status"),
         vec![("mydb.orders".to_string(), "status".to_string())]
     );
+}
+
+// ---- enrich_join_parent_tables (issue #24, Phase 3) -------------------
+
+#[tokio::test]
+async fn enrich_join_parent_tables_resolves_model_table() {
+    let (_dir, root) = project_with_model("User", PLAIN_USER); // → users
+    let mut ctx = eloquent_ctx(
+        "App\\Models\\User",
+        BuilderMode::BaseBuilder,
+        Vec::new(),
+        FromClause::Replace(AccessibleTable::bare("orders")),
+        None,
+    );
+    ctx.join_parent_model = Some("App\\Models\\User".to_string());
+
+    enrich_join_parent_tables(&mut ctx, &root).await;
+
+    let tables: Vec<&str> = ctx.joined_tables.iter().map(|t| t.table.as_str()).collect();
+    assert!(
+        tables.contains(&"users"),
+        "parent model table folded into accessible set; got {tables:?}"
+    );
+    assert!(ctx.join_parent_model.is_none(), "pending model consumed");
+}
+
+#[tokio::test]
+async fn enrich_join_parent_tables_noop_when_unset() {
+    let (_dir, root) = project_with_model("User", PLAIN_USER);
+    let mut ctx = eloquent_ctx(
+        "App\\Models\\User",
+        BuilderMode::BaseBuilder,
+        vec![AccessibleTable::bare("orders")],
+        FromClause::Replace(AccessibleTable::bare("orders")),
+        None,
+    );
+    // join_parent_model defaults to None.
+    enrich_join_parent_tables(&mut ctx, &root).await;
+    let tables: Vec<&str> = ctx.joined_tables.iter().map(|t| t.table.as_str()).collect();
+    assert_eq!(tables, vec!["orders"], "no change when no pending model");
 }

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -908,6 +908,7 @@ async fn columns_raw_narrows_via_alias() {
         vec![AccessibleTable {
             table: "orders".to_string(),
             alias: Some("o".to_string()),
+            virtual_columns: None,
         }],
         FromClause::Inherit,
         Some("o"),
@@ -932,6 +933,7 @@ async fn columns_raw_alias_qualifies_with_alias_not_table() {
         vec![AccessibleTable {
             table: "orders".to_string(),
             alias: Some("o".to_string()),
+            virtual_columns: None,
         }],
         FromClause::Inherit,
         None,
@@ -1238,6 +1240,83 @@ class User extends Model {
     assert!(!got.contains(&"users.full_name".to_string()));
 }
 
+// ---- subquery virtual tables (issue #24, Phase 4) --------------------
+
+#[tokio::test]
+async fn virtual_root_table_offers_subquery_columns() {
+    let dir = TempDir::new().unwrap();
+    // The DB has no table named "u" — columns come from the virtual table.
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![("users", vec![("id", "int")])],
+    )
+    .await;
+    let ctx = base_ctx(
+        None,
+        Vec::new(),
+        FromClause::Replace(AccessibleTable::virtual_table(
+            "u",
+            vec!["id".to_string(), "total".to_string()],
+        )),
+        None,
+    );
+    let got = labels(&columns_raw(&ctx, &db, None).await);
+    assert!(got.contains(&"id".to_string()), "got {got:?}");
+    assert!(got.contains(&"total".to_string()), "got {got:?}");
+}
+
+#[tokio::test]
+async fn virtual_joined_table_offers_qualified_columns() {
+    let dir = TempDir::new().unwrap();
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![("users", vec![("id", "int"), ("name", "string")])],
+    )
+    .await;
+    let ctx = base_ctx(
+        Some("users"),
+        vec![AccessibleTable::virtual_table(
+            "agg",
+            vec!["total".to_string()],
+        )],
+        FromClause::Inherit,
+        None,
+    );
+    let got = labels(&columns_raw(&ctx, &db, None).await);
+    assert!(got.contains(&"name".to_string()), "bare root; got {got:?}");
+    assert!(
+        got.contains(&"agg.total".to_string()),
+        "virtual joined column qualified; got {got:?}"
+    );
+}
+
+#[tokio::test]
+async fn virtual_table_narrows_on_alias() {
+    let dir = TempDir::new().unwrap();
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![("users", vec![("id", "int")])],
+    )
+    .await;
+    let ctx = base_ctx(
+        Some("users"),
+        vec![AccessibleTable::virtual_table(
+            "agg",
+            vec!["total".to_string(), "avg".to_string()],
+        )],
+        FromClause::Inherit,
+        Some("agg"),
+    );
+    let got = labels(&columns_raw(&ctx, &db, None).await);
+    assert_eq!(
+        got.len(),
+        2,
+        "only the virtual table's columns; got {got:?}"
+    );
+    assert!(got.contains(&"total".to_string()));
+    assert!(got.contains(&"avg".to_string()));
+}
+
 // ---- goto_column_candidates (issue #24) -------------------------------
 
 #[test]
@@ -1271,6 +1350,7 @@ fn goto_candidates_qualified_resolves_alias_to_real_table() {
         AccessibleTable {
             table: "orders".to_string(),
             alias: Some("o".to_string()),
+            virtual_columns: None,
         },
     ];
     assert_eq!(

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -113,6 +113,8 @@ fn make_ctx(class: &str) -> ChainContext {
         dotted_prefix: None,
         closure_relation_hop: None,
         quote: '\'',
+        joined_tables: Vec::new(),
+        from_clause: FromClause::Inherit,
     }
 }
 
@@ -697,6 +699,8 @@ class Post extends Model {
         dotted_prefix: Some("posts".to_string()),
         closure_relation_hop: None,
         quote: '\'',
+        joined_tables: Vec::new(),
+        from_clause: FromClause::Inherit,
     };
     let items = relations(&ctx, None, &root).await;
     let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
@@ -731,7 +735,285 @@ class User extends Model {
         dotted_prefix: Some("nonexistent".to_string()),
         closure_relation_hop: None,
         quote: '\'',
+        joined_tables: Vec::new(),
+        from_clause: FromClause::Inherit,
     };
     let items = relations(&ctx, None, &root).await;
     assert!(items.is_empty(), "unresolvable hop should yield no items");
+}
+
+// ---- columns_raw: joined-table column completion (issue #24) -----------
+
+/// Seed a provider with multiple tables at once. Base-builder completion
+/// never touches the project root, so the path is just a placeholder.
+async fn provider_with_tables(
+    root: PathBuf,
+    tables: Vec<(&str, Vec<(&str, &str)>)>,
+) -> DatabaseSchemaProvider {
+    use crate::database::DatabaseSchema;
+    use std::collections::HashMap;
+    use std::time::Instant;
+
+    let mut columns_map = HashMap::new();
+    let mut columns_with_types = HashMap::new();
+    let mut table_names = Vec::new();
+    for (table, cols) in &tables {
+        table_names.push(table.to_string());
+        columns_map.insert(
+            table.to_string(),
+            cols.iter().map(|(n, _)| n.to_string()).collect(),
+        );
+        columns_with_types.insert(
+            table.to_string(),
+            cols.iter()
+                .map(|(n, t)| (n.to_string(), t.to_string()))
+                .collect(),
+        );
+    }
+    let schema = DatabaseSchema {
+        tables: table_names,
+        columns: columns_map,
+        columns_with_types,
+        cached_at: Instant::now(),
+    };
+    let provider = DatabaseSchemaProvider::new(root);
+    provider.set_test_schema(schema).await;
+    provider
+}
+
+/// Build a base-builder `ChainContext` for column completion tests.
+fn base_ctx(
+    effective_table: Option<&str>,
+    joined_tables: Vec<AccessibleTable>,
+    from_clause: FromClause,
+    dotted_prefix: Option<&str>,
+) -> ChainContext {
+    ChainContext {
+        mode: BuilderMode::BaseBuilder,
+        effective_table: effective_table.map(|s| s.to_string()),
+        effective_model: None,
+        expecting: ArgKind::Column,
+        dotted_prefix: dotted_prefix.map(|s| s.to_string()),
+        closure_relation_hop: None,
+        quote: '\'',
+        joined_tables,
+        from_clause,
+    }
+}
+
+fn labels(items: &[CompletionItem]) -> Vec<String> {
+    items.iter().map(|i| i.label.clone()).collect()
+}
+
+#[tokio::test]
+async fn columns_raw_no_joins_offers_only_bare() {
+    let dir = TempDir::new().unwrap();
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![("users", vec![("id", "int"), ("email", "string")])],
+    )
+    .await;
+    let ctx = base_ctx(Some("users"), Vec::new(), FromClause::Inherit, None);
+    let got = labels(&columns_raw(&ctx, &db, None).await);
+    assert!(got.contains(&"id".to_string()));
+    assert!(got.contains(&"email".to_string()));
+    // No joins → no qualified `users.id` noise.
+    assert!(
+        !got.iter().any(|l| l.contains('.')),
+        "single-table query should not emit qualified columns; got {got:?}"
+    );
+}
+
+#[tokio::test]
+async fn columns_raw_with_join_offers_bare_root_and_qualified_both() {
+    let dir = TempDir::new().unwrap();
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![
+            ("users", vec![("id", "int"), ("name", "string")]),
+            ("orders", vec![("id", "int"), ("status", "string")]),
+        ],
+    )
+    .await;
+    let ctx = base_ctx(
+        Some("users"),
+        vec![AccessibleTable::bare("orders")],
+        FromClause::Inherit,
+        None,
+    );
+    let got = labels(&columns_raw(&ctx, &db, None).await);
+    // Bare root columns.
+    assert!(got.contains(&"id".to_string()), "bare root id; got {got:?}");
+    assert!(got.contains(&"name".to_string()));
+    // Qualified root columns (issue #24 criterion 3: `users.id`).
+    assert!(got.contains(&"users.id".to_string()));
+    assert!(got.contains(&"users.name".to_string()));
+    // Qualified joined columns.
+    assert!(got.contains(&"orders.status".to_string()));
+    assert!(got.contains(&"orders.id".to_string()));
+    // Joined columns are NOT offered bare (only `orders.*`).
+    assert!(
+        !got.contains(&"status".to_string()),
+        "joined column should only be qualified; got {got:?}"
+    );
+}
+
+#[tokio::test]
+async fn columns_raw_narrows_to_qualified_table() {
+    let dir = TempDir::new().unwrap();
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![
+            ("users", vec![("id", "int"), ("name", "string")]),
+            ("orders", vec![("status", "string"), ("total", "int")]),
+        ],
+    )
+    .await;
+    // User typed `orders.|` → dotted_prefix "orders".
+    let ctx = base_ctx(
+        Some("users"),
+        vec![AccessibleTable::bare("orders")],
+        FromClause::Inherit,
+        Some("orders"),
+    );
+    let got = labels(&columns_raw(&ctx, &db, None).await);
+    // Only orders columns, inserted BARE (the `orders.` is already typed).
+    assert_eq!(
+        got.len(),
+        2,
+        "expected exactly orders' columns; got {got:?}"
+    );
+    assert!(got.contains(&"status".to_string()));
+    assert!(got.contains(&"total".to_string()));
+}
+
+#[tokio::test]
+async fn columns_raw_narrows_via_alias() {
+    let dir = TempDir::new().unwrap();
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![
+            ("users", vec![("id", "int")]),
+            ("orders", vec![("status", "string")]),
+        ],
+    )
+    .await;
+    // `join('orders as o', …)->where('o.|')` → qualifier "o" resolves to orders.
+    let ctx = base_ctx(
+        Some("users"),
+        vec![AccessibleTable {
+            table: "orders".to_string(),
+            alias: Some("o".to_string()),
+        }],
+        FromClause::Inherit,
+        Some("o"),
+    );
+    let got = labels(&columns_raw(&ctx, &db, None).await);
+    assert_eq!(got, vec!["status".to_string()]);
+}
+
+#[tokio::test]
+async fn columns_raw_alias_qualifies_with_alias_not_table() {
+    let dir = TempDir::new().unwrap();
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![
+            ("users", vec![("id", "int")]),
+            ("orders", vec![("status", "string")]),
+        ],
+    )
+    .await;
+    let ctx = base_ctx(
+        Some("users"),
+        vec![AccessibleTable {
+            table: "orders".to_string(),
+            alias: Some("o".to_string()),
+        }],
+        FromClause::Inherit,
+        None,
+    );
+    let got = labels(&columns_raw(&ctx, &db, None).await);
+    // The qualifier is the ALIAS, not the real table name.
+    assert!(got.contains(&"o.status".to_string()), "got {got:?}");
+    assert!(!got.contains(&"orders.status".to_string()));
+}
+
+#[tokio::test]
+async fn columns_raw_from_replace_uses_new_table() {
+    let dir = TempDir::new().unwrap();
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![
+            ("users", vec![("id", "int")]),
+            ("admins", vec![("admin_id", "int"), ("level", "int")]),
+        ],
+    )
+    .await;
+    // `from('admins')` replaces the root — `effective_table` (users) is ignored.
+    let ctx = base_ctx(
+        Some("users"),
+        Vec::new(),
+        FromClause::Replace(AccessibleTable::bare("admins")),
+        None,
+    );
+    let got = labels(&columns_raw(&ctx, &db, None).await);
+    assert!(got.contains(&"admin_id".to_string()));
+    assert!(got.contains(&"level".to_string()));
+    assert!(
+        !got.contains(&"id".to_string()),
+        "users is replaced; got {got:?}"
+    );
+}
+
+#[tokio::test]
+async fn columns_raw_opaque_from_suppresses_root_but_keeps_joins() {
+    let dir = TempDir::new().unwrap();
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![
+            ("users", vec![("id", "int")]),
+            ("orders", vec![("status", "string")]),
+        ],
+    )
+    .await;
+    // `fromRaw(...)->join('orders', …)` → no bare root columns, joins still work.
+    let ctx = base_ctx(
+        Some("users"),
+        vec![AccessibleTable::bare("orders")],
+        FromClause::Opaque,
+        None,
+    );
+    let got = labels(&columns_raw(&ctx, &db, None).await);
+    assert!(got.contains(&"orders.status".to_string()));
+    assert!(
+        !got.contains(&"id".to_string()),
+        "opaque root suppressed; got {got:?}"
+    );
+}
+
+#[tokio::test]
+async fn columns_raw_wraps_qualified_insert_text() {
+    let dir = TempDir::new().unwrap();
+    let db = provider_with_tables(
+        dir.path().to_path_buf(),
+        vec![
+            ("users", vec![("id", "int")]),
+            ("orders", vec![("status", "string")]),
+        ],
+    )
+    .await;
+    let ctx = base_ctx(
+        Some("users"),
+        vec![AccessibleTable::bare("orders")],
+        FromClause::Inherit,
+        None,
+    );
+    // wrap_with_quote = Some('\'') → qualified insert text wraps the whole
+    // `orders.status` in quotes, not just the column.
+    let items = columns_raw(&ctx, &db, Some('\'')).await;
+    let qualified = items
+        .iter()
+        .find(|i| i.label == "orders.status")
+        .expect("qualified item");
+    assert_eq!(qualified.insert_text.as_deref(), Some("'orders.status'"));
 }

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -22,7 +22,7 @@
 
 use super::chain::*;
 use super::methods::{
-    arg_kind, chain_effect, is_table_join, CLOSURE_CARRIERS, RELATION_METHODS,
+    arg_kind, chain_effect, is_subquery_method, is_table_join, CLOSURE_CARRIERS, RELATION_METHODS,
     SAME_MODEL_CLOSURE_CARRIERS,
 };
 use super::use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};
@@ -239,13 +239,151 @@ fn extract_link(call_node: Node, bytes: &[u8]) -> Option<ChainLink> {
         .map(|n| extract_args(n, bytes))
         .unwrap_or_default();
 
+    // Subquery methods (`fromSub`/`joinSub`/lateral) expose a virtual table
+    // whose columns are the subquery's SELECT list. The cursor resolver only
+    // sees ChainArgs (closures as byte ranges, query exprs as `Other`), so we
+    // walk the first argument's AST here while the tree is still available.
+    let subquery_columns = if is_subquery_method(&method) {
+        Some(
+            args_node
+                .map(|n| extract_subquery_columns(n, bytes))
+                .unwrap_or_default(),
+        )
+    } else {
+        None
+    };
+
     Some(ChainLink {
         arg: arg_kind(&method),
         effect: chain_effect(&method),
         method,
         span_byte_range: (call_node.start_byte(), call_node.end_byte()),
         args,
+        subquery_columns,
     })
+}
+
+/// Extract the column names a subquery exposes, by walking the FIRST argument
+/// of a `fromSub`/`joinSub`/lateral call (a closure or a query-builder
+/// expression) for `select`/`addSelect` calls and collecting their string
+/// literals. Best-effort, per the issue:
+/// - `select('id', 'name')` / `addSelect('email')` / `select(['a', 'b'])` →
+///   `id, name, email, a, b`
+/// - `'users.id'` → `id` (table qualifier stripped — that's the outer name)
+/// - `'votes as score'` → `score` (the exposed alias)
+/// - `'*'` and expressions (`count(*)`, raw) → skipped
+///
+/// An empty result means the subquery's columns are unknown (no usable
+/// SELECT) — the caller treats the virtual table as opaque.
+fn extract_subquery_columns(args_node: Node, bytes: &[u8]) -> Vec<String> {
+    let mut cursor = args_node.walk();
+    let Some(first_arg) = args_node
+        .named_children(&mut cursor)
+        .find(|n| n.kind() == "argument")
+    else {
+        return Vec::new();
+    };
+    let Some(subquery) = first_arg.named_child(0) else {
+        return Vec::new();
+    };
+
+    // Walk the subquery subtree iteratively, collecting columns from every
+    // `select` / `addSelect` call. We tag each with its source byte offset and
+    // sort at the end, so the result follows the SELECT list as written
+    // (`select('id','name')->addSelect('email')` → id, name, email) regardless
+    // of tree-traversal order.
+    let mut columns: Vec<(usize, String)> = Vec::new();
+    let mut stack: Vec<Node> = vec![subquery];
+    while let Some(node) = stack.pop() {
+        if matches!(
+            node.kind(),
+            "member_call_expression" | "scoped_call_expression"
+        ) {
+            if let Some(name_node) = node.child_by_field_name("name") {
+                if let Some(name) = node_text(name_node, bytes) {
+                    if name == "select" || name == "addSelect" {
+                        if let Some(call_args) = node.child_by_field_name("arguments") {
+                            collect_select_columns(call_args, bytes, &mut columns);
+                        }
+                    }
+                }
+            }
+        }
+        let mut child_cursor = node.walk();
+        for child in node.children(&mut child_cursor) {
+            stack.push(child);
+        }
+    }
+    columns.sort_by_key(|(byte, _)| *byte);
+    columns.into_iter().map(|(_, name)| name).collect()
+}
+
+/// Append `(source_byte, exposed_column)` pairs from a `select(...)` /
+/// `addSelect(...)` argument list to `out`. Handles top-level string args and
+/// string elements inside an array arg (`select(['a', 'b'])`).
+fn collect_select_columns(args_node: Node, bytes: &[u8], out: &mut Vec<(usize, String)>) {
+    let mut cursor = args_node.walk();
+    for child in args_node.named_children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        let Some(inner) = child.named_child(0) else {
+            continue;
+        };
+        match inner.kind() {
+            "string" => {
+                if let Some((value, _)) = single_quoted_string(inner, bytes) {
+                    push_exposed_column(&value, inner.start_byte(), out);
+                }
+            }
+            "encapsed_string" => {
+                if let Some(value) = encapsed_string_content(inner, bytes) {
+                    push_exposed_column(&value, inner.start_byte(), out);
+                }
+            }
+            "array_creation_expression" => {
+                for elem in extract_array_elements(inner, bytes) {
+                    if let ChainArg::StringLit {
+                        value,
+                        span_byte_range,
+                        ..
+                    } = elem
+                    {
+                        push_exposed_column(&value, span_byte_range.0, out);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Resolve the outer-facing column name a SELECT entry exposes and push
+/// `(byte, name)` to `out` (skips wildcards and expressions). See
+/// [`extract_subquery_columns`].
+fn push_exposed_column(raw: &str, byte: usize, out: &mut Vec<(usize, String)>) {
+    let trimmed = raw.trim();
+    if trimmed == "*" || trimmed.is_empty() || trimmed.contains('(') {
+        return; // wildcard or expression — no single exposed name
+    }
+    // `col as alias` (case-insensitive `as`) → the alias is what's exposed.
+    let exposed = if let Some(idx) = find_as_keyword(trimmed) {
+        trimmed[idx..].trim()
+    } else {
+        // Strip a table qualifier: the subquery result exposes the bare column.
+        trimmed.rsplit('.').next().unwrap_or(trimmed)
+    };
+    if exposed.contains('*') || exposed.is_empty() {
+        return;
+    }
+    out.push((byte, exposed.to_string()));
+}
+
+/// Byte index of the character AFTER a whitespace-delimited `as` keyword
+/// (case-insensitive) in `s`, i.e. the start of the alias. `None` if absent.
+/// ASCII-lowercasing preserves byte offsets, so the index maps back to `s`.
+fn find_as_keyword(s: &str) -> Option<usize> {
+    s.to_ascii_lowercase().find(" as ").map(|idx| idx + 4)
 }
 
 /// Decode an `arguments` node into a `Vec<ChainArg>` in source order. We only

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -22,7 +22,8 @@
 
 use super::chain::*;
 use super::methods::{
-    arg_kind, chain_effect, CLOSURE_CARRIERS, RELATION_METHODS, SAME_MODEL_CLOSURE_CARRIERS,
+    arg_kind, chain_effect, is_table_join, CLOSURE_CARRIERS, RELATION_METHODS,
+    SAME_MODEL_CLOSURE_CARRIERS,
 };
 use super::use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};
 use tree_sitter::{Node, Tree};
@@ -696,19 +697,21 @@ fn detect_closure_scope_positional(
     // Relation-hop carrier? Extract the relation name from the first
     // string arg.
     if CLOSURE_CARRIERS.contains(&method_name) {
-        let mut args_cursor = args_node.walk();
-        let first_arg = args_node
-            .named_children(&mut args_cursor)
-            .find(|n| n.kind() == "argument")?;
-        let first_inner = first_arg.named_child(0)?;
-        let relation_name = match first_inner.kind() {
-            "string" => single_quoted_string(first_inner, bytes).map(|(s, _)| s)?,
-            "encapsed_string" => encapsed_string_content(first_inner, bytes)?,
-            _ => return None,
-        };
+        let relation_name = first_string_arg_value(args_node, bytes)?;
         return Some(ClosureScopeBinding {
             param_var,
             kind: ClosureScopeKind::RelationHop { relation_name },
+        });
+    }
+
+    // Join carrier? `join('orders', fn ($join) => …)` — `$join` is a
+    // JoinClause rooted at the joined table named by the first string arg
+    // (issue #24).
+    if is_table_join(method_name) {
+        let table_ref = first_string_arg_value(args_node, bytes)?;
+        return Some(ClosureScopeBinding {
+            param_var,
+            kind: ClosureScopeKind::JoinTable { table_ref },
         });
     }
 
@@ -721,6 +724,22 @@ fn detect_closure_scope_positional(
     }
 
     None
+}
+
+/// The value of the first string-literal argument in an `arguments` node —
+/// the relation name for `whereHas('rel', …)` or the table name for
+/// `join('orders', …)`. Returns `None` if the first argument isn't a string.
+fn first_string_arg_value(args_node: Node, bytes: &[u8]) -> Option<String> {
+    let mut args_cursor = args_node.walk();
+    let first_arg = args_node
+        .named_children(&mut args_cursor)
+        .find(|n| n.kind() == "argument")?;
+    let first_inner = first_arg.named_child(0)?;
+    match first_inner.kind() {
+        "string" => single_quoted_string(first_inner, bytes).map(|(s, _)| s),
+        "encapsed_string" => encapsed_string_content(first_inner, bytes),
+        _ => None,
+    }
 }
 
 /// Resolve `with(['rel' => fn ($q) => …])` shape. The closure is the

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -479,6 +479,7 @@ fn shift_chain_byte_ranges_shifts_every_span() {
                     body_byte_range: (44, 48),
                 },
             ],
+            subquery_columns: None,
         }],
     };
     // Region starts at outer byte 100. Wrapper prefix is 6 bytes (<?php ).
@@ -1255,4 +1256,94 @@ fn join_closure_records_aliased_table_ref_verbatim() {
         &binding.kind,
         ClosureScopeKind::JoinTable { table_ref } if table_ref == "orders as o"
     ));
+}
+
+// ---- subquery SELECT-column extraction (issue #24, Phase 4) -----------
+
+/// Pull the `subquery_columns` off the first link matching `method`.
+fn subquery_cols(chains: &[BuilderChain], method: &str) -> Option<Vec<String>> {
+    chains
+        .iter()
+        .flat_map(|c| &c.links)
+        .find(|l| l.method == method)
+        .and_then(|l| l.subquery_columns.clone())
+}
+
+#[test]
+fn from_sub_extracts_columns_from_closure_select() {
+    let chains = extract(
+        "DB::table('o')->fromSub(function ($q) { $q->from('users')->select('id', 'name'); }, 'u');",
+    );
+    assert_eq!(
+        subquery_cols(&chains, "fromSub").as_deref(),
+        Some(["id".to_string(), "name".to_string()].as_slice())
+    );
+}
+
+#[test]
+fn from_sub_extracts_columns_from_query_expression() {
+    // The subquery is a query-builder expression, not a closure.
+    let chains = extract("DB::query()->fromSub(User::select('id', 'email'), 'u');");
+    assert_eq!(
+        subquery_cols(&chains, "fromSub").as_deref(),
+        Some(["id".to_string(), "email".to_string()].as_slice())
+    );
+}
+
+#[test]
+fn from_sub_includes_add_select_and_arrays() {
+    let chains = extract(
+        "DB::query()->fromSub(function ($q) { $q->select(['id', 'name'])->addSelect('email'); }, 'u');",
+    );
+    assert_eq!(
+        subquery_cols(&chains, "fromSub").as_deref(),
+        Some(["id".to_string(), "name".to_string(), "email".to_string()].as_slice())
+    );
+}
+
+#[test]
+fn from_sub_exposed_names_strip_qualifiers_and_use_aliases() {
+    // `users.id` → `id`; `votes as score` → `score`; `count(*)` and `*` skipped.
+    let chains = extract(
+        "DB::query()->fromSub(function ($q) { $q->select('users.id', 'votes as score', 'count(*)', '*'); }, 'u');",
+    );
+    assert_eq!(
+        subquery_cols(&chains, "fromSub").as_deref(),
+        Some(["id".to_string(), "score".to_string()].as_slice())
+    );
+}
+
+#[test]
+fn from_sub_without_select_yields_empty_columns() {
+    // No SELECT → unknown columns → empty (the caller treats it as opaque).
+    let chains = extract("DB::query()->fromSub(function ($q) { $q->where('x', 1); }, 'u');");
+    assert_eq!(
+        subquery_cols(&chains, "fromSub").as_deref(),
+        Some([].as_slice())
+    );
+}
+
+#[test]
+fn join_sub_extracts_columns() {
+    let chains = extract(
+        "DB::table('users')->joinSub(function ($q) { $q->select('total'); }, 'agg', 'agg.user_id', '=', 'users.id');",
+    );
+    assert_eq!(
+        subquery_cols(&chains, "joinSub").as_deref(),
+        Some(["total".to_string()].as_slice())
+    );
+}
+
+#[test]
+fn non_subquery_methods_have_no_subquery_columns() {
+    let chains = extract("DB::table('users')->where('id', 1)->join('orders', 'a', '=', 'b');");
+    for chain in &chains {
+        for link in &chain.links {
+            assert!(
+                link.subquery_columns.is_none(),
+                "{} should have no subquery_columns",
+                link.method
+            );
+        }
+    }
 }

--- a/laravel-lsp/src/query_chain/extractor/tests.rs
+++ b/laravel-lsp/src/query_chain/extractor/tests.rs
@@ -1207,3 +1207,52 @@ function search() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn join_closure_records_join_table_binding() {
+    // `DB::table('users')->join('orders', function ($join) { $join->where(...) })`
+    // — the inner `$join->where(...)` chain should carry a JoinTable binding
+    // naming the joined table (issue #24).
+    let chains = extract(
+        "DB::table('users')->join('orders', function ($join) { $join->where('status', 1); });",
+    );
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) if var == "join"
+            )
+        })
+        .expect("inner $join chain not found");
+    let binding = inner
+        .closure_scope
+        .as_ref()
+        .expect("inner chain should have closure_scope set");
+    assert_eq!(binding.param_var, "join");
+    assert!(matches!(
+        &binding.kind,
+        ClosureScopeKind::JoinTable { table_ref } if table_ref == "orders"
+    ));
+}
+
+#[test]
+fn join_closure_records_aliased_table_ref_verbatim() {
+    // The alias is kept in the raw table_ref; the cursor resolver parses it.
+    let chains =
+        extract("DB::table('users')->join('orders as o', fn ($join) => $join->where('o.id', 1));");
+    let inner = chains
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.receiver,
+                ChainReceiver::Eloquent(EloquentReceiver::InstanceVar { var, .. }) if var == "join"
+            )
+        })
+        .expect("inner $join chain");
+    let binding = inner.closure_scope.as_ref().expect("scope set");
+    assert!(matches!(
+        &binding.kind,
+        ClosureScopeKind::JoinTable { table_ref } if table_ref == "orders as o"
+    ));
+}

--- a/laravel-lsp/src/query_chain/methods.rs
+++ b/laravel-lsp/src/query_chain/methods.rs
@@ -176,11 +176,27 @@ pub const TABLE_JOIN_METHODS: &[&str] = &[
 /// schema qualifier (`from('mydb.admins')`).
 pub const FROM_REPLACE_METHODS: &[&str] = &["from"];
 
-/// `from*()` methods whose argument is opaque SQL or a subquery we don't
-/// resolve to a concrete schema table (until Phase 4 adds `fromSub` virtual
-/// tables). After one of these, the root table is unknown, so no bare root
-/// columns can be offered — but any joined tables remain valid.
-pub const FROM_OPAQUE_METHODS: &[&str] = &["fromRaw", "fromSub"];
+/// `from*()` methods whose argument is opaque SQL — the root table becomes
+/// unknown, so no bare root columns can be offered (joined tables remain
+/// valid). `fromSub` is NOT here: it resolves to a virtual table (see
+/// [`FROM_SUB_METHODS`]).
+pub const FROM_OPAQUE_METHODS: &[&str] = &["fromRaw"];
+
+/// Subquery `from*()` — `fromSub($query, $alias)` synthesizes a virtual root
+/// table named by the `$alias`, whose columns come from the subquery's SELECT
+/// list (issue #24, Phase 4).
+pub const FROM_SUB_METHODS: &[&str] = &["fromSub"];
+
+/// Subquery joins — `joinSub`/`leftJoinSub`/`rightJoinSub`/`joinLateral`/
+/// `leftJoinLateral`($query, $alias, …). Each synthesizes a virtual joined
+/// table named by the `$alias`, columns from the subquery's SELECT list.
+pub const SUBQUERY_JOIN_METHODS: &[&str] = &[
+    "joinSub",
+    "leftJoinSub",
+    "rightJoinSub",
+    "joinLateral",
+    "leftJoinLateral",
+];
 
 /// Whether `name` is a join method whose first string arg names a table.
 pub fn is_table_join(name: &str) -> bool {
@@ -193,9 +209,25 @@ pub fn is_from_replace(name: &str) -> bool {
     FROM_REPLACE_METHODS.contains(&name)
 }
 
-/// Whether `name` makes the chain's root table opaque (`fromRaw`, `fromSub`).
+/// Whether `name` makes the chain's root table opaque (`fromRaw`).
 pub fn is_from_opaque(name: &str) -> bool {
     FROM_OPAQUE_METHODS.contains(&name)
+}
+
+/// Whether `name` is `fromSub` — a virtual-table root from a subquery.
+pub fn is_from_sub(name: &str) -> bool {
+    FROM_SUB_METHODS.contains(&name)
+}
+
+/// Whether `name` is a subquery join (`joinSub`, `joinLateral`, …).
+pub fn is_subquery_join(name: &str) -> bool {
+    SUBQUERY_JOIN_METHODS.contains(&name)
+}
+
+/// Whether `name` takes a subquery + alias and synthesizes a virtual table
+/// (either `fromSub` or a subquery join).
+pub fn is_subquery_method(name: &str) -> bool {
+    is_from_sub(name) || is_subquery_join(name)
 }
 
 /// Methods that flip the chain from Eloquent → base query builder. After

--- a/laravel-lsp/src/query_chain/methods.rs
+++ b/laravel-lsp/src/query_chain/methods.rs
@@ -150,6 +150,54 @@ pub const SAME_MODEL_CLOSURE_CARRIERS: &[&str] = &[
     "tap",
 ];
 
+/// Join methods whose FIRST string argument names a table. After any of
+/// these, that table's columns become referenceable for the rest of the
+/// chain (`->join('orders', …)->where('orders.status', …)`). The optional
+/// later arguments are either the join condition (4-arg form) or a closure
+/// (closure form — Phase 3); neither changes the fact that the FIRST arg is
+/// the table being joined.
+///
+/// Subquery joins (`joinSub`, `joinLateral`, …) take a *query*, not a table
+/// name, so they live in a separate Phase-4 list — their accessible table is
+/// named by the alias argument instead.
+pub const TABLE_JOIN_METHODS: &[&str] = &[
+    "join",
+    "leftJoin",
+    "rightJoin",
+    "crossJoin",
+    "joinWhere",
+    "leftJoinWhere",
+    "rightJoinWhere",
+];
+
+/// Receiver-replacing `from*()` methods whose first string argument names the
+/// new root table — `from('admins')` swaps the FROM clause. Like the joins,
+/// the table reference may carry an alias (`from('admins as a')`) or a
+/// schema qualifier (`from('mydb.admins')`).
+pub const FROM_REPLACE_METHODS: &[&str] = &["from"];
+
+/// `from*()` methods whose argument is opaque SQL or a subquery we don't
+/// resolve to a concrete schema table (until Phase 4 adds `fromSub` virtual
+/// tables). After one of these, the root table is unknown, so no bare root
+/// columns can be offered — but any joined tables remain valid.
+pub const FROM_OPAQUE_METHODS: &[&str] = &["fromRaw", "fromSub"];
+
+/// Whether `name` is a join method whose first string arg names a table.
+pub fn is_table_join(name: &str) -> bool {
+    TABLE_JOIN_METHODS.contains(&name)
+}
+
+/// Whether `name` replaces the chain's root table with a concrete table named
+/// by its first string arg (`from('admins')`).
+pub fn is_from_replace(name: &str) -> bool {
+    FROM_REPLACE_METHODS.contains(&name)
+}
+
+/// Whether `name` makes the chain's root table opaque (`fromRaw`, `fromSub`).
+pub fn is_from_opaque(name: &str) -> bool {
+    FROM_OPAQUE_METHODS.contains(&name)
+}
+
 /// Methods that flip the chain from Eloquent → base query builder. After
 /// these, the chain is operating on `Illuminate\Database\Query\Builder`, so
 /// relation methods would error at runtime — completion returns empty for

--- a/laravel-lsp/src/query_chain/methods/tests.rs
+++ b/laravel-lsp/src/query_chain/methods/tests.rs
@@ -237,3 +237,59 @@ fn raw_methods_are_unique() {
         sorted
     );
 }
+
+// ---- join / from classification (issue #24) ---------------------------
+
+#[test]
+fn table_join_methods_are_recognized() {
+    for name in [
+        "join",
+        "leftJoin",
+        "rightJoin",
+        "crossJoin",
+        "joinWhere",
+        "leftJoinWhere",
+        "rightJoinWhere",
+    ] {
+        assert!(is_table_join(name), "{name} should be a table join");
+    }
+}
+
+#[test]
+fn non_join_methods_are_not_table_joins() {
+    // Subquery joins take a query, not a table name — they're Phase 4, not
+    // table joins. And ordinary methods obviously aren't joins.
+    for name in ["joinSub", "joinLateral", "where", "select", "with", "from"] {
+        assert!(!is_table_join(name), "{name} should not be a table join");
+    }
+}
+
+#[test]
+fn from_replace_is_only_plain_from() {
+    assert!(is_from_replace("from"));
+    // The opaque from*() variants don't name a concrete table.
+    assert!(!is_from_replace("fromRaw"));
+    assert!(!is_from_replace("fromSub"));
+    assert!(!is_from_replace("join"));
+}
+
+#[test]
+fn from_opaque_covers_raw_and_sub() {
+    assert!(is_from_opaque("fromRaw"));
+    assert!(is_from_opaque("fromSub"));
+    assert!(!is_from_opaque("from"));
+}
+
+#[test]
+fn join_and_from_methods_dont_classify_as_columns() {
+    // Joins/from must not fire column completion inside their own table-name
+    // arg via the column path — they're handled by the accessible-tables scan
+    // instead, so arg_kind stays None for them.
+    for name in TABLE_JOIN_METHODS.iter().chain(FROM_REPLACE_METHODS.iter()) {
+        assert_eq!(
+            arg_kind(name),
+            ArgKind::None,
+            "{name} should not be an ArgKind::Column method"
+        );
+    }
+}

--- a/laravel-lsp/src/query_chain/methods/tests.rs
+++ b/laravel-lsp/src/query_chain/methods/tests.rs
@@ -274,10 +274,33 @@ fn from_replace_is_only_plain_from() {
 }
 
 #[test]
-fn from_opaque_covers_raw_and_sub() {
+fn from_opaque_is_only_from_raw() {
     assert!(is_from_opaque("fromRaw"));
-    assert!(is_from_opaque("fromSub"));
     assert!(!is_from_opaque("from"));
+    // fromSub resolves to a virtual table (Phase 4), not opaque.
+    assert!(!is_from_opaque("fromSub"));
+}
+
+#[test]
+fn subquery_methods_are_classified() {
+    assert!(is_from_sub("fromSub"));
+    assert!(!is_from_sub("from"));
+    assert!(!is_from_sub("fromRaw"));
+
+    for name in [
+        "joinSub",
+        "leftJoinSub",
+        "rightJoinSub",
+        "joinLateral",
+        "leftJoinLateral",
+    ] {
+        assert!(is_subquery_join(name), "{name} should be a subquery join");
+        assert!(is_subquery_method(name));
+    }
+    assert!(is_subquery_method("fromSub"));
+    // Plain table joins are not subquery joins.
+    assert!(!is_subquery_join("join"));
+    assert!(!is_subquery_method("join"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #24.

Resolves column completion, diagnostics, and goto-definition against **joined tables** — not just a chain's root model/table. Built in five reviewable phases (one commit each).

## What's covered

### Acceptance criteria (from the issue)
- [x] After `->join('orders', …)`, `where('|')` offers bare `users.*` columns **and** `orders.*` qualified
- [x] `where('orders.|')` narrows to `orders.*` only
- [x] `select('|')` offers `users.*`, `orders.*`, and `users.id` / `orders.id` qualified forms
- [x] Closure-form joins (`->join('orders', fn ($join) => …)`) complete against `orders` inside the closure
- [x] `from('admins')` replaces the root table
- [x] `fromRaw(...)` surfaces no incorrect completions
- [x] Multiple joins compose
- [x] `crossJoin('roles')->where('roles.|')` works like a regular join

### Pulled in from "out of scope" (per discussion)
- [x] **Aliased joins** — `join('users as u', …)` → `u.*`; alias resolves to the real table for column lookup
- [x] **Cross-database / schema-qualified names** — `join('mydb.orders', …)`, parsed on the last dot; column lookup best-effort
- [x] **Ambiguity detection** — a bare column on >1 accessible table is flagged (`laravel-lsp.ambiguous-column`) with "Qualify as `…`" quick-fixes

## Phase breakdown
1. **Base-builder joins** — `AccessibleTable`/`FromClause` model, global join scan, alias + schema-qualified parsing, multi-table completion, table-name completion inside join/`from` args + ON-condition columns, diagnostics with no false positives.
2. **Eloquent chains + `from()`** — unify all three column paths through one assembler; `from()` redirect + `fromRaw` opacity for models; bare-column goto.
3. **Closure-form joins** — bind `$join` to the joined table; `on`/`orOn` complete columns (disambiguated from the static `Model::on('connection')`); both sides of the ON clause (parent tables).
4. **Subquery virtual tables** — `fromSub`/`joinSub`/lateral synthesize a virtual table from the subquery's SELECT list (best-effort, source order).
5. **Ambiguity** — per-table column sets → ambiguous/valid/unknown classification, "Qualify as `…`" quick-fix, and a goto tiebreak that returns all matching tables' migration lines.

## Testing
- 1140 library tests passing (full suite green), `cargo clippy` clean, `cargo fmt` applied.
- New coverage across `methods`, `chain`, `extractor`, `cursor`, `eloquent_completion`, `diagnostics`, and `code_actions` test modules.

## Notes / known limitations
- Virtual (subquery) columns are typed `mixed` (no type inference through a subquery); goto on a virtual column no-ops (no migration defines it); diagnostics stay quiet when a virtual table is in scope (under-warn on best-effort columns).