### PR TITLE
docs: 📝 Document features since 0.1.19 + add "Why we built this" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ Route::middleware('admin-only')->group(...);
      ⚡ Create component with class --}}
 
 <livewire:admin-panel />
-{{-- ⚠️ Livewire component not found
+{{-- ❌ Livewire component not found
      ⚡ Create Livewire component --}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,44 +28,27 @@
 
 ---
 
-## 🤔 Why this extension?
+## 💛 Why we built this
 
-This extension brings Laravel-aware intelligence — go-to-definition, autocomplete, hover, diagnostics — to **Zed**. It isn't trying to replace the official Laravel VS Code extension; it's a different approach for a different editor, shaped by two design choices worth understanding before you install.
+We love Laravel, and we love Zed. When we moved our Laravel work into Zed, the deep, framework-aware tooling we'd relied on elsewhere wasn't there yet — so we built it. This extension exists to give Laravel first-class support in Zed, because a framework this good deserves great tooling everywhere its developers work.
 
-### Built on a real language server
+The intelligence lives in a standalone language server (LSP) — the same protocol your editor already speaks for other languages. Today it targets Zed; because it's LSP-based, the same engine could reach other LSP-capable editors (Neovim, Helix, Sublime Text, and more) down the road. That's a direction we'd love to grow toward, not something we ship yet.
 
-The intelligence lives in a standalone Language Server Protocol (LSP) server, not in editor-specific plugin code. Today it targets Zed. But because everything runs through the LSP — the same protocol your editor already speaks for other languages — the door is open to supporting other LSP-capable editors (Neovim, Helix, Sublime Text, Kate, and more) in the future. That portability is a deliberate architectural bet, not something we ship yet.
+### How it works — static analysis
 
-### No app boot — pure static analysis
+Everything is parsed statically with tree-sitter: the extension reads your files, it never runs them. It only touches your database when *you* opt into schema-backed completion, and it keeps working even when your app won't boot — a half-applied migration, a missing `.env`, or a dirty branch won't stop it. The honest trade-off: some deeply dynamic runtime behaviour (fully dynamic Eloquent magic, runtime-registered routes) is harder to reach through static analysis alone.
 
-The official VS Code extension boots your Laravel application in the background to gather its data. That means it executes your service providers (with whatever side effects they carry), can touch your database, and can struggle when local state is broken — a half-applied migration, a missing `.env`, a dirty branch. It runs your code, which is worth knowing when you open an unfamiliar project.
+### Laravel across editors
 
-The official extension is candid about this in its own README:
+Laravel developers are spoiled for choice — every major editor has a strong way to work with the framework. Here's roughly where things stand and what each needs, so you can pick whatever fits how you work:
 
-> This extension will occasionally boot your app in the background to collect information about your app for use in autocompletion, linking, hovering, and diagnostics.
-
-This extension takes the opposite approach: everything is parsed statically with tree-sitter — it reads your files, it never runs them. The trade-off is honest: some deep runtime behaviour (fully dynamic Eloquent magic, runtime-registered routes) is harder to reach through static analysis alone. But it never executes your code, it only reads your database when *you* opt into schema-backed column completion, and it keeps working even when your app won't boot.
-
-### How it compares
-
-The official VS Code extension is the Laravel tooling most developers already know, so it's a useful reference point. This isn't a head-to-head — they're different tools for different editors, with different trade-offs:
-
-| Capability | This extension (Zed) | Official Laravel VS Code |
+| Editor | Laravel-aware tooling | Cost |
 |---|---|---|
-| Editor | Zed today — LSP-based, designed to be portable to other editors later | VS Code |
-| Runtime model | ✅ Static parse (tree-sitter) — never runs your code | ⚠️ Runs your application code to gather data |
-| Works when the app won't boot | ✅ | ❌ |
-| Go-to-definition (views, routes, config, env, translations, components) | ✅ | ✅ |
-| Hover summaries | ✅ | ✅ |
-| Eloquent autocomplete (models, attributes, relations, columns) | ✅ | ✅ |
-| Blade directive autocomplete (`@if`, `@foreach`, …) | ✅ 100+ directives | ✅ |
-| Diagnostics | ✅ with quick-fixes & "did you mean" suggestions | ✅ existence checks; quick-fixes for env/view/Inertia |
-| Find references / rename across Laravel patterns | ✅ | ❌ |
-| Livewire | ✅ v3 + v4 + Volt · diagnostics · rename | ✅ completion, goto, hover (tag form) |
-| Laravel Pennant feature flags | ✅ | ❌ |
-| Inertia.js | 🚧 [#10](https://github.com/GeneaLabs/zed-laravel/issues/10) | ✅ |
+| **PHPStorm** | Laravel support built in, powered by the [Laravel Idea](https://laravel-idea.com/) plugin | Paid IDE (free for non-commercial use) |
+| **VS Code** | [Official Laravel extension](https://github.com/laravel/vs-code-extension), maintained by the Laravel team | Free |
+| **Zed** | This extension, plus [Laravel Blade](https://github.com/bajrangCoder/zed-laravel-blade) for syntax highlighting | Free |
 
-<sub>Official-extension column verified against its <a href="https://github.com/laravel/vs-code-extension">source code</a> on 2026-05-30 (its README is more conservative than its code — e.g. Livewire and Blade-component support ship but aren't documented there). Both extensions also cover assets, middleware, config, translations, validation rules, and container bindings. Corrections welcome via PR.</sub>
+<sub>A high-level snapshot as of 2026-05-30 — not a feature-by-feature scorecard. Every option here is capable and actively developed. (As of 2025, the Laravel Idea plugin is bundled free with PhpStorm.) Corrections welcome via PR.</sub>
 
 ## 📦 Install
 

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ The official VS Code extension is the Laravel tooling most developers already kn
 | Go-to-definition (views, routes, config, env, translations, components) | ✅ | ✅ |
 | Hover summaries | ✅ | ✅ |
 | Eloquent autocomplete (models, attributes, relations, columns) | ✅ | ✅ |
-| Blade directive autocomplete (`@if`, `@foreach`, …) | ✅ 100+ directives | ❌ |
-| Diagnostics | ✅ with quick-fixes & "did you mean" | ✅ existence checks (route/config/view…) |
+| Blade directive autocomplete (`@if`, `@foreach`, …) | ✅ 100+ directives | ✅ |
+| Diagnostics | ✅ with quick-fixes & "did you mean" suggestions | ✅ existence checks; quick-fixes for env/view/Inertia |
 | Find references / rename across Laravel patterns | ✅ | ❌ |
-| Livewire | ✅ v3 + v4 + Volt | 🚧 Roadmap |
+| Livewire | ✅ v3 + v4 + Volt · diagnostics · rename | ✅ completion, goto, hover (tag form) |
 | Laravel Pennant feature flags | ✅ | ❌ |
 | Inertia.js | 🚧 [#10](https://github.com/GeneaLabs/zed-laravel/issues/10) | ✅ |
 
-<sub>Official-extension column verified against its <a href="https://github.com/laravel/vs-code-extension">README</a> on 2026-05-30. Both extensions also cover assets, middleware, config, translations, validation rules, and container bindings. Corrections welcome via PR.</sub>
+<sub>Official-extension column verified against its <a href="https://github.com/laravel/vs-code-extension">source code</a> on 2026-05-30 (its README is more conservative than its code — e.g. Livewire and Blade-component support ship but aren't documented there). Both extensions also cover assets, middleware, config, translations, validation rules, and container bindings. Corrections welcome via PR.</sub>
 
 ## 📦 Install
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,43 @@
 
 ---
 
+## 🤔 Why this extension?
+
+Two design choices set this extension apart from the official Laravel VS Code extension — and they're the reason it exists.
+
+### A real language server — works in any editor
+
+This is a Language Server Protocol (LSP) server, not a VS Code plugin. It speaks the same protocol your editor already uses for every other language, so it runs anywhere an LSP client does: **Zed, Neovim** (`nvim-lspconfig`), **Helix, Sublime Text** (LSP package), **Kate, BBEdit**, and more. The official Laravel VS Code extension is VS Code–only by design. If you've moved off VS Code — or never used it — this is the cross-editor option.
+
+### No app boot — pure static analysis
+
+The official extension boots your Laravel application in the background to gather its data. That means it executes your service providers (with whatever side effects they carry), can touch your database, and breaks when local state is broken — a half-applied migration, a missing `.env`, a dirty branch. It also runs your code, which is a real consideration when you open an unfamiliar project.
+
+The official extension is candid about this in its own README:
+
+> This extension will occasionally boot your app in the background to collect information about your app for use in autocompletion, linking, hovering, and diagnostics.
+
+This extension does **none of that**. Everything is parsed statically with tree-sitter — it reads your files, it never runs them. The trade-off is honest: some deep runtime behaviour (fully dynamic Eloquent magic, runtime-registered routes) is harder to reach through static analysis alone. But it never executes your code, it only reads your database when *you* opt into schema-backed column completion, and it keeps working when your app won't even boot.
+
+### Feature comparison
+
+| Capability | This extension | Official Laravel VS Code |
+|---|---|---|
+| Editor support | ✅ Any LSP client (Zed, Neovim, Helix, Sublime, Kate…) | ❌ VS Code only |
+| Runtime model | ✅ Static parse (tree-sitter) — never runs your code | ⚠️ Runs your application code to gather data |
+| Works when the app won't boot | ✅ | ❌ |
+| Go-to-definition (views, routes, config, env, translations, components) | ✅ | ✅ |
+| Hover summaries | ✅ | ✅ |
+| Eloquent autocomplete (models, attributes, relations, columns) | ✅ | ✅ |
+| Blade directive autocomplete (`@if`, `@foreach`, …) | ✅ 100+ directives | ❌ |
+| Diagnostics | ✅ with quick-fixes & "did you mean" | ✅ existence checks (route/config/view…) |
+| Find references / rename across Laravel patterns | ✅ | ❌ |
+| Livewire | ✅ v3 + v4 + Volt | 🚧 Roadmap |
+| Laravel Pennant feature flags | ✅ | ❌ |
+| Inertia.js | 🚧 [#10](https://github.com/GeneaLabs/zed-laravel/issues/10) | ✅ |
+
+<sub>Official-extension column verified against its <a href="https://github.com/laravel/vs-code-extension">README</a> on 2026-05-30. Both extensions also cover assets, middleware, config, translations, validation rules, and container bindings. Corrections welcome via PR.</sub>
+
 ## 📦 Install
 
 Search **"Laravel"** in Zed Extensions and click Install.
@@ -128,13 +165,13 @@ Zed defaults to tree-sitter outlines, which don't call any LSP — opt into LSP 
 
 > **Quirks worth knowing** — Zed colors outline labels by word-matching them against the source buffer's tree-sitter highlights, which produces slightly inconsistent colors on multi-segment URLs (e.g., `/cra-details` may color `cra` and `details` differently if they match different tokens elsewhere in the file). Route names appear in the LSP `detail` field, which Zed's outline panel doesn't currently render (VSCode and Sublime/LSP do). Both are tracked upstream: [zed#57576](https://github.com/zed-industries/zed/issues/57576).
 
-## 🔧 Tuning Intelephense
+### 🔧 Tuning Intelephense
 
 If you use Intelephense as your PHP language server, goto-definition on a class name (e.g. `User`) can land you in a Zed multi-buffer with several unrelated files — the actual class, plus generated stubs from [barryvdh/laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper), `.phpstorm.meta.php`, and `class User` stub templates that packages like Jetstream ship under `vendor/*/stubs/`. Intelephense indexes all of them by default.
 
 Zed merges goto responses across every running LSP and only dedupes identical locations — distinct paths from the same logical click stay separate. So even though `laravel-lsp` returns nothing for bare class references (we don't claim that pattern), Intelephense's noisy results show through unfiltered.
 
-### Safe baseline
+#### Safe baseline
 
 Tell Intelephense to skip `vendor/*/stubs/` — those are scaffold templates (Jetstream, Filament, etc.), never loaded at runtime. Excluding them costs nothing.
 
@@ -164,7 +201,7 @@ After saving, restart Intelephense (`Cmd+Shift+P → lsp: restart`). The stub-te
 
 > ⚠️ **Cache caveat.** Intelephense keeps a persistent symbol index on disk, so already-indexed symbols can still surface after you add excludes. To force a rebuild, add `"clearCache": true` to `initialization_options` for one startup (then remove it — leaving it `true` re-indexes from scratch every launch). As a fallback, wipe `~/Library/Application Support/intelephense/` (macOS) while Zed isn't running.
 
-### More aggressive (with trade-offs)
+#### More aggressive (with trade-offs)
 
 If `_ide_helper_models.php` and `.phpstorm.meta.php` still cluttering goto bothers you more than the Intelephense fidelity they enable, add them to the exclude array:
 
@@ -185,7 +222,7 @@ What you trade:
 
 If you use packages that extend Laravel facades with their own methods (Scout adds `Searchable` methods, Telescope extends `Gate`, etc.), keep `_ide_helper*.php` in to retain completion for those package-added methods. Core Laravel facades resolve fine without it.
 
-### Per-project
+#### Per-project
 
 Drop the same exclude patterns into an `.intelephense.json` at your project root. Unlike the Zed `settings` block, this file is read directly by Intelephense, so it uses the standard namespaced shape:
 
@@ -250,7 +287,33 @@ DB::table('users')->get();
 ```
 
 **Supported patterns:**
-`view()` `View::make()` `@extends` `@include` `@component` `<x-*>` `</x-*>` `<livewire:*>` `</livewire:*>` `@livewire()` `route()` `to_route()` `config()` `Config::get()` `env()` `__()` `trans()` `@lang` `->middleware()` `app()` `resolve()` `asset()` `@vite` `app_path()` `base_path()` `storage_path()` `resource_path()` `public_path()` `Feature::active()` `Feature::inactive()` `Feature::value()` `@feature` · query-chain columns / relations / tables
+`view()` `View::make()` `@extends` `@include` `@component` `<x-*>` `</x-*>` `<livewire:*>` `</livewire:*>` `@livewire()` `route()` `to_route()` `signed_route()` `URL::signedRoute()` `config()` `Config::get()` `Config::getMany()` `config()->string()` `env()` `Env::get()` `__()` `trans()` `@lang` `->middleware()` `app()` `resolve()` `App::bound()` `App::isShared()` `asset()` `@vite` `app_path()` `base_path()` `storage_path()` `resource_path()` `public_path()` `Feature::active()` `Feature::inactive()` `Feature::value()` `@feature` · query-chain columns / relations / tables
+
+### ℹ️ Hover
+
+Hover any recognised pattern to get an Intelephense-style summary card — a header, the relevant source snippet, and a clickable link to the file it resolves to. No need to jump away from your current line to remember what a view, route, or config key points at.
+
+```php
+return view('users.profile');
+//          ^^^^^^^^^^^^^^^ hover →  resources/views/users/profile.blade.php
+//                                   @props([...]) declaration + click-to-open link
+
+$url = route('users.show', $user);
+//           ^^^^^^^^^^^^ hover →  Route::get('/users/{user}', ...)->name('users.show')
+//                                 verb · URI · controller@action · click-to-open link
+
+$tz = config('app.timezone');
+//           ^^^^^^^^^^^^^^ hover →  'UTC'   (the resolved value, from config/app.php)
+```
+
+```blade
+{{ $user->email }}
+{{-- ^^^^^ hover →  App\Models\User::$email, its PHPDoc summary, and the declaration --}}
+```
+
+**Hovered patterns:** views, Blade components (anonymous *and* class-backed), Livewire components, routes, config keys, env vars, translations (including `vendor::namespace.key`), middleware aliases, container bindings, assets (`asset()`, `Vite::asset()`, `mix()`, `public_path()`, …), `url()`, and Blade variables. The bottom-line source path renders as a `file://` link, so the whole card is click-to-open in any LSP client that supports markdown links.
+
+Class-backed components and Livewire components show the `class Foo extends Component` signature and link to the PHP class; anonymous components fall back to the `@props([...])` declaration from the `.blade.php` template. Patterns without a meaningful target (directives, controller actions, Pennant features) stay silent rather than showing an empty card.
 
 ### 🔍 Find References
 
@@ -362,6 +425,8 @@ return view('users.account');
 
 **Container bindings** follow the same shape as middleware aliases: the quoted name at the registration site PLUS every `app('x')`, `resolve('x')`, `app()->make('x')` call site.
 
+**Eloquent model classes** rename project-wide. Press `F2` on a model class name and every reference rewrites in one pass — `use` imports, `User::` static calls, `new User`, type hints, `::class` references, `extends`/`implements`, `instanceof`, and `@param`/`@return`/`@var` docblocks — and the backing `.php` file is renamed alongside. Aliased imports are respected (`use App\Models\User as U;` keeps `U`), and members that just happen to share the class's name are left untouched. Same-namespace renames only — moving a class to a different namespace returns a status message rather than a half-applied move.
+
 **Same parser-classified guarantee as Find References** — only positions the parser has tagged as the matching kind are mutated. A random string `'home'` in an unrelated literal is never touched.
 
 **Vendor-located files refuse to rename** — never moves a Composer-installed view, component, or Livewire class, and never rewrites a middleware alias or binding registered inside `vendor/`. You'll see a toast explaining why instead of a silent no-op.
@@ -443,6 +508,62 @@ $user->
 ```
 
 Works with type-hinted variables, PHPDoc annotations, and static chains like `User::find(1)->`.
+
+#### 🔗 Eloquent Query Chains
+
+Type a string literal inside a query-builder method and the extension completes it from your schema and model definitions — **columns** inside `where`, `orderBy`, `whereIn`, `pluck`, `select`, … and **relations** inside `with`, `whereHas`, `withCount`, `load`, `has`, …:
+
+```php
+User::where('')->orderBy('');
+//          ^ 🗄️ columns of the users table        ^ 🗄️ same
+
+User::with('');
+//         ^ 🔗 relation methods on User (posts, profile, roles…)
+
+DB::table('')->where('');
+//        ^ 🗄️ table names    ^ 🗄️ columns of the chosen table
+
+User::whereHas('posts', fn ($q) => $q->where(''));
+//                                           ^ 🗄️ columns of the *Post* model (relation hop)
+
+User::with('posts.author.');
+//                       ^ 🔗 relations of the final model in the dotted path
+```
+
+Chains rooted at a variable resolve through intervening statements and conditional rebuilds:
+
+```php
+$query = User::query();
+if ($active) { $query = $query->where('active', true); }
+$query->orderBy('');
+//              ^ 🗄️ still completes User's columns
+```
+
+**Joined tables** are fully resolved. After a `join`, `leftJoin`, or closure-form join, bare columns complete against *every* accessible table and `qualifier.` narrows to one; `from`/`fromSub`/`joinSub`/`lateral` are handled too (subquery `SELECT` lists become virtual columns):
+
+```php
+DB::table('orders')->join('users', 'users.id', '=', 'orders.user_id')->where('');
+//                                                                            ^ 🗄️ orders + users columns
+DB::table('orders')->join('users', ...)->where('users.');
+//                                                     ^ 🗄️ narrowed to users
+```
+
+Columns are read live from your database (cast-aware), so completions reflect the *actual* schema. Relations come from the model's relation methods, walking parent classes and traits. Works in PHP **and** in Blade-embedded expressions (`@php`, `{{ }}`). Raw-SQL methods (`whereRaw`, `havingRaw`, `selectRaw`, `DB::raw`, …) are deliberately left to your PHP language server — their arguments are opaque SQL, not column names.
+
+> 🗄️ Column and relation completion needs a working database connection (see [Configuration](#️-configuration)). Without one, the chain still parses — you just won't get column suggestions.
+
+#### 🧰 Query Builder Methods
+
+Type `Model::wher` and the extension surfaces the query-builder methods that PHP routes through `Model::__callStatic` — `where`, `whereIn`, `find`, `first`, `firstOrFail`, and dozens more. Laravel's `Model.php` carries no `@method` or `@mixin` tags for these, so most PHP language servers miss them at the static-call position; we fill the gap by parsing the `Builder` / `Query\Builder` classes (and their composed traits) from *your* installed `vendor/laravel/framework`:
+
+```php
+Portfolio::wher
+//        ^ 🧰 where, whereIn, whereNot, whereBetween…   (Builder<static>)
+//        🎯 active, popular…                            (your scopeActive / scopePopular methods)
+//        🪄 whereName, whereEmail, orWhereCreatedAt…    (dynamic where{Column}, synthesized per column)
+```
+
+Model **scopes** (`scopeActive` → `active`) and **dynamic `where{Column}` finders** are included. The dynamic finders are synthesized from the model's columns — `$fillable`, `$casts`, conventions, and the live schema — and only when no real method of that name already exists, mirroring exactly what PHP's magic methods would route at runtime. Scoped to the `Model::` static position; instance chains (`->`) yield to your PHP LSP, which already sees them via `Builder`'s `@mixin`. Every item we add is attributable in its docs panel header, so you can tell ours apart from your PHP LSP's.
 
 #### 📝 Blade Variables
 
@@ -560,6 +681,31 @@ Feature::active('undefined-feature');
 {{--      ^^^^^^^^^^^^^^^^^^ ❌ Feature not found --}}
 ```
 
+**Query-chain typos** are caught against your real schema — unknown columns, relations, and tables each get a Levenshtein "did you mean" suggestion:
+
+```php
+User::where('emial', $value);
+//          ^^^^^ ⚠️ Unknown column 'emial' on users — did you mean 'email'?
+
+User::with('postz');
+//         ^^^^^ ⚠️ Unknown relation 'postz' on User — did you mean 'posts'?
+
+DB::table('userz')->get();
+//        ^^^^^ ⚠️ Unknown table 'userz' — did you mean 'users'?
+
+User::whereEmial($value);
+//   ^^^^^^^^^^^ ⚠️ Unknown column 'emial' (dynamic where) — did you mean 'whereEmail'?
+```
+
+When joins put a bare column on more than one accessible table, it's flagged as **ambiguous** so you can qualify it:
+
+```php
+DB::table('orders')->join('users', ...)->where('id', 1);
+//                                              ^^ ⚠️ Ambiguous column 'id' — exists on orders and users
+```
+
+These diagnostics **under-warn on purpose**: they stay silent on a cold or absent schema, unresolved receivers, qualified/aliased/expression literals, and raw SQL — a missing squiggle never means "this is definitely fine," only "we couldn't prove it's wrong." Severity is configurable via `diagnostics.severity` (`warning` / `error` / `info` / `off`); see [Configuration](#️-configuration). A working database connection is required — column and relation linting silently disables when the schema can't be introspected.
+
 ### ⚡ Quick Actions
 
 Fix problems with a single click. When you see a warning, press `Cmd+.` to open quick actions. The extension offers to create missing files with the correct Laravel structure—views, components, middleware, translations, and more.
@@ -585,6 +731,20 @@ Route::middleware('admin-only')->group(...);
      ⚡ Create Livewire component --}}
 ```
 
+Query-chain diagnostics carry their own fixes:
+
+```php
+User::where('emial');
+//          ^^^^^ ⚡ Rename to 'email'
+//                ⚡ Create migration: add column 'emial' to users
+
+DB::table('orders')->join('users', ...)->where('id', 1);
+//                                              ^^ ⚡ Qualify as 'orders.id'
+//                                                 ⚡ Qualify as 'users.id'
+```
+
+The "Create migration" action scaffolds a timestamped `database/migrations/*.php` using your project's `migration.update.stub` (custom → vendor → built-in fallback, the same resolution `php artisan make:migration` uses), so your own stub format is honoured.
+
 **Available quick actions:**
 - 📄 Create missing views
 - 🧩 Create Blade components (anonymous or with class)
@@ -593,6 +753,9 @@ Route::middleware('admin-only')->group(...);
 - 🚩 Create Laravel Pennant feature classes
 - 🌐 Add translations to existing files
 - 🔐 Add environment variables to `.env`
+- 🗄️ Rename a mistyped column / relation / table to the suggested name
+- 🆕 Create a migration to add a missing column
+- 🏷️ Qualify an ambiguous column as `table.column`
 
 ### 🎨 Blade Editing Support
 
@@ -690,9 +853,9 @@ If your PHP class outline isn't appearing, make sure:
 
 ## 🚧 Planned Features
 
-**Rename — remaining work** (the class-backed kinds shipped; variables didn't):
+**Rename — remaining work** (the class-backed kinds and the Eloquent model-class engine shipped; variables didn't):
 
-- ✏️ **PHP class rename engine** — FQCN walker, `use`-statement updates, type-hint rewrites, instantiation / static-call / `::class` rewrites, and the file move. Foundation for renaming controllers, models, jobs, etc. as first-class symbols.
+- ✏️ **More PHP class kinds** — the FQCN rename engine (use-statement updates, type-hint / static-call / `new` / `::class` rewrites, docblocks, file move) now powers Eloquent model rename; extending it to controllers, jobs, services, and form requests as first-class symbols is the follow-up.
 - 📝 **Blade variable rename** — scope-aware within a template (`@foreach`, `@php`, etc.), plus cross-file via the `view('x', ['key' => …])` / `compact('key')` linkage from controller into view.
 - 🔧 **PHP variable rename** — scope-aware function-local. Class properties (`$this->foo`) are out of scope for this round and folded into a future class-property rename.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ DB_PASSWORD=secret
 
 Supports MySQL, PostgreSQL, SQLite, and SQL Server.
 
-**⚡ Indexing performance.** The extension indexes every PHP and Blade file in your project (including `vendor/`) at startup so find-references and goto-definition return instantly. A persistent on-disk cache makes subsequent project opens near-instant — only files whose `mtime` has changed since the last save get re-parsed. External changes (a `git pull`, a `composer install`, a formatter running outside Zed) are picked up live via `workspace/didChangeWatchedFiles`. The status bar shows progress during the initial warmup.
+**⚡ Indexing performance.** The extension indexes every PHP and Blade file in your project (including `vendor/`) at startup so find-references and goto-definition return instantly. A persistent on-disk cache makes subsequent project opens near-instant — only files whose `mtime` has changed since they were last indexed get re-parsed. External changes (a `git pull`, a `composer install`, a formatter running outside Zed) are picked up live via `workspace/didChangeWatchedFiles`. The status bar shows progress during the initial warmup.
 
 **🎨 Enhanced Blade directive highlighting** uses LSP semantic tokens to give directives like `@if`, `@foreach`, and `@section` distinct function-style coloring. This is also the only way to get correct highlighting for **custom directives** (e.g., `@myCustomDirective`, Livewire's `@teleport`, Pennant's `@feature`) that tree-sitter doesn't know about. Enable it in your Zed `settings.json`:
 
@@ -628,20 +628,20 @@ Feature::allAreActive(['']);
 {{--     ^ 🚩 feature names appear here --}}
 ```
 
-Features are discovered from `app/Features/*.php` class files. Both string keys (`'new-api'`) and class references (`NewApi::class`) are supported.
+Features are discovered from `app/Features/*.php` class files. String keys (`'new-api'`) get autocomplete; class references (`NewApi::class`) are resolved for go-to-definition and diagnostics.
 
 ### ❌ Diagnostics
 
 See problems in real-time as you type. The extension validates your Laravel code against your actual project structure, highlighting missing views, undefined components, invalid validation rules, and other issues before you run your application.
 
-**Missing files are reported as errors** to catch issues early:
+**Missing files — views, components, Livewire components, features, and invalid validation rules — are reported as errors** to catch issues early. (These existence checks are always errors; the `diagnostics.severity` setting only controls the query-chain diagnostics below.)
 
 ```php
 return view('users.dashboard');
 //          ^^^^^^^^^^^^^^^^^ ❌ View not found: resources/views/users/dashboard.blade.php
 
 Route::middleware('admin-only')->group(...);
-//                ^^^^^^^^^^^^ ⚠️ Middleware not found
+//                ^^^^^^^^^^^^ ❌ Middleware not found
 
 $request->validate([
     'email' => 'required|emal|unique:users',
@@ -746,7 +746,7 @@ The "Create migration" action scaffolds a timestamped `database/migrations/*.php
 
 #### Directive Autocomplete
 
-Type `@` to see all 100+ Blade directives with descriptions:
+Type `@` to see the Blade directives available in *your* project. The list is discovered live — Laravel's built-in directives are read from your installed framework, and **custom directives registered via `Blade::directive()`** (in your app or in packages) are picked up too, so a directive like `@feature` or your own `@money` shows up without us hardcoding it. A full Laravel app typically surfaces 100+; a built-in fallback set keeps completion working if the project can't be scanned.
 
 ```blade
 @fo

--- a/README.md
+++ b/README.md
@@ -697,17 +697,17 @@ Fix problems with a single click. When you see a warning, press `Cmd+.` to open 
 
 ```php
 return view('users.dashboard');
-//          ^^^^^^^^^^^^^^^^^ ⚠️ View not found
+//          ^^^^^^^^^^^^^^^^^ ❌ View not found
 //                            ⚡ Create view: users.dashboard
 
 Route::middleware('admin-only')->group(...);
-//                ^^^^^^^^^^^^ ⚠️ Middleware not found
+//                ^^^^^^^^^^^^ ❌ Middleware not found
 //                             ⚡ Create middleware: admin-only
 ```
 
 ```blade
 <x-dashboard-widget />
-{{-- ⚠️ Component not found
+{{-- ❌ Component not found
      ⚡ Create component (anonymous)
      ⚡ Create component with class --}}
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ return redirect()->route('dashboard');
 <a href="{{ route('dashboard') }}">
 ```
 
-Route group prefixes compose correctly — renaming a route from inside `Route::group(['as' => 'admin.'], …)` rewrites only the leaf segment in the declaration while every call site still gets the full new dotted name.
+Route group prefixes compose correctly — renaming a route nested in `Route::name('admin.')->group(…)` rewrites only the leaf segment at the `->name(...)` declaration (`users` → `dashboard`), while every call site still gets the full new dotted name (`admin.users` → `admin.dashboard`). The inherited `admin.` group prefix is left untouched, so the effective name stays `admin.dashboard` instead of doubling to `admin.admin.dashboard`.
 
 **Config keys** rewrite call sites and the array-key in the source config file:
 

--- a/README.md
+++ b/README.md
@@ -30,27 +30,29 @@
 
 ## 🤔 Why this extension?
 
-Two design choices set this extension apart from the official Laravel VS Code extension — and they're the reason it exists.
+This extension brings Laravel-aware intelligence — go-to-definition, autocomplete, hover, diagnostics — to **Zed**. It isn't trying to replace the official Laravel VS Code extension; it's a different approach for a different editor, shaped by two design choices worth understanding before you install.
 
-### A real language server — works in any editor
+### Built on a real language server
 
-This is a Language Server Protocol (LSP) server, not a VS Code plugin. It speaks the same protocol your editor already uses for every other language, so it runs anywhere an LSP client does: **Zed, Neovim** (`nvim-lspconfig`), **Helix, Sublime Text** (LSP package), **Kate, BBEdit**, and more. The official Laravel VS Code extension is VS Code–only by design. If you've moved off VS Code — or never used it — this is the cross-editor option.
+The intelligence lives in a standalone Language Server Protocol (LSP) server, not in editor-specific plugin code. Today it targets Zed. But because everything runs through the LSP — the same protocol your editor already speaks for other languages — the door is open to supporting other LSP-capable editors (Neovim, Helix, Sublime Text, Kate, and more) in the future. That portability is a deliberate architectural bet, not something we ship yet.
 
 ### No app boot — pure static analysis
 
-The official extension boots your Laravel application in the background to gather its data. That means it executes your service providers (with whatever side effects they carry), can touch your database, and breaks when local state is broken — a half-applied migration, a missing `.env`, a dirty branch. It also runs your code, which is a real consideration when you open an unfamiliar project.
+The official VS Code extension boots your Laravel application in the background to gather its data. That means it executes your service providers (with whatever side effects they carry), can touch your database, and can struggle when local state is broken — a half-applied migration, a missing `.env`, a dirty branch. It runs your code, which is worth knowing when you open an unfamiliar project.
 
 The official extension is candid about this in its own README:
 
 > This extension will occasionally boot your app in the background to collect information about your app for use in autocompletion, linking, hovering, and diagnostics.
 
-This extension does **none of that**. Everything is parsed statically with tree-sitter — it reads your files, it never runs them. The trade-off is honest: some deep runtime behaviour (fully dynamic Eloquent magic, runtime-registered routes) is harder to reach through static analysis alone. But it never executes your code, it only reads your database when *you* opt into schema-backed column completion, and it keeps working when your app won't even boot.
+This extension takes the opposite approach: everything is parsed statically with tree-sitter — it reads your files, it never runs them. The trade-off is honest: some deep runtime behaviour (fully dynamic Eloquent magic, runtime-registered routes) is harder to reach through static analysis alone. But it never executes your code, it only reads your database when *you* opt into schema-backed column completion, and it keeps working even when your app won't boot.
 
-### Feature comparison
+### How it compares
 
-| Capability | This extension | Official Laravel VS Code |
+The official VS Code extension is the Laravel tooling most developers already know, so it's a useful reference point. This isn't a head-to-head — they're different tools for different editors, with different trade-offs:
+
+| Capability | This extension (Zed) | Official Laravel VS Code |
 |---|---|---|
-| Editor support | ✅ Any LSP client (Zed, Neovim, Helix, Sublime, Kate…) | ❌ VS Code only |
+| Editor | Zed today — LSP-based, designed to be portable to other editors later | VS Code |
 | Runtime model | ✅ Static parse (tree-sitter) — never runs your code | ⚠️ Runs your application code to gather data |
 | Works when the app won't boot | ✅ | ❌ |
 | Go-to-definition (views, routes, config, env, translations, components) | ✅ | ✅ |
@@ -161,7 +163,7 @@ Zed defaults to tree-sitter outlines, which don't call any LSP — opt into LSP 
 }
 ```
 
-`document_symbols: on` for `PHP` unlocks both our route outline (for files under `routes/`) and your PHP LSP's class outline (for everything else). `document_symbols: on` for `Blade` unlocks our Blade outline. Editors that call `textDocument/documentSymbol` unconditionally (Helix, Neovim, Sublime/LSP, Kate) need no opt-in.
+`document_symbols: on` for `PHP` unlocks both our route outline (for files under `routes/`) and your PHP LSP's class outline (for everything else). `document_symbols: on` for `Blade` unlocks our Blade outline. (This opt-in is a Zed quirk — LSP clients that request `textDocument/documentSymbol` unconditionally, like Helix or Neovim, wouldn't need it.)
 
 > **Quirks worth knowing** — Zed colors outline labels by word-matching them against the source buffer's tree-sitter highlights, which produces slightly inconsistent colors on multi-segment URLs (e.g., `/cra-details` may color `cra` and `details` differently if they match different tokens elsewhere in the file). Route names appear in the LSP `detail` field, which Zed's outline panel doesn't currently render (VSCode and Sublime/LSP do). Both are tracked upstream: [zed#57576](https://github.com/zed-industries/zed/issues/57576).
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -15938,10 +15938,12 @@ fn collect_env_declaration_targets(
 }
 
 /// Walk every `routes/*.php` under the project root and surface
-/// `->name(...)` declaration sites whose full name matches `target`. Each
-/// emitted target writes `new_name` verbatim at the captured position. (For
-/// group-prefixed routes, the locator already emits one target per segment
-/// so the prefix composition stays intact.)
+/// `->name(...)` declaration sites whose full name matches `target`. The
+/// captured position spans only the declaration's own `local_segment`, so
+/// each target writes the LEAF of `new_name` (its inherited group prefix
+/// stripped) rather than the whole dotted form — otherwise a route inside
+/// `Route::name('admin.')->group(...)` would have its prefix doubled.
+/// See [`RouteNameDeclaration::rewritten_segment`].
 async fn collect_route_declaration_targets(
     server: &LaravelLanguageServer,
     root: &Path,
@@ -15974,7 +15976,9 @@ async fn collect_route_declaration_targets(
                 line: d.line,
                 start_column: d.start_column,
                 end_column: d.end_column,
-                new_text: new_name.to_string(),
+                // Decl spans only this segment; the group prefix (if any)
+                // lives elsewhere and must not be re-written here.
+                new_text: d.rewritten_segment(new_name).to_string(),
             });
         }
     }
@@ -17331,9 +17335,9 @@ impl LanguageServer for LaravelLanguageServer {
         let mut file_renames: Vec<laravel_lsp::rename::FileRename> = Vec::new();
         match &symbol {
             laravel_lsp::references::SymbolRef::Route(name) => {
-                // Route names are written verbatim at every declaration site
-                // (the locator emits one target per `->name(...)` segment;
-                // group prefixes get their own segments).
+                // Call sites get the full dotted `new_name` (above); each
+                // declaration site gets only its own leaf segment, since the
+                // group `->name('admin.')` prefix lives at a separate decl.
                 if let Some(root) = root_path.as_ref() {
                     targets.extend(
                         collect_route_declaration_targets(self, root, name, &new_name).await,

--- a/laravel-lsp/src/route_name_locator.rs
+++ b/laravel-lsp/src/route_name_locator.rs
@@ -39,6 +39,39 @@ pub struct RouteNameDeclaration {
     pub end_column: u32,
 }
 
+impl RouteNameDeclaration {
+    /// Given the new fully-qualified route name the user typed (e.g.
+    /// `admin.dashboard`), return the text to write at THIS declaration's
+    /// source position — which spans only `local_segment`, not the whole
+    /// dotted name.
+    ///
+    /// Because `full_name` is built as `inherited_prefix + local_segment`
+    /// (see [`process_chain`]), the prefix is recovered by stripping the
+    /// segment back off. We then drop that same prefix from the new name so
+    /// only this declaration's own segment is rewritten — the inherited
+    /// `Route::name('admin.')` group prefix lives at a separate declaration
+    /// the user renames independently.
+    ///
+    /// This deliberately differs from the config/translation rename, which
+    /// take `new_key.rsplit('.').next()` (last dot segment). Route leaf
+    /// segments can themselves be dotted (`->name('users.index')`), so a
+    /// last-dot split would corrupt them; suffix-based prefix stripping
+    /// preserves the full local segment.
+    ///
+    /// Fallback: if the new name doesn't carry the inherited prefix (the user
+    /// rewrote the group portion — something a leaf rename can't express
+    /// coherently), the new name is returned verbatim as a best effort.
+    pub fn rewritten_segment<'a>(&self, new_full_name: &'a str) -> &'a str {
+        let inherited_prefix = self
+            .full_name
+            .strip_suffix(&self.local_segment)
+            .unwrap_or("");
+        new_full_name
+            .strip_prefix(inherited_prefix)
+            .unwrap_or(new_full_name)
+    }
+}
+
 /// Walk a route file and return every `->name(...)` / `->as(...)` declaration
 /// in source order, regardless of whether they sit on leaf routes or on
 /// `Route::group(...)` containers.

--- a/laravel-lsp/src/route_name_locator/tests.rs
+++ b/laravel-lsp/src/route_name_locator/tests.rs
@@ -131,3 +131,88 @@ Route::name('api.')->group(function () {
         .unwrap();
     assert_eq!(leaf.local_segment, "users");
 }
+
+#[test]
+fn rewritten_segment_strips_group_prefix_from_new_name() {
+    // Regression: renaming `admin.users` → `admin.dashboard` on a route
+    // nested in `Route::name('admin.')->group(...)`. The leaf declaration
+    // physically spans only `users`, so it must receive `dashboard`, not
+    // the full `admin.dashboard` (which would yield `admin.admin.dashboard`).
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    Route::get('/users', [UserController::class, 'index'])->name('users');
+});
+"#;
+    let decls = extract_route_name_declarations(src);
+    let leaf = decls.iter().find(|d| d.full_name == "admin.users").unwrap();
+    assert_eq!(leaf.rewritten_segment("admin.dashboard"), "dashboard");
+}
+
+#[test]
+fn rewritten_segment_preserves_dotted_leaf_under_group() {
+    // The leaf segment itself is dotted (`users.index`). A naive
+    // `rsplit('.').next()` would corrupt it to `index`; prefix stripping
+    // keeps the whole local segment intact.
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    Route::get('/users', [UserController::class, 'index'])->name('users.index');
+});
+"#;
+    let decls = extract_route_name_declarations(src);
+    let leaf = decls
+        .iter()
+        .find(|d| d.full_name == "admin.users.index")
+        .unwrap();
+    assert_eq!(leaf.local_segment, "users.index");
+    assert_eq!(
+        leaf.rewritten_segment("admin.users.list"),
+        "users.list",
+        "the multi-segment leaf must survive — only the group prefix is dropped"
+    );
+}
+
+#[test]
+fn rewritten_segment_composes_nested_group_prefixes() {
+    // Two nested groups (`api.` + `v1.`). The leaf prefix is `api.v1.`.
+    let src = r#"<?php
+Route::name('api.')->group(function () {
+    Route::name('v1.')->group(function () {
+        Route::get('/users', [U::class, 'i'])->name('users');
+    });
+});
+"#;
+    let decls = extract_route_name_declarations(src);
+    let leaf = decls
+        .iter()
+        .find(|d| d.full_name == "api.v1.users")
+        .unwrap();
+    assert_eq!(leaf.rewritten_segment("api.v1.accounts"), "accounts");
+}
+
+#[test]
+fn rewritten_segment_is_verbatim_for_ungrouped_route() {
+    // No group prefix → inherited prefix is empty → the new name is written
+    // as-is, including a dotted form like `users.index`.
+    let src = r#"<?php
+Route::get('/home', [HomeController::class, 'index'])->name('home');
+"#;
+    let decls = extract_route_name_declarations(src);
+    let d = &decls[0];
+    assert_eq!(d.rewritten_segment("dashboard"), "dashboard");
+    assert_eq!(d.rewritten_segment("users.index"), "users.index");
+}
+
+#[test]
+fn rewritten_segment_falls_back_when_prefix_mismatches() {
+    // The user rewrote the group portion (`admin.` → `web.`) — something a
+    // leaf rename can't express coherently. Best effort: write the new name
+    // verbatim rather than silently dropping a non-matching prefix.
+    let decl = RouteNameDeclaration {
+        full_name: "admin.users".to_string(),
+        local_segment: "users".to_string(),
+        line: 0,
+        start_column: 0,
+        end_column: 5,
+    };
+    assert_eq!(decl.rewritten_segment("web.dashboard"), "web.dashboard");
+}


### PR DESCRIPTION
## Overview

Closes #15.

Adds a **"Why we built this"** section to the README and brings the feature documentation up to date with everything shipped since `0.1.19`.

### 💛 Why we built this (the #15 ask, reframed)

The opening section is warm and Laravel-loving, not competitive — we built this because we love Laravel and wanted first-class support for it in Zed. It covers:

- **Why it exists** — Laravel deserves great tooling in every editor; this brings it to Zed.
- **LSP architecture** — the intelligence is a standalone language server; Zed today, potentially other LSP editors later (framed as a direction, not a shipped claim).
- **How it works** — pure static analysis via tree-sitter; never runs your code; keeps working when the app won't boot.
- **Laravel across editors** — a neutral landscape table (PHPStorm / VS Code / Zed) presenting every option as capable and actively developed.

> **Note on scope vs. #15:** the issue originally asked for a head-to-head feature table *vs. the official VS Code extension*. Per project direction, we deliberately avoid competitive positioning — so that scorecard was replaced with the non-competitive landscape table above. The issue's intent (surface what this extension is and how it's built) is met, so this PR closes #15.

### 📝 Newly documented features (shipped since 0.1.19)

| Feature | PR |
|---|---|
| `textDocument/hover` for Laravel patterns + Blade variables | #17 |
| Eloquent query-chain completion (columns, relations, `DB::table`, dotted paths, closure scope, variable-flow tracking) | #21, #26 |
| Joined-table column resolution (joins, `fromSub`/`joinSub`, ambiguity) | #32 |
| Query-builder method-name completion (Builder methods, scopes, dynamic `where{Column}`) | #27 |
| Query-chain diagnostics with "did you mean" + quick-fixes | #31, #32 |
| Eloquent model class rename | #31 |
| Additional call-site variants (`signed_route`, `Env::get`, `App::bound`, `config()->string()`) | #16 |

### 🔧 Structural change

Nested the **Tuning Intelephense** section under **Configuration** (it's configuration detail, not a top-level concern).

## ✅ Accuracy: verified against the code

Every feature claim in the README was audited against the actual LSP source before this PR was finalised:

- The **Laravel-across-editors** table was checked against the official VS Code extension's source (not just its README) and against the current PHPStorm/Laravel Idea situation (the Laravel Idea plugin is now bundled free with PhpStorm).
- The **feature-section prose** was corrected where it drifted from the implementation:
  - Blade directive completion is **dynamically discovered** (installed framework + custom `Blade::directive()` registrations), not a static "100+" list.
  - Pennant: string keys get autocomplete; `::class` references are resolved for goto/diagnostics.
  - Existence diagnostics (view/component/Livewire/feature/validation rule) are always **errors**; `diagnostics.severity` controls only the query-chain diagnostics. Glyphs aligned to ❌.
  - mtime cache invalidation keys off "last indexed", not "last save".

## Follow-ups (separate from this PR)

- **#33** — split the feature reference into a `docs/` folder and slim the README to a feature ToC.
- A route-group **rename** bug surfaced during the audit (full dotted name written into the leaf position → `admin.admin.dashboard`). Tracked separately as a code fix.

## Notes

- README docs plus one targeted code fix (route-group rename) with its regression test. Full suite green (1421 tests).
- See commit history for the framing evolution (initial competitive table → non-competitive "why we built this").

