### PR TITLE
refactor: 🔧 use tower_lsp's re-exported lsp_types

### DIFF
--- a/laravel-lsp/Cargo.toml
+++ b/laravel-lsp/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT"
 [dependencies]
 # LSP framework
 tower-lsp = "0.20"
-lsp-types = "0.94"
 
 # Salsa incremental computation
 salsa = "0.26"

--- a/laravel-lsp/src/blade_directive_tokens.rs
+++ b/laravel-lsp/src/blade_directive_tokens.rs
@@ -27,7 +27,7 @@
 use std::collections::HashSet;
 
 use lazy_static::lazy_static;
-use lsp_types::SemanticToken;
+use tower_lsp::lsp_types::SemanticToken;
 use regex::Regex;
 
 lazy_static! {

--- a/laravel-lsp/src/blade_directive_tokens.rs
+++ b/laravel-lsp/src/blade_directive_tokens.rs
@@ -27,8 +27,8 @@
 use std::collections::HashSet;
 
 use lazy_static::lazy_static;
-use tower_lsp::lsp_types::SemanticToken;
 use regex::Regex;
+use tower_lsp::lsp_types::SemanticToken;
 
 lazy_static! {
     /// A `@`-prefixed directive candidate: `@` followed by a PHP-identifier-shaped

--- a/laravel-lsp/src/file_watcher.rs
+++ b/laravel-lsp/src/file_watcher.rs
@@ -44,7 +44,7 @@
 
 use std::path::{Path, PathBuf};
 
-use lsp_types::{
+use tower_lsp::lsp_types::{
     DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, Registration,
     WatchKind,
 };

--- a/laravel-lsp/src/indexing_progress.rs
+++ b/laravel-lsp/src/indexing_progress.rs
@@ -16,9 +16,9 @@
 
 use std::time::{Duration, Instant};
 
-use lsp_types::notification::Progress as ProgressNotification;
-use lsp_types::request::WorkDoneProgressCreate;
-use lsp_types::{
+use tower_lsp::lsp_types::notification::Progress as ProgressNotification;
+use tower_lsp::lsp_types::request::WorkDoneProgressCreate;
+use tower_lsp::lsp_types::{
     NumberOrString, ProgressParams, ProgressParamsValue, WorkDoneProgress, WorkDoneProgressBegin,
     WorkDoneProgressCreateParams, WorkDoneProgressEnd, WorkDoneProgressReport,
 };


### PR DESCRIPTION
## 🎯 What
Drops the direct `lsp-types` dependency; imports `lsp_types` exclusively via `tower_lsp::lsp_types::*` (3 files: `blade_directive_tokens.rs`, `file_watcher.rs`, `indexing_progress.rs`).

## 🤔 Why
`tower-lsp 0.20` pins and re-exports `lsp-types 0.94`. A separately-pinned direct dep can drift to an incompatible version — exactly what Dependabot's `lsp-types 0.94→0.97` bump (closed as #40) would have done: two `lsp_types` crates in the graph → `tower_lsp::Client` API bounds break (15 trait errors). Sourcing the types from `tower_lsp` guarantees they always match whatever tower-lsp re-exports, so this class of bump can never break again.

## ✅ Verified locally
build · fmt --check · clippy -D warnings · tests — all pass. No behavior change (same types, single version). `cargo tree` confirms one `lsp-types v0.94.1`.

Refs mike-bronner/zed-laravel#36