### PR TITLE
fix: 🐛 Namespaced anonymous Blade components — resolution (#44) + completion

### DIFF
--- a/laravel-lsp/src/cache_manager.rs
+++ b/laravel-lsp/src/cache_manager.rs
@@ -28,7 +28,12 @@ use tracing::{debug, info, warn};
 ///     line above the actual alias). v3 caches still parse but encode
 ///     the wrong line — drop them on read so rebuilt entries get the
 ///     correct line.
-const CACHE_VERSION: u32 = 4;
+/// v5: CachedLaravelConfig now persists the service-provider namespace maps
+///     (view namespaces, component namespaces, and anonymous-component
+///     paths/namespaces). v4 caches lack them, so namespaced components would
+///     resolve as "not found" until a provider edit forced a rebuild — drop
+///     v4 on read so the namespace maps are indexed and cached up front.
+const CACHE_VERSION: u32 = 5;
 
 /// Get the XDG-compliant cache directory for a project
 ///
@@ -150,6 +155,21 @@ pub struct CachedLaravelConfig {
     pub component_paths: Vec<(String, PathBuf)>,
     pub livewire_path: Option<PathBuf>,
     pub has_livewire: bool,
+    /// Package view namespaces from loadViewsFrom() — prefix → view path.
+    #[serde(default)]
+    pub view_namespaces: HashMap<String, PathBuf>,
+    /// Class-based component namespaces from Blade::componentNamespace() —
+    /// prefix → PHP namespace.
+    #[serde(default)]
+    pub component_namespaces: HashMap<String, String>,
+    /// Anonymous component paths from Blade::anonymousComponentPath() —
+    /// prefix → absolute components directory.
+    #[serde(default)]
+    pub anonymous_component_paths: HashMap<String, PathBuf>,
+    /// Anonymous component namespaces from Blade::anonymousComponentNamespace()
+    /// — prefix → view-relative directory.
+    #[serde(default)]
+    pub anonymous_component_namespaces: HashMap<String, String>,
 }
 
 /// Cached environment variables

--- a/laravel-lsp/src/component_completion.rs
+++ b/laravel-lsp/src/component_completion.rs
@@ -1,0 +1,181 @@
+//! Candidate collection for `<x-...>` Blade component autocomplete.
+//!
+//! A component tag can be backed by very different things — an anonymous
+//! `.blade.php` file, a PHP class in `app/View/Components`, a package's
+//! published views, or a class/anonymous *namespace* registered in a service
+//! provider. This module turns each of those sources into a flat list of
+//! `<x-...>` tag candidates and dedupes them by tag name (a class wins over an
+//! anonymous view, mirroring Laravel's class-first component resolution).
+//!
+//! The filesystem walking lives here (not in the LSP handler) so it can be
+//! unit-tested against tempdirs; the handler only gathers config and renders
+//! the result into `CompletionItem`s.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use walkdir::WalkDir;
+
+/// What backs a completion candidate — drives the LSP item kind and the
+/// dedup precedence when two sources produce the same tag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CandidateKind {
+    /// An anonymous `.blade.php`-backed component.
+    AnonymousView,
+    /// A PHP class-backed component (`app/View/Components` or a
+    /// `Blade::componentNamespace` registration).
+    Class,
+}
+
+/// One `<x-...>` completion candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentCandidate {
+    /// The tag text inserted after `<x-`, e.g. `alert` or `test::backstage`.
+    pub name: String,
+    /// Detail shown alongside the completion item (usually a relative path).
+    pub detail: String,
+    pub kind: CandidateKind,
+}
+
+/// kebab-case a PascalCase / dotted identifier, preserving `.` separators so
+/// nested component names stay dotted. `AlertDialog` → `alert-dialog`,
+/// `Forms.InputText` → `forms.input-text`.
+pub fn to_kebab_case(s: &str) -> String {
+    let mut result = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if c == '.' {
+            result.push('.');
+        } else if c.is_uppercase() {
+            if i > 0 && !result.ends_with('.') && !result.ends_with('-') {
+                result.push('-');
+            }
+            result.push(c.to_lowercase().next().unwrap());
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+/// Turn a path relative to a scan root into the dotted, kebab-cased tag body,
+/// or `None` if it isn't a PHP file. `Forms/InputText.php` → `forms.input-text`,
+/// `button.blade.php` → `button`.
+pub fn relative_path_to_tag_body(relative: &Path) -> Option<String> {
+    let s = relative.to_string_lossy();
+    let stem = s
+        .strip_suffix(".blade.php")
+        .or_else(|| s.strip_suffix(".php"))?;
+    if stem.is_empty() {
+        return None;
+    }
+    let dotted = stem.replace(['/', '\\'], ".");
+    Some(to_kebab_case(&dotted))
+}
+
+/// Walk `dir` for anonymous `.blade.php` components, emitting candidates named
+/// `{tag_prefix}{body}` (`tag_prefix` is `""` for the root component path or
+/// `"ns::"` for a namespaced one). `display_root` is the project root used to
+/// shorten the detail path.
+pub fn scan_anonymous_dir(
+    dir: &Path,
+    tag_prefix: &str,
+    display_root: &Path,
+) -> Vec<ComponentCandidate> {
+    scan_dir(dir, tag_prefix, display_root, CandidateKind::AnonymousView)
+}
+
+/// Walk `dir` for `.php` class-backed components (skipping `.blade.php` view
+/// files), emitting `{tag_prefix}{body}` candidates with PascalCase filenames
+/// kebab-cased.
+pub fn scan_class_dir(
+    dir: &Path,
+    tag_prefix: &str,
+    display_root: &Path,
+) -> Vec<ComponentCandidate> {
+    scan_dir(dir, tag_prefix, display_root, CandidateKind::Class)
+}
+
+fn scan_dir(
+    dir: &Path,
+    tag_prefix: &str,
+    display_root: &Path,
+    kind: CandidateKind,
+) -> Vec<ComponentCandidate> {
+    let mut out = Vec::new();
+    if !dir.is_dir() {
+        return out;
+    }
+
+    let want_blade = kind == CandidateKind::AnonymousView;
+
+    for entry in WalkDir::new(dir)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let is_blade = path.to_str().is_some_and(|s| s.ends_with(".blade.php"));
+
+        // Anonymous scan wants only blade files; class scan wants only
+        // non-blade `.php` files (a blade view paired with a class is found
+        // by the anonymous scan, not duplicated here).
+        if want_blade != is_blade {
+            continue;
+        }
+        // Class scan: require a plain `.php` extension.
+        if !is_blade && path.extension().and_then(|e| e.to_str()) != Some("php") {
+            continue;
+        }
+
+        let Ok(relative) = path.strip_prefix(dir) else {
+            continue;
+        };
+        let Some(body) = relative_path_to_tag_body(relative) else {
+            continue;
+        };
+
+        let detail = path
+            .strip_prefix(display_root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .to_string();
+
+        out.push(ComponentCandidate {
+            name: format!("{tag_prefix}{body}"),
+            detail,
+            kind,
+        });
+    }
+    out
+}
+
+/// Dedup candidates by tag name and sort by name. When two candidates share a
+/// name, a `Class` beats an `AnonymousView` (Laravel resolves the class first);
+/// otherwise the first occurrence wins.
+pub fn dedup_and_sort(candidates: Vec<ComponentCandidate>) -> Vec<ComponentCandidate> {
+    let mut by_name: HashMap<String, ComponentCandidate> = HashMap::new();
+    for candidate in candidates {
+        match by_name.get(&candidate.name) {
+            // A class already holds this name — nothing outranks it.
+            Some(existing) if existing.kind == CandidateKind::Class => {}
+            // A class displaces a previously-stored view of the same name.
+            Some(_) if candidate.kind == CandidateKind::Class => {
+                by_name.insert(candidate.name.clone(), candidate);
+            }
+            // Same name, no class involved — keep what's already there.
+            Some(_) => {}
+            None => {
+                by_name.insert(candidate.name.clone(), candidate);
+            }
+        }
+    }
+    let mut out: Vec<ComponentCandidate> = by_name.into_values().collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/component_completion/tests.rs
+++ b/laravel-lsp/src/component_completion/tests.rs
@@ -1,0 +1,141 @@
+use super::*;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// Build a tempdir containing the given (relative-path, body) files.
+fn dir_with_files(files: &[(&str, &str)]) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().unwrap();
+    for (relpath, body) in files {
+        let full = dir.path().join(relpath);
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        std::fs::write(&full, body).unwrap();
+    }
+    let root = dir.path().to_path_buf();
+    (dir, root)
+}
+
+fn names(candidates: &[ComponentCandidate]) -> Vec<String> {
+    candidates.iter().map(|c| c.name.clone()).collect()
+}
+
+// ─── name conversion ────────────────────────────────────────────────────
+
+#[test]
+fn to_kebab_case_handles_pascal_and_dots() {
+    assert_eq!(to_kebab_case("Button"), "button");
+    assert_eq!(to_kebab_case("AlertDialog"), "alert-dialog");
+    assert_eq!(to_kebab_case("Forms.InputText"), "forms.input-text");
+    assert_eq!(to_kebab_case("backstage"), "backstage");
+}
+
+#[test]
+fn relative_path_to_tag_body_strips_and_dots() {
+    assert_eq!(
+        relative_path_to_tag_body(Path::new("backstage.blade.php")).as_deref(),
+        Some("backstage"),
+    );
+    assert_eq!(
+        relative_path_to_tag_body(Path::new("forms/input.blade.php")).as_deref(),
+        Some("forms.input"),
+    );
+    assert_eq!(
+        relative_path_to_tag_body(Path::new("Forms/InputText.php")).as_deref(),
+        Some("forms.input-text"),
+    );
+    assert_eq!(relative_path_to_tag_body(Path::new("readme.md")), None);
+}
+
+// ─── anonymous (blade) scan ─────────────────────────────────────────────
+
+#[test]
+fn scan_anonymous_dir_emits_namespaced_blade_components() {
+    let (_dir, root) = dir_with_files(&[
+        ("views/test/components/backstage.blade.php", "x"),
+        ("views/test/components/forms/input.blade.php", "x"),
+        // A stray PHP class in the dir must be ignored by the anonymous scan.
+        ("views/test/components/Ignored.php", "<?php"),
+    ]);
+    let scan_dir = root.join("views/test/components");
+
+    let mut got = scan_anonymous_dir(&scan_dir, "test::", &root);
+    got.sort_by(|a, b| a.name.cmp(&b.name));
+
+    assert_eq!(names(&got), vec!["test::backstage", "test::forms.input"]);
+    assert!(got.iter().all(|c| c.kind == CandidateKind::AnonymousView));
+}
+
+#[test]
+fn scan_anonymous_dir_with_empty_prefix_for_root_components() {
+    let (_dir, root) = dir_with_files(&[("components/button.blade.php", "x")]);
+    let got = scan_anonymous_dir(&root.join("components"), "", &root);
+    assert_eq!(names(&got), vec!["button"]);
+}
+
+#[test]
+fn scan_missing_dir_is_empty() {
+    let (_dir, root) = dir_with_files(&[]);
+    assert!(scan_anonymous_dir(&root.join("nope"), "", &root).is_empty());
+}
+
+// ─── class scan ─────────────────────────────────────────────────────────
+
+#[test]
+fn scan_class_dir_emits_kebab_class_components_and_skips_blade() {
+    let (_dir, root) = dir_with_files(&[
+        ("app/View/Components/Alert.php", "<?php class Alert {}"),
+        ("app/View/Components/Forms/InputText.php", "<?php"),
+        // A blade view sitting alongside classes must NOT be picked up here.
+        ("app/View/Components/legacy.blade.php", "x"),
+    ]);
+    let scan_dir = root.join("app/View/Components");
+
+    let mut got = scan_class_dir(&scan_dir, "", &root);
+    got.sort_by(|a, b| a.name.cmp(&b.name));
+
+    assert_eq!(names(&got), vec!["alert", "forms.input-text"]);
+    assert!(got.iter().all(|c| c.kind == CandidateKind::Class));
+}
+
+// ─── dedup ──────────────────────────────────────────────────────────────
+
+#[test]
+fn dedup_prefers_class_over_anonymous_view_for_same_tag() {
+    let candidates = vec![
+        ComponentCandidate {
+            name: "alert".into(),
+            detail: "resources/views/components/alert.blade.php".into(),
+            kind: CandidateKind::AnonymousView,
+        },
+        ComponentCandidate {
+            name: "alert".into(),
+            detail: "app/View/Components/Alert.php".into(),
+            kind: CandidateKind::Class,
+        },
+    ];
+
+    let out = dedup_and_sort(candidates);
+
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].kind, CandidateKind::Class, "class must win the tie");
+    assert!(out[0].detail.ends_with("Alert.php"));
+}
+
+#[test]
+fn dedup_is_order_independent_for_class_precedence() {
+    // Same as above but class listed first — result must be identical.
+    let candidates = vec![
+        ComponentCandidate {
+            name: "alert".into(),
+            detail: "app/View/Components/Alert.php".into(),
+            kind: CandidateKind::Class,
+        },
+        ComponentCandidate {
+            name: "alert".into(),
+            detail: "resources/views/components/alert.blade.php".into(),
+            kind: CandidateKind::AnonymousView,
+        },
+    ];
+    let out = dedup_and_sort(candidates);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].kind, CandidateKind::Class);
+}

--- a/laravel-lsp/src/component_declaration_locator/tests.rs
+++ b/laravel-lsp/src/component_declaration_locator/tests.rs
@@ -13,6 +13,8 @@ fn config_for(root: &Path) -> LaravelConfigData {
         has_livewire: false,
         view_namespaces: HashMap::new(),
         component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
         component_aliases: HashMap::new(),
         icon_aliases: HashMap::new(),
     }

--- a/laravel-lsp/src/composer_autoload.rs
+++ b/laravel-lsp/src/composer_autoload.rs
@@ -77,6 +77,48 @@ impl ComposerAutoload {
         None
     }
 
+    /// Resolve a PHP **namespace** (not a class) to the source directory/-ies
+    /// that hold it, for every PSR-4 prefix that's an ancestor. The inverse of
+    /// [`resolve`]: where `resolve` maps `Acme\Foo\Bar` → `.../Bar.php`, this
+    /// maps the namespace `Acme\Foo` → `.../Foo/` so callers can walk it.
+    ///
+    /// Used by class-based component completion (`Blade::componentNamespace`):
+    /// the registered PHP namespace is turned into a directory whose class
+    /// files become `<x-prefix::name>` candidates. Only directories that exist
+    /// on disk are returned; a namespace with no matching prefix yields empty.
+    pub fn resolve_namespace_dirs(&self, namespace: &str) -> Vec<PathBuf> {
+        let normalized = namespace.trim_start_matches('\\').trim_end_matches('\\');
+        let mut dirs = Vec::new();
+        for (prefix, source_roots) in &self.prefixes {
+            // The namespace either equals the PSR-4 prefix exactly, or extends
+            // it past a `\` boundary (so prefix `App` matches `App\View` but
+            // not `Application`). `prefix` is stored without a trailing `\`.
+            let rel = if normalized == prefix {
+                Some(PathBuf::new())
+            } else if let Some(after) = normalized.strip_prefix(prefix.as_str()) {
+                after.strip_prefix('\\').map(|rest| {
+                    let mut p = PathBuf::new();
+                    for seg in rest.split('\\') {
+                        p.push(seg);
+                    }
+                    p
+                })
+            } else {
+                None
+            };
+
+            if let Some(rel) = rel {
+                for source_root in source_roots {
+                    let dir = source_root.join(&rel);
+                    if dir.is_dir() {
+                        dirs.push(dir);
+                    }
+                }
+            }
+        }
+        dirs
+    }
+
     /// Parse autoload data fresh from disk. Doesn't touch the cache —
     /// callers should normally use [`for_project`] instead.
     pub fn load(project_root: &Path) -> Self {

--- a/laravel-lsp/src/composer_autoload/tests.rs
+++ b/laravel-lsp/src/composer_autoload/tests.rs
@@ -187,3 +187,44 @@ fn leading_backslash_in_fqcn_is_tolerated() {
         "got {resolved:?}"
     );
 }
+
+#[test]
+fn resolve_namespace_dirs_maps_namespace_to_existing_directory() {
+    // Blade::componentNamespace('App\\View\\Components\\Nightshade', 'nightshade')
+    // must resolve to the on-disk directory so its class files can be walked
+    // for completion candidates.
+    let composer = r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#;
+    let (_dir, root) = project_with_files(&[
+        ("composer.json", composer),
+        (
+            "app/View/Components/Nightshade/Alert.php",
+            "<?php class Alert {}",
+        ),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+
+    let dirs = autoload.resolve_namespace_dirs("App\\View\\Components\\Nightshade");
+
+    assert_eq!(dirs.len(), 1, "expected one resolved dir, got {dirs:?}");
+    assert!(
+        dirs[0].ends_with("app/View/Components/Nightshade"),
+        "got {:?}",
+        dirs[0],
+    );
+}
+
+#[test]
+fn resolve_namespace_dirs_returns_empty_for_unknown_or_nonexistent() {
+    let composer = r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#;
+    let (_dir, root) = project_with_files(&[("composer.json", composer)]);
+    let autoload = ComposerAutoload::load(&root);
+
+    // No matching PSR-4 prefix.
+    assert!(autoload
+        .resolve_namespace_dirs("Vendor\\Pkg\\Components")
+        .is_empty());
+    // Matching prefix but the directory doesn't exist on disk.
+    assert!(autoload
+        .resolve_namespace_dirs("App\\View\\Components")
+        .is_empty());
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -19,6 +19,7 @@ pub mod cache_manager;
 pub mod class_locator;
 pub mod class_rename;
 pub mod completion_format;
+pub mod component_completion;
 pub mod component_declaration_locator;
 pub mod composer_autoload;
 pub mod config;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -193,14 +193,6 @@ struct ViewNameCompletion {
     path: String,
 }
 
-/// A Blade component for autocomplete
-struct BladeComponentCompletion {
-    /// The component name (e.g., "button", "forms.input")
-    name: String,
-    /// Relative path to the component file
-    path: String,
-}
-
 /// A Livewire component for autocomplete
 struct LivewireComponentCompletion {
     /// The component name in kebab-case (e.g., "user-profile", "admin.dashboard")
@@ -6759,6 +6751,9 @@ impl LaravelLanguageServer {
     /// - `<x-` returns Some(StringContext { prefix: "", start_col: 3, end_col: 3, ... })
     /// - `<x-button` returns Some(StringContext { prefix: "button", start_col: 3, end_col: 9, ... })
     /// - `<x-forms.` returns Some(StringContext { prefix: "forms.", start_col: 3, end_col: 9, ... })
+    /// - `<x-test::` returns Some(StringContext { prefix: "test::", ... }) — namespaced
+    ///   components (anonymous or class-based) are completed too, so `:` is a
+    ///   valid character in the partial name.
     fn get_blade_component_context(line_text: &str, character: u32) -> Option<StringContext> {
         let cursor = character as usize;
         if cursor > line_text.len() {
@@ -6785,10 +6780,12 @@ impl LaravelLanguageServer {
                 return None;
             }
 
-            // Validate that after_prefix only contains valid component name characters
+            // Validate that after_prefix only contains valid component name characters.
+            // `:` is allowed so namespaced components (`<x-test::backstage>`,
+            // `<x-flux::button>`) are recognized as a completion context.
             if after_prefix
                 .chars()
-                .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_')
+                .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_' || c == ':')
             {
                 return Some(StringContext {
                     prefix: after_prefix.to_string(),
@@ -10576,136 +10573,92 @@ impl LaravelLanguageServer {
     }
 
     /// Get all Blade component names from component directories for autocomplete
-    async fn get_all_blade_components(&self) -> Vec<BladeComponentCompletion> {
+    async fn get_all_blade_components(
+        &self,
+    ) -> Vec<laravel_lsp::component_completion::ComponentCandidate> {
+        use laravel_lsp::component_completion::{
+            dedup_and_sort, scan_anonymous_dir, scan_class_dir,
+        };
+
         let root = match self.root_path.read().await.clone() {
             Some(r) => r,
             None => return Vec::new(),
         };
 
-        // Get component paths from cached config
-        let component_paths = match self.cached_config.read().await.as_ref() {
-            Some(config) => config.component_paths.clone(),
-            None => {
-                // Default to resources/views/components if no config
-                vec![(String::new(), root.join("resources/views/components"))]
-            }
+        let mut candidates = Vec::new();
+
+        // Snapshot the config maps we need, then drop the lock before walking
+        // the filesystem (which can be slow and shouldn't hold the read lock).
+        let (
+            component_paths,
+            view_namespaces,
+            anon_paths,
+            anon_namespaces,
+            class_namespaces,
+            view_paths,
+        ) = match self.cached_config.read().await.as_ref() {
+            Some(config) => (
+                config.component_paths.clone(),
+                config.view_namespaces.clone(),
+                config.anonymous_component_paths.clone(),
+                config.anonymous_component_namespaces.clone(),
+                config.component_namespaces.clone(),
+                config.view_paths.clone(),
+            ),
+            None => (
+                vec![(String::new(), root.join("resources/views/components"))],
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                vec![root.join("resources/views")],
+            ),
         };
 
-        let mut completions = Vec::new();
+        // 1. Root anonymous components — `resources/views/components/*.blade.php`
+        //    (also where class-paired views live). No namespace prefix.
+        for (_namespace, component_path) in &component_paths {
+            candidates.extend(scan_anonymous_dir(component_path, "", &root));
+        }
 
-        for (namespace, component_path) in component_paths {
-            if !component_path.exists() {
-                continue;
+        // 2. Package view namespaces (loadViewsFrom) — `{path}/components/`.
+        for (namespace, package_path) in &view_namespaces {
+            let dir = package_path.join("components");
+            candidates.extend(scan_anonymous_dir(&dir, &format!("{namespace}::"), &root));
+        }
+
+        // 3. Anonymous component paths (Blade::anonymousComponentPath) — the
+        //    registered directory IS the components dir.
+        for (namespace, dir) in &anon_paths {
+            candidates.extend(scan_anonymous_dir(dir, &format!("{namespace}::"), &root));
+        }
+
+        // 4. Anonymous component namespaces (Blade::anonymousComponentNamespace)
+        //    — directory is relative to each view path.
+        for (namespace, rel_dir) in &anon_namespaces {
+            for view_path in &view_paths {
+                let dir = root.join(view_path).join(rel_dir);
+                candidates.extend(scan_anonymous_dir(&dir, &format!("{namespace}::"), &root));
             }
+        }
 
-            // Walk the directory recursively
-            for entry in walkdir::WalkDir::new(&component_path)
-                .follow_links(true)
-                .into_iter()
-                .filter_map(|e| e.ok())
-                .filter(|e| {
-                    e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "php")
-                })
-            {
-                let path = entry.into_path();
-
-                // Convert file path to component name
-                if let Ok(relative) = path.strip_prefix(&component_path) {
-                    let relative_str = relative.to_string_lossy();
-
-                    // Remove .blade.php or .php extension
-                    let component_name = if relative_str.ends_with(".blade.php") {
-                        relative_str.trim_end_matches(".blade.php")
-                    } else if relative_str.ends_with(".php") {
-                        relative_str.trim_end_matches(".php")
-                    } else {
-                        continue;
-                    };
-
-                    // Convert path separators to dots for nested components
-                    let component_name = component_name.replace(['/', '\\'], ".");
-
-                    // Convert to kebab-case (Laravel convention for Blade components)
-                    // PascalCase files become kebab-case: "Button" -> "button", "AlertDialog" -> "alert-dialog"
-                    let component_name = Self::to_kebab_case(&component_name);
-
-                    // Add namespace prefix if present
-                    let full_name = if namespace.is_empty() {
-                        component_name
-                    } else {
-                        format!("{}::{}", namespace, component_name)
-                    };
-
-                    // Get relative path from project root for display
-                    let display_path = path
-                        .strip_prefix(&root)
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_else(|_| path.to_string_lossy().to_string());
-
-                    completions.push(BladeComponentCompletion {
-                        name: full_name,
-                        path: display_path,
-                    });
+        // 5. Class component namespaces (Blade::componentNamespace) — resolve
+        //    the PHP namespace to a source directory via PSR-4 and walk classes.
+        if !class_namespaces.is_empty() {
+            let autoload = laravel_lsp::composer_autoload::ComposerAutoload::for_project(&root);
+            for (namespace, php_namespace) in &class_namespaces {
+                for dir in autoload.resolve_namespace_dirs(php_namespace) {
+                    candidates.extend(scan_class_dir(&dir, &format!("{namespace}::"), &root));
                 }
             }
         }
 
-        // Add package components from view_namespaces
-        // Package anonymous components live in {package_view_path}/components/
-        if let Some(config) = self.cached_config.read().await.as_ref() {
-            for (namespace, package_path) in &config.view_namespaces {
-                let components_path = package_path.join("components");
-                if !components_path.exists() {
-                    continue;
-                }
+        // 6. Non-namespaced class components — `app/View/Components/*.php`.
+        //    These have no blade file of their own when render() is inline, so
+        //    they're invisible to the view scans above.
+        candidates.extend(scan_class_dir(&root.join("app/View/Components"), "", &root));
 
-                for entry in walkdir::WalkDir::new(&components_path)
-                    .follow_links(true)
-                    .into_iter()
-                    .filter_map(|e| e.ok())
-                    .filter(|e| {
-                        e.file_type().is_file()
-                            && e.path().extension().is_some_and(|ext| ext == "php")
-                    })
-                {
-                    let path = entry.into_path();
-
-                    if let Ok(relative) = path.strip_prefix(&components_path) {
-                        let relative_str = relative.to_string_lossy();
-
-                        // Remove .blade.php or .php extension
-                        let component_name = if relative_str.ends_with(".blade.php") {
-                            relative_str.trim_end_matches(".blade.php")
-                        } else if relative_str.ends_with(".php") {
-                            relative_str.trim_end_matches(".php")
-                        } else {
-                            continue;
-                        };
-
-                        // Convert path separators to dots for nested components
-                        let component_name = component_name.replace(['/', '\\'], ".");
-
-                        // Convert to kebab-case
-                        let component_name = Self::to_kebab_case(&component_name);
-
-                        // Package components use namespace::component format
-                        let full_name = format!("{}::{}", namespace, component_name);
-
-                        // For display, show relative to package path or absolute
-                        let display_path = path.to_string_lossy().to_string();
-
-                        completions.push(BladeComponentCompletion {
-                            name: full_name,
-                            path: display_path,
-                        });
-                    }
-                }
-            }
-        }
-
-        // Sort by name for consistent ordering
-        completions.sort_by(|a, b| a.name.cmp(&b.name));
-        completions
+        dedup_and_sort(candidates)
     }
 
     /// Get all Livewire component names from app/Livewire directory for autocomplete
@@ -10862,21 +10815,9 @@ impl LaravelLanguageServer {
     /// "AlertDialog" -> "alert-dialog"
     /// "forms.Input" -> "forms.input"
     fn to_kebab_case(s: &str) -> String {
-        let mut result = String::new();
-        for (i, c) in s.chars().enumerate() {
-            if c == '.' {
-                // Preserve dots for nested components
-                result.push('.');
-            } else if c.is_uppercase() {
-                if i > 0 && !result.ends_with('.') && !result.ends_with('-') {
-                    result.push('-');
-                }
-                result.push(c.to_lowercase().next().unwrap());
-            } else {
-                result.push(c);
-            }
-        }
-        result
+        // Single source of truth lives in the component-completion module so
+        // Blade-component and Livewire naming stay in lockstep.
+        laravel_lsp::component_completion::to_kebab_case(s)
     }
 
     /// Locate any PHP class file under `app/` (or `src/`) and return its
@@ -18661,36 +18602,48 @@ impl LanguageServer for LaravelLanguageServer {
                 // Get all Blade components
                 let components = self.get_all_blade_components().await;
 
+                use laravel_lsp::component_completion::CandidateKind;
+
                 // Build completion items, filtering by prefix (case-insensitive)
                 let prefix_lower = component_ctx.prefix.to_lowercase();
                 let items: Vec<CompletionItem> = components
                     .into_iter()
                     .filter(|c| c.name.to_lowercase().starts_with(&prefix_lower))
-                    .map(|c| CompletionItem {
-                        label: c.name.clone(),
-                        kind: Some(CompletionItemKind::CLASS),
-                        detail: Some(c.path.clone()),
-                        documentation: Some(
-                            CompletionDoc::new()
-                                .header(format!("<x-{}>", c.name))
-                                .summary("Blade component.")
-                                .section(format!("Source: {}", c.path))
-                                .into_documentation(),
-                        ),
-                        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
-                            range: Range {
-                                start: Position {
-                                    line: position.line,
-                                    character: component_ctx.start_col,
+                    .map(|c| {
+                        let (item_kind, summary) = match c.kind {
+                            CandidateKind::Class => {
+                                (CompletionItemKind::CLASS, "Class-based Blade component.")
+                            }
+                            CandidateKind::AnonymousView => {
+                                (CompletionItemKind::STRUCT, "Anonymous Blade component.")
+                            }
+                        };
+                        CompletionItem {
+                            label: c.name.clone(),
+                            kind: Some(item_kind),
+                            detail: Some(c.detail.clone()),
+                            documentation: Some(
+                                CompletionDoc::new()
+                                    .header(format!("<x-{}>", c.name))
+                                    .summary(summary)
+                                    .section(format!("Source: {}", c.detail))
+                                    .into_documentation(),
+                            ),
+                            text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                                range: Range {
+                                    start: Position {
+                                        line: position.line,
+                                        character: component_ctx.start_col,
+                                    },
+                                    end: Position {
+                                        line: position.line,
+                                        character: component_ctx.end_col,
+                                    },
                                 },
-                                end: Position {
-                                    line: position.line,
-                                    character: component_ctx.end_col,
-                                },
-                            },
-                            new_text: c.name.clone(),
-                        })),
-                        ..Default::default()
+                                new_text: c.name.clone(),
+                            })),
+                            ..Default::default()
+                        }
                     })
                     .collect();
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4367,8 +4367,12 @@ impl LaravelLanguageServer {
                     component_paths: cached_config.component_paths.clone(),
                     livewire_path: cached_config.livewire_path.clone(),
                     has_livewire: cached_config.has_livewire,
-                    view_namespaces: std::collections::HashMap::new(),
-                    component_namespaces: std::collections::HashMap::new(),
+                    view_namespaces: cached_config.view_namespaces.clone(),
+                    component_namespaces: cached_config.component_namespaces.clone(),
+                    anonymous_component_paths: cached_config.anonymous_component_paths.clone(),
+                    anonymous_component_namespaces: cached_config
+                        .anonymous_component_namespaces
+                        .clone(),
                     component_aliases: laravel_lsp::config::load_component_aliases(
                         &cached_config.root,
                     ),
@@ -4436,8 +4440,10 @@ impl LaravelLanguageServer {
                 component_paths: c.component_paths.clone(),
                 livewire_path: c.livewire_path.clone(),
                 has_livewire: c.has_livewire,
-                view_namespaces: std::collections::HashMap::new(),
-                component_namespaces: std::collections::HashMap::new(),
+                view_namespaces: c.view_namespaces.clone(),
+                component_namespaces: c.component_namespaces.clone(),
+                anonymous_component_paths: c.anonymous_component_paths.clone(),
+                anonymous_component_namespaces: c.anonymous_component_namespaces.clone(),
                 component_aliases: laravel_lsp::config::load_component_aliases(&c.root),
                 icon_aliases: laravel_lsp::config::scan_vendor_for_icon_sets(&c.root),
             });
@@ -4856,23 +4862,45 @@ impl LaravelLanguageServer {
 
     /// Populate cache with all data from Salsa (config, env, middleware, bindings)
     async fn populate_cache_from_salsa(&self) {
+        // Fetch the authoritative Laravel config from Salsa once, up front. This
+        // is called after the vendor/app rescans have registered the service
+        // providers, so it now carries the namespace maps (view, component, and
+        // anonymous-component) that the initial config — built before those
+        // rescans — was missing.
+        let salsa_config = self.salsa.get_laravel_config().await.ok().flatten();
+
+        // Refresh the in-memory cached config so diagnostics THIS session see the
+        // namespace maps immediately. Without this the config first built during
+        // init (before providers were parsed) lingers with empty namespaces, and
+        // `<x-ns::component>` reports a false "not found" until a provider edit
+        // forces a rebuild. The on-disk cache below persists the same maps for
+        // the next launch.
+        if let Some(ref config) = salsa_config {
+            *self.cached_config.write().await = Some(config.clone());
+        }
+
         let mut cache_guard = self.cache.write().await;
         let Some(ref mut cache) = *cache_guard else {
             return;
         };
 
-        // 1. Cache Laravel config
-        if let Ok(Some(config)) = self.salsa.get_laravel_config().await {
+        // 1. Cache Laravel config (including namespace maps, for next launch)
+        if let Some(ref config) = salsa_config {
             let cached_config = CachedLaravelConfig {
                 root: config.root.clone(),
                 view_paths: config.view_paths.clone(),
                 component_paths: config.component_paths.clone(),
                 livewire_path: config.livewire_path.clone(),
                 has_livewire: config.has_livewire,
+                view_namespaces: config.view_namespaces.clone(),
+                component_namespaces: config.component_namespaces.clone(),
+                anonymous_component_paths: config.anonymous_component_paths.clone(),
+                anonymous_component_namespaces: config.anonymous_component_namespaces.clone(),
             };
             info!(
-                "📋 Caching Laravel config: {} view paths",
-                config.view_paths.len()
+                "📋 Caching Laravel config: {} view paths, {} anon-component paths",
+                config.view_paths.len(),
+                config.anonymous_component_paths.len()
             );
             cache.set_laravel_config(cached_config);
         }

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -1490,6 +1490,44 @@ pub struct ParsedComponentNamespaceReg<'db> {
     pub source_file: PathBuf,
 }
 
+/// A parsed anonymous component path registration from
+/// Blade::anonymousComponentPath() (Salsa tracked).
+/// Example: Blade::anonymousComponentPath(resource_path('views/backstage/components'), 'backstage')
+#[salsa::tracked]
+pub struct ParsedAnonymousComponentPathReg<'db> {
+    /// Component prefix (e.g., "backstage")
+    pub prefix: PackageNamespace<'db>,
+    /// Resolved absolute directory holding the anonymous components
+    #[returns(ref)]
+    pub directory: PathBuf,
+    /// Line in source file where registered
+    pub source_line: u32,
+    /// Priority (0=framework, 1=package, 2=app)
+    pub priority: u8,
+    /// Source file where registered
+    #[returns(ref)]
+    pub source_file: PathBuf,
+}
+
+/// A parsed anonymous component namespace registration from
+/// Blade::anonymousComponentNamespace() (Salsa tracked).
+/// Example: Blade::anonymousComponentNamespace('components.flux', 'flux')
+#[salsa::tracked]
+pub struct ParsedAnonymousComponentNamespaceReg<'db> {
+    /// Component prefix (e.g., "flux")
+    pub prefix: PackageNamespace<'db>,
+    /// Directory relative to the view paths (dots normalized to slashes)
+    #[returns(ref)]
+    pub directory: String,
+    /// Line in source file where registered
+    pub source_line: u32,
+    /// Priority (0=framework, 1=package, 2=app)
+    pub priority: u8,
+    /// Source file where registered
+    #[returns(ref)]
+    pub source_file: PathBuf,
+}
+
 /// Parsed service provider content
 #[salsa::tracked]
 pub struct ParsedServiceProvider<'db> {
@@ -1508,6 +1546,12 @@ pub struct ParsedServiceProvider<'db> {
     /// Component namespace registrations from Blade::componentNamespace()
     #[returns(ref)]
     pub component_namespaces: Vec<ParsedComponentNamespaceReg<'db>>,
+    /// Anonymous component path registrations from Blade::anonymousComponentPath()
+    #[returns(ref)]
+    pub anonymous_component_paths: Vec<ParsedAnonymousComponentPathReg<'db>>,
+    /// Anonymous component namespace registrations from Blade::anonymousComponentNamespace()
+    #[returns(ref)]
+    pub anonymous_component_namespaces: Vec<ParsedAnonymousComponentNamespaceReg<'db>>,
 }
 
 /// Parse a service provider file and extract middleware, bindings, views, and components
@@ -1842,6 +1886,37 @@ pub fn parse_service_provider_source<'db>(
         }
     }
 
+    // Parse Blade::anonymousComponentPath() registrations.
+    // Example: Blade::anonymousComponentPath(resource_path('views/backstage/components'), 'backstage')
+    let provider_dir = path.parent().unwrap_or(path.as_path());
+    let mut anonymous_component_paths = Vec::new();
+    for (prefix, directory, line) in extract_anonymous_component_paths(text, &root, provider_dir) {
+        let pkg_namespace = PackageNamespace::new(db, prefix);
+        anonymous_component_paths.push(ParsedAnonymousComponentPathReg::new(
+            db,
+            pkg_namespace,
+            directory,
+            line,
+            priority,
+            path.clone(),
+        ));
+    }
+
+    // Parse Blade::anonymousComponentNamespace() registrations.
+    // Example: Blade::anonymousComponentNamespace('components.flux', 'flux')
+    let mut anonymous_component_namespaces = Vec::new();
+    for (prefix, directory, line) in extract_anonymous_component_namespaces(text) {
+        let pkg_namespace = PackageNamespace::new(db, prefix);
+        anonymous_component_namespaces.push(ParsedAnonymousComponentNamespaceReg::new(
+            db,
+            pkg_namespace,
+            directory,
+            line,
+            priority,
+            path.clone(),
+        ));
+    }
+
     ParsedServiceProvider::new(
         db,
         middleware,
@@ -1849,7 +1924,139 @@ pub fn parse_service_provider_source<'db>(
         view_namespaces,
         blade_components,
         component_namespaces,
+        anonymous_component_paths,
+        anonymous_component_namespaces,
     )
+}
+
+/// Resolve a PHP path expression to an absolute filesystem path without
+/// executing PHP. Handles the path forms that appear in real service-provider
+/// `anonymousComponentPath()` calls:
+///
+/// - Laravel path helpers: `resource_path('x')`, `base_path('x')`, `app_path('x')`,
+///   `storage_path('x')`, `public_path('x')`, `config_path('x')`,
+///   `database_path('x')`, `lang_path('x')` — and their no-argument forms.
+/// - `__DIR__ . '/relative'` — resolved against the provider file's directory.
+/// - A plain string literal — absolute as-is, otherwise joined to the project root.
+///
+/// Returns `None` for expressions we can't statically resolve (e.g. a variable).
+fn resolve_php_path_expr(expr: &str, root: &Path, provider_dir: &Path) -> Option<PathBuf> {
+    use lazy_static::lazy_static;
+    use regex::Regex;
+
+    lazy_static! {
+        /// `helper('sub/dir')` or `helper()` for the Laravel path helpers.
+        static ref HELPER_RE: Regex = Regex::new(
+            r#"^(resource_path|base_path|app_path|storage_path|public_path|config_path|database_path|lang_path)\s*\(\s*(?:['"]([^'"]*)['"]\s*)?\)$"#
+        ).unwrap();
+        /// `__DIR__ . '/relative'`
+        static ref DIR_CONST_RE: Regex = Regex::new(
+            r#"^__DIR__\s*\.\s*['"]([^'"]+)['"]$"#
+        ).unwrap();
+        /// A bare string literal.
+        static ref LITERAL_RE: Regex = Regex::new(r#"^['"]([^'"]+)['"]$"#).unwrap();
+    }
+
+    let expr = expr.trim();
+
+    if let Some(cap) = HELPER_RE.captures(expr) {
+        let helper = cap.get(1).unwrap().as_str();
+        let sub = cap.get(2).map(|m| m.as_str()).unwrap_or("");
+        let base = match helper {
+            "base_path" => root.to_path_buf(),
+            "resource_path" => root.join("resources"),
+            "app_path" => root.join("app"),
+            "storage_path" => root.join("storage"),
+            "public_path" => root.join("public"),
+            "config_path" => root.join("config"),
+            "database_path" => root.join("database"),
+            "lang_path" => root.join("lang"),
+            _ => return None,
+        };
+        let joined = if sub.is_empty() {
+            base
+        } else {
+            base.join(sub.trim_start_matches('/'))
+        };
+        return Some(normalize_path(&joined));
+    }
+
+    if let Some(cap) = DIR_CONST_RE.captures(expr) {
+        let sub = cap.get(1).unwrap().as_str().trim_start_matches('/');
+        return Some(normalize_path(&provider_dir.join(sub)));
+    }
+
+    if let Some(cap) = LITERAL_RE.captures(expr) {
+        let lit = cap.get(1).unwrap().as_str();
+        let p = Path::new(lit);
+        let joined = if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            root.join(lit)
+        };
+        return Some(normalize_path(&joined));
+    }
+
+    None
+}
+
+/// Extract `Blade::anonymousComponentPath(<path>, 'prefix')` registrations from
+/// service-provider source. Pure (regex + path resolution) so it can be unit
+/// tested without a Salsa database. Returns `(prefix, absolute_directory,
+/// source_line)` tuples; registrations whose path argument can't be statically
+/// resolved are skipped.
+fn extract_anonymous_component_paths(
+    text: &str,
+    root: &Path,
+    provider_dir: &Path,
+) -> Vec<(String, PathBuf, u32)> {
+    use lazy_static::lazy_static;
+    use regex::Regex;
+
+    lazy_static! {
+        /// Group 1 is the path expression (non-greedy, single line); group 2 is
+        /// the string prefix. The two-argument (prefixed) form is the only one
+        /// that produces `<x-prefix::component>` namespaced usage.
+        static ref ANON_PATH_RE: Regex = Regex::new(
+            r#"Blade::anonymousComponentPath\s*\(\s*(.+?)\s*,\s*['"]([^'"]+)['"]\s*\)"#
+        ).unwrap();
+    }
+
+    let mut out = Vec::new();
+    for cap in ANON_PATH_RE.captures_iter(text) {
+        if let (Some(path_expr), Some(prefix)) = (cap.get(1), cap.get(2)) {
+            if let Some(directory) = resolve_php_path_expr(path_expr.as_str(), root, provider_dir) {
+                let line = text[..prefix.start()].lines().count() as u32;
+                out.push((prefix.as_str().to_string(), directory, line));
+            }
+        }
+    }
+    out
+}
+
+/// Extract `Blade::anonymousComponentNamespace('dir', 'prefix')` registrations.
+/// The directory is relative to the registered view paths; dots are normalized
+/// to slashes (Laravel resolves it through the dot-notation view finder).
+/// Returns `(prefix, view_relative_directory, source_line)` tuples.
+fn extract_anonymous_component_namespaces(text: &str) -> Vec<(String, String, u32)> {
+    use lazy_static::lazy_static;
+    use regex::Regex;
+
+    lazy_static! {
+        static ref ANON_NS_RE: Regex = Regex::new(
+            r#"Blade::anonymousComponentNamespace\s*\(\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]+)['"]\s*\)"#
+        ).unwrap();
+    }
+
+    let mut out = Vec::new();
+    for cap in ANON_NS_RE.captures_iter(text) {
+        if let (Some(directory), Some(prefix)) = (cap.get(1), cap.get(2)) {
+            let line = text[..prefix.start()].lines().count() as u32;
+            let normalized = directory.as_str().replace('.', "/");
+            out.push((prefix.as_str().to_string(), normalized, line));
+        }
+    }
+    out
 }
 
 /// Normalize a path by resolving . and .. components without requiring the path to exist
@@ -2070,6 +2277,17 @@ pub struct LaravelConfigData {
     /// Package component namespaces from Blade::componentNamespace() calls
     /// Maps prefix (e.g., "nightshade") to PHP namespace
     pub component_namespaces: HashMap<String, String>,
+    /// Anonymous component paths from Blade::anonymousComponentPath($path, 'prefix').
+    /// Maps prefix (e.g., "backstage") to the **absolute** directory holding the
+    /// anonymous components. Resolution is `{dir}/{component}.blade.php` — no
+    /// `components/` segment is appended, because Laravel registers the directory
+    /// itself (unlike the package-publish `resources/views/vendor/<ns>/` convention).
+    pub anonymous_component_paths: HashMap<String, PathBuf>,
+    /// Anonymous component namespaces from Blade::anonymousComponentNamespace($dir, 'prefix').
+    /// Maps prefix (e.g., "flux") to a directory **relative to the view paths**
+    /// (dots normalized to slashes). Resolution is
+    /// `{view_path}/{dir}/{component}.blade.php`.
+    pub anonymous_component_namespaces: HashMap<String, String>,
     /// Component aliases registered via Blade::component($view, $alias) or via
     /// config-based registration loops. Maps alias (e.g., "light-button") to
     /// the target view path in dot notation (e.g., "components.buttons.light-button").
@@ -2180,6 +2398,31 @@ impl LaravelConfigData {
         let component_path = actual_component.replace('.', "/");
 
         if let Some(ns) = namespace {
+            // Anonymous component path (Blade::anonymousComponentPath): the
+            // registered directory IS the components directory, so resolve
+            // directly with no `components/` segment. Both the flat file and
+            // Laravel's `{component}/index.blade.php` index convention are valid.
+            // Pushed first so the correct path is `paths.first()` — the
+            // diagnostic reports that as the "Expected at:" location.
+            if let Some(dir) = self.anonymous_component_paths.get(ns) {
+                let mut direct = dir.join(&component_path);
+                direct.set_extension("blade.php");
+                paths.push(direct);
+                paths.push(dir.join(&component_path).join("index.blade.php"));
+            }
+
+            // Anonymous component namespace (Blade::anonymousComponentNamespace):
+            // the registered directory is relative to each view path.
+            if let Some(dir) = self.anonymous_component_namespaces.get(ns) {
+                for view_path in &self.view_paths {
+                    let base = self.root.join(view_path).join(dir);
+                    let mut direct = base.join(&component_path);
+                    direct.set_extension("blade.php");
+                    paths.push(direct);
+                    paths.push(base.join(&component_path).join("index.blade.php"));
+                }
+            }
+
             // Package component - check package view path first
             if let Some(package_view_path) = self.view_namespaces.get(ns) {
                 // Anonymous package component: {package_views}/components/{component}.blade.php
@@ -5153,6 +5396,8 @@ impl SalsaActor {
         // Collect view namespaces from all parsed service providers
         let mut view_namespaces: HashMap<String, PathBuf> = HashMap::new();
         let mut component_namespaces: HashMap<String, String> = HashMap::new();
+        let mut anonymous_component_paths: HashMap<String, PathBuf> = HashMap::new();
+        let mut anonymous_component_namespaces: HashMap<String, String> = HashMap::new();
 
         if let Some(sp_root) = self.salsa_sp_root.as_ref() {
             for sp_file in self.salsa_sp_files.values() {
@@ -5183,6 +5428,22 @@ impl SalsaActor {
                         }
                     }
                 }
+
+                // Collect anonymous component paths (Blade::anonymousComponentPath)
+                for acp in parsed.anonymous_component_paths(&self.db) {
+                    let prefix = acp.prefix(&self.db).namespace(&self.db).clone();
+                    let directory = acp.directory(&self.db).clone();
+                    anonymous_component_paths.entry(prefix).or_insert(directory);
+                }
+
+                // Collect anonymous component namespaces (Blade::anonymousComponentNamespace)
+                for acn in parsed.anonymous_component_namespaces(&self.db) {
+                    let prefix = acn.prefix(&self.db).namespace(&self.db).clone();
+                    let directory = acn.directory(&self.db).clone();
+                    anonymous_component_namespaces
+                        .entry(prefix)
+                        .or_insert(directory);
+                }
             }
         }
 
@@ -5212,6 +5473,8 @@ impl SalsaActor {
             has_livewire: config_ref.has_livewire(&self.db),
             view_namespaces,
             component_namespaces,
+            anonymous_component_paths,
+            anonymous_component_namespaces,
             component_aliases,
             icon_aliases,
         };
@@ -6007,6 +6270,16 @@ impl SalsaActor {
         use salsa::Setter;
         self.salsa_sp_version += 1;
         self.salsa_sp_root = Some(root_path);
+
+        // The Laravel config's namespace maps (view namespaces, component
+        // namespaces, and anonymous-component paths/namespaces) are derived by
+        // parsing these service-provider files. Registering or updating one can
+        // therefore change the config, so the memoized config_cache must be
+        // dropped — otherwise `get_laravel_config` keeps serving the config that
+        // was built before this provider was known, and namespaced components
+        // resolve as "not found". Bumping salsa_sp_version alone is not enough;
+        // config_cache is keyed on config_version, which this doesn't touch.
+        self.config_cache = None;
 
         if let Some(file) = self.salsa_sp_files.get(&path) {
             // Update existing file

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -3241,9 +3241,12 @@ pub enum SalsaRequest {
         reply: oneshot::Sender<()>,
     },
 
-    /// Register Laravel config from disk cache (bypasses parsing)
+    /// Register Laravel config from disk cache (bypasses parsing).
+    /// Boxed because `LaravelConfigData` is by far the largest payload of any
+    /// `SalsaRequest` variant; keeping it inline bloats every message (see
+    /// clippy::large_enum_variant).
     RegisterCachedConfig {
-        config: LaravelConfigData,
+        config: Box<LaravelConfigData>,
         reply: oneshot::Sender<()>,
     },
 
@@ -4082,7 +4085,7 @@ impl SalsaHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(SalsaRequest::RegisterCachedConfig {
-                config,
+                config: Box::new(config),
                 reply: reply_tx,
             })
             .await
@@ -4729,7 +4732,7 @@ impl SalsaActor {
                 SalsaRequest::RegisterCachedConfig { config, reply } => {
                     // Set config directly from cache, bypassing parsing
                     self.config_root = Some(config.root.clone());
-                    self.config_cache = Some((self.config_version, config));
+                    self.config_cache = Some((self.config_version, *config));
                     tracing::info!("📋 Registered cached Laravel config");
                     let _ = reply.send(());
                 }

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -105,6 +105,8 @@ fn make_config_with_alias(alias: &str, view: &str) -> LaravelConfigData {
         has_livewire: false,
         view_namespaces: HashMap::new(),
         component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
         component_aliases: aliases,
         icon_aliases: HashMap::new(),
     }
@@ -122,6 +124,8 @@ fn make_config_with_icon(tag: &str, svg_path: &str) -> LaravelConfigData {
         has_livewire: false,
         view_namespaces: HashMap::new(),
         component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
         component_aliases: HashMap::new(),
         icon_aliases: icons,
     }
@@ -201,6 +205,335 @@ fn namespaced_component_bypasses_alias_map() {
             .all(|p| !p.to_string_lossy().contains("components/never/this")),
         "namespaced lookup must bypass alias map: {:?}",
         paths,
+    );
+}
+
+// ─── Anonymous component path / namespace resolution (issue #44) ────────
+
+fn make_config_with_anonymous_path(prefix: &str, abs_dir: &str) -> LaravelConfigData {
+    let mut anon = HashMap::new();
+    anon.insert(prefix.to_string(), PathBuf::from(abs_dir));
+
+    LaravelConfigData {
+        root: PathBuf::from("/project"),
+        view_paths: vec![PathBuf::from("resources/views")],
+        component_paths: Vec::new(),
+        livewire_path: None,
+        has_livewire: false,
+        view_namespaces: HashMap::new(),
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths: anon,
+        anonymous_component_namespaces: HashMap::new(),
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+    }
+}
+
+fn make_config_with_anonymous_namespace(prefix: &str, dir: &str) -> LaravelConfigData {
+    let mut anon = HashMap::new();
+    anon.insert(prefix.to_string(), dir.to_string());
+
+    LaravelConfigData {
+        root: PathBuf::from("/project"),
+        view_paths: vec![PathBuf::from("resources/views")],
+        component_paths: Vec::new(),
+        livewire_path: None,
+        has_livewire: false,
+        view_namespaces: HashMap::new(),
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: anon,
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+    }
+}
+
+#[test]
+fn anonymous_component_path_resolves_to_registered_directory() {
+    // Issue #44: Blade::anonymousComponentPath(resource_path('views/backstage/components'), 'backstage')
+    // <x-backstage::layout> must resolve to the registered directory directly —
+    // not the package-publish `resources/views/vendor/backstage/...` guess.
+    let config = make_config_with_anonymous_path(
+        "backstage",
+        "/project/resources/views/backstage/components",
+    );
+
+    let paths = config.resolve_component_path("backstage::layout");
+
+    assert_eq!(
+        paths.first(),
+        Some(&PathBuf::from(
+            "/project/resources/views/backstage/components/layout.blade.php"
+        )),
+        "registered anonymousComponentPath must be the first (expected) candidate: {:?}",
+        paths,
+    );
+}
+
+#[test]
+fn anonymous_component_path_supports_index_convention() {
+    let config = make_config_with_anonymous_path(
+        "backstage",
+        "/project/resources/views/backstage/components",
+    );
+
+    let paths = config.resolve_component_path("backstage::layout");
+
+    assert!(
+        paths.iter().any(|p| p
+            == &PathBuf::from(
+                "/project/resources/views/backstage/components/layout/index.blade.php"
+            )),
+        "expected the index.blade.php convention candidate, got: {:?}",
+        paths,
+    );
+}
+
+#[test]
+fn anonymous_component_path_resolves_dotted_component_name() {
+    let config = make_config_with_anonymous_path(
+        "backstage",
+        "/project/resources/views/backstage/components",
+    );
+
+    let paths = config.resolve_component_path("backstage::forms.input");
+
+    assert!(
+        paths.iter().any(|p| p
+            == &PathBuf::from(
+                "/project/resources/views/backstage/components/forms/input.blade.php"
+            )),
+        "dotted component name must map dots to slashes: {:?}",
+        paths,
+    );
+}
+
+#[test]
+fn anonymous_component_namespace_resolves_relative_to_view_paths() {
+    // Blade::anonymousComponentNamespace('components.flux', 'flux')
+    // <x-flux::button> -> resources/views/components/flux/button.blade.php
+    let config = make_config_with_anonymous_namespace("flux", "components/flux");
+
+    let paths = config.resolve_component_path("flux::button");
+
+    assert!(
+        paths
+            .iter()
+            .any(|p| p
+                == &PathBuf::from("/project/resources/views/components/flux/button.blade.php")),
+        "anonymous namespace must resolve under the view path: {:?}",
+        paths,
+    );
+}
+
+#[test]
+fn unregistered_anonymous_prefix_does_not_borrow_registered_directory() {
+    let config = make_config_with_anonymous_path(
+        "backstage",
+        "/project/resources/views/backstage/components",
+    );
+
+    // A different prefix must not resolve into the backstage directory.
+    let paths = config.resolve_component_path("other::layout");
+
+    assert!(
+        paths
+            .iter()
+            .all(|p| !p.to_string_lossy().contains("backstage/components")),
+        "unregistered prefix must not resolve into a registered anon directory: {:?}",
+        paths,
+    );
+}
+
+// ─── PHP path-expression resolution ─────────────────────────────────────
+
+#[test]
+fn resolve_php_path_expr_handles_resource_path() {
+    let root = PathBuf::from("/project");
+    let provider_dir = PathBuf::from("/project/app/Providers");
+    assert_eq!(
+        resolve_php_path_expr(
+            "resource_path('views/backstage/components')",
+            &root,
+            &provider_dir
+        ),
+        Some(PathBuf::from(
+            "/project/resources/views/backstage/components"
+        )),
+    );
+}
+
+#[test]
+fn resolve_php_path_expr_handles_base_and_app_path() {
+    let root = PathBuf::from("/project");
+    let provider_dir = PathBuf::from("/project/app/Providers");
+    assert_eq!(
+        resolve_php_path_expr("base_path('resources/views/x')", &root, &provider_dir),
+        Some(PathBuf::from("/project/resources/views/x")),
+    );
+    assert_eq!(
+        resolve_php_path_expr("app_path('View/Components')", &root, &provider_dir),
+        Some(PathBuf::from("/project/app/View/Components")),
+    );
+}
+
+#[test]
+fn resolve_php_path_expr_handles_dir_constant() {
+    let root = PathBuf::from("/project");
+    let provider_dir = PathBuf::from("/pkg/src/Providers");
+    assert_eq!(
+        resolve_php_path_expr(
+            "__DIR__ . '/../resources/views/components'",
+            &root,
+            &provider_dir
+        ),
+        Some(PathBuf::from("/pkg/src/resources/views/components")),
+    );
+}
+
+#[test]
+fn resolve_php_path_expr_handles_absolute_literal() {
+    let root = PathBuf::from("/project");
+    let provider_dir = PathBuf::from("/project/app/Providers");
+    assert_eq!(
+        resolve_php_path_expr("'/abs/components'", &root, &provider_dir),
+        Some(PathBuf::from("/abs/components")),
+    );
+}
+
+#[test]
+fn resolve_php_path_expr_rejects_unresolvable_expression() {
+    let root = PathBuf::from("/project");
+    let provider_dir = PathBuf::from("/project/app/Providers");
+    assert_eq!(
+        resolve_php_path_expr("$this->componentPath", &root, &provider_dir),
+        None,
+    );
+}
+
+// ─── Service-provider registration extraction ───────────────────────────
+
+#[test]
+fn extract_anonymous_component_paths_reads_registration() {
+    let src = r#"
+        public function boot(): void
+        {
+            Blade::anonymousComponentPath(resource_path('views/backstage/components'), 'backstage');
+        }
+    "#;
+    let root = PathBuf::from("/project");
+    let provider_dir = PathBuf::from("/project/app/Providers");
+
+    let regs = extract_anonymous_component_paths(src, &root, &provider_dir);
+
+    assert_eq!(regs.len(), 1);
+    assert_eq!(regs[0].0, "backstage");
+    assert_eq!(
+        regs[0].1,
+        PathBuf::from("/project/resources/views/backstage/components"),
+    );
+}
+
+#[test]
+fn extract_anonymous_component_namespaces_normalizes_dots() {
+    let src = "Blade::anonymousComponentNamespace('components.flux', 'flux');";
+
+    let regs = extract_anonymous_component_namespaces(src);
+
+    assert_eq!(regs.len(), 1);
+    assert_eq!(regs[0].0, "flux");
+    assert_eq!(regs[0].1, "components/flux");
+}
+
+// ─── Salsa actor: config reflects provider registrations (issue #44) ────
+
+/// A provider that registers both anonymous-component forms. Parsing is
+/// text-based, so the paths need not exist on disk.
+fn anon_component_provider_src() -> String {
+    r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Facades\Blade;
+class AppServiceProvider {
+    public function boot(): void {
+        Blade::anonymousComponentPath(resource_path('views/test/components'), 'test');
+        Blade::anonymousComponentNamespace('components.flux', 'flux');
+    }
+}
+"#
+    .to_string()
+}
+
+#[tokio::test]
+async fn salsa_config_indexes_anonymous_component_registrations() {
+    let handle = SalsaActor::spawn();
+    let root = PathBuf::from("/tmp/zed-laravel-issue44");
+
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    handle
+        .register_service_provider_source(
+            root.join("app/Providers/AppServiceProvider.php"),
+            anon_component_provider_src(),
+            2,
+            root.clone(),
+        )
+        .await
+        .unwrap();
+
+    let config = handle.get_laravel_config().await.unwrap().unwrap();
+
+    assert_eq!(
+        config.anonymous_component_paths.get("test"),
+        Some(&root.join("resources/views/test/components")),
+        "anonymousComponentPath must be indexed into the Laravel config",
+    );
+    assert_eq!(
+        config.anonymous_component_namespaces.get("flux"),
+        Some(&"components/flux".to_string()),
+        "anonymousComponentNamespace must be indexed into the Laravel config",
+    );
+}
+
+#[tokio::test]
+async fn salsa_config_refreshes_when_provider_registered_after_first_build() {
+    // Regression for the stale-config bug: the config is built (and memoized)
+    // before the provider is registered, then the provider arrives via the
+    // init-time app rescan. get_laravel_config must rebuild — not serve the
+    // cached empty-namespace config — or `<x-test::...>` stays a false
+    // "not found" until an unrelated provider edit forces an invalidation.
+    let handle = SalsaActor::spawn();
+    let root = PathBuf::from("/tmp/zed-laravel-issue44-late");
+
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+
+    // First build — no providers registered yet. This memoizes config_cache.
+    let before = handle.get_laravel_config().await.unwrap().unwrap();
+    assert!(
+        before.anonymous_component_paths.is_empty(),
+        "precondition: no anon paths before the provider is registered",
+    );
+
+    // Provider registered late, as during the init-time app rescan.
+    handle
+        .register_service_provider_source(
+            root.join("app/Providers/AppServiceProvider.php"),
+            anon_component_provider_src(),
+            2,
+            root.clone(),
+        )
+        .await
+        .unwrap();
+
+    let after = handle.get_laravel_config().await.unwrap().unwrap();
+    assert_eq!(
+        after.anonymous_component_paths.get("test"),
+        Some(&root.join("resources/views/test/components")),
+        "config must refresh after late provider registration (config_cache must be invalidated)",
     );
 }
 

--- a/laravel-lsp/src/tests/blade_component_context.rs
+++ b/laravel-lsp/src/tests/blade_component_context.rs
@@ -1,0 +1,47 @@
+use crate::LaravelLanguageServer;
+
+/// `<x-test::` must be recognized as a Blade component context so namespaced
+/// components get completion — the `:` used to be rejected, killing the menu.
+#[test]
+fn namespaced_component_is_a_completion_context() {
+    let line = "<x-test::";
+    let ctx = LaravelLanguageServer::get_blade_component_context(line, line.len() as u32)
+        .expect("`<x-test::` should be a component context");
+    assert_eq!(ctx.prefix, "test::");
+    assert_eq!(ctx.start_col, 3, "replacement starts right after `<x-`");
+}
+
+#[test]
+fn namespaced_component_with_partial_name() {
+    let line = "    <x-test::back";
+    let ctx = LaravelLanguageServer::get_blade_component_context(line, line.len() as u32)
+        .expect("partial namespaced name should still be a context");
+    assert_eq!(ctx.prefix, "test::back");
+}
+
+#[test]
+fn plain_component_still_detected() {
+    // Regression: allowing `:` must not break the non-namespaced case.
+    let line = "<x-button";
+    let ctx = LaravelLanguageServer::get_blade_component_context(line, line.len() as u32)
+        .expect("plain component context");
+    assert_eq!(ctx.prefix, "button");
+}
+
+#[test]
+fn dotted_component_still_detected() {
+    let line = "<x-forms.input";
+    let ctx = LaravelLanguageServer::get_blade_component_context(line, line.len() as u32)
+        .expect("dotted component context");
+    assert_eq!(ctx.prefix, "forms.input");
+}
+
+#[test]
+fn space_after_tag_name_ends_the_context() {
+    // Once attributes begin, we're past the component name.
+    let line = "<x-test::backstage ";
+    assert!(
+        LaravelLanguageServer::get_blade_component_context(line, line.len() as u32).is_none(),
+        "a space (start of attributes) must end the component-name context",
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod array_context_detection;
+mod blade_component_context;
 mod cast_type_context;
 mod class_locator_and_properties;
 mod dynamic_where_sparseness;

--- a/laravel-lsp/src/tests/rename_integration.rs
+++ b/laravel-lsp/src/tests/rename_integration.rs
@@ -50,6 +50,8 @@ fn fake_config(root: &Path) -> LaravelConfigData {
         has_livewire: true,
         view_namespaces: HashMap::new(),
         component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
         component_aliases: HashMap::new(),
         icon_aliases: HashMap::new(),
     }

--- a/laravel-lsp/src/view_declaration_locator/tests.rs
+++ b/laravel-lsp/src/view_declaration_locator/tests.rs
@@ -13,6 +13,8 @@ fn config_for(root: &Path) -> LaravelConfigData {
         has_livewire: false,
         view_namespaces: HashMap::new(),
         component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
         component_aliases: HashMap::new(),
         icon_aliases: HashMap::new(),
     }


### PR DESCRIPTION
## Summary

Two related, independently-reviewable commits around namespaced Blade components:

### 1. `fix: 🐛` Resolve namespaced anonymous Blade components (Fixes #44)
`<x-{ns}::{component}>` registered via `Blade::anonymousComponentPath()` /
`anonymousComponentNamespace()` was falsely flagged **"Blade component not found"** —
the resolver only knew the package-publish convention (`resources/views/vendor/<ns>/`)
and never parsed those registrations.

- Parse both registration forms from service providers (`resource_path()`, `base_path()`,
  `__DIR__ . '…'`, and literal path args).
- Resolve directly against the registered directory (no `components/` segment, matching
  Laravel), also trying the `{component}/index.blade.php` convention.
- Thread the namespace maps through the Salsa config so **diagnostics, hover, and goto** agree.
- **Latent bug also fixed:** registering a service provider now invalidates the memoized
  config cache (previously it only bumped the provider version, so namespace maps never
  reached a re-validated config), and the maps are now **persisted in the on-disk cache
  (v5)** so they survive restarts. This also repairs `componentNamespace()` /
  `loadViewsFrom()` resolution, which shared the bug.

### 2. `feat: ✨` Complete namespaced and class-based Blade components
Autocomplete after `<x-` now also offers:
- namespaced **anonymous** components (`test::backstage`)
- **class-based** `componentNamespace()` components, resolved via PSR-4
  (new `ComposerAutoload::resolve_namespace_dirs`)
- `app/View/Components` **class** components — previously invisible to completion

Candidates are deduped by tag name (class wins, mirroring Laravel). The tag-context
detector now accepts `:` so `<x-ns::` triggers completion (the `:` was being rejected).
Scanning + dedup live in a new tested `component_completion` module.

## Test plan
- `cargo test` — **1460 passing** (29 new: anon resolution, Salsa actor cache-invalidation,
  PSR-4 reverse-resolution, completion scan/dedup, context detection).
- `cargo fmt --check` clean; `cargo clippy` no new warnings.
- Manually verified in Zed against a Laravel 12 project:
  - `Blade::anonymousComponentPath(resource_path('views/test/components'), 'test')` +
    `<x-test::backstage>` → no diagnostic; hover/goto land on the right file.
  - `<x-test` → `test::backstage` completes.

## Note
Cache format bumped to **v5** — the first reload after this rebuilds the on-disk cache
(one-time reindex).

Fixes: #44
