### PR TITLE
fix: 🐛 Resolve route names from group-loaded files + Route::resource, unify route handling (#43)

### DIFF
--- a/laravel-lsp/src/document_symbols.rs
+++ b/laravel-lsp/src/document_symbols.rs
@@ -116,8 +116,25 @@ pub fn classify_file(path: &Path) -> FileKind {
 /// Dispatch to the right extractor based on file kind. `Php` returns
 /// empty — see module-level docs.
 pub fn extract_symbols(content: &str, kind: FileKind) -> Vec<SymbolEntry> {
+    extract_symbols_with_external(content, kind, &[])
+}
+
+/// [`extract_symbols`], but applying external-file group name prefixes (issue
+/// #43) to route-file symbols. `external_prefixes` is ignored for non-route
+/// kinds; an empty slice yields byte-identical output to [`extract_symbols`].
+///
+/// This is NOT used on the Salsa-cached path (that stays keyed on file mtime
+/// with no cross-file input — see `salsa_impl::document_symbols_query`). The
+/// `document_symbol` handler calls it directly for the rare route file reached
+/// through an external `->group(<path>)` load, so the outline shows the
+/// project-level prefixed names there.
+pub fn extract_symbols_with_external(
+    content: &str,
+    kind: FileKind,
+    external_prefixes: &[String],
+) -> Vec<SymbolEntry> {
     match kind {
-        FileKind::RouteFile => extract_route_symbols(content),
+        FileKind::RouteFile => extract_route_symbols_with_external(content, external_prefixes),
         FileKind::Blade => extract_blade_symbols(content),
         FileKind::Php | FileKind::Other => Vec::new(),
     }
@@ -132,8 +149,19 @@ pub fn extract_symbols(content: &str, kind: FileKind) -> Vec<SymbolEntry> {
 /// become hierarchical `Namespace`-kind symbols with their child routes
 /// nested inside; leaf routes become `Function`-kind symbols with label
 /// `METHOD URI` and a `[name=…]` detail when named.
+/// Test-only thin wrapper preserving the original no-prefix entry point used
+/// by `document_symbols/tests.rs`.
+#[cfg(test)]
 fn extract_route_symbols(content: &str) -> Vec<SymbolEntry> {
-    let outline = crate::route_outline::extract_route_outline(content);
+    extract_route_symbols_with_external(content, &[])
+}
+
+fn extract_route_symbols_with_external(
+    content: &str,
+    external_prefixes: &[String],
+) -> Vec<SymbolEntry> {
+    let outline =
+        crate::route_outline::extract_route_outline_with_external(content, external_prefixes);
     outline.iter().map(route_outline_to_symbol).collect()
 }
 

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -53,6 +53,7 @@ pub mod query_chain;
 pub mod references;
 pub mod rename;
 pub mod route_binding;
+pub mod route_chain;
 pub mod route_discovery;
 pub mod route_name_locator;
 pub mod route_outline;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -26,7 +26,9 @@ use laravel_lsp::completion_format::CompletionDoc;
 use laravel_lsp::config::find_project_root;
 use laravel_lsp::middleware_parser::{middleware_base_alias, resolve_class_to_file};
 use laravel_lsp::migration_index::{build_migration_index, MigrationIndex};
-use laravel_lsp::route_discovery::{build_route_index, discover_route_files, RouteIndex};
+use laravel_lsp::route_discovery::{
+    build_route_index, discover_route_files, normalize_path, RouteIndex,
+};
 
 // Salsa 0.25 database - integrated via actor pattern for async compatibility
 use laravel_lsp::salsa_impl::{
@@ -183,6 +185,17 @@ struct RouteNameCompletion {
     name: String,
     /// Source file (e.g., "routes/web.php")
     source: String,
+}
+
+/// Render a route definition's file as a short, project-relative label for the
+/// completion detail line (e.g. `routes/api.php`). Falls back to the file name,
+/// then the lossy full path, when the file isn't under `root`.
+fn route_source_label(file: &Path, root: &Path) -> String {
+    file.strip_prefix(root)
+        .ok()
+        .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+        .or_else(|| file.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .unwrap_or_else(|| file.to_string_lossy().into_owned())
 }
 
 /// A view name for autocomplete
@@ -4021,6 +4034,16 @@ impl LaravelLanguageServer {
             .await
             .insert(path.to_path_buf(), (disk_mtime, decls.clone()));
         Some(decls)
+    }
+
+    /// Return the current content of `uri` — the editor buffer if the file is
+    /// open (so unsaved edits are reflected), otherwise the on-disk text.
+    /// Returns `None` only when neither source is readable.
+    async fn document_or_disk_content(&self, uri: &Url, path: &Path) -> Option<String> {
+        if let Some((content, _version)) = self.documents.read().await.get(uri).cloned() {
+            return Some(content);
+        }
+        tokio::fs::read_to_string(path).await.ok()
     }
 
     /// Register environment files directly with Salsa for parsing
@@ -11004,161 +11027,58 @@ impl LaravelLanguageServer {
         properties
     }
 
-    /// Get all route names from routes/*.php files for autocomplete
+    /// Get all route names for autocomplete from the unified route index.
+    ///
+    /// Reads the pre-built [`RouteIndex`] (the SAME source hover/goto use), so
+    /// completions cover every discovered file, carry group/inherited prefixes,
+    /// and include `Route::resource`/`apiResource`-derived names — all without
+    /// the old per-call regex extraction. Falls back to building an index on the
+    /// fly if one hasn't been populated yet.
     async fn get_all_route_names(&self) -> Vec<RouteNameCompletion> {
         let root = match self.root_path.read().await.clone() {
             Some(r) => r,
             None => return Vec::new(),
         };
 
-        let routes_dir = root.join("routes");
-        if !routes_dir.exists() {
-            return Vec::new();
-        }
-
-        let mut completions = Vec::new();
-        let route_files = ["web.php", "api.php", "channels.php", "console.php"];
-
-        // Regex to match ->name('route.name') or ->name("route.name")
-        let name_pattern = regex::Regex::new(r#"->name\s*\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap();
-
-        // Regex to match Route::resource('name', Controller::class) with optional modifiers
-        // Captures: 1=resource name, 2=rest of the chain (for only/except parsing)
-        let resource_pattern =
-            regex::Regex::new(r#"Route::resource\s*\(\s*['"]([^'"]+)['"]\s*,[^)]+\)([^;]*)"#)
-                .unwrap();
-
-        // Regex to match Route::apiResource('name', Controller::class) with optional modifiers
-        let api_resource_pattern =
-            regex::Regex::new(r#"Route::apiResource\s*\(\s*['"]([^'"]+)['"]\s*,[^)]+\)([^;]*)"#)
-                .unwrap();
-
-        // Regex to extract ->only([...]) actions
-        let only_pattern = regex::Regex::new(r#"->only\s*\(\s*\[([^\]]*)\]"#).unwrap();
-
-        // Regex to extract ->except([...]) actions
-        let except_pattern = regex::Regex::new(r#"->except\s*\(\s*\[([^\]]*)\]"#).unwrap();
-
-        // Standard resource actions
-        let resource_actions = [
-            "index", "create", "store", "show", "edit", "update", "destroy",
-        ];
-        // API resource actions (no create/edit - those are for forms)
-        let api_resource_actions = ["index", "store", "show", "update", "destroy"];
-
-        for file_name in route_files {
-            let route_file = routes_dir.join(file_name);
-            if route_file.exists() {
-                if let Ok(content) = std::fs::read_to_string(&route_file) {
-                    let source = format!("routes/{}", file_name);
-
-                    // Find all ->name('...') patterns
-                    for caps in name_pattern.captures_iter(&content) {
-                        if let Some(name_match) = caps.get(1) {
-                            completions.push(RouteNameCompletion {
-                                name: name_match.as_str().to_string(),
-                                source: source.clone(),
-                            });
-                        }
-                    }
-
-                    // Find all Route::resource() patterns
-                    for caps in resource_pattern.captures_iter(&content) {
-                        if let Some(resource_name) = caps.get(1) {
-                            let chain = caps.get(2).map(|m| m.as_str()).unwrap_or("");
-                            let actions = Self::get_resource_actions(
-                                chain,
-                                &resource_actions,
-                                &only_pattern,
-                                &except_pattern,
-                            );
-
-                            for action in actions {
-                                completions.push(RouteNameCompletion {
-                                    name: format!("{}.{}", resource_name.as_str(), action),
-                                    source: source.clone(),
-                                });
-                            }
-                        }
-                    }
-
-                    // Find all Route::apiResource() patterns
-                    for caps in api_resource_pattern.captures_iter(&content) {
-                        if let Some(resource_name) = caps.get(1) {
-                            let chain = caps.get(2).map(|m| m.as_str()).unwrap_or("");
-                            let actions = Self::get_resource_actions(
-                                chain,
-                                &api_resource_actions,
-                                &only_pattern,
-                                &except_pattern,
-                            );
-
-                            for action in actions {
-                                completions.push(RouteNameCompletion {
-                                    name: format!("{}.{}", resource_name.as_str(), action),
-                                    source: source.clone(),
-                                });
-                            }
-                        }
-                    }
+        // Prefer the already-built index. Clone out the (name, file) pairs so we
+        // can drop the read lock before doing any string work.
+        let entries: Vec<(String, PathBuf)> = {
+            let guard = self.route_index.read().await;
+            match guard.as_ref() {
+                Some(index) => index
+                    .routes
+                    .iter()
+                    .map(|(name, def)| (name.clone(), def.file.clone()))
+                    .collect(),
+                None => {
+                    // Index not ready yet — build one synchronously as a fallback.
+                    let root = root.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let files = discover_route_files(&root);
+                        let index = build_route_index(&root, &files);
+                        index
+                            .routes
+                            .into_iter()
+                            .map(|(name, def)| (name, def.file))
+                            .collect::<Vec<_>>()
+                    })
+                    .await
+                    .unwrap_or_default()
                 }
             }
-        }
+        };
 
-        // Sort by name for consistent ordering
+        let mut completions: Vec<RouteNameCompletion> = entries
+            .into_iter()
+            .map(|(name, file)| RouteNameCompletion {
+                name,
+                source: route_source_label(&file, &root),
+            })
+            .collect();
+
+        // Sort by name for consistent ordering.
         completions.sort_by(|a, b| a.name.cmp(&b.name));
-
-        // Remove duplicates (same route name from different files - keep first occurrence)
-        completions.dedup_by(|a, b| a.name == b.name);
-
         completions
-    }
-
-    /// Parse ->only() and ->except() modifiers to determine which resource actions to include
-    fn get_resource_actions<'a>(
-        chain: &str,
-        all_actions: &'a [&'a str],
-        only_pattern: &regex::Regex,
-        except_pattern: &regex::Regex,
-    ) -> Vec<&'a str> {
-        // Check for ->only([...])
-        if let Some(only_caps) = only_pattern.captures(chain) {
-            if let Some(only_list) = only_caps.get(1) {
-                let only_actions: Vec<&str> = only_list
-                    .as_str()
-                    .split(',')
-                    .map(|s| s.trim().trim_matches('\'').trim_matches('"'))
-                    .filter(|s| !s.is_empty())
-                    .collect();
-
-                return all_actions
-                    .iter()
-                    .filter(|a| only_actions.contains(a))
-                    .copied()
-                    .collect();
-            }
-        }
-
-        // Check for ->except([...])
-        if let Some(except_caps) = except_pattern.captures(chain) {
-            if let Some(except_list) = except_caps.get(1) {
-                let except_actions: Vec<&str> = except_list
-                    .as_str()
-                    .split(',')
-                    .map(|s| s.trim().trim_matches('\'').trim_matches('"'))
-                    .filter(|s| !s.is_empty())
-                    .collect();
-
-                return all_actions
-                    .iter()
-                    .filter(|a| !except_actions.contains(a))
-                    .copied()
-                    .collect();
-            }
-        }
-
-        // No modifiers - return all actions
-        all_actions.to_vec()
     }
 
     /// Get all translation keys from lang/*.php files for autocomplete
@@ -12907,7 +12827,7 @@ return [
         let index = tokio::task::spawn_blocking(move || {
             let files = discover_route_files(&root);
             let count = files.len();
-            let index = build_route_index(&files);
+            let index = build_route_index(&root, &files);
             (count, index)
         })
         .await;
@@ -15560,6 +15480,7 @@ return [
 /// the locator's full route name.
 async fn classify_with_decl_fallback(
     server: &LaravelLanguageServer,
+    root: Option<&Path>,
     file_path: &Path,
     patterns: &laravel_lsp::salsa_impl::ParsedPatternsData,
     position: Position,
@@ -15580,17 +15501,26 @@ async fn classify_with_decl_fallback(
         return None;
     }
     let decls = server.cached_route_decls(file_path).await?;
-    for decl in decls.iter() {
-        if decl.line == position.line
+    let decl = decls.iter().find(|decl| {
+        decl.line == position.line
             && position.character >= decl.start_column
             && position.character <= decl.end_column
-        {
-            return Some(laravel_lsp::references::SymbolRef::Route(
-                decl.full_name.clone(),
-            ));
-        }
-    }
-    None
+    })?;
+
+    // If this file is loaded by an external `->group(<path>)` with a name
+    // prefix (issue #43), its in-file `->name('x')` resolves to a prefixed
+    // project-level name (`admin.x`). Anchor the symbol to that resolved name
+    // so find-references / rename match every contributing site across files.
+    // The raw name still matches via `find_declarations_named_with_external`'s
+    // always-present `""` prefix. `external_prefixes_for_file` runs the
+    // cross-file load graph, so it's only worth paying when `root` is known.
+    let resolved = root
+        .map(|r| laravel_lsp::route_discovery::external_prefixes_for_file(r, file_path))
+        .and_then(|prefixes| prefixes.into_iter().find(|p| !p.is_empty()))
+        .map(|primary| format!("{}{}", primary, decl.full_name))
+        .unwrap_or_else(|| decl.full_name.clone());
+
+    Some(laravel_lsp::references::SymbolRef::Route(resolved))
 }
 
 /// Look up the source-text range a `prepare_rename` should return when the
@@ -15598,6 +15528,7 @@ async fn classify_with_decl_fallback(
 /// locator did). Used for prepare_rename's editor-highlight range.
 async fn decl_range_at(
     server: &LaravelLanguageServer,
+    root: Option<&Path>,
     file_path: &Path,
     position: Position,
     symbol: &laravel_lsp::references::SymbolRef,
@@ -15608,7 +15539,16 @@ async fn decl_range_at(
         return None;
     };
     let decls = server.cached_route_decls(file_path).await?;
-    for d in decls.iter().filter(|d| d.full_name == *name) {
+    // `name` may carry an external-file group prefix (issue #43); match a raw
+    // in-file decl whose name equals `name` once that prefix is prepended.
+    let external = root
+        .map(|r| laravel_lsp::route_discovery::external_prefixes_for_file(r, file_path))
+        .unwrap_or_else(|| vec![String::new()]);
+    for d in decls.iter().filter(|d| {
+        external
+            .iter()
+            .any(|ext| format!("{}{}", ext, d.full_name) == *name)
+    }) {
         if d.line == position.line
             && position.character >= d.start_column
             && position.character <= d.end_column
@@ -15732,6 +15672,10 @@ async fn collect_declaration_locations(
             if !routes_dir.exists() {
                 return out;
             }
+            // Inherited external-load prefixes for EVERY route file, computed
+            // once per request instead of re-running the project load graph per
+            // file inside the loop below (avoids O(files²)).
+            let external_prefix_map = laravel_lsp::route_discovery::external_prefixes_map(root);
             for entry in WalkDir::new(&routes_dir)
                 .max_depth(6)
                 .into_iter()
@@ -15744,7 +15688,18 @@ async fn collect_declaration_locations(
                 let Some(all_decls) = server.cached_route_decls(path).await else {
                     continue;
                 };
-                for d in all_decls.iter().filter(|d| d.full_name == *name) {
+                // A file loaded via `Route::as('admin.')->group(<path>)` has
+                // its raw in-file names match `name` only once the external
+                // prefix is prepended (issue #43).
+                let external = external_prefix_map
+                    .get(&laravel_lsp::route_discovery::normalize_path(path))
+                    .cloned()
+                    .unwrap_or_else(|| vec![String::new()]);
+                for d in all_decls.iter().filter(|d| {
+                    external
+                        .iter()
+                        .any(|ext| format!("{}{}", ext, d.full_name) == *name)
+                }) {
                     if let Ok(uri) = Url::from_file_path(path) {
                         out.push(Location {
                             uri,
@@ -15899,6 +15854,10 @@ async fn collect_route_declaration_targets(
     if !routes_dir.exists() {
         return targets;
     }
+    // Inherited external-load prefixes for EVERY route file, computed once per
+    // request instead of re-running the project load graph per file inside the
+    // loop below (avoids O(files²)).
+    let external_prefix_map = laravel_lsp::route_discovery::external_prefixes_map(root);
     for entry in WalkDir::new(&routes_dir)
         .max_depth(6)
         .into_iter()
@@ -15914,7 +15873,31 @@ async fn collect_route_declaration_targets(
         let Some(all_decls) = server.cached_route_decls(path).await else {
             continue;
         };
-        for d in all_decls.iter().filter(|d| d.full_name == target) {
+        // External-file group prefixes (issue #43): a file loaded via
+        // `Route::as('admin.')->group(<path>)` resolves its raw `->name('x')`
+        // to `admin.x` at the project level. For each matching decl we
+        // re-anchor `full_name` to that combined prefix so `rewritten_segment`
+        // strips the WHOLE prefix (external + in-file group) and rewrites only
+        // the leaf — never doubling either prefix in source. The always-present
+        // `""` prefix preserves the plain (non-external) match.
+        let external = external_prefix_map
+            .get(&laravel_lsp::route_discovery::normalize_path(path))
+            .cloned()
+            .unwrap_or_else(|| vec![String::new()]);
+        for d in all_decls.iter() {
+            let Some(ext) = external
+                .iter()
+                .find(|ext| format!("{}{}", ext, d.full_name) == target)
+            else {
+                continue;
+            };
+            let resolved = laravel_lsp::route_name_locator::RouteNameDeclaration {
+                full_name: format!("{}{}", ext, d.full_name),
+                local_segment: d.local_segment.clone(),
+                line: d.line,
+                start_column: d.start_column,
+                end_column: d.end_column,
+            };
             targets.push(laravel_lsp::rename::EditTarget {
                 file_path: path.to_path_buf(),
                 line: d.line,
@@ -15922,7 +15905,7 @@ async fn collect_route_declaration_targets(
                 end_column: d.end_column,
                 // Decl spans only this segment; the group prefix (if any)
                 // lives elsewhere and must not be re-written here.
-                new_text: d.rewritten_segment(new_name).to_string(),
+                new_text: resolved.rewritten_segment(new_name).to_string(),
             });
         }
     }
@@ -16462,6 +16445,34 @@ impl LanguageServer for LaravelLanguageServer {
                 }
                 _ => {}
             }
+
+            // Route files: rebuild the route-name index on save so completion,
+            // hover and goto reflect the change. The index reads from disk, and
+            // did_save fires after the editor has flushed the buffer, so the
+            // content is current. (App-provider / bootstrap route registration
+            // already triggers an App rescan above, which also rebuilds it.)
+            //
+            // A saved `.php` triggers a rebuild when EITHER it already
+            // contributes to the current index (covers files reached via
+            // `->group(<path>)` external loads that live outside `routes/`,
+            // issue #43), OR it lives under a `/routes/` directory (fallback so
+            // brand-new route files not yet in the index still trigger). Both
+            // sides are normalized before comparing.
+            if file_name.is_some_and(|n| n.ends_with(".php")) {
+                let normalized = normalize_path(&path);
+                let in_index = {
+                    let guard = self.route_index.read().await;
+                    guard
+                        .as_ref()
+                        .is_some_and(|idx| idx.source_files.contains(&normalized))
+                };
+                if in_index || path_str.contains("/routes/") {
+                    if let Some(root) = self.root_path.read().await.clone() {
+                        info!("🛣️  Route file saved — rebuilding route index");
+                        self.rebuild_route_index(&root).await;
+                    }
+                }
+            }
         }
 
         // Cancel any pending debounced diagnostics for this file
@@ -16986,6 +16997,36 @@ impl LanguageServer for LaravelLanguageServer {
             }
         };
 
+        // Route files reached through an external `->group(<path>)` load (issue
+        // #43) need their outline names prefixed with the inherited group name
+        // (e.g. `admin.users.index`). That depends on a cross-file load graph,
+        // which the mtime-keyed Salsa document-symbols query deliberately does
+        // NOT see (it must stay cacheable on this file alone). So for the rare
+        // externally-prefixed route file we recompute the route symbols here
+        // with the prefix applied; every other file uses the cached Salsa
+        // result unchanged.
+        let root_path = self.root_path.read().await.clone();
+        if laravel_lsp::document_symbols::classify_file(&file_path)
+            == laravel_lsp::document_symbols::FileKind::RouteFile
+        {
+            if let Some(root) = root_path.as_ref() {
+                let external =
+                    laravel_lsp::route_discovery::external_prefixes_for_file(root, &file_path);
+                if external.iter().any(|p| !p.is_empty()) {
+                    if let Some(content) = self.document_or_disk_content(uri, &file_path).await {
+                        let entries = laravel_lsp::document_symbols::extract_symbols_with_external(
+                            &content,
+                            laravel_lsp::document_symbols::FileKind::RouteFile,
+                            &external,
+                        );
+                        let symbols: Vec<DocumentSymbol> =
+                            entries.iter().map(symbol_entry_to_lsp).collect();
+                        return Ok(Some(DocumentSymbolResponse::Nested(symbols)));
+                    }
+                }
+            }
+        }
+
         let entries = match self.salsa.get_document_symbols(file_path).await {
             Ok(Some(arc)) => arc,
             Ok(None) => {
@@ -17035,7 +17076,15 @@ impl LanguageServer for LaravelLanguageServer {
             _ => return Ok(None),
         };
 
-        let symbol = match classify_with_decl_fallback(self, &file_path, &patterns, position).await
+        let root_path = self.root_path.read().await.clone();
+        let symbol = match classify_with_decl_fallback(
+            self,
+            root_path.as_deref(),
+            &file_path,
+            &patterns,
+            position,
+        )
+        .await
         {
             Some(s) => s,
             None => return Ok(None),
@@ -17070,7 +17119,6 @@ impl LanguageServer for LaravelLanguageServer {
         // separately. Per the LSP spec (and Zed's default), we include them
         // when `include_declaration` is set.
         if include_declaration {
-            let root_path = self.root_path.read().await.clone();
             if let Some(root) = root_path.as_ref() {
                 lsp_locations.extend(collect_declaration_locations(self, root, &symbol).await);
             }
@@ -17107,7 +17155,15 @@ impl LanguageServer for LaravelLanguageServer {
             _ => return Ok(None),
         };
 
-        let symbol = match classify_with_decl_fallback(self, &file_path, &patterns, position).await
+        let root_path = self.root_path.read().await.clone();
+        let symbol = match classify_with_decl_fallback(
+            self,
+            root_path.as_deref(),
+            &file_path,
+            &patterns,
+            position,
+        )
+        .await
         {
             Some(s) => {
                 debug!(
@@ -17143,7 +17199,7 @@ impl LanguageServer for LaravelLanguageServer {
         let pattern_range = pattern_range_at(&patterns, position.line, position.character);
         let range = match pattern_range {
             Some(r) => Some(r),
-            None => decl_range_at(self, &file_path, position, &symbol).await,
+            None => decl_range_at(self, root_path.as_deref(), &file_path, position, &symbol).await,
         };
         match &range {
             Some(r) => debug!(
@@ -17185,7 +17241,15 @@ impl LanguageServer for LaravelLanguageServer {
             _ => return Ok(None),
         };
 
-        let symbol = match classify_with_decl_fallback(self, &file_path, &patterns, position).await
+        let root_path = self.root_path.read().await.clone();
+        let symbol = match classify_with_decl_fallback(
+            self,
+            root_path.as_deref(),
+            &file_path,
+            &patterns,
+            position,
+        )
+        .await
         {
             Some(s) => {
                 debug!("rename: classified as {:?}", s);
@@ -17274,8 +17338,8 @@ impl LanguageServer for LaravelLanguageServer {
         //
         // Phase 3+: kinds whose "declaration" is a file (not a source
         // position) push into `file_renames` instead of `targets`. Both
-        // travel together in the final WorkspaceEdit.
-        let root_path = self.root_path.read().await.clone();
+        // travel together in the final WorkspaceEdit. `root_path` was already
+        // read above for the decl-fallback classifier.
         let mut file_renames: Vec<laravel_lsp::rename::FileRename> = Vec::new();
         match &symbol {
             laravel_lsp::references::SymbolRef::Route(name) => {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13542,6 +13542,50 @@ return [
         }
     }
 
+    /// Build "route not found" ERROR diagnostics for every `route('name')`
+    /// reference whose name is absent from the project route index (issue #43).
+    ///
+    /// Fires ONLY when the index is built AND non-empty — during startup, before
+    /// the index exists, every route would otherwise look missing, so an absent
+    /// or empty index yields no diagnostics.
+    fn route_not_found_diagnostics(
+        index: Option<&laravel_lsp::route_discovery::RouteIndex>,
+        route_refs: &[std::sync::Arc<laravel_lsp::salsa_impl::RouteReferenceData>],
+    ) -> Vec<Diagnostic> {
+        let mut out = Vec::new();
+        let Some(index) = index else {
+            return out;
+        };
+        if index.is_empty() {
+            return out;
+        }
+        for r in route_refs {
+            if index.get(&r.name).is_none() {
+                out.push(Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: r.line,
+                            character: r.column,
+                        },
+                        end: Position {
+                            line: r.line,
+                            character: r.end_column,
+                        },
+                    },
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: None,
+                    source: Some("laravel".to_string()),
+                    message: format!("Route not found in index: '{}'", r.name),
+                    related_information: None,
+                    tags: None,
+                    code_description: None,
+                    data: None,
+                });
+            }
+        }
+        out
+    }
+
     /// Validate a document (Blade or PHP) and publish diagnostics
     ///
     /// This function uses Salsa-cached patterns for efficient incremental validation:
@@ -14349,6 +14393,15 @@ return [
             let validation_diagnostics = self.validate_validation_rules(source).await;
             diagnostics.extend(validation_diagnostics);
 
+            // Check route('name') calls against the route index (issue #43).
+            {
+                let idx = self.route_index.read().await;
+                diagnostics.extend(Self::route_not_found_diagnostics(
+                    idx.as_ref(),
+                    &patterns.route_refs,
+                ));
+            }
+
             // Store and publish diagnostics for PHP files
             self.diagnostics
                 .write()
@@ -14727,6 +14780,16 @@ return [
         }
 
         // Store diagnostics for hover filtering
+        // Check route('name') calls against the route index (issue #43) — Blade
+        // `{{ route('…') }}` usages, same check as the PHP branch above.
+        {
+            let idx = self.route_index.read().await;
+            diagnostics.extend(Self::route_not_found_diagnostics(
+                idx.as_ref(),
+                &patterns.route_refs,
+            ));
+        }
+
         self.diagnostics
             .write()
             .await
@@ -16470,6 +16533,10 @@ impl LanguageServer for LaravelLanguageServer {
                     if let Some(root) = self.root_path.read().await.clone() {
                         info!("🛣️  Route file saved — rebuilding route index");
                         self.rebuild_route_index(&root).await;
+                        // Route names changed — re-validate open documents so
+                        // `route('…')` not-found diagnostics elsewhere reflect
+                        // the added/removed/renamed routes.
+                        self.revalidate_open_documents().await;
                     }
                 }
             }

--- a/laravel-lsp/src/route_chain.rs
+++ b/laravel-lsp/src/route_chain.rs
@@ -1,0 +1,390 @@
+//! Shared tree-sitter route-chain walker.
+//!
+//! Both [`crate::route_name_locator`] (rename / find-references) and
+//! [`crate::route_outline`] (document symbols) need to walk the SAME AST shape:
+//! traverse statement lists, recognize `Route::*(...)->...` fluent chains,
+//! pull the `->name`/`->as`/`prefix`/verb arguments off each chain, and recurse
+//! into `->group(closure)` bodies. This module owns that traversal exactly once
+//! and hands back a structured intermediate tree — [`RouteChainNode`] — that
+//! each consumer folds into its own output type (applying its own prefix
+//! accumulation and emitting only the pieces it cares about).
+//!
+//! ## Why a tree, not a visitor
+//!
+//! The outline consumer builds a hierarchical result where each group node owns
+//! its children, so it needs structured nesting with per-group data. A flat
+//! visitor would force the outline builder to reconstruct that hierarchy from a
+//! callback stream. Returning a tree keeps both consumers as a simple
+//! `nodes.iter().map(fold)` over plain data — no shared mutable accumulator and
+//! no lifetime entanglement with the tree-sitter `Tree` (positions are copied
+//! out as `u32`, strings as owned `String`).
+//!
+//! ## Behavior parity
+//!
+//! The traversal reproduces the previous (independently duplicated) walks:
+//! - Only chains whose innermost call is scoped to `Route` (`Route::` or
+//!   `…\Route::`) are reported (`is_route_chain`).
+//! - The first `->name(...)`/`->as(...)` string argument is captured with its
+//!   `string_content` range (between the quotes) — the exact rename target.
+//! - `->group(...)` closures are recursed into; their bodies' chains become
+//!   `children`.
+//! - Statement recursion descends into `namespace_definition` and
+//!   `compound_statement` wrappers (group closure bodies are reached only via
+//!   the explicit group recursion, never twice).
+
+use tree_sitter::Node;
+
+/// One `Route::...` chain, captured as plain data (no tree-sitter lifetimes).
+///
+/// A node is emitted for every chain whose innermost call is `Route::*`. The
+/// same node can be both a route definition (has `verb`) and a group container
+/// (has `group_children`); in practice a chain is one or the other, but callers
+/// should not assume mutual exclusivity beyond what their own logic enforces.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteChainNode {
+    /// The route verb / method that opened the chain (`get`, `post`, `view`,
+    /// `resource`, `livewire`, …), lowercased as written in source. `None` when
+    /// the chain is a group container or a non-definition chain (e.g. a bare
+    /// `Route::prefix(...)->group(...)`).
+    pub verb: Option<String>,
+    /// First string argument of the verb call (the URI). `None` when absent or
+    /// not a string literal.
+    pub uri: Option<String>,
+    /// `->prefix('...')` argument from anywhere in the chain. `None` if unset.
+    pub prefix_arg: Option<String>,
+    /// First `->name('...')`/`->as('...')` string argument with its source
+    /// position (the `string_content` range, between the quotes).
+    pub name: Option<RouteNameArg>,
+    /// Range of the `->group(...)` closure expression itself (not its body),
+    /// when this chain is a group. Used by the outline to position the group
+    /// symbol so it overlaps the editor's tree-sitter "Closure" symbol.
+    pub group_closure_range: Option<ChainRange>,
+    /// Child chains found inside this chain's `->group(closure)` body, in source
+    /// order. Empty for leaf routes and for groups with empty bodies.
+    pub group_children: Vec<RouteChainNode>,
+    /// Range of the entire chain expression. Used by the outline to position
+    /// leaf-route symbols.
+    pub chain_range: ChainRange,
+}
+
+impl RouteChainNode {
+    /// True when this chain is a `->group(...)` container (it had a closure
+    /// argument), regardless of whether the body produced any children.
+    pub fn is_group(&self) -> bool {
+        self.group_closure_range.is_some()
+    }
+}
+
+/// A `->name('...')`/`->as('...')` argument string captured with the source
+/// position of its content (between the quotes). All fields 0-based.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteNameArg {
+    /// Literal inner text of the argument (no quotes, no prefix).
+    pub segment: String,
+    /// Row of the string content.
+    pub line: u32,
+    /// Column of the first character of the content (after the opening quote).
+    pub start_column: u32,
+    /// Column one past the last character of the content (before the closing
+    /// quote).
+    pub end_column: u32,
+}
+
+/// A 0-based `(line, column)` span of a chain or closure expression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChainRange {
+    pub start_line: u32,
+    pub start_column: u32,
+    pub end_line: u32,
+    pub end_column: u32,
+}
+
+/// Parse `content` as PHP and return the top-level `Route::...` chains as a
+/// tree. Returns an empty vec on parse failure. This is the single entry point
+/// both route consumers use; they fold the resulting tree into their own types.
+pub fn extract_route_chains(content: &str) -> Vec<RouteChainNode> {
+    let Ok(tree) = crate::parser::parse_php(content) else {
+        return Vec::new();
+    };
+    let source = content.as_bytes();
+    let mut output = Vec::new();
+    walk_statements(tree.root_node(), source, &mut output);
+    output
+}
+
+/// Walk a statement list (file root, namespace body, or group closure body)
+/// looking for `Route::*(...)` expression statements, appending one
+/// [`RouteChainNode`] per route chain to `output`.
+fn walk_statements(node: Node, source: &[u8], output: &mut Vec<RouteChainNode>) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "expression_statement" => {
+                let mut inner = child.walk();
+                for expr in child.children(&mut inner) {
+                    if is_call_node(expr) {
+                        if let Some(chain) = build_chain_node(expr, source) {
+                            output.push(chain);
+                        }
+                    }
+                }
+            }
+            // Recurse into wrappers that can contain expression statements.
+            // Group closure bodies are reached only via the explicit group
+            // recursion below, never here, so chains aren't double-counted.
+            "namespace_definition" | "compound_statement" => {
+                walk_statements(child, source, output);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Build a [`RouteChainNode`] from a single `Route::method()->method()->...`
+/// chain expression. Returns `None` when the chain isn't scoped to `Route`.
+fn build_chain_node(chain: Node, source: &[u8]) -> Option<RouteChainNode> {
+    let data = collect_chain(chain, source);
+    if !data.is_route_chain {
+        return None;
+    }
+
+    let mut group_children = Vec::new();
+    let mut group_closure_range = None;
+    if let Some(closure) = data.group_closure {
+        group_closure_range = Some(range_of(closure));
+        if let Some(body) = closure.child_by_field_name("body") {
+            walk_statements(body, source, &mut group_children);
+        }
+    }
+
+    Some(RouteChainNode {
+        verb: data.verb,
+        uri: data.uri,
+        prefix_arg: data.prefix_arg,
+        name: data.name,
+        group_closure_range,
+        group_children,
+        chain_range: range_of(chain),
+    })
+}
+
+/// Mutable accumulator while walking one chain from outermost call inward.
+#[derive(Default)]
+struct ChainData<'a> {
+    is_route_chain: bool,
+    verb: Option<String>,
+    uri: Option<String>,
+    prefix_arg: Option<String>,
+    name: Option<RouteNameArg>,
+    group_closure: Option<Node<'a>>,
+}
+
+/// Route definition verbs / methods. Anything in this set, when it opens the
+/// chain, is treated as a leaf-route definition whose first string argument is
+/// the URI. Matches the previous outline allow-list exactly.
+const ROUTE_VERBS: &[&str] = &[
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "options",
+    "any",
+    "match",
+    "view",
+    "redirect",
+    "fallback",
+    "livewire",
+    "resource",
+    "apiResource",
+    "singleton",
+    "apiSingleton",
+    "permanentRedirect",
+];
+
+/// Walk a method chain from outermost call inward, collecting each method's
+/// name and relevant arguments.
+fn collect_chain<'a>(chain: Node<'a>, source: &[u8]) -> ChainData<'a> {
+    let mut data = ChainData::default();
+    let mut current = Some(chain);
+
+    while let Some(node) = current {
+        match node.kind() {
+            "member_call_expression" => {
+                if let Some((name, args)) = method_name_and_args(node, source) {
+                    apply_method(&mut data, &name, args, source);
+                }
+                current = node.child_by_field_name("object");
+            }
+            "scoped_call_expression" => {
+                // Innermost call (`Route::method(...)`). Verify the scope is
+                // `Route` so we don't claim chains like `Foo::bar()->baz()`.
+                if let Some(scope) = node.child_by_field_name("scope") {
+                    if let Ok(scope_text) = scope.utf8_text(source) {
+                        if scope_text == "Route" || scope_text.ends_with("\\Route") {
+                            data.is_route_chain = true;
+                        }
+                    }
+                }
+                if let Some((name, args)) = method_name_and_args(node, source) {
+                    apply_method(&mut data, &name, args, source);
+                }
+                current = None;
+            }
+            _ => current = None,
+        }
+    }
+
+    data
+}
+
+/// Apply one method call from the chain to the accumulated data.
+fn apply_method<'a>(data: &mut ChainData<'a>, name: &str, args: Node<'a>, source: &[u8]) {
+    if ROUTE_VERBS.contains(&name) {
+        // First verb wins (outermost call inward, the innermost `Route::verb`
+        // is visited last; route definitions only have one verb so order is
+        // immaterial). The URI is the first string argument.
+        data.verb = Some(name.to_string());
+        data.uri = first_string_arg(args, source);
+        return;
+    }
+    match name {
+        "group" => data.group_closure = find_closure_node(args),
+        "prefix" => data.prefix_arg = first_string_arg(args, source),
+        // `as()` is Laravel's alias for `name()`. First captured wins.
+        "name" | "as" if data.name.is_none() => {
+            data.name = first_string_arg_with_pos(args, source);
+        }
+        _ => {}
+    }
+}
+
+/// Get the method `name:` and `arguments:` fields from a call node.
+fn method_name_and_args<'a>(node: Node<'a>, source: &[u8]) -> Option<(String, Node<'a>)> {
+    let name = node
+        .child_by_field_name("name")?
+        .utf8_text(source)
+        .ok()?
+        .to_string();
+    let args = node.child_by_field_name("arguments")?;
+    Some((name, args))
+}
+
+/// Extract the first string-literal argument's inner text (no position).
+fn first_string_arg(args: Node, source: &[u8]) -> Option<String> {
+    let mut cursor = args.walk();
+    for arg in args.children(&mut cursor) {
+        if arg.kind() != "argument" {
+            continue;
+        }
+        let mut arg_cursor = arg.walk();
+        for inner in arg.children(&mut arg_cursor) {
+            if inner.kind() == "string" || inner.kind() == "encapsed_string" {
+                return read_string_content(inner, source);
+            }
+        }
+    }
+    None
+}
+
+/// Extract the first string-literal argument with its `string_content` range.
+fn first_string_arg_with_pos(args: Node, source: &[u8]) -> Option<RouteNameArg> {
+    let mut cursor = args.walk();
+    for arg in args.children(&mut cursor) {
+        if arg.kind() != "argument" {
+            continue;
+        }
+        let mut arg_cursor = arg.walk();
+        for inner in arg.children(&mut arg_cursor) {
+            if inner.kind() == "string" || inner.kind() == "encapsed_string" {
+                return string_content_with_pos(inner, source);
+            }
+        }
+    }
+    None
+}
+
+/// Read the inner content of a `string`/`encapsed_string` node, stripping the
+/// surrounding quotes. Falls back to trimming the raw text when no
+/// `string_content` child is present.
+fn read_string_content(node: Node, source: &[u8]) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "string_content" {
+            return child.utf8_text(source).ok().map(|s| s.to_string());
+        }
+    }
+    node.utf8_text(source).ok().map(|s| {
+        s.trim_start_matches(['\'', '"'])
+            .trim_end_matches(['\'', '"'])
+            .to_string()
+    })
+}
+
+/// Locate the `string_content` child node of a `string`/`encapsed_string` and
+/// return its inner text plus 0-based content range (between the quotes).
+fn string_content_with_pos(node: Node, source: &[u8]) -> Option<RouteNameArg> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "string_content" {
+            let segment = child.utf8_text(source).ok()?.to_string();
+            let start = child.start_position();
+            let end = child.end_position();
+            // `string_content` always sits on a single line in tree-sitter-php.
+            // Defensive: clamp the end column to the start line so a misparse
+            // doesn't produce a multi-line range.
+            return Some(RouteNameArg {
+                segment,
+                line: start.row as u32,
+                start_column: start.column as u32,
+                end_column: if end.row == start.row {
+                    end.column as u32
+                } else {
+                    start.column as u32
+                },
+            });
+        }
+    }
+    None
+}
+
+/// Find the closure expression node inside an arguments list. Handles the
+/// modern `Route::group(function () { ... })`, the legacy
+/// `Route::group(['prefix' => '/x'], function () { ... })`, and arrow-function
+/// forms. Returns the closure expression itself (not its body).
+fn find_closure_node(args: Node) -> Option<Node> {
+    let mut cursor = args.walk();
+    for arg in args.children(&mut cursor) {
+        if arg.kind() != "argument" {
+            continue;
+        }
+        let mut arg_cursor = arg.walk();
+        for inner in arg.children(&mut arg_cursor) {
+            if inner.kind() == "anonymous_function_creation_expression"
+                || inner.kind() == "anonymous_function"
+                || inner.kind() == "arrow_function"
+            {
+                return Some(inner);
+            }
+        }
+    }
+    None
+}
+
+fn is_call_node(node: Node) -> bool {
+    matches!(
+        node.kind(),
+        "member_call_expression" | "scoped_call_expression"
+    )
+}
+
+fn range_of(node: Node) -> ChainRange {
+    let start = node.start_position();
+    let end = node.end_position();
+    ChainRange {
+        start_line: start.row as u32,
+        start_column: start.column as u32,
+        end_line: end.row as u32,
+        end_column: end.column as u32,
+    }
+}

--- a/laravel-lsp/src/route_discovery.rs
+++ b/laravel-lsp/src/route_discovery.rs
@@ -32,6 +32,22 @@ struct RouteGroupSpan {
     body_end: usize,
 }
 
+/// A `->group(...)`/`::group(...)` callsite that loads an *external file*
+/// instead of running a closure body (issue #43). Laravel `require`s the file
+/// and applies the group's attributes — including its `->as('admin.')` name
+/// prefix — to every route declared in it.
+#[derive(Debug, Clone)]
+struct ExternalGroupLoad {
+    /// Byte offset of the `->`/`::` that introduces this `group(...)` call.
+    /// Used to locate enclosing closure groups in the same file.
+    offset: usize,
+    /// This load's OWN name prefix (from a chained `->as(...)`/`->name(...)`
+    /// link or an `['as' => ...]` array literal). May be empty.
+    own_prefix: String,
+    /// Resolved absolute path of the file this group loads.
+    target: PathBuf,
+}
+
 /// A located route definition. Stored in [`RouteIndex`] keyed by route name.
 #[derive(Debug, Clone)]
 pub struct RouteDefinition {
@@ -73,6 +89,13 @@ pub const PRIORITY_APP: u8 = 2;
 #[derive(Debug, Default, Clone)]
 pub struct RouteIndex {
     pub routes: HashMap<String, RouteDefinition>,
+    /// Every file that contributed to this index, keyed by normalized
+    /// (lexically-cleaned) absolute path. Includes both files found by
+    /// [`discover_route_files`] AND files reached transitively through
+    /// `->group(<path>)` external loads — even when they live outside `routes/`
+    /// (issue #43). Used by `did_save` to decide whether a saved file should
+    /// trigger a route-index rebuild.
+    pub source_files: std::collections::HashSet<PathBuf>,
 }
 
 impl RouteIndex {
@@ -182,18 +205,279 @@ pub fn discover_route_files(root: &Path) -> Vec<RouteFile> {
 }
 
 /// Build a complete route name → location index from the given files.
-pub fn build_route_index(files: &[RouteFile]) -> RouteIndex {
+///
+/// `root` is the project root, used to resolve `base_path(...)` arguments in
+/// external-file group loads (issue #43). The working set is BFS-expanded along
+/// `->group(<path>)` load edges, so a file referenced via
+/// `Route::as('admin.')->group(base_path('app/Custom/admin.php'))` is indexed
+/// even when it lives OUTSIDE `routes/` and was never returned by
+/// [`discover_route_files`]. Referenced files inherit their loader's priority.
+///
+/// Files reached by such loads inherit the loading group's name prefix
+/// transitively, so their routes are indexed under both their bare and prefixed
+/// names. The resulting [`RouteIndex::source_files`] lists every contributing
+/// file (discovered + referenced), keyed by normalized path.
+pub fn build_route_index(root: &Path, files: &[RouteFile]) -> RouteIndex {
+    let expansion = expand_load_graph(root, files);
+    let effective = compute_effective_prefixes(root, &expansion.files, &expansion.contents);
+
     let mut index = RouteIndex::new();
-    for file in files {
-        if let Ok(content) = std::fs::read_to_string(&file.path) {
-            for def in extract_named_routes(&content, &file.path, file.priority) {
-                if let Some(name) = def.0 {
-                    index.insert(name, def.1);
-                }
+    for file in &expansion.files {
+        let key = normalize_path(&file.path);
+        index.source_files.insert(key.clone());
+        let Some(content) = expansion.contents.get(&key) else {
+            continue;
+        };
+        let inherited = effective.get(&key).cloned().unwrap_or_default();
+        for def in extract_named_routes(content, &file.path, file.priority, &inherited) {
+            if let Some(name) = def.0 {
+                index.insert(name, def.1);
             }
         }
     }
     index
+}
+
+/// Return the inherited external-file name prefixes that apply to `file`
+/// (issue #43), ALWAYS including `""` and deduplicated.
+///
+/// A file referenced via `Route::as('admin.')->group(base_path('that.php'))`
+/// from somewhere in the project inherits the loading group's name prefix
+/// (`"admin."`) transitively across the entire `->group(<path>)` load graph.
+/// This is exactly the set [`build_route_index`] applies when indexing the file
+/// — exposed standalone so rename / find-references / document-symbols can
+/// resolve a route's project-level name without re-running a full index build.
+///
+/// Runs [`discover_route_files`] + the same BFS load-graph expansion and
+/// prefix propagation as [`build_route_index`], then looks up `file`'s
+/// normalized key. Returns `["".into()]` when `file` isn't reachable (it's
+/// still scanned directly, so the empty prefix always applies).
+pub fn external_prefixes_for_file(root: &Path, file: &Path) -> Vec<String> {
+    let files = discover_route_files(root);
+    let expansion = expand_load_graph(root, &files);
+    let effective = compute_effective_prefixes(root, &expansion.files, &expansion.contents);
+
+    let key = normalize_path(file);
+    let mut out = vec![String::new()];
+    if let Some(prefixes) = effective.get(&key) {
+        for p in prefixes {
+            if !p.is_empty() && !out.contains(p) {
+                out.push(p.clone());
+            }
+        }
+    }
+    out
+}
+
+/// Like [`external_prefixes_for_file`] but computes the inherited external-load
+/// prefixes for EVERY route file in one pass, keyed by normalized path. Callers
+/// iterating many files (rename / find-references) build this once instead of
+/// re-running the whole project load graph per file (avoids O(files²)).
+///
+/// Each returned entry always includes `""`. A file with no inherited prefix is
+/// simply absent from the map — callers should treat a miss as `["".into()]`.
+pub fn external_prefixes_map(root: &Path) -> HashMap<PathBuf, Vec<String>> {
+    let files = discover_route_files(root);
+    let expansion = expand_load_graph(root, &files);
+    let effective = compute_effective_prefixes(root, &expansion.files, &expansion.contents);
+
+    let mut map: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    for (key, prefixes) in effective {
+        let mut out = vec![String::new()];
+        for p in prefixes {
+            if !p.is_empty() && !out.contains(&p) {
+                out.push(p);
+            }
+        }
+        map.insert(key, out);
+    }
+    map
+}
+
+/// The fully-expanded working set produced by following `->group(<path>)`
+/// external loads from a seed file list. Keyed by normalized path so a file
+/// reached more than once is read and indexed exactly once.
+struct LoadGraphExpansion {
+    /// Every contributing file (seed + transitively referenced), with the
+    /// highest priority observed for each.
+    files: Vec<RouteFile>,
+    /// Each file's source text, keyed by normalized path.
+    contents: HashMap<PathBuf, String>,
+}
+
+/// BFS-expand `files` along external `->group(<path>)` load edges, reading each
+/// reachable file's contents. Shared by [`build_route_index`] and
+/// [`external_prefixes_for_file`] so both see the identical working set.
+fn expand_load_graph(root: &Path, files: &[RouteFile]) -> LoadGraphExpansion {
+    // `contents`/`paths`/`priorities` are all keyed by normalized path so a file
+    // reached by two routes (discovered + referenced, or via two loaders) is
+    // read and indexed exactly once.
+    let mut contents: HashMap<PathBuf, String> = HashMap::new();
+    // Original (non-normalized) path to use for the RouteDefinition's `file`.
+    let mut paths: HashMap<PathBuf, PathBuf> = HashMap::new();
+    let mut priorities: HashMap<PathBuf, u8> = HashMap::new();
+
+    // Queue of (path, priority, depth) still to read/expand.
+    let mut queue: std::collections::VecDeque<(PathBuf, u8, usize)> =
+        std::collections::VecDeque::new();
+    for file in files {
+        queue.push_back((file.path.clone(), file.priority, 0));
+    }
+
+    while let Some((path, priority, depth)) = queue.pop_front() {
+        let key = normalize_path(&path);
+
+        // Record the best (highest) priority and remember the path/contents the
+        // first time we see this file.
+        let already_seen = contents.contains_key(&key);
+        priorities
+            .entry(key.clone())
+            .and_modify(|p| {
+                if priority > *p {
+                    *p = priority;
+                }
+            })
+            .or_insert(priority);
+        if already_seen {
+            // Contents already read and this file's edges already expanded;
+            // just merging priority above is enough.
+            continue;
+        }
+
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            // Unreadable target (e.g. a referenced file that doesn't exist) —
+            // record nothing; it simply contributes no routes.
+            continue;
+        };
+
+        // Discover this file's external `->group(<path>)` targets and enqueue
+        // any not yet read. Depth is capped in the spirit of MAX_LOAD_DEPTH so a
+        // pathological chain can't loop forever (the `already_seen` check breaks
+        // cycles directly).
+        if depth < MAX_LOAD_DEPTH {
+            let loader_dir = path.parent().unwrap_or(root).to_path_buf();
+            for load in find_external_group_loads(text.as_bytes(), root, &loader_dir) {
+                let target_key = normalize_path(&load.target);
+                if !contents.contains_key(&target_key) {
+                    queue.push_back((load.target, priority, depth + 1));
+                }
+            }
+        }
+
+        paths.insert(key.clone(), path);
+        contents.insert(key, text);
+    }
+
+    // Build the full expanded file set.
+    let expanded: Vec<RouteFile> = paths
+        .iter()
+        .map(|(key, original)| RouteFile {
+            path: original.clone(),
+            priority: priorities.get(key).copied().unwrap_or(PRIORITY_APP),
+        })
+        .collect();
+
+    LoadGraphExpansion {
+        files: expanded,
+        contents,
+    }
+}
+
+/// Maximum transitive load depth — a backstop against pathological chains even
+/// with the cycle guard in place.
+const MAX_LOAD_DEPTH: usize = 10;
+
+/// Build the per-file set of inherited name prefixes contributed by
+/// external-file group loads, propagated transitively across the load graph.
+///
+/// Returns a map keyed by normalized file path. Every entry includes `""`
+/// (every file is also scanned directly). Cycles are broken by a per-target
+/// visited set, and chains are capped at [`MAX_LOAD_DEPTH`].
+fn compute_effective_prefixes(
+    root: &Path,
+    files: &[RouteFile],
+    contents: &HashMap<PathBuf, String>,
+) -> HashMap<PathBuf, Vec<String>> {
+    // Set of files we actually index — only these can receive inherited
+    // prefixes, and only loads pointing at one matter.
+    let known: std::collections::HashSet<PathBuf> =
+        files.iter().map(|f| normalize_path(&f.path)).collect();
+
+    // edges[source] = Vec<(target, edge_prefix)>
+    let mut edges: HashMap<PathBuf, Vec<(PathBuf, String)>> = HashMap::new();
+    for file in files {
+        let source = normalize_path(&file.path);
+        let Some(content) = contents.get(&source) else {
+            continue;
+        };
+        let bytes = content.as_bytes();
+        let loader_dir = file.path.parent().unwrap_or(root).to_path_buf();
+        let loads = find_external_group_loads(bytes, root, &loader_dir);
+        if loads.is_empty() {
+            continue;
+        }
+        // Closure-group spans in the SAME file — needed to prepend any enclosing
+        // closure prefixes to each load's edge.
+        let groups = find_route_groups(bytes);
+        for load in loads {
+            let target = normalize_path(&load.target);
+            if !known.contains(&target) {
+                continue;
+            }
+            let mut edge_prefix = String::new();
+            for grp in &groups {
+                if grp.body_start <= load.offset && load.offset < grp.body_end {
+                    edge_prefix.push_str(&grp.prefix);
+                }
+            }
+            edge_prefix.push_str(&load.own_prefix);
+            edges
+                .entry(source.clone())
+                .or_default()
+                .push((target, edge_prefix));
+        }
+    }
+
+    // Propagate. For each known file, the inherited prefixes are the set of
+    // accumulated edge-prefix concatenations along every load path that reaches
+    // it. We DFS from each source so cycles are naturally bounded per traversal.
+    let mut effective: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    for start in &known {
+        propagate(start, "", &edges, &mut effective, &mut Vec::new(), 0);
+    }
+    effective
+}
+
+/// Depth-first propagation of accumulated prefixes along load edges. `acc` is
+/// the prefix accumulated from the root of this traversal up to (but excluding)
+/// `current`. `stack` holds the files on the current path for cycle detection.
+fn propagate(
+    current: &Path,
+    acc: &str,
+    edges: &HashMap<PathBuf, Vec<(PathBuf, String)>>,
+    effective: &mut HashMap<PathBuf, Vec<String>>,
+    stack: &mut Vec<PathBuf>,
+    depth: usize,
+) {
+    if stack.iter().any(|p| p == current) || depth > MAX_LOAD_DEPTH {
+        return;
+    }
+    // Record this accumulated prefix for `current` (skip the empty root case —
+    // every file already gets "" implicitly in `extract_named_routes`).
+    if !acc.is_empty() {
+        let entry = effective.entry(current.to_path_buf()).or_default();
+        if !entry.iter().any(|p| p == acc) {
+            entry.push(acc.to_string());
+        }
+    }
+    stack.push(current.to_path_buf());
+    if let Some(targets) = edges.get(current) {
+        for (target, edge_prefix) in targets {
+            let next_acc = format!("{}{}", acc, edge_prefix);
+            propagate(target, &next_acc, edges, effective, stack, depth + 1);
+        }
+    }
+    stack.pop();
 }
 
 /// Extract every `->name('X')` callsite from the given source.
@@ -204,13 +488,32 @@ pub fn build_route_index(files: &[RouteFile]) -> RouteIndex {
 /// Only matches single-quoted or double-quoted string literals. Variable
 /// arguments (`->name($var)`) are skipped because we can't resolve them
 /// statically.
+///
+/// `inherited_prefixes` carries name prefixes contributed by *external-file*
+/// group loads that target this file (issue #43). For each callsite, one
+/// `RouteDefinition` is emitted per inherited prefix, with the final name being
+/// `inherited_prefix + in_file_closure_prefix + leaf`. A file that is loaded
+/// both directly and via a prefixed group therefore contributes both its bare
+/// and prefixed names. Passing `&[]` (or `&["".into()]`) means "no inherited
+/// prefix" and yields byte-identical behavior to a plain direct scan.
 pub fn extract_named_routes(
     content: &str,
     file: &Path,
     priority: u8,
+    inherited_prefixes: &[String],
 ) -> Vec<(Option<String>, RouteDefinition)> {
     let mut results = Vec::new();
     let bytes = content.as_bytes();
+
+    // Normalize inherited prefixes to a non-empty set that always contains the
+    // empty string (the file is always scanned directly too). Dedupe so a load
+    // graph that reaches this file by two equal-prefix paths doesn't duplicate.
+    let mut effective: Vec<&str> = vec![""];
+    for p in inherited_prefixes {
+        if !p.is_empty() && !effective.contains(&p.as_str()) {
+            effective.push(p.as_str());
+        }
+    }
 
     // Build group-span index once per file. Each span tells us "any
     // `->name('X')` inside body_start..body_end gets `prefix` prepended."
@@ -271,16 +574,16 @@ pub fn extract_named_routes(
             }
         };
 
-        // Compose the final route name from enclosing group prefixes plus the
-        // literal `->name('X')` value. Groups are pre-sorted by body_start so
-        // iterating in order yields outermost-first.
-        let mut name = String::new();
+        // Compose the in-file portion of the name from enclosing closure-group
+        // prefixes plus the literal `->name('X')` value. Groups are pre-sorted
+        // by body_start so iterating in order yields outermost-first.
+        let mut in_file_name = String::new();
         for grp in &groups {
             if grp.body_start <= i && i < grp.body_end {
-                name.push_str(&grp.prefix);
+                in_file_name.push_str(&grp.prefix);
             }
         }
-        name.push_str(&literal_name);
+        in_file_name.push_str(&literal_name);
 
         let (line, column) = byte_to_line_col(bytes, i);
         let end_column = column + (j - i + 1) as u32; // include closing quote
@@ -290,24 +593,288 @@ pub fn extract_named_routes(
         // controller@action target for hover display.
         let metadata = extract_route_metadata(bytes, i);
 
-        results.push((
-            Some(name),
-            RouteDefinition {
-                file: file.to_path_buf(),
-                line,
-                column,
-                end_column,
-                priority,
-                method: metadata.method,
-                uri: metadata.uri,
-                action: metadata.action,
-            },
-        ));
+        // Emit one definition per inherited prefix (always including ""), so a
+        // file reachable via an external-file group load contributes both its
+        // bare and prefixed names.
+        for prefix in &effective {
+            let mut name = String::with_capacity(prefix.len() + in_file_name.len());
+            name.push_str(prefix);
+            name.push_str(&in_file_name);
+            results.push((
+                Some(name),
+                RouteDefinition {
+                    file: file.to_path_buf(),
+                    line,
+                    column,
+                    end_column,
+                    priority,
+                    method: metadata.method.clone(),
+                    uri: metadata.uri.clone(),
+                    action: metadata.action.clone(),
+                },
+            ));
+        }
 
         i = j + 1;
     }
 
+    // Second pass: derive route names from `Route::resource(...)` /
+    // `Route::apiResource(...)` (and their `->resource(...)` / `->apiResource(...)`
+    // fluent forms). Laravel synthesizes one named route per CRUD action — e.g.
+    // `Route::resource('photos', PhotoController::class)` registers
+    // `photos.index`, `photos.create`, ... `photos.destroy`. We compose these
+    // leaf names with the same group/inherited prefixes as `->name()` routes.
+    extract_resource_routes(bytes, file, priority, &effective, &groups, &mut results);
+
     results
+}
+
+/// Default action set for `Route::resource(...)` — full CRUD.
+const RESOURCE_ACTIONS: &[&str] = &[
+    "index", "create", "store", "show", "edit", "update", "destroy",
+];
+
+/// Default action set for `Route::apiResource(...)` — no `create`/`edit` (those
+/// render forms, which an API doesn't serve).
+const API_RESOURCE_ACTIONS: &[&str] = &["index", "store", "show", "update", "destroy"];
+
+/// Append resource-derived route definitions to `results`.
+///
+/// Detects `resource(` / `apiResource(` callsites preceded by `->` or `::`,
+/// extracts the first string-literal argument (the resource URI/name), strips
+/// leading AND trailing `/`, applies any `->only([...])`/`->except([...])`
+/// filter found in the same statement, then emits one [`RouteDefinition`] per
+/// surviving action × effective prefix × enclosing closure-group prefix.
+///
+/// Punted (common case only): `->names([...])` / `->name('…')` overrides on the
+/// resource, `Route::resources([...])` plural registration, and shallow/nested
+/// resources. These are uncommon and would need substantially more parsing.
+fn extract_resource_routes(
+    bytes: &[u8],
+    file: &Path,
+    priority: u8,
+    effective: &[&str],
+    groups: &[RouteGroupSpan],
+    results: &mut Vec<(Option<String>, RouteDefinition)>,
+) {
+    // Scan for `->`/`::` connectors and read the method identifier that follows.
+    // We can't keyword-match on `resource` alone because `apiResource` spells it
+    // with a capital `R` (`api` + `Resource`); matching the connector + full
+    // identifier handles both spellings cleanly.
+    let paren_pairs = build_paren_pairs(bytes);
+    let mut i = 0usize;
+
+    while i + 2 < bytes.len() {
+        let connector = &bytes[i..i + 2];
+        if connector != b"->" && connector != b"::" {
+            i += 1;
+            continue;
+        }
+
+        // Read the identifier immediately after the connector.
+        let name_start = i + 2;
+        let mut name_end = name_start;
+        while name_end < bytes.len() && is_identifier_byte(bytes[name_end]) {
+            name_end += 1;
+        }
+        let method = match std::str::from_utf8(&bytes[name_start..name_end]) {
+            Ok(s) => s,
+            Err(_) => {
+                i += 2;
+                continue;
+            }
+        };
+        let is_api = match method {
+            "resource" => false,
+            "apiResource" => true,
+            _ => {
+                i += 2;
+                continue;
+            }
+        };
+
+        // Right boundary: an opening `(` (after optional whitespace).
+        let mut j = name_end;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if j >= bytes.len() || bytes[j] != b'(' {
+            i += 2;
+            continue;
+        }
+        let args_open = j;
+        let Some(&args_close) = paren_pairs.get(&args_open) else {
+            i = args_open + 1;
+            continue;
+        };
+
+        // First argument: the resource name/URI. Must be a string literal.
+        let stripped = match nth_arg_slice(bytes, args_open + 1, args_close, 0)
+            .and_then(parse_string_literal)
+        {
+            Some(name) => {
+                let trimmed = name.trim_matches('/');
+                if trimmed.is_empty() {
+                    i = args_open + 1;
+                    continue;
+                }
+                trimmed.to_string()
+            }
+            None => {
+                i = args_open + 1;
+                continue;
+            }
+        };
+
+        // Determine the action set, honoring `->only([...])` / `->except([...])`
+        // appearing anywhere in the same statement.
+        let (_stmt_start, stmt_end) = statement_containing(bytes, name_start);
+        let defaults = if is_api {
+            API_RESOURCE_ACTIONS
+        } else {
+            RESOURCE_ACTIONS
+        };
+        let actions = resource_actions_in_statement(bytes, args_open, stmt_end, defaults);
+
+        // Position of the call (for goto-definition). Point at the start of the
+        // method identifier, ending after the closing `)` of the arg list.
+        let (line, column) = byte_to_line_col(bytes, name_start);
+        let end_column = column + (args_close + 1 - name_start) as u32;
+
+        // Enclosing closure-group prefix(es) for this call's offset.
+        let mut in_file_prefix = String::new();
+        for grp in groups {
+            if grp.body_start <= name_start && name_start < grp.body_end {
+                in_file_prefix.push_str(&grp.prefix);
+            }
+        }
+
+        for action in &actions {
+            let leaf = format!("{}.{}", stripped, action);
+            for prefix in effective {
+                let mut name =
+                    String::with_capacity(prefix.len() + in_file_prefix.len() + leaf.len());
+                name.push_str(prefix);
+                name.push_str(&in_file_prefix);
+                name.push_str(&leaf);
+                results.push((
+                    Some(name),
+                    RouteDefinition {
+                        file: file.to_path_buf(),
+                        line,
+                        column,
+                        end_column,
+                        priority,
+                        // Resource routes register multiple verbs; no single
+                        // method applies, so leave it unresolved.
+                        method: None,
+                        uri: Some(stripped.clone()),
+                        action: Some((*action).to_string()),
+                    },
+                ));
+            }
+        }
+
+        i = args_open + 1;
+    }
+}
+
+/// Resolve the surviving action set for a resource registration by scanning the
+/// statement (`start..end`) for `->only([...])` then `->except([...])`. `only`
+/// wins when both are present (matching Laravel's runtime, where the last
+/// applied modifier governs, but `only` is the common explicit case). Returns a
+/// filtered, owned subset of `defaults` preserving their canonical order.
+fn resource_actions_in_statement<'a>(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    defaults: &'a [&'a str],
+) -> Vec<&'a str> {
+    if let Some(list) = method_array_arg(bytes, start, end, b"only") {
+        return defaults
+            .iter()
+            .filter(|a| list.contains(&a.to_string()))
+            .copied()
+            .collect();
+    }
+    if let Some(list) = method_array_arg(bytes, start, end, b"except") {
+        return defaults
+            .iter()
+            .filter(|a| !list.contains(&a.to_string()))
+            .copied()
+            .collect();
+    }
+    defaults.to_vec()
+}
+
+/// Find `->{method}([ ... ])` within `start..end` and return the string-literal
+/// elements of its array argument. Returns `None` if the method isn't called.
+fn method_array_arg(bytes: &[u8], start: usize, end: usize, method: &[u8]) -> Option<Vec<String>> {
+    let mut i = start;
+    while i + method.len() < end {
+        // Match `->{method}` with a `->` connector and a word boundary after.
+        if i >= 2
+            && &bytes[i - 2..i] == b"->"
+            && i + method.len() <= end
+            && &bytes[i..i + method.len()] == method
+        {
+            let after = i + method.len();
+            let boundary_ok = after >= end || !is_identifier_byte(bytes[after]);
+            if boundary_ok {
+                let mut j = after;
+                while j < end && bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                if j < end && bytes[j] == b'(' {
+                    return Some(parse_string_array(bytes, j + 1, end));
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Collect string-literal elements from an array literal opening at `start`
+/// (the byte just after the `(`). Reads up to the matching `]`, returning each
+/// quoted element's inner text. Tolerant of a missing `[` (treats the call
+/// argument list as the element source).
+fn parse_string_array(bytes: &[u8], start: usize, end: usize) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut i = start;
+    while i < end && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if i < end && bytes[i] == b'[' {
+        i += 1;
+    }
+    while i < end {
+        let b = bytes[i];
+        if b == b']' || b == b')' {
+            break;
+        }
+        if b == b'\'' || b == b'"' {
+            let quote = b;
+            i += 1;
+            let lit_start = i;
+            while i < end && bytes[i] != quote {
+                if bytes[i] == b'\\' && i + 1 < end {
+                    i += 2;
+                    continue;
+                }
+                i += 1;
+            }
+            if i < end {
+                if let Ok(s) = std::str::from_utf8(&bytes[lit_start..i]) {
+                    out.push(s.to_string());
+                }
+                i += 1; // skip closing quote
+            }
+            continue;
+        }
+        i += 1;
+    }
+    out
 }
 
 /// Resolved data describing the verb call that opens a route's fluent chain.
@@ -818,6 +1385,222 @@ fn find_route_groups(bytes: &[u8]) -> Vec<RouteGroupSpan> {
     groups
 }
 
+/// Scan `bytes` for every `->group(...)`/`::group(...)` callsite that loads an
+/// *external file* rather than running a closure body (issue #43). A load is
+/// recorded only when the call has NO closure body and its (path) argument
+/// resolves to a file path. The own-prefix (which may be empty) is captured the
+/// same way closure groups capture theirs.
+///
+/// `root` is the project root (for `base_path(...)`); `loader_dir` is the
+/// directory of the file being scanned (for `__DIR__ . '...'`).
+fn find_external_group_loads(
+    bytes: &[u8],
+    root: &Path,
+    loader_dir: &Path,
+) -> Vec<ExternalGroupLoad> {
+    let paren_pairs = build_paren_pairs(bytes);
+    let mut loads = Vec::new();
+    let keyword = b"group";
+    let mut i = 0usize;
+
+    while i + keyword.len() < bytes.len() {
+        if &bytes[i..i + keyword.len()] != keyword {
+            i += 1;
+            continue;
+        }
+        if i < 2 {
+            i += 1;
+            continue;
+        }
+        let connector = &bytes[i - 2..i];
+        if connector != b"->" && connector != b"::" {
+            i += 1;
+            continue;
+        }
+        let after_g = i + keyword.len();
+        if after_g < bytes.len() && is_identifier_byte(bytes[after_g]) {
+            i = after_g;
+            continue;
+        }
+        let mut j = after_g;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if j >= bytes.len() || bytes[j] != b'(' {
+            i = j.max(i + 1);
+            continue;
+        }
+        let args_open = j;
+        let Some(&args_close) = paren_pairs.get(&args_open) else {
+            i = args_open + 1;
+            continue;
+        };
+
+        // An external load never has a closure body — skip closure groups so we
+        // don't double-handle them (they're owned by `find_route_groups`).
+        if find_function_body(bytes, args_open + 1, args_close).is_some() {
+            i += 1;
+            continue;
+        }
+
+        let group_offset = i - 2;
+        let chain_prefix = extract_chain_name_prefix(bytes, group_offset, &paren_pairs);
+        let array_prefix = extract_array_as_prefix(bytes, args_open + 1, args_close);
+
+        // Determine which argument holds the path. With an array `['as' => ...]`
+        // first arg (array form), the path is the SECOND argument; otherwise the
+        // fluent `->as(...)->group($path)` form puts it FIRST.
+        let array_first = first_arg_is_array_literal(bytes, args_open + 1, args_close);
+        let path_slice = if array_first {
+            nth_arg_slice(bytes, args_open + 1, args_close, 1)
+        } else {
+            nth_arg_slice(bytes, args_open + 1, args_close, 0)
+        };
+
+        if let Some(slice) = path_slice {
+            if let Some(target) = resolve_path_argument(slice, root, loader_dir) {
+                loads.push(ExternalGroupLoad {
+                    offset: group_offset,
+                    own_prefix: chain_prefix.or(array_prefix).unwrap_or_default(),
+                    target,
+                });
+            }
+        }
+
+        i += 1;
+    }
+
+    loads
+}
+
+/// Does the first argument in `[start..end]` begin with a `[` array literal?
+fn first_arg_is_array_literal(bytes: &[u8], start: usize, end: usize) -> bool {
+    let mut i = start;
+    while i < end && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    i < end && bytes[i] == b'['
+}
+
+/// Return the trimmed byte slice of the `n`-th (0-based) comma-separated
+/// argument inside `[start..end)`, respecting nested parens/brackets/braces and
+/// string literals. `None` if there is no such argument.
+fn nth_arg_slice(bytes: &[u8], start: usize, end: usize, n: usize) -> Option<&[u8]> {
+    let mut depth_paren = 0i32;
+    let mut depth_bracket = 0i32;
+    let mut depth_brace = 0i32;
+    let mut in_string: Option<u8> = None;
+    let mut arg_index = 0usize;
+    let mut arg_start = start;
+    let mut i = start;
+    while i < end {
+        let b = bytes[i];
+        if let Some(quote) = in_string {
+            if b == b'\\' && i + 1 < end {
+                i += 2;
+                continue;
+            }
+            if b == quote {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' | b'"' => in_string = Some(b),
+            b'(' => depth_paren += 1,
+            b')' => depth_paren -= 1,
+            b'[' => depth_bracket += 1,
+            b']' => depth_bracket -= 1,
+            b'{' => depth_brace += 1,
+            b'}' => depth_brace -= 1,
+            b',' if depth_paren == 0 && depth_bracket == 0 && depth_brace == 0 => {
+                if arg_index == n {
+                    return trimmed_slice(bytes, arg_start, i);
+                }
+                arg_index += 1;
+                arg_start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if arg_index == n {
+        trimmed_slice(bytes, arg_start, end)
+    } else {
+        None
+    }
+}
+
+/// Resolve a `->group(...)` path argument to an absolute path. Recognized
+/// forms (the file need not exist — `.`/`..` are normalized lexically):
+/// - `base_path('sub/dir')` → `root/sub/dir`; `base_path()` → `root`
+/// - `__DIR__ . '/sub'` / `__DIR__.'sub'` → `loader_dir/sub`
+/// - bare string literal `'x'` → absolute as-is, else `root/x`
+/// - anything else → `None` (skip).
+fn resolve_path_argument(slice: &[u8], root: &Path, loader_dir: &Path) -> Option<PathBuf> {
+    let text = std::str::from_utf8(slice).ok()?.trim();
+    if text.is_empty() {
+        return None;
+    }
+
+    // base_path('...') / base_path()
+    if let Some(rest) = text.strip_prefix("base_path") {
+        let rest = rest.trim_start();
+        let inner = rest.strip_prefix('(')?.strip_suffix(')')?.trim();
+        if inner.is_empty() {
+            return Some(normalize_path(root));
+        }
+        let sub = parse_string_literal(inner.as_bytes())?;
+        return Some(normalize_path(&root.join(sub)));
+    }
+
+    // __DIR__ . '...'  (the dot and surrounding whitespace are optional spacing)
+    if let Some(rest) = text.strip_prefix("__DIR__") {
+        let rest = rest.trim_start().strip_prefix('.')?.trim_start();
+        let sub = parse_string_literal(rest.as_bytes())?;
+        let sub = sub.trim_start_matches('/');
+        return Some(normalize_path(&loader_dir.join(sub)));
+    }
+
+    // Bare string literal.
+    if let Some(s) = parse_string_literal(text.as_bytes()) {
+        let p = Path::new(&s);
+        if p.is_absolute() {
+            return Some(normalize_path(p));
+        }
+        return Some(normalize_path(&root.join(s)));
+    }
+
+    None
+}
+
+/// Lexically normalize a path: collapse `.` and resolve `..` against prior
+/// components without touching the filesystem (the target may not exist).
+///
+/// Public so callers (e.g. `did_save` in `main.rs`) can normalize a path the
+/// same way before comparing it against [`RouteIndex::source_files`].
+pub fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // Pop only a real directory segment; preserve root/prefix and
+                // any leading `..` that can't be resolved lexically.
+                if matches!(out.components().next_back(), Some(Component::Normal(_))) {
+                    out.pop();
+                } else {
+                    out.push(comp.as_os_str());
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
 /// Walk backward from a `->group(` offset through prior chain links looking
 /// for a `->name('X')` whose string argument should prefix routes in this
 /// group. Returns the prefix string (e.g. `"admin."`).
@@ -871,12 +1654,14 @@ fn extract_chain_name_prefix(
             return None;
         }
 
-        if method == "name" {
+        // `Route::name('admin.')` and its alias `Route::as('admin.')` both set
+        // a group's name prefix.
+        if method == "name" || method == "as" {
             // Extract the string literal first-argument from the `()`.
             return read_first_string_literal(bytes, open_paren + 1, close_paren);
         }
 
-        // Not `name` — continue walking back from the connector position.
+        // Not a name-setter — continue walking back from the connector position.
         cursor = name_start - 2;
     }
 }

--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -6,7 +6,7 @@ fn extracts_single_quoted_route_name() {
 Route::get('/login', [LoginController::class, 'show'])->name('login');
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
 
     assert_eq!(results.len(), 1);
     let (name, def) = &results[0];
@@ -21,7 +21,7 @@ fn extracts_double_quoted_route_name() {
 Route::get('/dashboard')->name("dashboard.index");
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].0.as_deref(), Some("dashboard.index"));
@@ -35,7 +35,7 @@ Route::post('/logout')->name('logout');
 Route::get('/register')->name('register');
 "#;
     let path = PathBuf::from("/fake/routes/auth.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
 
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(names, vec!["login", "logout", "register"]);
@@ -45,7 +45,7 @@ Route::get('/register')->name('register');
 fn tolerates_whitespace_in_call() {
     let src = "<?php\nRoute::get('/x')->name ( 'spaced' );\n";
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].0.as_deref(), Some("spaced"));
 }
@@ -54,7 +54,7 @@ fn tolerates_whitespace_in_call() {
 fn skips_variable_route_names() {
     let src = "<?php\nRoute::get('/x')->name($name);\n";
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     assert!(results.is_empty(), "should skip variable name arguments");
 }
 
@@ -74,7 +74,7 @@ public function auth()
 }
 "#;
     let path = PathBuf::from("/fake/vendor/laravel/ui/src/AuthRouteMethods.php");
-    let results = extract_named_routes(src, &path, PRIORITY_PACKAGE);
+    let results = extract_named_routes(src, &path, PRIORITY_PACKAGE, &[]);
 
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(names, vec!["login", "logout"]);
@@ -231,7 +231,7 @@ fn priority_for_vendor_path_distinguishes_framework() {
 /// `RouteDefinition`. Tests are about extraction shape, not file paths.
 fn first_def(src: &str) -> RouteDefinition {
     let path = PathBuf::from("/fake/routes/web.php");
-    let mut results = extract_named_routes(src, &path, PRIORITY_APP);
+    let mut results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     assert!(
         !results.is_empty(),
         "expected at least one route definition"
@@ -353,7 +353,7 @@ Route::post('/wrong', [Wrong::class, 'wrong']);
 Route::get('/right', [Right::class, 'right'])->name('right');
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     assert_eq!(results.len(), 1);
     let def = &results[0].1;
     assert_eq!(def.method.as_deref(), Some("get"));
@@ -367,7 +367,7 @@ fn metadata_returns_none_when_verb_call_missing() {
     // routes through a builder we don't recognise.
     let src = "<?php\n$builder->name('orphan');\n";
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     // content_registers_named_routes filters this in the discovery pipeline, but
     // the raw extractor still surfaces the name with empty metadata.
     assert_eq!(results.len(), 1);
@@ -383,7 +383,7 @@ fn metadata_does_not_match_longer_verb_lookalike() {
     // enforce a word boundary after the verb.
     let src = "<?php\n$obj->getUser('/x', SomeController::class)->name('user');\n";
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     assert_eq!(results.len(), 1);
     let def = &results[0].1;
     assert!(
@@ -404,7 +404,7 @@ Route::name('admin.')->group(function () {
 });
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(names, vec!["admin.users.index"]);
 }
@@ -417,7 +417,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api'], function () {
 });
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(names, vec!["api.users.index"]);
 }
@@ -432,7 +432,7 @@ Route::name('admin.')->middleware(['auth', 'verified'])->group(function () {
 });
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(names, vec!["admin.users.index"]);
 }
@@ -447,7 +447,7 @@ Route::name('api.')->group(function () {
 });
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(names, vec!["api.v1.users.index"]);
 }
@@ -468,7 +468,7 @@ Route::name('decision-cloud.')->group(function () {
 });
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(
         names,
@@ -486,7 +486,7 @@ Route::name('api.')->group(function () {
 });
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(names, vec!["api.v1.users.index"]);
 }
@@ -500,7 +500,7 @@ Route::name('admin.')->group(function () {
 Route::get('/login')->name('login');
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(
         names,
@@ -519,7 +519,7 @@ Route::middleware('auth')->group(function () {
 });
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(names, vec!["dashboard"]);
 }
@@ -535,7 +535,603 @@ Route::name('api.')->group(function () {
 });
 "#;
     let path = PathBuf::from("/fake/routes/web.php");
-    let results = extract_named_routes(src, &path, PRIORITY_APP);
+    let results = extract_named_routes(src, &path, PRIORITY_APP, &[]);
     let names: Vec<&str> = results.iter().filter_map(|(n, _)| n.as_deref()).collect();
     assert_eq!(names, vec!["admin.x", "api.y"]);
+}
+
+// ============================================================================
+// External-file route group loads (issue #43)
+// ============================================================================
+//
+// `Route::as('admin.')->group(base_path('routes/web_backstage.php'))` loads an
+// external file and applies the group's name prefix to every route inside it.
+// These tests exercise `build_route_index` end-to-end over a temp directory,
+// because the load resolution + transitive propagation only happen there.
+
+use tempfile::TempDir;
+
+/// Build a `routes/` tree from `(relative_path, contents)` pairs under a fresh
+/// temp dir, then run `build_route_index` over the project routes. Returns the
+/// temp dir (kept alive) and the resulting index.
+fn index_routes(files: &[(&str, &str)]) -> (TempDir, RouteIndex) {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let mut route_files = Vec::new();
+    for (rel, contents) in files {
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, contents).unwrap();
+        route_files.push(RouteFile {
+            path,
+            priority: PRIORITY_APP,
+        });
+    }
+    let index = build_route_index(root, &route_files);
+    (tmp, index)
+}
+
+#[test]
+fn external_group_base_path_applies_prefix() {
+    let (_tmp, index) = index_routes(&[
+        (
+            "routes/web.php",
+            "<?php\nRoute::as('admin.')->group(base_path('routes/web_backstage.php'));\n",
+        ),
+        (
+            "routes/web_backstage.php",
+            "<?php\nRoute::get('/patients', fn () => 'ok')->name('patient.index');\n",
+        ),
+    ]);
+
+    // Both the prefixed AND the bare name must be present — the loaded file is
+    // also scanned directly, so its bare leaf stays in the index.
+    assert!(
+        index.get("admin.patient.index").is_some(),
+        "external group prefix must produce admin.patient.index"
+    );
+    assert!(
+        index.get("patient.index").is_some(),
+        "bare leaf name must remain in the index"
+    );
+}
+
+#[test]
+fn external_group_dir_concat_applies_prefix() {
+    let (_tmp, index) = index_routes(&[
+        (
+            "routes/web.php",
+            "<?php\nRoute::as('admin.')->group(__DIR__ . '/web_backstage.php');\n",
+        ),
+        (
+            "routes/web_backstage.php",
+            "<?php\nRoute::get('/patients', fn () => 'ok')->name('patient.index');\n",
+        ),
+    ]);
+
+    assert!(
+        index.get("admin.patient.index").is_some(),
+        "__DIR__ . '/file' load form must resolve and apply prefix"
+    );
+}
+
+#[test]
+fn external_group_nested_closure_prefix_combines() {
+    // An enclosing CLOSURE group `admin.` wraps a `->as('v1.')->group($file)`
+    // external load. The loaded file's routes get `admin.v1.`.
+    let (_tmp, index) = index_routes(&[
+        (
+            "routes/web.php",
+            "<?php\nRoute::as('admin.')->group(function () {\n    Route::as('v1.')->group(base_path('routes/web_backstage.php'));\n});\n",
+        ),
+        (
+            "routes/web_backstage.php",
+            "<?php\nRoute::get('/patients', fn () => 'ok')->name('patient.index');\n",
+        ),
+    ]);
+
+    assert!(
+        index.get("admin.v1.patient.index").is_some(),
+        "enclosing closure prefix must combine with the load's own prefix"
+    );
+}
+
+#[test]
+fn external_group_transitive_chain_of_loads() {
+    // a.php --admin.--> b.php --patient.--> c.php
+    let (_tmp, index) = index_routes(&[
+        (
+            "routes/a.php",
+            "<?php\nRoute::as('admin.')->group(base_path('routes/b.php'));\n",
+        ),
+        (
+            "routes/b.php",
+            "<?php\nRoute::as('patient.')->group(base_path('routes/c.php'));\n",
+        ),
+        (
+            "routes/c.php",
+            "<?php\nRoute::get('/edit', fn () => 'ok')->name('edit');\n",
+        ),
+    ]);
+
+    assert!(
+        index.get("admin.patient.edit").is_some(),
+        "transitive load chain must accumulate prefixes"
+    );
+}
+
+#[test]
+fn external_group_array_form_applies_prefix() {
+    // Array form: the file path is the SECOND argument; the first is the array.
+    let (_tmp, index) = index_routes(&[
+        (
+            "routes/web.php",
+            "<?php\nRoute::group(['as' => 'admin.'], base_path('routes/web_backstage.php'));\n",
+        ),
+        (
+            "routes/web_backstage.php",
+            "<?php\nRoute::get('/patients', fn () => 'ok')->name('patient.index');\n",
+        ),
+    ]);
+
+    assert!(
+        index.get("admin.patient.index").is_some(),
+        "array-form external group must apply the 'as' prefix"
+    );
+}
+
+#[test]
+fn external_prefixes_for_file_returns_inherited_prefix() {
+    // `routes/web.php` loads `routes/web_backstage.php` via an `admin.` group.
+    // `external_prefixes_for_file` must return `["", "admin."]` for the loaded
+    // file — discovered through `discover_route_files` + the load graph.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let routes = root.join("routes");
+    std::fs::create_dir_all(&routes).unwrap();
+    std::fs::write(
+        routes.join("web.php"),
+        "<?php\nRoute::as('admin.')->group(base_path('routes/web_backstage.php'));\n",
+    )
+    .unwrap();
+    let backstage = routes.join("web_backstage.php");
+    std::fs::write(
+        &backstage,
+        "<?php\nRoute::get('/patients', fn () => 'ok')->name('patient.index');\n",
+    )
+    .unwrap();
+
+    let prefixes = external_prefixes_for_file(root, &backstage);
+    assert!(
+        prefixes.contains(&String::new()),
+        "the empty prefix is always present (file scanned directly)"
+    );
+    assert!(
+        prefixes.contains(&"admin.".to_string()),
+        "the loaded file inherits the loader group's `admin.` prefix, got {prefixes:?}"
+    );
+    assert_eq!(
+        prefixes.len(),
+        2,
+        "exactly `\"\"` and `admin.`: {prefixes:?}"
+    );
+}
+
+#[test]
+fn external_prefixes_for_file_loader_has_only_empty() {
+    // The LOADER file (web.php) inherits no external prefix itself — only the
+    // always-present empty prefix.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let routes = root.join("routes");
+    std::fs::create_dir_all(&routes).unwrap();
+    let web = routes.join("web.php");
+    std::fs::write(
+        &web,
+        "<?php\nRoute::as('admin.')->group(base_path('routes/web_backstage.php'));\n",
+    )
+    .unwrap();
+    std::fs::write(
+        routes.join("web_backstage.php"),
+        "<?php\nRoute::get('/patients', fn () => 'ok')->name('patient.index');\n",
+    )
+    .unwrap();
+
+    let prefixes = external_prefixes_for_file(root, &web);
+    assert_eq!(
+        prefixes,
+        vec![String::new()],
+        "loader has no inherited prefix"
+    );
+}
+
+#[test]
+fn external_prefixes_for_file_transitive_chain_accumulates() {
+    // a.php --admin.--> b.php --patient.--> c.php. The deepest file inherits the
+    // accumulated `admin.patient.` prefix.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let routes = root.join("routes");
+    std::fs::create_dir_all(&routes).unwrap();
+    std::fs::write(
+        routes.join("a.php"),
+        "<?php\nRoute::as('admin.')->group(base_path('routes/b.php'));\n",
+    )
+    .unwrap();
+    std::fs::write(
+        routes.join("b.php"),
+        "<?php\nRoute::as('patient.')->group(base_path('routes/c.php'));\n",
+    )
+    .unwrap();
+    let c = routes.join("c.php");
+    std::fs::write(
+        &c,
+        "<?php\nRoute::get('/edit', fn () => 'ok')->name('edit');\n",
+    )
+    .unwrap();
+
+    let prefixes = external_prefixes_for_file(root, &c);
+    assert!(prefixes.contains(&String::new()));
+    assert!(
+        prefixes.contains(&"admin.patient.".to_string()),
+        "transitive chain must accumulate: {prefixes:?}"
+    );
+}
+
+#[test]
+fn external_group_cycle_is_guarded() {
+    // a.php loads b.php; b.php loads a.php. Must terminate and still index
+    // both files' bare names without blowing up.
+    let (_tmp, index) = index_routes(&[
+        (
+            "routes/a.php",
+            "<?php\nRoute::as('x.')->group(base_path('routes/b.php'));\nRoute::get('/a', fn () => 'ok')->name('a');\n",
+        ),
+        (
+            "routes/b.php",
+            "<?php\nRoute::as('y.')->group(base_path('routes/a.php'));\nRoute::get('/b', fn () => 'ok')->name('b');\n",
+        ),
+    ]);
+
+    assert!(index.get("a").is_some(), "bare name a must index");
+    assert!(index.get("b").is_some(), "bare name b must index");
+    // One hop each direction is fine.
+    assert!(index.get("x.b").is_some(), "a loads b with prefix x.");
+    assert!(index.get("y.a").is_some(), "b loads a with prefix y.");
+}
+
+/// Like [`index_routes`] but lets callers place files at ARBITRARY relative
+/// paths (e.g. `app/Custom/admin.php`) while still seeding the working set only
+/// with the `routes/` entry points. Files NOT under `routes/` are written to
+/// disk but NOT added to `route_files`, so they can only enter the index via a
+/// transitive `->group(<path>)` load — exactly the issue #43 scenario.
+fn index_with_entrypoints(files: &[(&str, &str)], entrypoints: &[&str]) -> (TempDir, RouteIndex) {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let mut route_files = Vec::new();
+    for (rel, contents) in files {
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, contents).unwrap();
+        if entrypoints.contains(rel) {
+            route_files.push(RouteFile {
+                path,
+                priority: PRIORITY_APP,
+            });
+        }
+    }
+    let index = build_route_index(root, &route_files);
+    (tmp, index)
+}
+
+#[test]
+fn external_group_indexes_file_outside_routes_dir() {
+    // The loaded file lives OUTSIDE routes/ (app/Custom/admin.php) and is NOT a
+    // discovered entry point — it can only enter the index transitively.
+    let (_tmp, index) = index_with_entrypoints(
+        &[
+            (
+                "routes/web.php",
+                "<?php\nRoute::as('admin.')->group(base_path('app/Custom/admin.php'));\n",
+            ),
+            (
+                "app/Custom/admin.php",
+                "<?php\nRoute::get('/dashboard', fn () => 'ok')->name('dash');\nRoute::resource('widgets', WidgetController::class);\n",
+            ),
+        ],
+        &["routes/web.php"],
+    );
+
+    // The ->name('dash') leaf indexes under the load's admin. prefix...
+    assert!(
+        index.get("admin.dash").is_some(),
+        "external file outside routes/ must index its ->name under the load prefix"
+    );
+    // ...and its bare leaf survives (file scanned directly too).
+    assert!(
+        index.get("dash").is_some(),
+        "bare leaf name from the external file must remain"
+    );
+    // Resource routes in the external file also compose with the load prefix.
+    for action in [
+        "index", "create", "store", "show", "edit", "update", "destroy",
+    ] {
+        assert!(
+            index.get(&format!("admin.widgets.{action}")).is_some(),
+            "expected admin.widgets.{action} from external file"
+        );
+    }
+}
+
+#[test]
+fn source_files_includes_referenced_external_file() {
+    let (tmp, index) = index_with_entrypoints(
+        &[
+            (
+                "routes/web.php",
+                "<?php\nRoute::as('admin.')->group(base_path('app/Custom/admin.php'));\n",
+            ),
+            (
+                "app/Custom/admin.php",
+                "<?php\nRoute::get('/dashboard', fn () => 'ok')->name('dash');\n",
+            ),
+        ],
+        &["routes/web.php"],
+    );
+
+    let root = tmp.path();
+    let web = normalize_path(&root.join("routes/web.php"));
+    let admin = normalize_path(&root.join("app/Custom/admin.php"));
+    assert!(
+        index.source_files.contains(&web),
+        "source_files must contain the discovered routes/web.php"
+    );
+    assert!(
+        index.source_files.contains(&admin),
+        "source_files must contain the transitively-referenced app/Custom/admin.php"
+    );
+}
+
+#[test]
+fn external_group_transitive_chain_outside_routes_dir() {
+    // a (entry, in routes/) --admin.--> b (outside) --patient.--> c (outside)
+    let (tmp, index) = index_with_entrypoints(
+        &[
+            (
+                "routes/a.php",
+                "<?php\nRoute::as('admin.')->group(base_path('app/Custom/b.php'));\n",
+            ),
+            (
+                "app/Custom/b.php",
+                "<?php\nRoute::as('patient.')->group(base_path('app/Custom/c.php'));\n",
+            ),
+            (
+                "app/Custom/c.php",
+                "<?php\nRoute::get('/edit', fn () => 'ok')->name('edit');\n",
+            ),
+        ],
+        &["routes/a.php"],
+    );
+
+    assert!(
+        index.get("admin.patient.edit").is_some(),
+        "transitive chain through files outside routes/ must accumulate prefixes"
+    );
+
+    let root = tmp.path();
+    for rel in ["routes/a.php", "app/Custom/b.php", "app/Custom/c.php"] {
+        let key = normalize_path(&root.join(rel));
+        assert!(
+            index.source_files.contains(&key),
+            "source_files must contain {rel}"
+        );
+    }
+}
+
+#[test]
+fn external_group_cycle_outside_routes_dir_terminates() {
+    // a (entry) <-> b (outside): each loads the other. Must terminate and index
+    // a finite set of names.
+    let (_tmp, index) = index_with_entrypoints(
+        &[
+            (
+                "routes/a.php",
+                "<?php\nRoute::as('x.')->group(base_path('app/Custom/b.php'));\nRoute::get('/a', fn () => 'ok')->name('a');\n",
+            ),
+            (
+                "app/Custom/b.php",
+                "<?php\nRoute::as('y.')->group(base_path('routes/a.php'));\nRoute::get('/b', fn () => 'ok')->name('b');\n",
+            ),
+        ],
+        &["routes/a.php"],
+    );
+
+    // Bare names from both files index.
+    assert!(index.get("a").is_some(), "bare name a must index");
+    assert!(index.get("b").is_some(), "bare name b must index");
+    // One hop each direction.
+    assert!(index.get("x.b").is_some(), "a loads b with prefix x.");
+    assert!(index.get("y.a").is_some(), "b loads a with prefix y.");
+    // Finite: the index can't have exploded into an unbounded name set.
+    assert!(
+        index.routes.len() < 50,
+        "cycle must produce a finite, small name set, got {}",
+        index.routes.len()
+    );
+}
+
+// ============================================================================
+// Resource route derivation (Route::resource / Route::apiResource)
+// ============================================================================
+
+/// Collect just the route names from a direct extraction over `src`.
+fn names_of(src: &str) -> Vec<String> {
+    let path = PathBuf::from("/fake/routes/web.php");
+    extract_named_routes(src, &path, PRIORITY_APP, &[])
+        .into_iter()
+        .filter_map(|(n, _)| n)
+        .collect()
+}
+
+#[test]
+fn resource_inside_name_group_applies_prefix_and_strips_slash() {
+    // `/leads` (leading slash) inside `Route::name('api.')->group(fn)` with an
+    // `->only(['store', 'update'])` filter. Must yield `api.leads.store` and
+    // `api.leads.update` — and NEVER a slash-prefixed `/leads.*` name.
+    let src = r#"<?php
+Route::name('api.')->group(function () {
+    Route::resource('/leads', LeadController::class)->only(['store', 'update']);
+});
+"#;
+    let names = names_of(src);
+    assert!(
+        names.contains(&"api.leads.store".to_string()),
+        "expected api.leads.store, got {names:?}"
+    );
+    assert!(
+        names.contains(&"api.leads.update".to_string()),
+        "expected api.leads.update, got {names:?}"
+    );
+    // only() must drop the rest.
+    assert!(!names.iter().any(|n| n.ends_with(".index")));
+    assert!(!names.iter().any(|n| n.ends_with(".show")));
+    // No name may carry a literal slash from the stripped resource URI.
+    assert!(
+        !names.iter().any(|n| n.contains('/')),
+        "no name may contain a slash, got {names:?}"
+    );
+}
+
+#[test]
+fn api_resource_yields_five_actions_slash_free() {
+    let src = r#"<?php
+Route::apiResource('photos', PhotoController::class);
+"#;
+    let mut names = names_of(src);
+    names.sort();
+    assert_eq!(
+        names,
+        vec![
+            "photos.destroy",
+            "photos.index",
+            "photos.show",
+            "photos.store",
+            "photos.update",
+        ],
+        "apiResource must register exactly the 5 api actions"
+    );
+    // create/edit are form routes — excluded from apiResource.
+    assert!(!names.iter().any(|n| n == "photos.create"));
+    assert!(!names.iter().any(|n| n == "photos.edit"));
+}
+
+#[test]
+fn resource_except_filters_actions() {
+    let src = r#"<?php
+Route::resource('posts', PostController::class)->except(['create', 'edit', 'destroy']);
+"#;
+    let mut names = names_of(src);
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["posts.index", "posts.show", "posts.store", "posts.update",]
+    );
+}
+
+#[test]
+fn resource_strips_trailing_slash() {
+    let src = r#"<?php
+Route::resource('photos/', PhotoController::class)->only(['index']);
+"#;
+    let names = names_of(src);
+    assert_eq!(names, vec!["photos.index"]);
+}
+
+#[test]
+fn resource_skips_non_string_first_arg() {
+    // A variable resource URI can't be resolved statically — skip it entirely.
+    let src = r#"<?php
+Route::resource($name, PhotoController::class);
+"#;
+    let names = names_of(src);
+    assert!(
+        names.is_empty(),
+        "non-literal resource URI must be skipped, got {names:?}"
+    );
+}
+
+#[test]
+fn resource_in_external_file_composes_with_load_prefix() {
+    // A `Route::resource('patient', …)` in a file loaded via
+    // `Route::as('admin.')->group(base_path('routes/b.php'))` must yield
+    // `admin.patient.*` (resource derivation + external-file prefix compose).
+    let (_tmp, index) = index_routes(&[
+        (
+            "routes/web.php",
+            "<?php\nRoute::as('admin.')->group(base_path('routes/b.php'));\n",
+        ),
+        (
+            "routes/b.php",
+            "<?php\nRoute::resource('patient', PatientController::class);\n",
+        ),
+    ]);
+
+    for action in [
+        "index", "create", "store", "show", "edit", "update", "destroy",
+    ] {
+        assert!(
+            index.get(&format!("admin.patient.{action}")).is_some(),
+            "expected admin.patient.{action} in index"
+        );
+        // The bare leaf survives too (file scanned directly).
+        assert!(
+            index.get(&format!("patient.{action}")).is_some(),
+            "expected bare patient.{action} in index"
+        );
+    }
+}
+
+#[test]
+fn no_indexed_resource_name_ever_starts_with_slash() {
+    // Belt-and-suspenders: across a realistic mix, assert the slash bug is gone.
+    let (_tmp, index) = index_routes(&[(
+        "routes/web.php",
+        "<?php\nRoute::name('api.')->group(function () {\n    Route::resource('/leads', LeadController::class);\n    Route::apiResource('/photos/', PhotoController::class);\n});\nRoute::resource('/bare', BareController::class);\n",
+    )]);
+
+    for name in index.routes.keys() {
+        assert!(
+            !name.starts_with('/'),
+            "indexed route name must never start with a slash: {name}"
+        );
+        assert!(
+            !name.contains('/'),
+            "indexed route name must never contain a slash: {name}"
+        );
+    }
+    // Spot-check a couple of expected names exist.
+    assert!(index.get("api.leads.index").is_some());
+    assert!(index.get("api.photos.store").is_some());
+    assert!(index.get("bare.show").is_some());
+}
+
+#[test]
+fn closure_group_behavior_unchanged_regression() {
+    // A plain in-file closure group must behave exactly as before — no external
+    // load, no extra prefixes leaking in.
+    let (_tmp, index) = index_routes(&[(
+        "routes/web.php",
+        "<?php\nRoute::name('admin.')->group(function () {\n    Route::get('/users', [UserController::class, 'index'])->name('users.index');\n});\nRoute::get('/login')->name('login');\n",
+    )]);
+
+    assert!(index.get("admin.users.index").is_some());
+    assert!(index.get("login").is_some());
+    assert!(
+        index.get("users.index").is_none(),
+        "in-file closure group should not also emit the bare leaf"
+    );
 }

--- a/laravel-lsp/src/route_name_locator.rs
+++ b/laravel-lsp/src/route_name_locator.rs
@@ -4,9 +4,9 @@
 //!
 //! The companion to `route_outline.rs`: that module extracts the *name string*
 //! to label outline entries, this one extracts the *position of the name
-//! string's content* so we can rewrite it in place. Same AST walk approach;
-//! the divergence is that we need column ranges rather than concatenated
-//! strings.
+//! string's content* so we can rewrite it in place. Both share the AST walk in
+//! [`crate::route_chain`]; the divergence is that we need column ranges rather
+//! than concatenated strings.
 //!
 //! Group prefixes are followed honestly: a route inside `Route::name('api.')`
 //! whose own `->name('users')` resolves to declared name `api.users`, but the
@@ -15,7 +15,7 @@
 //! in source — the prefix lives in a separate declaration that the user can
 //! rename independently if desired.
 
-use tree_sitter::Node;
+use crate::route_chain::{extract_route_chains, RouteChainNode};
 
 /// One declaration site that contributes to a full route name. The
 /// `name_arg_line/start_column/end_column` identifies the physical source
@@ -46,9 +46,9 @@ impl RouteNameDeclaration {
     /// dotted name.
     ///
     /// Because `full_name` is built as `inherited_prefix + local_segment`
-    /// (see [`process_chain`]), the prefix is recovered by stripping the
-    /// segment back off. We then drop that same prefix from the new name so
-    /// only this declaration's own segment is rewritten — the inherited
+    /// (see [`fold_chain`]), the prefix is recovered by stripping the segment
+    /// back off. We then drop that same prefix from the new name so only this
+    /// declaration's own segment is rewritten — the inherited
     /// `Route::name('admin.')` group prefix lives at a separate declaration
     /// the user renames independently.
     ///
@@ -76,13 +76,10 @@ impl RouteNameDeclaration {
 /// in source order, regardless of whether they sit on leaf routes or on
 /// `Route::group(...)` containers.
 pub fn extract_route_name_declarations(content: &str) -> Vec<RouteNameDeclaration> {
-    let Ok(tree) = crate::parser::parse_php(content) else {
-        return Vec::new();
-    };
-    let source = content.as_bytes();
-    let ctx = NameContext::default();
     let mut output = Vec::new();
-    walk_statements(tree.root_node(), source, &ctx, &mut output);
+    for chain in extract_route_chains(content) {
+        fold_chain(&chain, "", &mut output);
+    }
     output
 }
 
@@ -91,223 +88,86 @@ pub fn extract_route_name_declarations(content: &str) -> Vec<RouteNameDeclaratio
 /// name (a route inside multiple nested `name('a.')` `name('b.')` groups has
 /// one leaf and two group declarations).
 pub fn find_declarations_named(content: &str, target: &str) -> Vec<RouteNameDeclaration> {
-    extract_route_name_declarations(content)
-        .into_iter()
-        .filter(|d| d.full_name == target)
-        .collect()
+    find_declarations_named_with_external(content, target, &["".to_string()])
 }
 
-/// Inherited context from enclosing `Route::group(...)` blocks — only the
-/// name prefix matters for our purpose (URI prefixes are irrelevant to route
-/// *name* rename).
-#[derive(Debug, Clone, Default)]
-struct NameContext {
-    name_prefix: String,
-}
+/// `find_declarations_named`, but also matching declarations whose name only
+/// equals `target` once an *external-file* group prefix is prepended (issue
+/// #43). A file loaded via `Route::as('admin.')->group(base_path('that.php'))`
+/// has its in-file `->name('x')` resolve to `admin.x` at the project level,
+/// even though this file's own AST only sees `x`.
+///
+/// For each declaration `d` and each `external_prefix` in `external_prefixes`,
+/// the declaration matches when `external_prefix + d.full_name == target`. On a
+/// match, the returned declaration's `full_name` is rewritten to the resolved
+/// project-level name (`external_prefix + raw`) so that
+/// [`RouteNameDeclaration::rewritten_segment`] strips the *combined* prefix and
+/// still rewrites only the same leaf segment in source.
+///
+/// `external_prefixes` should always include `""` (the file is scanned directly
+/// too); an empty slice is treated as `[""]`.
+pub fn find_declarations_named_with_external(
+    content: &str,
+    target: &str,
+    external_prefixes: &[String],
+) -> Vec<RouteNameDeclaration> {
+    // Normalize to a non-empty set that always contains the empty prefix.
+    let mut effective: Vec<&str> = vec![""];
+    for p in external_prefixes {
+        if !p.is_empty() && !effective.contains(&p.as_str()) {
+            effective.push(p.as_str());
+        }
+    }
 
-fn walk_statements(
-    node: Node,
-    source: &[u8],
-    ctx: &NameContext,
-    output: &mut Vec<RouteNameDeclaration>,
-) {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        match child.kind() {
-            "expression_statement" => {
-                let mut inner = child.walk();
-                for expr in child.children(&mut inner) {
-                    if is_call_node(expr) {
-                        process_chain(expr, source, ctx, output);
-                    }
+    let mut out = Vec::new();
+    for d in extract_route_name_declarations(content) {
+        for ext in &effective {
+            if ext.is_empty() {
+                if d.full_name == target {
+                    out.push(d.clone());
                 }
-            }
-            _ => {
-                walk_statements(child, source, ctx, output);
+            } else if format!("{}{}", ext, d.full_name) == target {
+                // Re-anchor `full_name` to the resolved project-level name so
+                // `rewritten_segment` strips the combined (external + group)
+                // prefix and rewrites only this declaration's own leaf.
+                let mut resolved = d.clone();
+                resolved.full_name = format!("{}{}", ext, d.full_name);
+                out.push(resolved);
             }
         }
     }
+    out
 }
 
-fn process_chain(
-    chain: Node,
-    source: &[u8],
-    ctx: &NameContext,
-    output: &mut Vec<RouteNameDeclaration>,
-) {
-    let data = collect_chain(chain, source);
-    if !data.is_route_chain {
-        return;
-    }
-
-    // Borrow the name string by reference so we can both emit a declaration
-    // for it AND use its segment when computing the recursive group context.
-    if let Some(name_pos) = data.name_string.as_ref() {
-        let full_name = format!("{}{}", ctx.name_prefix, name_pos.segment);
+/// Fold one shared-walker chain node (and its group children) into route-name
+/// declarations, accumulating the enclosing group `name(...)` prefix.
+///
+/// A declaration is emitted for any chain that carries a `->name`/`->as`
+/// argument — whether it's a leaf route or a group container (the group's own
+/// `->name('admin.')` is itself a renameable declaration). The group's segment
+/// then extends the prefix for its children.
+fn fold_chain(chain: &RouteChainNode, name_prefix: &str, output: &mut Vec<RouteNameDeclaration>) {
+    if let Some(name) = chain.name.as_ref() {
         output.push(RouteNameDeclaration {
-            full_name,
-            local_segment: name_pos.segment.clone(),
-            line: name_pos.line,
-            start_column: name_pos.start_column,
-            end_column: name_pos.end_column,
+            full_name: format!("{}{}", name_prefix, name.segment),
+            local_segment: name.segment.clone(),
+            line: name.line,
+            start_column: name.start_column,
+            end_column: name.end_column,
         });
     }
 
-    // Recurse into group closures, applying this group's name prefix.
-    if let Some(closure_node) = data.group_closure {
-        let extra_prefix = data
-            .name_string
+    if chain.is_group() {
+        let extra = chain
+            .name
             .as_ref()
             .map(|n| n.segment.as_str())
             .unwrap_or("");
-        let new_ctx = NameContext {
-            name_prefix: format!("{}{}", ctx.name_prefix, extra_prefix),
-        };
-        if let Some(body) = closure_node.child_by_field_name("body") {
-            walk_statements(body, source, &new_ctx, output);
+        let child_prefix = format!("{}{}", name_prefix, extra);
+        for child in &chain.group_children {
+            fold_chain(child, &child_prefix, output);
         }
     }
-}
-
-/// Position-bearing record of a `->name(...)` / `->as(...)` argument string.
-#[derive(Debug, Clone)]
-struct NameString {
-    segment: String,
-    line: u32,
-    start_column: u32,
-    end_column: u32,
-}
-
-#[derive(Debug, Default)]
-struct ChainData<'a> {
-    is_route_chain: bool,
-    /// The `->name('xxx')` / `->as('xxx')` argument captured with position.
-    name_string: Option<NameString>,
-    /// Closure node for `->group(...)`, so we can recurse for nested decls.
-    group_closure: Option<Node<'a>>,
-}
-
-fn collect_chain<'a>(chain: Node<'a>, source: &[u8]) -> ChainData<'a> {
-    let mut data = ChainData::default();
-    let mut current = Some(chain);
-    while let Some(node) = current {
-        match node.kind() {
-            "member_call_expression" => {
-                if let Some((name, args)) = method_name_and_args(node, source) {
-                    apply_method(&mut data, &name, args, source);
-                }
-                current = node.child_by_field_name("object");
-            }
-            "scoped_call_expression" => {
-                if let Some(scope) = node.child_by_field_name("scope") {
-                    if let Ok(scope_text) = scope.utf8_text(source) {
-                        if scope_text == "Route" || scope_text.ends_with("\\Route") {
-                            data.is_route_chain = true;
-                        }
-                    }
-                }
-                if let Some((name, args)) = method_name_and_args(node, source) {
-                    apply_method(&mut data, &name, args, source);
-                }
-                current = None;
-            }
-            _ => current = None,
-        }
-    }
-    data
-}
-
-fn apply_method<'a>(data: &mut ChainData<'a>, name: &str, args: Node<'a>, source: &[u8]) {
-    match name {
-        "name" | "as" if data.name_string.is_none() => {
-            data.name_string = first_string_arg_with_pos(args, source);
-        }
-        "group" => {
-            data.group_closure = find_closure_node(args);
-        }
-        _ => {}
-    }
-}
-
-fn method_name_and_args<'a>(node: Node<'a>, source: &[u8]) -> Option<(String, Node<'a>)> {
-    let name = node
-        .child_by_field_name("name")?
-        .utf8_text(source)
-        .ok()?
-        .to_string();
-    let args = node.child_by_field_name("arguments")?;
-    Some((name, args))
-}
-
-fn first_string_arg_with_pos(args: Node, source: &[u8]) -> Option<NameString> {
-    let mut cursor = args.walk();
-    for arg in args.children(&mut cursor) {
-        if arg.kind() != "argument" {
-            continue;
-        }
-        let mut arg_cursor = arg.walk();
-        for inner in arg.children(&mut arg_cursor) {
-            if inner.kind() == "string" || inner.kind() == "encapsed_string" {
-                return string_content_with_pos(inner, source);
-            }
-        }
-    }
-    None
-}
-
-/// Locate the `string_content` child node of a `string` / `encapsed_string`
-/// and return its range. The content range excludes the surrounding quotes,
-/// which is exactly what a rename `TextEdit` should target.
-fn string_content_with_pos(node: Node, source: &[u8]) -> Option<NameString> {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "string_content" {
-            let segment = child.utf8_text(source).ok()?.to_string();
-            let start = child.start_position();
-            let end = child.end_position();
-            // string_content always sits on a single line in tree-sitter-php
-            // (multiline strings use distinct nodes). Defensive: clamp the
-            // end column to the start line so a misparse doesn't produce
-            // a multi-line range.
-            return Some(NameString {
-                segment,
-                line: start.row as u32,
-                start_column: start.column as u32,
-                end_column: if end.row == start.row {
-                    end.column as u32
-                } else {
-                    start.column as u32
-                },
-            });
-        }
-    }
-    None
-}
-
-fn find_closure_node(args: Node) -> Option<Node> {
-    let mut cursor = args.walk();
-    for arg in args.children(&mut cursor) {
-        if arg.kind() != "argument" {
-            continue;
-        }
-        let mut arg_cursor = arg.walk();
-        for inner in arg.children(&mut arg_cursor) {
-            if inner.kind() == "anonymous_function_creation_expression"
-                || inner.kind() == "anonymous_function"
-                || inner.kind() == "arrow_function"
-            {
-                return Some(inner);
-            }
-        }
-    }
-    None
-}
-
-fn is_call_node(node: Node) -> bool {
-    matches!(
-        node.kind(),
-        "member_call_expression" | "scoped_call_expression"
-    )
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/route_name_locator/tests.rs
+++ b/laravel-lsp/src/route_name_locator/tests.rs
@@ -202,6 +202,82 @@ Route::get('/home', [HomeController::class, 'index'])->name('home');
     assert_eq!(d.rewritten_segment("users.index"), "users.index");
 }
 
+// ============================================================================
+// External-file group prefixes (issue #43)
+// ============================================================================
+
+#[test]
+fn find_with_external_matches_prefixed_target() {
+    // A file loaded via `Route::as('admin.')->group(base_path('that.php'))`
+    // has its in-file `->name('x')` resolve to `admin.x` at the project level.
+    // `find_declarations_named_with_external` must match target `admin.x` and
+    // still yield the leaf `x` for rewrite.
+    let src = r#"<?php
+Route::get('/x', [X::class, 'i'])->name('x');
+"#;
+    let found = find_declarations_named_with_external(
+        src,
+        "admin.x",
+        &["".to_string(), "admin.".to_string()],
+    );
+    assert_eq!(found.len(), 1, "the prefixed target must match");
+    let d = &found[0];
+    // The decl is re-anchored to the resolved project-level name so
+    // `rewritten_segment` strips the WHOLE prefix and rewrites only the leaf.
+    assert_eq!(d.full_name, "admin.x");
+    assert_eq!(d.local_segment, "x");
+    assert_eq!(d.rewritten_segment("admin.accounts"), "accounts");
+}
+
+#[test]
+fn find_with_external_still_matches_bare_target() {
+    // The same call must keep matching the bare name `x` via the always-present
+    // empty prefix — the loaded file is also scanned directly.
+    let src = r#"<?php
+Route::get('/x', [X::class, 'i'])->name('x');
+"#;
+    let found =
+        find_declarations_named_with_external(src, "x", &["".to_string(), "admin.".to_string()]);
+    assert_eq!(found.len(), 1, "the bare target must still match");
+    assert_eq!(found[0].full_name, "x");
+    assert_eq!(found[0].local_segment, "x");
+}
+
+#[test]
+fn find_with_external_empty_prefixes_behaves_like_plain() {
+    // An empty external-prefix slice is treated as `[""]`, so this is exactly
+    // `find_declarations_named`.
+    let src = r#"<?php
+Route::get('/x', [X::class, 'i'])->name('x');
+"#;
+    let found = find_declarations_named_with_external(src, "x", &[]);
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].full_name, "x");
+    let none = find_declarations_named_with_external(src, "admin.x", &[]);
+    assert!(none.is_empty(), "no external prefix → no prefixed match");
+}
+
+#[test]
+fn find_with_external_combines_with_in_file_group_prefix() {
+    // External prefix `admin.` + in-file group `api.` → the leaf `x` resolves
+    // to `admin.api.x`. The decl's source position still spans only `x`, so the
+    // rewrite must strip the full `admin.api.` prefix.
+    let src = r#"<?php
+Route::name('api.')->group(function () {
+    Route::get('/x', [X::class, 'i'])->name('x');
+});
+"#;
+    let found = find_declarations_named_with_external(
+        src,
+        "admin.api.x",
+        &["".to_string(), "admin.".to_string()],
+    );
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].full_name, "admin.api.x");
+    assert_eq!(found[0].local_segment, "x");
+    assert_eq!(found[0].rewritten_segment("admin.api.accounts"), "accounts");
+}
+
 #[test]
 fn rewritten_segment_falls_back_when_prefix_mismatches() {
     // The user rewrote the group portion (`admin.` → `web.`) — something a

--- a/laravel-lsp/src/route_outline.rs
+++ b/laravel-lsp/src/route_outline.rs
@@ -1,19 +1,20 @@
-//! Tree-sitter walker for Laravel route files.
+//! Route outline builder for Laravel route files.
 //!
 //! Produces a hierarchical outline of routes that preserves group nesting,
 //! computes combined URIs (a route inside `prefix('/api')` shows `/api/users`,
 //! not `/users`), and combines route name prefixes (a route inside
 //! `name('api.')` shows `api.users`, not `users`).
 //!
-//! Unlike a regex-based extractor, this walks the PHP AST and matches every
-//! `Route::*` method by structure — so `Route::livewire`, `Route::resource`,
-//! `Route::apiResource`, and any future custom route method surface
-//! automatically without us maintaining a verb allow-list.
+//! The AST walk is owned by [`crate::route_chain`]; this module folds the
+//! resulting chain tree into the `RouteOutline` hierarchy. Because the walker
+//! matches every `Route::*` method by structure, `Route::livewire`,
+//! `Route::resource`, `Route::apiResource`, and any future custom route method
+//! surface automatically without us maintaining a verb allow-list here.
 //!
 //! The output is plain data (`RouteOutline`) so it can be memoized through
 //! Salsa and converted to `SymbolEntry` by `document_symbols.rs`.
 
-use tree_sitter::Node;
+use crate::route_chain::{extract_route_chains, RouteChainNode};
 
 /// One entry in the route outline tree. Leaf entries are route definitions
 /// (HTTP verbs, `livewire`, `resource`, etc.); container entries are
@@ -43,309 +44,126 @@ pub struct RouteOutline {
 /// Parse a route file's content and return the outline tree. Returns an
 /// empty vec on parse failure.
 pub fn extract_route_outline(content: &str) -> Vec<RouteOutline> {
-    let Ok(tree) = crate::parser::parse_php(content) else {
-        return Vec::new();
-    };
-    let source = content.as_bytes();
-    let ctx = GroupContext::default();
-    let mut output = Vec::new();
-    walk_statements(tree.root_node(), source, &ctx, &mut output);
-    output
+    extract_route_outline_with_external(content, &[])
 }
 
-/// Inherited context from enclosing `Route::group(...)` blocks. Accumulated
-/// as we descend; the empty default is the file's top level.
-#[derive(Debug, Clone, Default)]
-struct GroupContext {
-    /// URI prefix (combined `prefix('...')` from all enclosing groups).
-    prefix: String,
-    /// Route name prefix (combined `name('...')` from all enclosing groups).
-    name_prefix: String,
+/// Like [`extract_route_outline`], but prepends an *external-file* group name
+/// prefix to every displayed full route name (issue #43).
+///
+/// A file loaded via `Route::as('admin.')->group(base_path('that.php'))` has
+/// its in-file routes resolve to `admin.<name>` at the project level, even
+/// though this file's own AST only sees `<name>`. `external_prefixes` carries
+/// those inherited prefixes; the *first* non-empty entry is used as the primary
+/// display prefix (a single file can only display one outline, so we don't
+/// duplicate the tree per prefix). An empty slice — or one containing only `""`
+/// — yields byte-identical output to [`extract_route_outline`].
+///
+/// Only the displayed route *name* gains the prefix; URIs are unaffected
+/// (external loads contribute name prefixes, not URI prefixes, in this code
+/// path's resolution model).
+pub fn extract_route_outline_with_external(
+    content: &str,
+    external_prefixes: &[String],
+) -> Vec<RouteOutline> {
+    let primary = external_prefixes
+        .iter()
+        .find(|p| !p.is_empty())
+        .map(String::as_str)
+        .unwrap_or("");
+
+    extract_route_chains(content)
+        .iter()
+        .filter_map(|chain| fold_chain(chain, primary, ""))
+        .collect()
 }
 
-/// Walk a statement list (file root, namespace body, or group closure body)
-/// looking for `Route::*(...)` expression statements.
-fn walk_statements(node: Node, source: &[u8], ctx: &GroupContext, output: &mut Vec<RouteOutline>) {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        match child.kind() {
-            "expression_statement" => {
-                // The expression statement wraps a single expression — find it.
-                let mut inner = child.walk();
-                for expr in child.children(&mut inner) {
-                    if is_call_node(expr) {
-                        process_chain(expr, source, ctx, output);
-                    }
-                }
-            }
-            // Recurse into wrappers that can contain expression statements
-            // (namespaces, compound statements). Closures are handled
-            // separately via `walk_statements` from inside group processing.
-            "namespace_definition" | "compound_statement" => {
-                walk_statements(child, source, ctx, output);
-            }
-            _ => {}
-        }
-    }
-}
-
-/// Process a single `Route::method()->method()->...` chain. Decides whether
-/// it's a leaf route definition or a group container, and emits accordingly.
-fn process_chain(chain: Node, source: &[u8], ctx: &GroupContext, output: &mut Vec<RouteOutline>) {
-    let data = collect_chain(chain, source);
-
-    // Bail if the chain doesn't start with `Route::` — we don't want to
-    // emit entries for unrelated method calls that happen to live in a
-    // route file.
-    if !data.is_route_chain {
-        return;
-    }
-
-    if let Some(method) = data.route_method {
+/// Fold one shared-walker chain node into a `RouteOutline`, accumulating the
+/// inherited URI prefix (`uri_prefix`) and the externally-applied name prefix
+/// (`ext_name_prefix`, propagated to every nested level).
+///
+/// Returns `None` for chains that are neither a route definition nor a
+/// non-empty group (e.g. a config-only `Route::pattern(...)` chain, or an empty
+/// group — empty groups are noise and omitted).
+fn fold_chain(
+    chain: &RouteChainNode,
+    ext_name_prefix: &str,
+    uri_prefix: &str,
+) -> Option<RouteOutline> {
+    if let Some(verb) = chain.verb.as_ref() {
         // Leaf route definition.
-        let route_uri = data.route_uri.unwrap_or_default();
-        let combined_uri = format!("{}{}", ctx.prefix, route_uri);
-        // For leaf routes, `name_arg` is the route's own `->name('foo')` call.
-        let combined_name = data.name_arg.map(|n| format!("{}{}", ctx.name_prefix, n));
+        let route_uri = chain.uri.clone().unwrap_or_default();
+        let combined_uri = format!("{}{}", uri_prefix, route_uri);
+        let combined_name = chain
+            .name
+            .as_ref()
+            .map(|n| format!("{}{}", ext_name_prefix, n.segment));
 
-        let (start_line, start_column) = pos(chain.start_position());
-        let (end_line, end_column) = pos(chain.end_position());
-
-        output.push(RouteOutline {
-            method: method.to_uppercase(),
+        return Some(RouteOutline {
+            method: verb.to_uppercase(),
             uri: combined_uri,
             name: combined_name,
-            start_line,
-            start_column,
-            end_line,
-            end_column,
+            start_line: chain.chain_range.start_line,
+            start_column: chain.chain_range.start_column,
+            end_line: chain.chain_range.end_line,
+            end_column: chain.chain_range.end_column,
             children: Vec::new(),
             is_group: false,
         });
-    } else if let Some(closure_node) = data.group_closure {
+    }
+
+    if chain.is_group() {
         // Group container. Apply this group's modifiers to the inherited
-        // context, then recurse into the closure body with the new context.
-        let prefix_arg = data.prefix_arg.unwrap_or_default();
-        let name_arg = data.name_arg.unwrap_or_default();
-        let new_ctx = GroupContext {
-            prefix: format!("{}{}", ctx.prefix, prefix_arg),
-            name_prefix: format!("{}{}", ctx.name_prefix, name_arg),
-        };
+        // context, then recurse into the children with the new context.
+        let prefix_arg = chain.prefix_arg.clone().unwrap_or_default();
+        let name_arg = chain
+            .name
+            .as_ref()
+            .map(|n| n.segment.as_str())
+            .unwrap_or("");
+        let group_uri = format!("{}{}", uri_prefix, prefix_arg);
+        // The displayed group name prefix combines the external prefix with
+        // this and all enclosing groups' name segments. We thread the combined
+        // string down so children inherit it; the group node itself displays
+        // the same combined value.
+        let group_name = format!("{}{}", ext_name_prefix, name_arg);
 
-        let mut children = Vec::new();
-        if let Some(body) = closure_node.child_by_field_name("body") {
-            walk_statements(body, source, &new_ctx, &mut children);
-        }
-
-        // Position the group entry at the closure expression itself (not
-        // the wider chain) so it overlaps Zed's tree-sitter "Closure" symbol
-        // at the exact same range — gives the outline UI a chance to dedupe.
-        let (start_line, start_column) = pos(closure_node.start_position());
-        let (end_line, end_column) = pos(closure_node.end_position());
+        let children: Vec<RouteOutline> = chain
+            .group_children
+            .iter()
+            // Children inherit the FULL accumulated name prefix (external +
+            // this group's segment) and the FULL accumulated URI prefix.
+            .filter_map(|c| fold_chain(c, &group_name, &group_uri))
+            .collect();
 
         // Skip empty groups — they're noise.
         if children.is_empty() {
-            return;
+            return None;
         }
 
-        output.push(RouteOutline {
+        // Position the group entry at the closure expression itself (not the
+        // wider chain) so it overlaps the editor's tree-sitter "Closure" symbol
+        // at the exact same range — gives the outline UI a chance to dedupe.
+        let range = chain.group_closure_range.unwrap_or(chain.chain_range);
+
+        return Some(RouteOutline {
             method: "GROUP".to_string(),
-            uri: new_ctx.prefix,
-            name: if new_ctx.name_prefix.is_empty() {
+            uri: group_uri,
+            name: if group_name.is_empty() {
                 None
             } else {
-                Some(new_ctx.name_prefix)
+                Some(group_name)
             },
-            start_line,
-            start_column,
-            end_line,
-            end_column,
+            start_line: range.start_line,
+            start_column: range.start_column,
+            end_line: range.end_line,
+            end_column: range.end_column,
             children,
             is_group: true,
         });
     }
+
     // Other chains (e.g. `Route::pattern(...)` config calls) are ignored.
-}
-
-/// Data collected from one chain. All fields are populated by walking the
-/// chain from outermost call inward.
-#[derive(Default)]
-struct ChainData<'a> {
-    /// True if the chain's innermost call is `Route::*` (scoped to `Route`).
-    is_route_chain: bool,
-    /// Set when we encounter a route definition method like `get`/`post`.
-    route_method: Option<String>,
-    /// The first string argument to the route method (the URI pattern).
-    route_uri: Option<String>,
-    /// Combined `->name('...')` argument from anywhere in the chain. For
-    /// leaf routes this is the route name; for groups it's the name prefix.
-    name_arg: Option<String>,
-    /// `->prefix('...')` argument (only meaningful for groups).
-    prefix_arg: Option<String>,
-    /// The `anonymous_function_creation_expression` node passed to
-    /// `->group(...)`, if the chain is a group. Tracked instead of just the
-    /// body so the consumer can position the group symbol at the closure's
-    /// own range — this lets the outline merge cleanly with Zed's tree-sitter
-    /// "Closure" symbol that would otherwise appear alongside ours.
-    group_closure: Option<Node<'a>>,
-}
-
-/// Walk a method chain from outermost call inward, collecting each method's
-/// name and relevant arguments into `ChainData`.
-fn collect_chain<'a>(chain: Node<'a>, source: &[u8]) -> ChainData<'a> {
-    let mut data = ChainData::default();
-    let mut current = Some(chain);
-
-    while let Some(node) = current {
-        match node.kind() {
-            "member_call_expression" => {
-                if let Some((name, args)) = method_name_and_args(node, source) {
-                    apply_method(&mut data, &name, args, source);
-                }
-                current = node.child_by_field_name("object");
-            }
-            "scoped_call_expression" => {
-                // Innermost call (`Route::method(...)`). Verify the scope is
-                // `Route` so we don't claim chains like `Foo::bar()->baz()`.
-                if let Some(scope) = node.child_by_field_name("scope") {
-                    if let Ok(scope_text) = scope.utf8_text(source) {
-                        if scope_text == "Route" || scope_text.ends_with("\\Route") {
-                            data.is_route_chain = true;
-                        }
-                    }
-                }
-                if let Some((name, args)) = method_name_and_args(node, source) {
-                    apply_method(&mut data, &name, args, source);
-                }
-                current = None;
-            }
-            _ => {
-                current = None;
-            }
-        }
-    }
-
-    data
-}
-
-/// Apply one method call from the chain to the accumulated data.
-fn apply_method<'a>(data: &mut ChainData<'a>, name: &str, args: Node<'a>, source: &[u8]) {
-    match name {
-        // Route definition methods. The first string argument is the URI.
-        // We don't allow-list these specifically — anything that's not a
-        // known modifier or `group` is treated as a definition. But to keep
-        // false positives low, we still match against the common methods.
-        "get" | "post" | "put" | "patch" | "delete" | "options" | "any" | "match" | "view"
-        | "redirect" | "fallback" | "livewire" | "resource" | "apiResource" | "singleton"
-        | "apiSingleton" | "permanentRedirect" => {
-            data.route_method = Some(name.to_string());
-            data.route_uri = first_string_arg(args, source);
-        }
-
-        // Group container. The closure argument is the group body.
-        "group" => {
-            data.group_closure = find_closure_node(args);
-        }
-
-        // Modifiers — meaning depends on whether we end up as route or group.
-        "prefix" => {
-            data.prefix_arg = first_string_arg(args, source);
-        }
-        // `as()` is an alias for `name()` in Laravel.
-        "name" | "as" => {
-            data.name_arg = first_string_arg(args, source);
-        }
-
-        // Modifiers we don't currently visualize: middleware, withoutMiddleware,
-        // domain, where, whereNumber, whereAlpha, controller, etc.
-        _ => {}
-    }
-}
-
-/// Get the method `name:` and `arguments:` fields from a call node.
-fn method_name_and_args<'a>(node: Node<'a>, source: &[u8]) -> Option<(String, Node<'a>)> {
-    let name = node
-        .child_by_field_name("name")?
-        .utf8_text(source)
-        .ok()?
-        .to_string();
-    let args = node.child_by_field_name("arguments")?;
-    Some((name, args))
-}
-
-/// Extract the first string literal from an arguments list. Handles both
-/// `'single-quoted'` and `"double-quoted"` forms (tree-sitter-php names them
-/// `string` and `encapsed_string` respectively).
-fn first_string_arg(args: Node, source: &[u8]) -> Option<String> {
-    let mut cursor = args.walk();
-    for arg in args.children(&mut cursor) {
-        if arg.kind() != "argument" {
-            continue;
-        }
-        let mut arg_cursor = arg.walk();
-        for inner in arg.children(&mut arg_cursor) {
-            match inner.kind() {
-                "string" | "encapsed_string" => {
-                    return read_string_content(inner, source);
-                }
-                _ => {}
-            }
-        }
-    }
     None
-}
-
-/// Read the inner content of a `string` / `encapsed_string` node, stripping
-/// the surrounding quotes. tree-sitter exposes a `string_content` child for
-/// the body; if it's missing (rare), fall back to trimming the raw text.
-fn read_string_content(node: Node, source: &[u8]) -> Option<String> {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "string_content" {
-            return child.utf8_text(source).ok().map(|s| s.to_string());
-        }
-    }
-    // Fallback: strip the leading/trailing quote chars from the raw node.
-    node.utf8_text(source).ok().map(|s| {
-        s.trim_start_matches(['\'', '"'])
-            .trim_end_matches(['\'', '"'])
-            .to_string()
-    })
-}
-
-/// Find the closure expression node inside an arguments list. Handles both
-/// the modern `Route::group(function () { ... })` form and the legacy
-/// `Route::group(['prefix' => '/x'], function () { ... })` form by scanning
-/// every argument for an anonymous-function node. Returns the closure
-/// expression itself (not its body) so callers can use its range.
-fn find_closure_node(args: Node) -> Option<Node> {
-    let mut cursor = args.walk();
-    for arg in args.children(&mut cursor) {
-        if arg.kind() != "argument" {
-            continue;
-        }
-        let mut arg_cursor = arg.walk();
-        for inner in arg.children(&mut arg_cursor) {
-            if inner.kind() == "anonymous_function_creation_expression"
-                || inner.kind() == "anonymous_function"
-                || inner.kind() == "arrow_function"
-            {
-                return Some(inner);
-            }
-        }
-    }
-    None
-}
-
-fn is_call_node(node: Node) -> bool {
-    matches!(
-        node.kind(),
-        "member_call_expression" | "scoped_call_expression"
-    )
-}
-
-fn pos(point: tree_sitter::Point) -> (u32, u32) {
-    (point.row as u32, point.column as u32)
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/route_outline/tests.rs
+++ b/laravel-lsp/src/route_outline/tests.rs
@@ -289,3 +289,67 @@ fn positions_are_zero_based() {
     assert_eq!(routes[0].start_line, 1, "second line is index 1");
     assert_eq!(routes[0].start_column, 0, "line starts at column 0");
 }
+
+// ============================================================================
+// External-file group prefixes (issue #43)
+// ============================================================================
+
+#[test]
+fn external_prefix_prepends_to_route_names() {
+    // A file loaded via `Route::as('admin.')->group(base_path('that.php'))`
+    // should display its routes' names with the inherited `admin.` prefix.
+    let content = "<?php\nRoute::get('/users', fn () => 1)->name('users.index');\n";
+    let routes = extract_route_outline_with_external(content, &["admin.".to_string()]);
+    assert_eq!(routes.len(), 1);
+    assert_eq!(
+        routes[0].uri, "/users",
+        "URIs are unaffected by name prefix"
+    );
+    assert_eq!(routes[0].name.as_deref(), Some("admin.users.index"));
+}
+
+#[test]
+fn external_prefix_combines_with_in_file_group() {
+    // External `admin.` + in-file `api.` group → `admin.api.users`.
+    let content = r#"<?php
+Route::name('api.')->group(function () {
+    Route::get('/users', fn () => 1)->name('users');
+});
+"#;
+    let routes = extract_route_outline_with_external(content, &["admin.".to_string()]);
+    assert_eq!(routes.len(), 1);
+    assert!(routes[0].is_group);
+    assert_eq!(routes[0].name.as_deref(), Some("admin.api."));
+    assert_eq!(
+        routes[0].children[0].name.as_deref(),
+        Some("admin.api.users")
+    );
+}
+
+#[test]
+fn external_prefix_uses_first_non_empty() {
+    // The slice always contains "" (file scanned directly); the first non-empty
+    // entry is the display prefix.
+    let content = "<?php\nRoute::get('/x', fn () => 1)->name('x');\n";
+    let routes =
+        extract_route_outline_with_external(content, &["".to_string(), "admin.".to_string()]);
+    assert_eq!(routes[0].name.as_deref(), Some("admin.x"));
+}
+
+#[test]
+fn external_prefix_empty_matches_plain_extraction() {
+    // No external prefix → byte-identical to `extract_route_outline`.
+    let content = r#"<?php
+Route::name('api.')->group(function () {
+    Route::get('/users', fn () => 1)->name('users');
+});
+"#;
+    assert_eq!(
+        extract_route_outline_with_external(content, &[]),
+        extract_route_outline(content),
+    );
+    assert_eq!(
+        extract_route_outline_with_external(content, &["".to_string()]),
+        extract_route_outline(content),
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -8,4 +8,5 @@ mod livewire_component_resolution;
 mod loop_variable_resolution;
 mod rename_integration;
 mod route_binding_resolution;
+mod route_diagnostics;
 mod slot_variable_resolution;

--- a/laravel-lsp/src/tests/route_diagnostics.rs
+++ b/laravel-lsp/src/tests/route_diagnostics.rs
@@ -1,0 +1,68 @@
+use crate::LaravelLanguageServer;
+use laravel_lsp::route_discovery::{RouteDefinition, RouteIndex};
+use laravel_lsp::salsa_impl::RouteReferenceData;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower_lsp::lsp_types::DiagnosticSeverity;
+
+fn route_ref(name: &str) -> Arc<RouteReferenceData> {
+    Arc::new(RouteReferenceData {
+        name: name.to_string(),
+        line: 0,
+        column: 0,
+        end_column: 5,
+    })
+}
+
+fn index_with(names: &[&str]) -> RouteIndex {
+    let mut idx = RouteIndex::new();
+    for n in names {
+        idx.insert(
+            n.to_string(),
+            RouteDefinition {
+                file: PathBuf::from("routes/web.php"),
+                line: 0,
+                column: 0,
+                end_column: 0,
+                priority: 0,
+                method: None,
+                uri: None,
+                action: None,
+            },
+        );
+    }
+    idx
+}
+
+#[test]
+fn flags_only_unknown_routes() {
+    let idx = index_with(&["home", "admin.dashboard"]);
+    let refs = vec![route_ref("home"), route_ref("does.not.exist")];
+    let diags = LaravelLanguageServer::route_not_found_diagnostics(Some(&idx), &refs);
+    assert_eq!(diags.len(), 1, "only the unknown route should be flagged");
+    assert!(diags[0].message.contains("does.not.exist"));
+    assert_eq!(diags[0].severity, Some(DiagnosticSeverity::ERROR));
+}
+
+#[test]
+fn empty_index_flags_nothing() {
+    // Guard: before the index is built (empty), we must NOT flag every route —
+    // that would be a false-positive storm at startup.
+    let idx = RouteIndex::new();
+    let diags = LaravelLanguageServer::route_not_found_diagnostics(Some(&idx), &[route_ref("x")]);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn absent_index_flags_nothing() {
+    let diags = LaravelLanguageServer::route_not_found_diagnostics(None, &[route_ref("x")]);
+    assert!(diags.is_empty());
+}
+
+#[test]
+fn all_known_routes_flag_nothing() {
+    let idx = index_with(&["home"]);
+    let diags =
+        LaravelLanguageServer::route_not_found_diagnostics(Some(&idx), &[route_ref("home")]);
+    assert!(diags.is_empty());
+}

--- a/laravel-lsp/tests/integration_tests.rs
+++ b/laravel-lsp/tests/integration_tests.rs
@@ -347,7 +347,7 @@ mod routes {
 
         let root = test_project_path();
         let files = discover_route_files(&root);
-        let index = build_route_index(&files);
+        let index = build_route_index(&root, &files);
 
         let def = index
             .get("home")
@@ -370,7 +370,7 @@ mod routes {
 
         let root = test_project_path();
         let files = discover_route_files(&root);
-        let index = build_route_index(&files);
+        let index = build_route_index(&root, &files);
 
         let def = index
             .get("login")


### PR DESCRIPTION
## Summary

Fixes the false "route not found" for names assembled from a `Route::group(...)` that loads an **external file** (`->as('admin.')->group(base_path('routes/web_backstage.php'))`), unifies route-name handling so hover, goto, completion, rename, find-references and the outline all agree, and adds a route-not-found diagnostic now that the index is complete enough to make one safe.

## What changed

**Route index (`route_discovery.rs`)**
- Follows `->group('<path>')` external loads **transitively** (cycle-guarded, depth-capped) and indexes referenced files **wherever they live**, including outside `routes/`.
- Derives **`Route::resource`/`apiResource`** names (slashes stripped → `leads.store`, not `/leads.store`), honoring `->only`/`->except`.
- Applies group + external-file name prefixes consistently. Exposes `source_files` and `external_prefixes_for_file` / `external_prefixes_map`.

**Single source of truth**
- **Completion** reads the same `RouteIndex` as hover/goto — the old regex extractor (slash bug, no prefixes, 4 hardcoded files) is deleted.
- The two near-identical tree-sitter walkers (rename/find-refs + outline) are consolidated into one shared **`route_chain`** walker, made external-file-prefix aware (applied at match/render time so per-file mtime caches stay valid).

**Freshness**
- Saving any route-contributing file (in `source_files`, or under `routes/`) rebuilds the index and re-validates open documents.

**Route-not-found diagnostic (ERROR)**
- Flags `route('name')` (PHP and Blade `{{ route('…') }}`) whose name isn't in the index. One testable helper; **guarded** to fire only when the index is built AND non-empty, so it can't false-positive every route at startup. Because the index now resolves resources / prefixes / external loads, it doesn't flag those valid routes.

## Test plan
- `cargo test` — **1493 passing** (29 preserved walker tests + rename-integration; ~34 new across resource derivation, external/transitive loads, `source_files`, slash-guard, external-prefix match/render, and the diagnostic helper).
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- Verified in Zed (Laravel 12): external-group-loaded + resource routes resolve in completion/hover/goto; rename/find-refs/outline name them consistently; editing+saving a route file updates completion and clears/raises diagnostics.

## Notes
- Follow-up filed: **#48** (discovery — unify the route caches into one canonical source, with a perf measurement).
- Two commits: the resolution/consolidation fix, then the diagnostic.

Fixes: #43
