### PR TITLE
fix: 🐛 @vite() root resolution + ✨ autocomplete + diagnostic severity audit

### DIFF
--- a/laravel-lsp/Cargo.toml
+++ b/laravel-lsp/Cargo.toml
@@ -37,6 +37,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # File system and paths
 walkdir = "2.5"
+ignore = "0.4"  # ripgrep's .gitignore-respecting directory walker
 glob = "0.3"
 directories = "6"  # Cross-platform XDG cache directories
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -12701,22 +12701,10 @@ return [
         let root_guard = self.root_path.read().await;
         let root = root_guard.as_ref()?;
 
-        // Determine the base path based on helper type
-        use laravel_lsp::salsa_impl::AssetHelperType;
-        let base_path = match asset.helper_type {
-            AssetHelperType::Asset | AssetHelperType::PublicPath | AssetHelperType::Mix => {
-                root.join("public")
-            }
-            AssetHelperType::BasePath => root.clone(),
-            AssetHelperType::AppPath => root.join("app"),
-            AssetHelperType::StoragePath => root.join("storage"),
-            AssetHelperType::DatabasePath => root.join("database"),
-            AssetHelperType::LangPath => root.join("lang"),
-            AssetHelperType::ConfigPath => root.join("config"),
-            AssetHelperType::ResourcePath | AssetHelperType::ViteAsset => root.join("resources"),
-        };
-
-        let asset_path = base_path.join(&asset.path);
+        // Resolve through the single asset-path brain so goto/hover/diagnostics
+        // never disagree — notably @vite, whose entry is project-root-relative
+        // and must NOT be re-prefixed with `resources/` (issue #46).
+        let (asset_path, _) = Self::asset_expected_path(asset.helper_type, root, &asset.path);
 
         if self.file_exists_cached(&asset_path).await {
             if let Ok(target_uri) = Url::from_file_path(&asset_path) {
@@ -15308,21 +15296,9 @@ return [
         &self,
         asset: &laravel_lsp::salsa_impl::AssetReferenceData,
     ) -> Option<String> {
-        use laravel_lsp::salsa_impl::AssetHelperType;
         let root = self.root_path.read().await.clone()?;
-        let base = match asset.helper_type {
-            AssetHelperType::Asset | AssetHelperType::PublicPath | AssetHelperType::Mix => {
-                root.join("public")
-            }
-            AssetHelperType::BasePath => root.clone(),
-            AssetHelperType::AppPath => root.join("app"),
-            AssetHelperType::StoragePath => root.join("storage"),
-            AssetHelperType::DatabasePath => root.join("database"),
-            AssetHelperType::LangPath => root.join("lang"),
-            AssetHelperType::ConfigPath => root.join("config"),
-            AssetHelperType::ResourcePath | AssetHelperType::ViteAsset => root.join("resources"),
-        };
-        let asset_path = base.join(&asset.path);
+        // Single asset-path brain — see asset_expected_path (issue #46).
+        let (asset_path, _) = Self::asset_expected_path(asset.helper_type, &root, &asset.path);
         if self.file_exists_cached(&asset_path).await {
             Some(self.source_link(&asset_path, None).await)
         } else {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -6941,34 +6941,77 @@ impl LaravelLanguageServer {
 
         let before_cursor = &line_text[..cursor];
 
-        let patterns: Vec<(&str, char, usize)> = vec![
-            ("@vite('", '\'', 7),
-            ("@vite(\"", '"', 7),
-            ("@vite(['", '\'', 8),
-            ("@vite([\"", '"', 8),
-            ("Vite::asset('", '\'', 13),
-            ("Vite::asset(\"", '"', 13),
-        ];
+        // Find the directive opener. `@vite()` takes a single path OR an array
+        // of paths, so we can't match a fixed opening pattern per quote — the
+        // cursor may be in the 2nd, 3rd, … array element.
+        let open = before_cursor
+            .rfind("@vite(")
+            .map(|p| p + "@vite(".len())
+            .or_else(|| {
+                before_cursor
+                    .rfind("Vite::asset(")
+                    .map(|p| p + "Vite::asset(".len())
+            })?;
 
-        for (pattern, quote_char, pattern_len) in patterns {
-            if let Some(pos) = before_cursor.rfind(pattern) {
-                let start_pos = pos + pattern_len;
-                let after_quote = &before_cursor[start_pos..];
-
-                // Check that we haven't hit the closing quote
-                if !after_quote.contains(quote_char) {
-                    let end_col = Self::find_string_end(line_text, start_pos, quote_char);
-                    return Some(StringContext {
-                        prefix: after_quote.to_string(),
-                        start_col: start_pos as u32,
-                        end_col,
-                        quote_char,
-                    });
-                }
+        // Scan the arguments from the opener to the cursor, tracking string
+        // open/close state. Quotes (`'`/`"`) are single ASCII bytes that can't
+        // occur inside a multi-byte UTF-8 sequence, so byte scanning is safe.
+        // If the cursor lands inside an open string, that string is the active
+        // completion context — whether it's `@vite('x')` or any element of
+        // `@vite(['a', 'b', …])`.
+        let args = &before_cursor.as_bytes()[open..];
+        let mut in_string: Option<(u8, usize)> = None; // (quote byte, content start in line)
+        for (i, &b) in args.iter().enumerate() {
+            match in_string {
+                None if b == b'\'' || b == b'"' => in_string = Some((b, open + i + 1)),
+                Some((quote, _)) if b == quote => in_string = None,
+                _ => {}
             }
         }
 
-        None
+        let (quote, content_start) = in_string?;
+        let quote_char = quote as char;
+        let end_col = Self::find_string_end(line_text, content_start, quote_char);
+        Some(StringContext {
+            prefix: line_text[content_start..cursor].to_string(),
+            start_col: content_start as u32,
+            end_col,
+            quote_char,
+        })
+    }
+
+    /// Collect candidate Vite entry files: every asset-extension file under the
+    /// project root that isn't git-ignored. Uses ripgrep's `ignore` walker so
+    /// `vendor/`, `node_modules/`, build output, etc. (git-ignored in a Laravel
+    /// app) are pruned at the directory level — keeping the walk fast even on
+    /// huge repos. Returns paths relative to `root`, forward-slashed and sorted,
+    /// ready to drop into `@vite(...)` (which is project-root-relative).
+    fn vite_entry_files(root: &Path) -> Vec<String> {
+        const VITE_EXTS: &[&str] = &[
+            "js", "ts", "jsx", "tsx", "css", "scss", "sass", "less", "vue", "svelte",
+        ];
+        let mut out = Vec::new();
+        for entry in ignore::WalkBuilder::new(root)
+            .require_git(false) // honor .gitignore even when .git isn't present
+            .build()
+            .filter_map(|e| e.ok())
+        {
+            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+                continue;
+            }
+            let path = entry.path();
+            let is_asset = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| VITE_EXTS.contains(&e));
+            if is_asset {
+                if let Ok(rel) = path.strip_prefix(root) {
+                    out.push(rel.to_string_lossy().replace('\\', "/"));
+                }
+            }
+        }
+        out.sort();
+        out
     }
 
     /// Check if cursor is inside a path helper call like app_path('...'), base_path('...'), etc.
@@ -18903,25 +18946,23 @@ impl LanguageServer for LaravelLanguageServer {
                     None => return Ok(None),
                 };
 
-                // Vite assets are typically in resources/ directory
-                let resources_dir = root.join("resources");
-                let vite_extensions = &[
-                    "js", "ts", "jsx", "tsx", "css", "scss", "sass", "less", "vue", "svelte",
-                ];
-                let files = self
-                    .get_directory_files(&resources_dir, Some(vite_extensions))
-                    .await;
+                // Every non-git-ignored asset file in the project, relative to
+                // the root (the form `@vite()` expects). The walk runs off the
+                // async runtime; Zed fuzzy-filters the list against the typed
+                // text, so we return the full candidate set rather than
+                // prefix-filtering here.
+                let walk_root = root.clone();
+                let files = tokio::task::spawn_blocking(move || Self::vite_entry_files(&walk_root))
+                    .await
+                    .unwrap_or_default();
 
-                // Prefix paths with "resources/" for proper Vite resolution
-                let prefix_lower = vite_ctx.prefix.to_lowercase();
                 let items: Vec<CompletionItem> = files
                     .into_iter()
-                    .map(|f| format!("resources/{}", f.path))
-                    .filter(|p| p.to_lowercase().starts_with(&prefix_lower))
                     .map(|path| CompletionItem {
                         label: path.clone(),
                         kind: Some(CompletionItemKind::FILE),
                         detail: Some("vite entry".to_string()),
+                        filter_text: Some(path.clone()),
                         documentation: Some(
                             CompletionDoc::new()
                                 .header(&path)

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -15265,29 +15265,6 @@ return [
         })
     }
 
-    /// Map a Salsa `AssetHelperType` to the function-call form a developer
-    /// would have literally written. No current caller (asset hovers don't
-    /// surface the helper label anymore now that the unified template
-    /// dropped the call-form header) but kept available for future use —
-    /// e.g. a completion item that wants to render the helper name.
-    #[allow(dead_code)]
-    fn asset_helper_label(t: laravel_lsp::salsa_impl::AssetHelperType) -> &'static str {
-        use laravel_lsp::salsa_impl::AssetHelperType;
-        match t {
-            AssetHelperType::Asset => "asset",
-            AssetHelperType::PublicPath => "public_path",
-            AssetHelperType::Mix => "mix",
-            AssetHelperType::BasePath => "base_path",
-            AssetHelperType::AppPath => "app_path",
-            AssetHelperType::StoragePath => "storage_path",
-            AssetHelperType::DatabasePath => "database_path",
-            AssetHelperType::LangPath => "lang_path",
-            AssetHelperType::ConfigPath => "config_path",
-            AssetHelperType::ResourcePath => "resource_path",
-            AssetHelperType::ViteAsset => "Vite::asset",
-        }
-    }
-
     /// Resolve an asset reference to its on-disk file path. Mirrors the
     /// directory mapping used by `create_asset_location_from_salsa` for
     /// goto-definition — `asset()`/`Vite::asset()` look under `public/` or

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -11885,7 +11885,6 @@ return [
         line: u32,
         column: u32,
         end_column: u32,
-        dotted_severity: DiagnosticSeverity,
     ) -> Diagnostic {
         let expected_path_str = check
             .expected_path
@@ -11903,7 +11902,12 @@ return [
                 "\nFile does not exist".to_string()
             };
             (
-                dotted_severity,
+                // A missing translation key does NOT throw — Laravel's
+                // Translator::get returns the key string verbatim — so the page
+                // still renders. That's a WARNING, not an error, and the same
+                // severity regardless of call form (`__()`, `trans()`, `@lang`),
+                // which previously disagreed (ERROR vs WARNING).
+                DiagnosticSeverity::WARNING,
                 format!(
                     "Translation not found: '{}'\nExpected at: {}{}",
                     translation_key, expected_path_str, action_hint
@@ -14213,7 +14217,6 @@ return [
                             trans_ref.line,
                             trans_ref.column,
                             trans_ref.end_column,
-                            DiagnosticSeverity::ERROR, // ERROR for dotted keys in PHP
                         ));
                     }
                 }
@@ -14423,7 +14426,11 @@ return [
                                             character: feature_ref.end_column,
                                         },
                                     },
-                                    severity: Some(DiagnosticSeverity::ERROR),
+                                    // An undefined Pennant feature does NOT throw:
+                                    // the driver dispatches UnknownFeatureResolved
+                                    // and returns the unknown-feature value (false).
+                                    // The app keeps running, so this is a WARNING.
+                                    severity: Some(DiagnosticSeverity::WARNING),
                                     code: None,
                                     source: Some("laravel".to_string()),
                                     message: format!(
@@ -14459,7 +14466,9 @@ return [
                                         character: feature_ref.end_column,
                                     },
                                 },
-                                severity: Some(DiagnosticSeverity::ERROR),
+                                // Undefined feature → driver returns false, no
+                                // throw (see UnknownFeatureResolved). WARNING.
+                                severity: Some(DiagnosticSeverity::WARNING),
                                 code: None,
                                 source: Some("laravel".to_string()),
                                 message: format!(
@@ -14523,7 +14532,6 @@ return [
                         trans_ref.line,
                         trans_ref.column,
                         trans_ref.end_column,
-                        DiagnosticSeverity::ERROR, // ERROR for dotted keys in Blade __()
                     ));
                 }
             }
@@ -14699,7 +14707,6 @@ return [
                                     dir_ref.line,
                                     dir_ref.column,
                                     dir_ref.end_column,
-                                    DiagnosticSeverity::WARNING, // WARNING for dotted keys in @lang
                                 ));
                             }
                         }
@@ -14744,7 +14751,9 @@ return [
                                             character: dir_ref.string_end_column,
                                         },
                                     },
-                                    severity: Some(DiagnosticSeverity::ERROR),
+                                    // Undefined feature → driver returns false, no
+                                    // throw (see UnknownFeatureResolved). WARNING.
+                                    severity: Some(DiagnosticSeverity::WARNING),
                                     code: None,
                                     source: Some("laravel".to_string()),
                                     message: format!(

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13646,6 +13646,80 @@ return [
         (base.join(arg), name)
     }
 
+    /// Build a "missing asset" diagnostic for a single asset reference, or
+    /// `None` if it resolves to a real target.
+    ///
+    /// Severity follows *runtime* behavior, per the rule "if a bad value breaks
+    /// the app, it's an error":
+    /// - `@vite()` entries are looked up in the build manifest by `Vite::chunk`,
+    ///   which throws `ViteException` on a miss (a production 500). Any bad
+    ///   entry — typo, directory, or empty — is app-breaking, so it's an ERROR
+    ///   and must resolve to a real *file* (`is_file`), not just any path.
+    /// - Other helpers (`asset()`, `mix()`, `resource_path()`, …) only yield a
+    ///   dead URL/path string at runtime; the page still renders, so a miss is a
+    ///   WARNING and mere existence (file or directory) clears it.
+    ///
+    /// This is the single source of severity + detection so the Blade and PHP
+    /// validation passes can never disagree (they once emitted ERROR vs WARNING
+    /// for identical references).
+    fn asset_diagnostic(
+        asset_ref: &laravel_lsp::salsa_impl::AssetReferenceData,
+        root: &Path,
+    ) -> Option<Diagnostic> {
+        use laravel_lsp::salsa_impl::AssetHelperType;
+        let (asset_path, helper_name) =
+            Self::asset_expected_path(asset_ref.helper_type, root, &asset_ref.path);
+
+        let is_vite = matches!(asset_ref.helper_type, AssetHelperType::ViteAsset);
+        let is_empty = asset_ref.path.trim().is_empty();
+        let broken = is_empty
+            || if is_vite {
+                !asset_path.is_file()
+            } else {
+                !asset_path.exists()
+            };
+        if !broken {
+            return None;
+        }
+
+        let severity = if is_vite {
+            DiagnosticSeverity::ERROR
+        } else {
+            DiagnosticSeverity::WARNING
+        };
+        let message = if is_empty {
+            format!("Empty {helper_name}() entry.")
+        } else {
+            format!(
+                "Asset file not found: '{}'\nExpected at: {}\nHelper: {}()",
+                asset_ref.path,
+                asset_path.to_string_lossy(),
+                helper_name
+            )
+        };
+
+        Some(Diagnostic {
+            range: Range {
+                start: Position {
+                    line: asset_ref.line,
+                    character: asset_ref.column,
+                },
+                end: Position {
+                    line: asset_ref.line,
+                    character: asset_ref.end_column,
+                },
+            },
+            severity: Some(severity),
+            code: None,
+            source: Some("laravel".to_string()),
+            message,
+            related_information: None,
+            tags: None,
+            code_description: None,
+            data: None,
+        })
+    }
+
     /// Validate a document (Blade or PHP) and publish diagnostics
     ///
     /// This function uses Salsa-cached patterns for efficient incremental validation:
@@ -14313,35 +14387,7 @@ return [
             let root_guard = self.root_path.read().await;
             if let Some(root) = root_guard.as_ref() {
                 for asset_ref in &patterns.asset_refs {
-                    let (asset_path, helper_name) =
-                        Self::asset_expected_path(asset_ref.helper_type, root, &asset_ref.path);
-
-                    if !asset_path.exists() {
-                        let diagnostic = Diagnostic {
-                            range: Range {
-                                start: Position {
-                                    line: asset_ref.line,
-                                    character: asset_ref.column,
-                                },
-                                end: Position {
-                                    line: asset_ref.line,
-                                    character: asset_ref.end_column,
-                                },
-                            },
-                            severity: Some(DiagnosticSeverity::ERROR),
-                            code: None,
-                            source: Some("laravel".to_string()),
-                            message: format!(
-                                "Asset file not found: '{}'\nExpected at: {}\nHelper: {}()",
-                                asset_ref.path,
-                                asset_path.to_string_lossy(),
-                                helper_name
-                            ),
-                            related_information: None,
-                            tags: None,
-                            code_description: None,
-                            data: None,
-                        };
+                    if let Some(diagnostic) = Self::asset_diagnostic(asset_ref, root) {
                         diagnostics.push(diagnostic);
                     }
                 }
@@ -14724,35 +14770,7 @@ return [
         let root_guard = self.root_path.read().await;
         if let Some(root) = root_guard.as_ref() {
             for asset_ref in &patterns.asset_refs {
-                let (asset_path, helper_name) =
-                    Self::asset_expected_path(asset_ref.helper_type, root, &asset_ref.path);
-
-                if !asset_path.exists() {
-                    let diagnostic = Diagnostic {
-                        range: Range {
-                            start: Position {
-                                line: asset_ref.line,
-                                character: asset_ref.column,
-                            },
-                            end: Position {
-                                line: asset_ref.line,
-                                character: asset_ref.end_column,
-                            },
-                        },
-                        severity: Some(DiagnosticSeverity::WARNING),
-                        code: None,
-                        source: Some("laravel".to_string()),
-                        message: format!(
-                            "Asset file not found: '{}'\nExpected at: {}\nHelper: {}()",
-                            asset_ref.path,
-                            asset_path.to_string_lossy(),
-                            helper_name
-                        ),
-                        related_information: None,
-                        tags: None,
-                        code_description: None,
-                        data: None,
-                    };
+                if let Some(diagnostic) = Self::asset_diagnostic(asset_ref, root) {
                     diagnostics.push(diagnostic);
                 }
             }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13586,6 +13586,35 @@ return [
         out
     }
 
+    /// Resolve an asset-helper reference to the absolute path the helper points
+    /// at, plus the helper's display name. Each helper's base directory follows
+    /// its Laravel convention.
+    fn asset_expected_path(
+        helper_type: laravel_lsp::salsa_impl::AssetHelperType,
+        root: &Path,
+        arg: &str,
+    ) -> (PathBuf, &'static str) {
+        use laravel_lsp::salsa_impl::AssetHelperType;
+        let (base, name) = match helper_type {
+            AssetHelperType::Asset => (root.join("public"), "asset"),
+            AssetHelperType::PublicPath => (root.join("public"), "public_path"),
+            AssetHelperType::Mix => (root.join("public"), "mix"),
+            AssetHelperType::BasePath => (root.to_path_buf(), "base_path"),
+            AssetHelperType::AppPath => (root.join("app"), "app_path"),
+            AssetHelperType::StoragePath => (root.join("storage"), "storage_path"),
+            AssetHelperType::DatabasePath => (root.join("database"), "database_path"),
+            AssetHelperType::LangPath => (root.join("lang"), "lang_path"),
+            AssetHelperType::ConfigPath => (root.join("config"), "config_path"),
+            AssetHelperType::ResourcePath => (root.join("resources"), "resource_path"),
+            // `@vite()` entry paths are PROJECT-ROOT-relative and already begin
+            // with `resources/` — matching Laravel's `Vite::hotAsset`/`chunk`,
+            // which use the entry verbatim. Joining to `root/resources` doubled
+            // the `resources/` segment (issue #46).
+            AssetHelperType::ViteAsset => (root.to_path_buf(), "@vite"),
+        };
+        (base.join(arg), name)
+    }
+
     /// Validate a document (Blade or PHP) and publish diagnostics
     ///
     /// This function uses Salsa-cached patterns for efficient incremental validation:
@@ -14253,24 +14282,8 @@ return [
             let root_guard = self.root_path.read().await;
             if let Some(root) = root_guard.as_ref() {
                 for asset_ref in &patterns.asset_refs {
-                    use laravel_lsp::salsa_impl::AssetHelperType;
-
-                    // Determine base path based on helper type
-                    let (base_path, helper_name) = match asset_ref.helper_type {
-                        AssetHelperType::Asset => (root.join("public"), "asset"),
-                        AssetHelperType::PublicPath => (root.join("public"), "public_path"),
-                        AssetHelperType::Mix => (root.join("public"), "mix"),
-                        AssetHelperType::BasePath => (root.clone(), "base_path"),
-                        AssetHelperType::AppPath => (root.join("app"), "app_path"),
-                        AssetHelperType::StoragePath => (root.join("storage"), "storage_path"),
-                        AssetHelperType::DatabasePath => (root.join("database"), "database_path"),
-                        AssetHelperType::LangPath => (root.join("lang"), "lang_path"),
-                        AssetHelperType::ConfigPath => (root.join("config"), "config_path"),
-                        AssetHelperType::ResourcePath => (root.join("resources"), "resource_path"),
-                        AssetHelperType::ViteAsset => (root.join("resources"), "@vite"),
-                    };
-
-                    let asset_path = base_path.join(&asset_ref.path);
+                    let (asset_path, helper_name) =
+                        Self::asset_expected_path(asset_ref.helper_type, root, &asset_ref.path);
 
                     if !asset_path.exists() {
                         let diagnostic = Diagnostic {
@@ -14680,24 +14693,8 @@ return [
         let root_guard = self.root_path.read().await;
         if let Some(root) = root_guard.as_ref() {
             for asset_ref in &patterns.asset_refs {
-                use laravel_lsp::salsa_impl::AssetHelperType;
-
-                // Determine base path based on helper type
-                let (base_path, helper_name) = match asset_ref.helper_type {
-                    AssetHelperType::Asset => (root.join("public"), "asset"),
-                    AssetHelperType::PublicPath => (root.join("public"), "public_path"),
-                    AssetHelperType::Mix => (root.join("public"), "mix"),
-                    AssetHelperType::BasePath => (root.clone(), "base_path"),
-                    AssetHelperType::AppPath => (root.join("app"), "app_path"),
-                    AssetHelperType::StoragePath => (root.join("storage"), "storage_path"),
-                    AssetHelperType::DatabasePath => (root.join("database"), "database_path"),
-                    AssetHelperType::LangPath => (root.join("lang"), "lang_path"),
-                    AssetHelperType::ConfigPath => (root.join("config"), "config_path"),
-                    AssetHelperType::ResourcePath => (root.join("resources"), "resource_path"),
-                    AssetHelperType::ViteAsset => (root.join("resources"), "@vite"),
-                };
-
-                let asset_path = base_path.join(&asset_ref.path);
+                let (asset_path, helper_name) =
+                    Self::asset_expected_path(asset_ref.helper_type, root, &asset_ref.path);
 
                 if !asset_path.exists() {
                     let diagnostic = Diagnostic {

--- a/laravel-lsp/src/queries/tests/column_positions.rs
+++ b/laravel-lsp/src/queries/tests/column_positions.rs
@@ -222,6 +222,37 @@ fn blade_component_column_positions() {
 }
 
 #[test]
+fn empty_vite_array_entry_survives_blade_extraction() {
+    // End-to-end guard for `@vite([..., ''])`: parse Blade → pull the @vite
+    // directive's arguments → run parse_vite_directive_assets, exactly as the
+    // Salsa path does. The empty trailing entry must survive — it used to be
+    // dropped, so the editor showed no diagnostic for it at all.
+    let blade_code = "@vite(['resources/css/app.css', ''])";
+    let tree = parse_blade(blade_code).expect("Should parse Blade");
+    let lang = language_blade();
+    let patterns =
+        extract_all_blade_patterns(&tree, blade_code, &lang).expect("Should extract patterns");
+
+    let vite = patterns
+        .directives
+        .iter()
+        .find(|d| d.directive_name == "vite")
+        .expect("@vite directive should be extracted");
+    let args = vite.arguments.expect("@vite should carry its arguments");
+
+    let entries = crate::salsa_impl::parse_vite_directive_assets(
+        args,
+        vite.row,
+        vite.column,
+        "vite".len() + 1,
+    );
+    assert!(
+        entries.iter().any(|(p, ..)| p.is_empty()),
+        "empty @vite entry must survive extraction: args={args:?} entries={entries:?}",
+    );
+}
+
+#[test]
 fn livewire_component_column_positions() {
     let blade_code = "<div><livewire:counter /></div>";
     let tree = parse_blade(blade_code).expect("Should parse Blade");

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -532,7 +532,7 @@ pub fn extract_translation_from_echo(php_content: &str) -> Option<(String, usize
 /// - @vite(['resources/css/app.css', 'resources/js/app.js'])
 ///
 /// Returns Vec of (path, line, column, end_column) for each file path
-fn parse_vite_directive_assets(
+pub fn parse_vite_directive_assets(
     args: &str,
     directive_row: usize,
     directive_col: usize,
@@ -570,18 +570,24 @@ fn parse_vite_directive_assets(
 
         if pos < chars.len() {
             let path: String = path_chars.into_iter().collect();
-            if !path.is_empty() {
-                // Calculate column positions for the path content (excluding quotes)
-                // directive_col is where @ starts
-                // directive_len is length of @vite (5)
-                // quote_start is position of opening quote within args (which includes the paren)
-                // +1 to skip the opening quote itself and point to the path content
-                // +1 more because LSP columns are 0-based but we need to account for the @ symbol position
-                let col = (directive_col + directive_len + quote_start + 2) as u32;
-                let end_col = col + path.len() as u32; // Just the path, no quotes
+            // Calculate column positions for the path content (excluding quotes)
+            // directive_col is where @ starts
+            // directive_len is length of @vite (5)
+            // quote_start is position of opening quote within args (which includes the paren)
+            // +1 to skip the opening quote itself and point to the path content
+            // +1 more because LSP columns are 0-based but we need to account for the @ symbol position
+            let col = (directive_col + directive_len + quote_start + 2) as u32;
+            // Empty entries (`@vite('')`) are kept, not dropped: Laravel can't
+            // resolve them and throws at build time, so they must be flagged. A
+            // zero-width range wouldn't render a squiggle, so span the two quote
+            // characters around the (absent) content instead.
+            let (col, end_col) = if path.is_empty() {
+                (col.saturating_sub(1), col + 1)
+            } else {
+                (col, col + path.len() as u32) // Just the path, no quotes
+            };
 
-                results.push((path, directive_row as u32, col, end_col));
-            }
+            results.push((path, directive_row as u32, col, end_col));
             pos += 1; // Move past closing quote
         }
     }

--- a/laravel-lsp/src/tests/asset_path_resolution.rs
+++ b/laravel-lsp/src/tests/asset_path_resolution.rs
@@ -1,6 +1,18 @@
 use crate::LaravelLanguageServer;
-use laravel_lsp::salsa_impl::AssetHelperType;
+use laravel_lsp::salsa_impl::{parse_vite_directive_assets, AssetHelperType, AssetReferenceData};
 use std::path::Path;
+use tower_lsp::lsp_types::DiagnosticSeverity;
+
+/// Minimal asset reference at line 0 for diagnostic tests.
+fn asset_ref(helper: AssetHelperType, path: &str) -> AssetReferenceData {
+    AssetReferenceData {
+        path: path.to_string(),
+        helper_type: helper,
+        line: 0,
+        column: 0,
+        end_column: 5,
+    }
+}
 
 #[test]
 fn vite_entry_is_resolved_relative_to_project_root() {
@@ -36,4 +48,88 @@ fn resource_path_resolves_against_resources() {
     let (path, _) =
         LaravelLanguageServer::asset_expected_path(AssetHelperType::ResourcePath, root, "views");
     assert_eq!(path, Path::new("/project/resources/views"));
+}
+
+// ── Severity follows runtime behavior: @vite throws (ERROR), others degrade (WARNING) ──
+
+#[test]
+fn vite_missing_entry_is_an_error() {
+    // @vite() resolves its entry via Vite::chunk(), which throws ViteException
+    // on a manifest miss — a production 500. So a missing entry is an ERROR.
+    let dir = tempfile::TempDir::new().unwrap();
+    let r = asset_ref(AssetHelperType::ViteAsset, "resources/css/missing.css");
+    let d = LaravelLanguageServer::asset_diagnostic(&r, dir.path())
+        .expect("missing @vite entry must be flagged");
+    assert_eq!(d.severity, Some(DiagnosticSeverity::ERROR));
+}
+
+#[test]
+fn vite_directory_entry_is_an_error() {
+    // A directory is not a manifest file — Vite::chunk still throws. Requiring
+    // is_file() (not just exists) catches `@vite('resources')`.
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join("resources")).unwrap();
+    let r = asset_ref(AssetHelperType::ViteAsset, "resources");
+    let d = LaravelLanguageServer::asset_diagnostic(&r, dir.path())
+        .expect("a directory is not a valid @vite entry");
+    assert_eq!(d.severity, Some(DiagnosticSeverity::ERROR));
+}
+
+#[test]
+fn vite_empty_entry_is_an_error() {
+    // `@vite('')` can't resolve and throws at build time — an ERROR with a
+    // message that names it rather than the confusing "file not found: ''".
+    let dir = tempfile::TempDir::new().unwrap();
+    let r = asset_ref(AssetHelperType::ViteAsset, "");
+    let d = LaravelLanguageServer::asset_diagnostic(&r, dir.path())
+        .expect("empty @vite entry must be flagged");
+    assert_eq!(d.severity, Some(DiagnosticSeverity::ERROR));
+    assert!(
+        d.message.contains("Empty"),
+        "message should name the empty entry: {}",
+        d.message
+    );
+}
+
+#[test]
+fn vite_real_file_is_clean() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let p = dir.path().join("resources/css/app.css");
+    std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+    std::fs::write(&p, "").unwrap();
+    let r = asset_ref(AssetHelperType::ViteAsset, "resources/css/app.css");
+    assert!(LaravelLanguageServer::asset_diagnostic(&r, dir.path()).is_none());
+}
+
+#[test]
+fn asset_helper_miss_is_a_warning_not_error() {
+    // asset('x') just builds a URL; a miss 404s in the browser but the page
+    // still renders, so it's a WARNING — not app-breaking like @vite.
+    let dir = tempfile::TempDir::new().unwrap();
+    let r = asset_ref(AssetHelperType::Asset, "css/missing.css");
+    let d = LaravelLanguageServer::asset_diagnostic(&r, dir.path())
+        .expect("missing asset should be flagged");
+    assert_eq!(d.severity, Some(DiagnosticSeverity::WARNING));
+}
+
+#[test]
+fn asset_helper_existing_file_is_clean() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let p = dir.path().join("public/css/app.css");
+    std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+    std::fs::write(&p, "").unwrap();
+    let r = asset_ref(AssetHelperType::Asset, "css/app.css");
+    assert!(LaravelLanguageServer::asset_diagnostic(&r, dir.path()).is_none());
+}
+
+#[test]
+fn empty_vite_entry_is_parsed_with_a_visible_range() {
+    // The parser keeps empty entries (it used to silently drop them) so the
+    // diagnostic can flag them, and spans the two quote chars so the squiggle
+    // renders instead of collapsing to a zero-width range.
+    let entries = parse_vite_directive_assets("(['app.css', ''])", 0, 0, 5);
+    assert_eq!(entries.len(), 2, "both entries kept: {entries:?}");
+    let (path, _row, col, end_col) = &entries[1];
+    assert_eq!(path, "");
+    assert_eq!(*end_col - *col, 2, "empty entry should span the two quotes");
 }

--- a/laravel-lsp/src/tests/asset_path_resolution.rs
+++ b/laravel-lsp/src/tests/asset_path_resolution.rs
@@ -1,0 +1,39 @@
+use crate::LaravelLanguageServer;
+use laravel_lsp::salsa_impl::AssetHelperType;
+use std::path::Path;
+
+#[test]
+fn vite_entry_is_resolved_relative_to_project_root() {
+    // Laravel's Vite directive treats the entry path as PROJECT-ROOT-relative,
+    // verbatim (Vite::hotAsset → hotUrl + entry; Vite::chunk → manifest[entry]).
+    // `@vite('resources/css/app.scss')` must resolve to
+    // `<root>/resources/css/app.scss` — NOT `<root>/resources/resources/...`
+    // (issue #46: the `resources/` segment was doubled).
+    let root = Path::new("/project");
+    let (path, name) = LaravelLanguageServer::asset_expected_path(
+        AssetHelperType::ViteAsset,
+        root,
+        "resources/css/app.scss",
+    );
+    assert_eq!(path, Path::new("/project/resources/css/app.scss"));
+    assert_eq!(name, "@vite");
+}
+
+#[test]
+fn asset_helper_resolves_against_public() {
+    // Regression guard: asset() stays public/-relative.
+    let root = Path::new("/project");
+    let (path, _) =
+        LaravelLanguageServer::asset_expected_path(AssetHelperType::Asset, root, "css/app.css");
+    assert_eq!(path, Path::new("/project/public/css/app.css"));
+}
+
+#[test]
+fn resource_path_resolves_against_resources() {
+    // Regression guard / contrast: resource_path('views') IS resources-relative,
+    // unlike @vite.
+    let root = Path::new("/project");
+    let (path, _) =
+        LaravelLanguageServer::asset_expected_path(AssetHelperType::ResourcePath, root, "views");
+    assert_eq!(path, Path::new("/project/resources/views"));
+}

--- a/laravel-lsp/src/tests/diagnostic_severity.rs
+++ b/laravel-lsp/src/tests/diagnostic_severity.rs
@@ -1,0 +1,40 @@
+//! Severity follows runtime behavior: a diagnostic is an ERROR only when the
+//! bad value makes Laravel *throw* (a 500). Helpers that degrade silently —
+//! returning a key, null, or false — are WARNINGs. These tests lock in the
+//! cases the severity audit corrected.
+
+use crate::LaravelLanguageServer;
+use tower_lsp::lsp_types::DiagnosticSeverity;
+
+#[test]
+fn missing_dotted_translation_is_a_warning_not_error() {
+    // Translator::get returns the requested key verbatim on a miss — no throw,
+    // the page still renders — so a missing translation is a WARNING. It is
+    // also the SAME severity for `__()`, `trans()`, and `@lang`, which once
+    // disagreed (ERROR for `__()`, WARNING for `@lang`).
+    let check = crate::TranslationCheck {
+        exists: false,
+        is_dotted_key: true,
+        expected_path: Some(std::path::PathBuf::from("/p/lang/en/messages.php")),
+        file_exists: true,
+        nested_key: Some("welcome".to_string()),
+    };
+    let d =
+        LaravelLanguageServer::create_translation_diagnostic("messages.welcome", &check, 0, 0, 5);
+    assert_eq!(d.severity, Some(DiagnosticSeverity::WARNING));
+}
+
+#[test]
+fn missing_non_dotted_translation_stays_information() {
+    // A bare string like `__('Welcome')` is usually a literal default, not a
+    // key reference — the softest visible level (INFORMATION), left unchanged.
+    let check = crate::TranslationCheck {
+        exists: false,
+        is_dotted_key: false,
+        expected_path: None,
+        file_exists: false,
+        nested_key: None,
+    };
+    let d = LaravelLanguageServer::create_translation_diagnostic("Welcome", &check, 0, 0, 5);
+    assert_eq!(d.severity, Some(DiagnosticSeverity::INFORMATION));
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod array_context_detection;
+mod asset_path_resolution;
 mod blade_component_context;
 mod cast_type_context;
 mod class_locator_and_properties;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod asset_path_resolution;
 mod blade_component_context;
 mod cast_type_context;
 mod class_locator_and_properties;
+mod diagnostic_severity;
 mod dynamic_where_sparseness;
 mod generic_type_parsing;
 mod livewire_component_resolution;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -11,3 +11,4 @@ mod rename_integration;
 mod route_binding_resolution;
 mod route_diagnostics;
 mod slot_variable_resolution;
+mod vite_completion_context;

--- a/laravel-lsp/src/tests/vite_completion_context.rs
+++ b/laravel-lsp/src/tests/vite_completion_context.rs
@@ -1,0 +1,94 @@
+use crate::LaravelLanguageServer;
+
+/// Prefix extracted by the `@vite()` completion context at the end of `line`.
+fn prefix(line: &str) -> Option<String> {
+    LaravelLanguageServer::get_vite_call_context(line, line.len() as u32).map(|c| c.prefix)
+}
+
+#[test]
+fn string_form_detected() {
+    assert_eq!(prefix("@vite('reso").as_deref(), Some("reso"));
+    assert_eq!(prefix("@vite(\"reso").as_deref(), Some("reso"));
+}
+
+#[test]
+fn array_first_element_detected() {
+    assert_eq!(prefix("@vite(['reso").as_deref(), Some("reso"));
+    assert_eq!(prefix("@vite([\"reso").as_deref(), Some("reso"));
+}
+
+#[test]
+fn array_subsequent_element_detected() {
+    // The gap (issue): cursor inside the 2nd array element. The opening-pattern
+    // detector stops at the first element's closing quote and returns None.
+    assert_eq!(
+        prefix("@vite(['resources/css/app.css', 'reso").as_deref(),
+        Some("reso"),
+    );
+    assert_eq!(
+        prefix("@vite([\"resources/css/app.css\", \"reso").as_deref(),
+        Some("reso"),
+    );
+}
+
+#[test]
+fn array_third_element_detected() {
+    assert_eq!(
+        prefix("@vite(['a.css', 'b.js', 'reso").as_deref(),
+        Some("reso"),
+    );
+}
+
+#[test]
+fn subsequent_element_reports_correct_start_col() {
+    // `@vite(['a.css', 'reso` — the 2nd string's content starts at index 17.
+    let line = "@vite(['a.css', 'reso";
+    let c = LaravelLanguageServer::get_vite_call_context(line, line.len() as u32).unwrap();
+    assert_eq!(c.prefix, "reso");
+    assert_eq!(c.start_col, 17);
+}
+
+#[test]
+fn not_inside_a_string_returns_none() {
+    // Between elements (after the comma, before the next quote).
+    assert!(prefix("@vite(['a.css', ").is_none());
+    // After the directive is closed.
+    assert!(prefix("@vite(['a.css'])").is_none());
+}
+
+#[test]
+fn vite_entry_files_lists_assets_and_respects_gitignore() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let write = |rel: &str| {
+        let p = root.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, "").unwrap();
+    };
+    std::fs::write(root.join(".gitignore"), "/vendor\n/node_modules\n").unwrap();
+    write("resources/css/app.css");
+    write("resources/js/app.js");
+    write("resources/views/home.blade.php"); // not a Vite asset extension
+    write("vendor/pkg/style.css"); // git-ignored
+    write("node_modules/lib/index.js"); // git-ignored
+
+    let files = LaravelLanguageServer::vite_entry_files(root);
+
+    assert!(
+        files.contains(&"resources/css/app.css".to_string()),
+        "asset under resources/ should be listed: {files:?}",
+    );
+    assert!(files.contains(&"resources/js/app.js".to_string()));
+    assert!(
+        !files.iter().any(|f| f.contains("vendor/")),
+        "vendor/ is git-ignored and must be pruned: {files:?}",
+    );
+    assert!(
+        !files.iter().any(|f| f.contains("node_modules/")),
+        "node_modules/ is git-ignored and must be pruned: {files:?}",
+    );
+    assert!(
+        !files.iter().any(|f| f.ends_with(".blade.php")),
+        "non-asset extensions must be excluded: {files:?}",
+    );
+}


### PR DESCRIPTION
## What

Started as the issue #46 `@vite()` double-`resources/` fix and grew, through review, into a broader correctness pass on asset resolution and diagnostic severity.

### 1. `@vite()` resolves against the project root (fixes #46)
`@vite('resources/css/app.css')` was resolving to `resources/resources/...`. Laravel's `Vite::hotAsset`/`chunk` treat the entry as project-root-relative, verbatim. Fixed the base, and unified **all three** asset-path resolvers (diagnostic, goto-definition, hover) into one `asset_expected_path` brain so they can't drift again. Dropped a dead `asset_helper_label` orphan that disagreed with the brain on `@vite`.

### 2. `@vite()` autocomplete
Completion for both string (`@vite('…')`) and array (`@vite(['…', '…'])`) forms. Lists project asset files via a `.gitignore`-respecting walk (ripgrep's `ignore` crate), editor-side fuzzy filtering.

### 3. `@vite()` severity + empty/directory entries
Every bad `@vite` entry throws `ViteException` in build mode → a production 500, so all are **ERROR** now (was WARNING in the Blade pass, ERROR in the PHP pass — the two diagnostic loops disagreed; now one shared `asset_diagnostic` builder). `@vite` requires a real *file* (`is_file`), catching directory and empty `''` entries that `exists()` let through. Other helpers (`asset()`, `mix()`, …) only yield a dead URL → stay WARNING.

### 4. Diagnostic severity audit (the rule: throws → ERROR, degrades silently → WARNING)
Verified each helper against the framework source:
- **Translation** (`__()`/`trans()`/`@lang`): `Translator::get` returns the key on a miss, no throw → **WARNING** (was ERROR for `__()`, WARNING for `@lang` — inconsistent; now one severity).
- **Pennant** (`@feature`/`Feature::active`): undefined feature returns `false` (dispatches `UnknownFeatureResolved`), no throw → **WARNING**.
- Unchanged (verified they throw → ERROR): `view()`, `route()`, `<x-component>`, `<livewire:>`, `app()` bindings, validation rules. `config()` was already WARNING.

## Tests
1512 passing. New coverage: asset severity/detection (vite missing/dir/empty → ERROR, asset miss → WARNING, valid → clean), empty-entry parsing, translation severity. `cargo clippy --all-targets -- -D warnings` and `cargo fmt` clean.