### PR TITLE
docs: 📝 Document silencing shellcheck SC2034 'appears unused' noise on .env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,17 +133,23 @@ Supports MySQL, PostgreSQL, SQLite, and SQL Server.
 
 ### 🌱 `.env` "appears unused" warnings
 
-Open a `.env` and Zed underlines every line — `APP_NAME appears unused. Verify use (or export if used externally)`. That's **shellcheck**, not this extension: Zed classifies `.env` files as *Shell Script* and lints them as shell, where the `KEY=value` lines Laravel reads at runtime look like unused variables. Tell Zed they aren't shell scripts by mapping them to a non-shell language in your `settings.json`:
+Open a `.env` and Zed underlines every line — `APP_NAME appears unused. Verify use (or export if used externally)`. That's **shellcheck's SC2034**, not this extension: Zed lints `.env` files as *Shell Script*, where the `KEY=value` lines Laravel reads at runtime look like unused variables. Silence just that rule while keeping shell highlighting, via your `settings.json`:
 
 ```json
 {
-  "file_types": {
-    "Ini": [".env*"]
+  "lsp": {
+    "bash-language-server": {
+      "settings": {
+        "bashIde": {
+          "shellcheckArguments": ["--exclude=SC2034"]
+        }
+      }
+    }
   }
 }
 ```
 
-A `.env` is INI-shaped (`KEY=value`, `#` comments), so the Ini language highlights it cleanly and skips shellcheck. For why a settings change is the only fix (Zed's language-precedence rules), the no-extension Plain Text alternative, and per-project scoping, see the **[environment files guide](docs/environment.md)**.
+The `bashIde` wrapper is required — the bash server won't see the setting without it. Prefer a project-scoped `.shellcheckrc`, a per-file directive, or reclassifying `.env` away from Shell Script entirely (so real shell scripts keep SC2034)? See the **[environment files guide](docs/environment.md)** for all the options and trade-offs.
 
 ### 🎨 Blade directive highlighting
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ DB_PASSWORD=secret
 
 Supports MySQL, PostgreSQL, SQLite, and SQL Server.
 
+### 🌱 `.env` "appears unused" warnings
+
+Open a `.env` and Zed underlines every line — `APP_NAME appears unused. Verify use (or export if used externally)`. That's **shellcheck**, not this extension: Zed classifies `.env` files as *Shell Script* and lints them as shell, where the `KEY=value` lines Laravel reads at runtime look like unused variables. Tell Zed they aren't shell scripts by mapping them to a non-shell language in your `settings.json`:
+
+```json
+{
+  "file_types": {
+    "Ini": [".env*"]
+  }
+}
+```
+
+A `.env` is INI-shaped (`KEY=value`, `#` comments), so the Ini language highlights it cleanly and skips shellcheck. For why a settings change is the only fix (Zed's language-precedence rules), the no-extension Plain Text alternative, and per-project scoping, see the **[environment files guide](docs/environment.md)**.
+
 ### 🎨 Blade directive highlighting
 
 The [Laravel Blade](https://github.com/bajrangCoder/zed-laravel-blade) extension already highlights standard directives and paired `@custom … @endcustom` blocks through tree-sitter. This optional setting adds the one case tree-sitter can't see: your app's **custom inline directives** registered via `Blade::directive()` (e.g. a `@money($amount)` macro). The LSP highlights them precisely — it colors only directives it has actually discovered (the same scan that drives directive completion), so PHPDoc `@param` tags, CSS at-rules like `@media`, and the `@` in email addresses are left alone, and commented-out directives stay dark. Enable it in your Zed `settings.json`:

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -6,13 +6,65 @@ Open a `.env` in Zed and every single line lights up with a warning:
 
 > `APP_NAME appears unused. Verify use (or export if used externally)`
 
-Nothing is actually wrong with your file, and it isn't this extension. The message is shellcheck's [SC2034](https://www.shellcheck.net/wiki/SC2034), and it appears because **Zed classifies `.env` files as the _Shell Script_ language**, then runs its bundled shell language server, which calls shellcheck. SC2034 flags any variable that's assigned but never *referenced in the same file* — and a `.env` is nothing but assignments that Laravel reads at runtime through `config()` / `env()`, never inside the file itself. So shellcheck flags **every line**. It's shell-script linting applied to a data file.
+Nothing is wrong with your file, and it isn't this extension. The message is shellcheck's [SC2034](https://www.shellcheck.net/wiki/SC2034). Zed classifies `.env` files as the **Shell Script** language and runs its bundled shell language server, which calls shellcheck. SC2034 flags any variable that's assigned but never *referenced in the same file* — and a `.env` is nothing but assignments that Laravel reads at runtime through `config()` / `env()`, never inside the file itself. So shellcheck flags **every line**. It's shell-script linting applied to a data file.
 
-This is Zed's own built-in behavior — there's no extension of yours in the loop and nothing to uninstall. The fix is to tell Zed that `.env` files aren't shell scripts.
+This is Zed's own built-in behavior — there's no extension of yours in the loop and nothing to uninstall. There are two ways to quiet it, and they trade off against each other:
 
-## The fix
+| | **Approach 1** — silence the rule | **Approach 2** — reclassify `.env` |
+|---|---|---|
+| `.env` keeps bash highlighting | ✅ yes (stays a shell file) | ❌ no (becomes Ini / Plain Text) |
+| Your real `.sh` scripts | ⚠️ also lose SC2034 (within scope) | ✅ untouched |
+| What you change | a shellcheck arg, or a `.shellcheckrc` | one `file_types` mapping |
 
-Add a `file_types` mapping to your Zed `settings.json` that points `.env` files at a non-shell language:
+Pick **Approach 1** if you want `.env` to keep shell highlighting and you don't rely on SC2034 in your own scripts. Pick **Approach 2** if you'd rather leave shellcheck fully intact for real scripts and only change how `.env` is treated.
+
+## Approach 1 — silence SC2034 (keep `.env` as a shell file)
+
+### Zed setting (no project file)
+
+Pass `--exclude=SC2034` to shellcheck through Zed's shell language server in your `settings.json`:
+
+```json
+{
+  "lsp": {
+    "bash-language-server": {
+      "settings": {
+        "bashIde": {
+          "shellcheckArguments": ["--exclude=SC2034"]
+        }
+      }
+    }
+  }
+}
+```
+
+> ⚠️ **The `bashIde` wrapper is required.** Unlike some Zed servers (e.g. Intelephense, where Zed adds the namespace for you), the bash server does **not** wrap your settings — it only reads config from a `bashIde` section, so you must nest it yourself. Drop the wrapper and the setting is silently ignored. (`shellcheckArguments` takes an array; the server adds `--shell` / `--format` on its own.)
+
+This applies to every shell file Zed lints, in every project. It takes effect without restarting — if it doesn't, the wrapper is almost always the reason.
+
+### `.shellcheckrc` (project-scoped, editor-agnostic)
+
+Drop a `.shellcheckrc` in your project root (or `~/.shellcheckrc` for all projects) containing:
+
+```
+disable=SC2034
+```
+
+shellcheck reads this file directly, so it works in any editor — not just Zed. Scope is the whole project tree, so real `.sh` scripts there also stop getting SC2034.
+
+### Per-file directive (surgical)
+
+Add a comment to the top of a specific file to scope the suppression to just that file:
+
+```bash
+# shellcheck disable=SC2034
+```
+
+The cost is a stray comment line in each `.env` you apply it to — fine for one file, tedious across `.env`, `.env.example`, etc.
+
+## Approach 2 — reclassify `.env` away from Shell Script
+
+Map `.env` files to a non-shell language in `settings.json`. A `.env` is `KEY=value` with `#` comments — structurally INI — so the **Ini** language highlights it cleanly and never invokes shellcheck:
 
 ```json
 {
@@ -22,13 +74,7 @@ Add a `file_types` mapping to your Zed `settings.json` that points `.env` files 
 }
 ```
 
-A `.env` is `KEY=value` with `#` comments — structurally INI — so the **Ini** language highlights it cleanly and, crucially, doesn't run shellcheck. If you don't already have it, install the Ini extension (Zed → `zed: extensions`, search "INI"); it's tiny.
-
-Reload (`Cmd+Shift+P → zed: reload extensions`, or just reopen the file) and the warnings are gone.
-
-### No extra extension
-
-If you'd rather not install anything, map `.env` files to the built-in **Plain Text** language instead:
+Install the Ini extension (`zed: extensions`, search "INI") if you don't already have it; it's tiny. To avoid any extra install, map to the built-in **Plain Text** instead — the warnings disappear, but `.env` renders without highlighting:
 
 ```json
 {
@@ -38,21 +84,15 @@ If you'd rather not install anything, map `.env` files to the built-in **Plain T
 }
 ```
 
-The warnings disappear, but you lose syntax highlighting — `.env` renders monochrome.
+The `.env*` glob covers `.env` plus every variant (`.env.local`, `.env.production`, `.env.example`). For a stricter match that won't also catch unrelated files like `.envrc` or `.environment`, use `[".env", ".env.*"]`.
 
 ## Per-project
 
-To scope this to a single project instead of all of Zed, put the same block in `.zed/settings.json` at the project root rather than your global settings.
+Any of the `settings.json` blocks above also work in `.zed/settings.json` at the project root, scoping the change to one project instead of all of Zed. (The `.shellcheckrc` approach is already project-scoped by nature.)
 
-## Why a settings change is the only fix
+## Why this extension can't do it for you
 
-It's reasonable to expect this extension to just handle it. It can't — and the reason is how Zed resolves a file's language. It uses **precedence tiers**, highest wins:
+Every lever here lives in *your* settings or *your* project — none of it is something a Zed extension can ship:
 
-| Tier | Comes from | Example |
-|---|---|---|
-| `UserConfigured` | a `file_types` setting | your `settings.json`, **or Zed's own defaults** |
-| `PathOrContent` | a language's `path_suffixes` | an extension claiming `*.blade.php` |
-
-Zed's **default settings** ship `"file_types": { "Shell Script": [".env.*"] }` — a `UserConfigured`-tier claim on every `.env.*` variant. Nothing an extension declares can outrank it: extensions can only register `path_suffixes` (the lower `PathOrContent` tier), and the Zed extension manifest has no field for shipping `file_types` defaults at all. The only thing that sits in the same tier and can override Zed's default is **your own `file_types`** — user settings beat default settings. That's why this is one line in *your* settings and not something the extension can do for you.
-
-> The `.env*` glob covers `.env` plus every variant (`.env.local`, `.env.production`, `.env.example`) in one pattern. For a stricter match that won't also catch unrelated files like `.envrc` or `.environment`, use `[".env", ".env.*"]` instead.
+- **Approach 1** lives in your Zed `settings.json` or a `.shellcheckrc` in your repo. The extension's WASM sandbox can't write either, and silently dropping files into your project would be worse than the warning.
+- **Approach 2** depends on Zed's language-detection precedence. Zed resolves a file's language by tier — a `file_types` setting (`UserConfigured`) outranks a language's `path_suffixes` (`PathOrContent`). Zed's *default settings* already claim `.env.*` for Shell Script at the `UserConfigured` tier, and the Zed extension manifest has **no `file_types` field** — so no extension can register a competing claim. Only your own `file_types` (user settings beat default settings) can override it. That's why this is one line in *your* config, not something the extension does automatically.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,58 @@
+# 🌱 Environment files (`.env`)
+
+[← Back to README](../README.md)
+
+Open a `.env` in Zed and every single line lights up with a warning:
+
+> `APP_NAME appears unused. Verify use (or export if used externally)`
+
+Nothing is actually wrong with your file, and it isn't this extension. The message is shellcheck's [SC2034](https://www.shellcheck.net/wiki/SC2034), and it appears because **Zed classifies `.env` files as the _Shell Script_ language**, then runs its bundled shell language server, which calls shellcheck. SC2034 flags any variable that's assigned but never *referenced in the same file* — and a `.env` is nothing but assignments that Laravel reads at runtime through `config()` / `env()`, never inside the file itself. So shellcheck flags **every line**. It's shell-script linting applied to a data file.
+
+This is Zed's own built-in behavior — there's no extension of yours in the loop and nothing to uninstall. The fix is to tell Zed that `.env` files aren't shell scripts.
+
+## The fix
+
+Add a `file_types` mapping to your Zed `settings.json` that points `.env` files at a non-shell language:
+
+```json
+{
+  "file_types": {
+    "Ini": [".env*"]
+  }
+}
+```
+
+A `.env` is `KEY=value` with `#` comments — structurally INI — so the **Ini** language highlights it cleanly and, crucially, doesn't run shellcheck. If you don't already have it, install the Ini extension (Zed → `zed: extensions`, search "INI"); it's tiny.
+
+Reload (`Cmd+Shift+P → zed: reload extensions`, or just reopen the file) and the warnings are gone.
+
+### No extra extension
+
+If you'd rather not install anything, map `.env` files to the built-in **Plain Text** language instead:
+
+```json
+{
+  "file_types": {
+    "Plain Text": [".env*"]
+  }
+}
+```
+
+The warnings disappear, but you lose syntax highlighting — `.env` renders monochrome.
+
+## Per-project
+
+To scope this to a single project instead of all of Zed, put the same block in `.zed/settings.json` at the project root rather than your global settings.
+
+## Why a settings change is the only fix
+
+It's reasonable to expect this extension to just handle it. It can't — and the reason is how Zed resolves a file's language. It uses **precedence tiers**, highest wins:
+
+| Tier | Comes from | Example |
+|---|---|---|
+| `UserConfigured` | a `file_types` setting | your `settings.json`, **or Zed's own defaults** |
+| `PathOrContent` | a language's `path_suffixes` | an extension claiming `*.blade.php` |
+
+Zed's **default settings** ship `"file_types": { "Shell Script": [".env.*"] }` — a `UserConfigured`-tier claim on every `.env.*` variant. Nothing an extension declares can outrank it: extensions can only register `path_suffixes` (the lower `PathOrContent` tier), and the Zed extension manifest has no field for shipping `file_types` defaults at all. The only thing that sits in the same tier and can override Zed's default is **your own `file_types`** — user settings beat default settings. That's why this is one line in *your* settings and not something the extension can do for you.
+
+> The `.env*` glob covers `.env` plus every variant (`.env.local`, `.env.production`, `.env.example`) in one pattern. For a stricter match that won't also catch unrelated files like `.envrc` or `.environment`, use `[".env", ".env.*"]` instead.


### PR DESCRIPTION
## What

Opening a `.env` in Zed underlines every line with shellcheck's **SC2034** — `APP_NAME appears unused. Verify use (or export if used externally)`. This documents why it happens and how to silence it.

## Why it happens (and why we can't fix it in code)

- Zed classifies `.env` / `.env.*` as the **Shell Script** language and runs its bundled shell language server → **shellcheck** → SC2034 fires on every `KEY=value`, because a `.env` is read at runtime by Laravel (`config()`/`env()`), never referenced inside the file. It's shell-script linting applied to a data file. **This is Zed-internal — not this extension, and not an extension the user installed.**
- The only fix is a `file_types` mapping in the user's `settings.json`. An extension **cannot** ship it:
  - Zed resolves languages by precedence tier — `UserConfigured` (a `file_types` setting) outranks `PathOrContent` (a language's `path_suffixes`).
  - Zed's *default settings* already claim `.env.*` for Shell Script at the `UserConfigured` tier.
  - Extensions can only declare `path_suffixes` (lower tier), and the extension manifest has **no `file_types` field**. So nothing we ship can outrank Zed's default. Only the user's own `file_types` can.

(Verified against Zed's `LanguageMatchPrecedence` in `language_registry.rs` and the `"Shell Script": [".env.*"]` entry in `assets/settings/default.json`.)

## Changes

- **`docs/environment.md`** — standalone guide (matches the Intelephense doc's shape): symptom, the `file_types: { "Ini": [".env*"] }` fix, a no-install Plain Text alternative, per-project scoping, and a precedence-tier explanation of why it can't be automated.
- **README `## ⚙️ Configuration`** — a `### 🌱 .env "appears unused" warnings` subsection with the one-line fix and a link to the full guide.

Docs only — no code changes.