### PR TITLE
feat: ✨ Capture magic call/property sites + data model (semantic-index M2)

### DIFF
--- a/laravel-lsp/queries/php.scm
+++ b/laravel-lsp/queries/php.scm
@@ -2221,3 +2221,28 @@
     default_value: (encapsed_string
       (string_content) @feature_name_value))
   (#eq? @_feature_name_prop "$name"))
+
+; ============================================================================
+; Pattern 40: Property-form member access ($user->email, $this->profile)
+; ============================================================================
+; Matches: $user->email          (potential accessor / column)
+;          $user->posts          (potential relationship)
+;          $this->profile        (typed-property access)
+;          $user?->name          (nullsafe form)
+;
+; Captures the member NAME node; the receiver expression (object) and the
+; nullsafe-ness are read from its parent in `extract_all_php_patterns`. This
+; is the property-form half of the magic-member capture (M2 of the semantic-
+; index plan) — method calls ($user->posts()) are `member_call_expression`
+; and are already covered by builder-chain extraction, so they are NOT matched
+; here. Receiver resolution + classification happen later (M3); this query is
+; the raw capture only.
+;
+; `name: (name)` restricts to static identifiers — dynamic access like
+; `$user->$prop` (name is a variable) is intentionally excluded.
+
+(member_access_expression
+  name: (name) @member_access_name)
+
+(nullsafe_member_access_expression
+  name: (name) @member_access_name)

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -14941,9 +14941,11 @@ return [
             PatternAtPosition::Asset(asset) => self.hover_for_asset(&asset).await,
             PatternAtPosition::Url(url) => self.hover_for_url(&url.path).await,
             // Patterns we don't yet surface in hover — silently drop.
+            // `MemberAccess` gets semantic hover cards in M6.
             PatternAtPosition::Directive(_)
             | PatternAtPosition::Action(_)
-            | PatternAtPosition::Feature(_) => return None,
+            | PatternAtPosition::Feature(_)
+            | PatternAtPosition::MemberAccess(_) => return None,
         };
 
         if rendered.is_empty() {
@@ -15730,6 +15732,9 @@ fn pattern_range_at(
         laravel_lsp::salsa_impl::PatternAtPosition::Url(u) => (u.line, u.column, u.end_column),
         laravel_lsp::salsa_impl::PatternAtPosition::Action(a) => (a.line, a.column, a.end_column),
         laravel_lsp::salsa_impl::PatternAtPosition::Feature(f) => (f.line, f.column, f.end_column),
+        laravel_lsp::salsa_impl::PatternAtPosition::MemberAccess(m) => {
+            (m.line, m.column, m.end_column)
+        }
     };
     Some(Range {
         start: Position {
@@ -16991,6 +16996,11 @@ impl LanguageServer for LaravelLanguageServer {
             PatternAtPosition::Feature(feature) => {
                 debug!("Laravel: Found feature: {}", feature.feature_name);
                 self.create_feature_location_from_salsa(&feature).await
+            }
+            PatternAtPosition::MemberAccess(_) => {
+                // Goto-definition for magic members (the inheritance-resolved
+                // declaration locator) lands in M4.
+                None
             }
         };
 

--- a/laravel-lsp/src/queries.rs
+++ b/laravel-lsp/src/queries.rs
@@ -336,6 +336,35 @@ pub struct FeatureNamePropertyMatch<'a> {
     pub end_column: usize,
 }
 
+/// Represents a property-form member access (`$user->email`, `$this->profile`,
+/// `$user?->name`) in PHP code.
+///
+/// Method calls (`$user->posts()`) are NOT captured here — those are
+/// `member_call_expression` nodes already covered by builder-chain extraction.
+/// This is the raw capture only: resolving the receiver to a declaring class
+/// and classifying the member (scope / accessor / relationship / column /
+/// dynamic finder) happens later (M3 of the semantic-index plan).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemberAccessMatch<'a> {
+    /// The accessed member name (e.g. `email`, `posts`, `profile`).
+    pub member: &'a str,
+    /// Raw source text of the receiver expression (e.g. `$user`, `$this`).
+    pub receiver: &'a str,
+    /// Byte range of the receiver expression — lets the M3 resolver locate the
+    /// receiver node in the live tree to run `var_type::resolve`.
+    pub receiver_byte_start: usize,
+    pub receiver_byte_end: usize,
+    /// Whether the access used the nullsafe operator (`?->`).
+    pub is_nullsafe: bool,
+    /// Byte range of the member name node.
+    pub byte_start: usize,
+    pub byte_end: usize,
+    /// Position of the member name (0-based — repo convention).
+    pub row: usize,
+    pub column: usize,
+    pub end_column: usize,
+}
+
 // ============================================================================
 // Extracted Patterns - Result structs for single-pass extraction
 // ============================================================================
@@ -359,6 +388,9 @@ pub struct ExtractedPhpPatterns<'a> {
     pub feature_calls: Vec<FeatureMatch<'a>>,
     /// Custom $name property values from feature classes
     pub feature_name_properties: Vec<FeatureNamePropertyMatch<'a>>,
+    /// Property-form member accesses (`$user->email`, `$this->profile`).
+    /// Raw capture for the semantic-index magic-member work (M2).
+    pub member_accesses: Vec<MemberAccessMatch<'a>>,
 }
 
 /// Represents PHP content inside Blade echo statements {{ ... }}
@@ -783,6 +815,33 @@ pub fn extract_all_php_patterns<'a>(
                         column: start_pos.column,
                         end_column: end_pos.column,
                     });
+            }
+
+            // Property-form member access ($user->email, $this->profile).
+            // `node` is the member NAME; its parent is the
+            // (nullsafe_)member_access_expression carrying the receiver.
+            "member_access_name" => {
+                let Some(parent) = node.parent() else {
+                    continue;
+                };
+                let Some(object) = parent.child_by_field_name("object") else {
+                    continue;
+                };
+                let Ok(receiver) = object.utf8_text(source_bytes) else {
+                    continue;
+                };
+                result.member_accesses.push(MemberAccessMatch {
+                    member: text,
+                    receiver,
+                    receiver_byte_start: object.start_byte(),
+                    receiver_byte_end: object.end_byte(),
+                    is_nullsafe: parent.kind() == "nullsafe_member_access_expression",
+                    byte_start: node.start_byte(),
+                    byte_end: node.end_byte(),
+                    row: start_pos.row,
+                    column: start_pos.column,
+                    end_column: end_pos.column,
+                });
             }
 
             // Ignore other captures (function_name, class_name, etc. used for matching)

--- a/laravel-lsp/src/queries/tests/member_access_extraction.rs
+++ b/laravel-lsp/src/queries/tests/member_access_extraction.rs
@@ -1,0 +1,139 @@
+//! Tests for property-form member-access capture (`$user->email`,
+//! `$this->profile`, `$user?->name`) in `extract_all_php_patterns`.
+//!
+//! This is the raw-capture half of the magic-member semantic-index work (M2).
+//! Resolution/classification of the receiver is a later milestone, so these
+//! tests assert only what the capture layer knows: the member name, the raw
+//! receiver text + byte range, nullsafe-ness, and the member-name position.
+
+use super::super::*;
+use crate::parser::{language_php, parse_php};
+
+/// Extract member accesses from PHP source. The returned matches borrow
+/// `php` (not the tree), so dropping the tree here is fine.
+fn extract(php: &str) -> Vec<MemberAccessMatch<'_>> {
+    let tree = parse_php(php).expect("Should parse PHP");
+    let lang = language_php();
+    extract_all_php_patterns(&tree, php, &lang)
+        .expect("Should extract patterns")
+        .member_accesses
+}
+
+#[test]
+fn captures_simple_property_access() {
+    let matches = extract("<?php\n$email = $user->email;\n");
+    assert_eq!(matches.len(), 1);
+    let m = &matches[0];
+    assert_eq!(m.member, "email");
+    assert_eq!(m.receiver, "$user");
+    assert!(!m.is_nullsafe);
+}
+
+#[test]
+fn captures_this_property_access() {
+    let php = r#"<?php
+class Foo {
+    public function bar() {
+        return $this->profile;
+    }
+}
+"#;
+    let matches = extract(php);
+    let profile = matches
+        .iter()
+        .find(|m| m.member == "profile")
+        .expect("profile access");
+    assert_eq!(profile.receiver, "$this");
+}
+
+#[test]
+fn captures_nullsafe_access() {
+    let matches = extract("<?php\n$name = $user?->name;\n");
+    assert_eq!(matches.len(), 1);
+    let m = &matches[0];
+    assert_eq!(m.member, "name");
+    assert_eq!(m.receiver, "$user");
+    assert!(m.is_nullsafe, "?-> should set is_nullsafe");
+}
+
+#[test]
+fn ignores_method_calls() {
+    // `$user->posts()` is a member_call_expression, not a member_access_expression.
+    // It is covered by builder-chain extraction, never by this capture.
+    let php = r#"<?php
+$posts = $user->posts();
+$active = User::query()->active();
+"#;
+    let matches = extract(php);
+    assert!(
+        matches.is_empty(),
+        "method calls must not be captured as property accesses, got: {:?}",
+        matches.iter().map(|m| m.member).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ignores_dynamic_member_names() {
+    // `$user->$prop` — the name is a variable, not a static identifier.
+    let matches = extract("<?php\n$value = $user->$prop;\n");
+    assert!(
+        matches.is_empty(),
+        "dynamic member names must not be captured"
+    );
+}
+
+#[test]
+fn captures_chained_property_reads_at_each_hop() {
+    // `$user->profile->name` is two member accesses: `profile` on `$user`,
+    // and `name` on `$user->profile`. Both are worth indexing.
+    let matches = extract("<?php\n$n = $user->profile->name;\n");
+    assert_eq!(matches.len(), 2);
+
+    let profile = matches
+        .iter()
+        .find(|m| m.member == "profile")
+        .expect("profile hop");
+    assert_eq!(profile.receiver, "$user");
+
+    let name = matches
+        .iter()
+        .find(|m| m.member == "name")
+        .expect("name hop");
+    assert_eq!(name.receiver, "$user->profile");
+}
+
+#[test]
+fn member_name_position_points_at_member_not_receiver() {
+    // Line layout (0-based rows): row 0 is `<?php`, row 1 is the access.
+    let php = "<?php\n$x = $user->email;\n";
+    let matches = extract(php);
+    let m = &matches[0];
+
+    assert_eq!(m.row, 1, "access is on row 1");
+    // `$x = $user->` is 12 chars (cols 0..=11); `email` starts at col 12.
+    assert_eq!(
+        m.column, 12,
+        "column should point at the member name 'email'"
+    );
+    assert_eq!(m.end_column, 17, "end_column should be one past 'email'");
+
+    // Receiver byte range should slice `$user` out of the source.
+    assert_eq!(&php[m.receiver_byte_start..m.receiver_byte_end], "$user");
+    // Member byte range should slice `email`.
+    assert_eq!(&php[m.byte_start..m.byte_end], "email");
+}
+
+#[test]
+fn captures_multiple_accesses_in_one_file() {
+    let php = r#"<?php
+$a = $user->email;
+$b = $post->title;
+$c = $this->config;
+"#;
+    let matches = extract(php);
+    let members: Vec<&str> = matches.iter().map(|m| m.member).collect();
+    assert_eq!(members.len(), 3);
+    assert!(members.contains(&"email"));
+    assert!(members.contains(&"title"));
+    assert!(members.contains(&"config"));
+}

--- a/laravel-lsp/src/queries/tests/mod.rs
+++ b/laravel-lsp/src/queries/tests/mod.rs
@@ -8,5 +8,6 @@ mod call_site_variants;
 mod column_positions;
 mod extraction_performance;
 mod feature_pattern_extraction;
+mod member_access_extraction;
 mod middleware_extraction;
 mod php_pattern_extraction;

--- a/laravel-lsp/src/references.rs
+++ b/laravel-lsp/src/references.rs
@@ -100,10 +100,13 @@ pub fn classify_pattern_at_cursor(
             Some(SymbolRef::View(view_name))
         }
         // Patterns that don't yet participate in cross-file references.
+        // `MemberAccess` is captured (M2) but not yet resolved/classified —
+        // it gets armed for find-references in M4.
         PatternAtPosition::Asset(_)
         | PatternAtPosition::Url(_)
         | PatternAtPosition::Action(_)
-        | PatternAtPosition::Feature(_) => None,
+        | PatternAtPosition::Feature(_)
+        | PatternAtPosition::MemberAccess(_) => None,
     }
 }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2269,6 +2269,89 @@ pub struct FeatureReferenceData {
     pub end_column: u32,
 }
 
+/// Confidence that a captured member-access site's receiver was resolved to a
+/// concrete declaring class.
+///
+/// Populated by M3's receiver resolution; at capture time (M2) every site is
+/// [`Confidence::Unresolved`]. The tiers mirror the plan's resolution tiers:
+/// HIGH (static call, `(new X)`, typed param, `@var`, simple local assignment),
+/// MEDIUM (multi-hop reassignment / indirect flow), LOW (foreach iter var,
+/// typed property, return chain — captured but not yet resolvable; widened in
+/// later work, never guessed).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
+pub enum Confidence {
+    High,
+    Medium,
+    Low,
+    /// Not yet run through the resolver — the state at capture time (M2).
+    #[default]
+    Unresolved,
+}
+
+/// The kind of member a resolved access maps to.
+///
+/// `None` on the reference until M3 classifies the site against the
+/// class-hierarchy index. The Eloquent-magic variants are what make
+/// find-references / rename / hover magic-aware; `PlainMember` is a generic
+/// (non-magic) property on a resolved class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum MagicMemberKind {
+    /// Eloquent local scope accessed via `__call` (`scopeActive` → `->active()`).
+    Scope,
+    /// Eloquent accessor / attribute (`getFullNameAttribute` / `Attribute`).
+    Accessor,
+    /// Eloquent relationship method accessed as a property (`$user->posts`).
+    Relationship,
+    /// Database column surfaced as a model attribute (`$user->email`).
+    Column,
+    /// Dynamic finder (`User::whereEmail(...)` → `where('email', ...)`).
+    DynamicFinder,
+    /// Generic (non-magic) property on a resolved class.
+    PlainMember,
+}
+
+/// A property-form member access (`$user->email`, `$this->profile`,
+/// `$user?->name`) captured for the magic-member semantic index.
+///
+/// **Capture-only at M2.** The `member`, `receiver`, byte ranges, nullsafe
+/// flag, and position fields are populated now. The resolution fields
+/// (`declaring_fqcn`, `kind`, `confidence`) are a reserved scaffold M3 fills
+/// once receiver resolution + `ClassView` classification land — until then
+/// `declaring_fqcn`/`kind` are `None` and `confidence` is
+/// [`Confidence::Unresolved`]. Wiring the index here once keeps M3 a pure
+/// "fill in resolution" diff with no structural churn.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MemberAccessReferenceData {
+    /// The accessed member name (`email`, `posts`, `profile`).
+    pub member: String,
+    /// Raw source text of the receiver expression (`$user`, `$this`).
+    pub receiver: String,
+    /// Byte range of the receiver expression in the file — lets the M3
+    /// resolver locate the receiver node in the live tree for
+    /// `var_type::resolve`.
+    pub receiver_byte_start: usize,
+    pub receiver_byte_end: usize,
+    /// Whether the access used the nullsafe operator (`?->`).
+    pub is_nullsafe: bool,
+    /// Position of the member name (0-based — repo convention).
+    pub line: u32,
+    pub column: u32,
+    pub end_column: u32,
+    // ─── Reserved resolution scaffold (filled by M3) ───
+    /// Declaring class FQCN once the receiver resolves (inheritance/trait
+    /// resolved). `None` until M3.
+    #[serde(default)]
+    pub declaring_fqcn: Option<String>,
+    /// What kind of member this resolves to. `None` until M3 classifies.
+    #[serde(default)]
+    pub kind: Option<MagicMemberKind>,
+    /// Resolution confidence. [`Confidence::Unresolved`] until M3.
+    #[serde(default)]
+    pub confidence: Confidence,
+}
+
 /// Laravel configuration data for transfer across async boundaries
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LaravelConfigData {
@@ -2783,6 +2866,16 @@ pub struct ParsedPatternsData {
     /// populates chains properly.
     #[serde(default)]
     pub chains: Vec<Arc<crate::query_chain::BuilderChain>>,
+    /// Property-form member accesses (`$user->email`, `$this->profile`)
+    /// captured for the magic-member semantic index (M2). Like `chains`,
+    /// stored here rather than as a `ParsedPatterns` Salsa field because that
+    /// struct is at its 12-element tuple-Hash cap.
+    ///
+    /// `#[serde(default)]` so older disk-cache entries (written before this
+    /// field existed) deserialize with an empty list; the next edit re-runs
+    /// extraction and repopulates.
+    #[serde(default)]
+    pub member_access_refs: Vec<Arc<MemberAccessReferenceData>>,
     /// Sorted index of all patterns by (line, column) for O(log n) lookup.
     /// Skipped during (de)serialization — when loading from the on-disk
     /// cache, the caller must invoke `build_position_index()` to rebuild
@@ -2812,6 +2905,7 @@ pub enum PatternAtPosition {
     Url(Arc<UrlReferenceData>),
     Action(Arc<ActionReferenceData>),
     Feature(Arc<FeatureReferenceData>),
+    MemberAccess(Arc<MemberAccessReferenceData>),
 }
 
 impl ParsedPatternsData {
@@ -2944,6 +3038,15 @@ impl ParsedPatternsData {
                 column: feature.column,
                 end_column: feature.end_column,
                 pattern: PatternAtPosition::Feature(feature.clone()),
+            });
+        }
+
+        for member in &self.member_access_refs {
+            entries.push(PositionEntry {
+                line: member.line,
+                column: member.column,
+                end_column: member.end_column,
+                pattern: PatternAtPosition::MemberAccess(member.clone()),
             });
         }
 
@@ -5143,6 +5246,7 @@ impl SalsaActor {
         let mut url_refs = Vec::new();
         let mut action_refs = Vec::new();
         let mut feature_refs = Vec::new();
+        let mut member_access_refs: Vec<Arc<MemberAccessReferenceData>> = Vec::new();
         let mut chains: Vec<Arc<crate::query_chain::BuilderChain>> = Vec::new();
 
         // Skip the full-file PHP parse for Blade files — same rationale as
@@ -5192,6 +5296,27 @@ impl SalsaActor {
                             line: f.row as u32,
                             column: f.column as u32,
                             end_column: f.end_column as u32,
+                        }));
+                    }
+
+                    // Property-form member-access sites (`$user->email`).
+                    // Captured raw here (M2); the receiver-resolution fields
+                    // stay at their `None`/`Unresolved` defaults until M3.
+                    // Blade-embedded member access is intentionally deferred —
+                    // resolving Blade-scope receivers is M3 work.
+                    for m in php_patterns.member_accesses {
+                        member_access_refs.push(Arc::new(MemberAccessReferenceData {
+                            member: m.member.to_string(),
+                            receiver: m.receiver.to_string(),
+                            receiver_byte_start: m.receiver_byte_start,
+                            receiver_byte_end: m.receiver_byte_end,
+                            is_nullsafe: m.is_nullsafe,
+                            line: m.row as u32,
+                            column: m.column as u32,
+                            end_column: m.end_column as u32,
+                            declaring_fqcn: None,
+                            kind: None,
+                            confidence: Confidence::Unresolved,
                         }));
                     }
                 }
@@ -5339,6 +5464,7 @@ impl SalsaActor {
             action_refs,
             feature_refs,
             chains,
+            member_access_refs,
             sorted_positions: Vec::new(),
         };
 

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -768,3 +768,92 @@ fn collect_returns_empty_for_no_matches() {
         "a view name must not satisfy a route reference query"
     );
 }
+
+// ─── Member-access capture data model (M2) ──────────────────────────────
+
+/// A captured property-form access with the capture-time defaults (the
+/// resolution scaffold left unfilled, as M2 leaves it).
+fn unresolved_member_access(member: &str, line: u32, col: u32) -> MemberAccessReferenceData {
+    MemberAccessReferenceData {
+        member: member.into(),
+        receiver: "$user".into(),
+        receiver_byte_start: 0,
+        receiver_byte_end: 5,
+        is_nullsafe: false,
+        line,
+        column: col,
+        end_column: col + member.len() as u32,
+        declaring_fqcn: None,
+        kind: None,
+        confidence: Confidence::Unresolved,
+    }
+}
+
+#[test]
+fn member_access_is_indexed_and_found_at_position() {
+    let mut p = ParsedPatternsData::default();
+    // `$user->email` — member name spans cols 12..17 on row 1.
+    p.member_access_refs
+        .push(Arc::new(unresolved_member_access("email", 1, 12)));
+    p.build_position_index();
+
+    let found = p
+        .find_at_position(1, 14)
+        .expect("cursor inside the member name should hit the access");
+    match found {
+        PatternAtPosition::MemberAccess(m) => assert_eq!(m.member, "email"),
+        other => panic!("expected MemberAccess, got {other:?}"),
+    }
+
+    // Cursor before the member name (on the receiver) must not match —
+    // the access is indexed at the member span, not the whole expression.
+    assert!(p.find_at_position(1, 2).is_none());
+}
+
+#[test]
+fn member_access_capture_defaults_are_unresolved() {
+    let m = unresolved_member_access("email", 1, 12);
+    assert!(m.declaring_fqcn.is_none());
+    assert!(m.kind.is_none());
+    assert_eq!(m.confidence, Confidence::Unresolved);
+    assert_eq!(Confidence::default(), Confidence::Unresolved);
+}
+
+#[test]
+fn member_access_deserializes_without_resolution_fields() {
+    // A disk-cache entry written before the resolution scaffold existed:
+    // only the capture fields are present. `#[serde(default)]` must fill the
+    // rest rather than failing the whole entry.
+    let json = r#"{
+        "member": "email",
+        "receiver": "$user",
+        "receiver_byte_start": 0,
+        "receiver_byte_end": 5,
+        "is_nullsafe": false,
+        "line": 1,
+        "column": 12,
+        "end_column": 17
+    }"#;
+    let m: MemberAccessReferenceData =
+        serde_json::from_str(json).expect("legacy entry should deserialize");
+    assert_eq!(m.member, "email");
+    assert!(m.declaring_fqcn.is_none());
+    assert!(m.kind.is_none());
+    assert_eq!(m.confidence, Confidence::Unresolved);
+}
+
+#[test]
+fn member_access_resolution_fields_round_trip() {
+    // Once M3 fills the scaffold, it must survive (de)serialization.
+    let mut m = unresolved_member_access("active", 3, 8);
+    m.declaring_fqcn = Some("App\\Models\\User".into());
+    m.kind = Some(MagicMemberKind::Scope);
+    m.confidence = Confidence::High;
+
+    let json = serde_json::to_string(&m).expect("serialize");
+    let back: MemberAccessReferenceData = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(back.declaring_fqcn.as_deref(), Some("App\\Models\\User"));
+    assert_eq!(back.kind, Some(MagicMemberKind::Scope));
+    assert_eq!(back.confidence, Confidence::High);
+}


### PR DESCRIPTION
Relates to #59. **Stacked on #63 (M1)** — base branch is `feat/class-hierarchy-index`, so this diff shows only M2's changes. Do not merge before #63.

## Summary

Second milestone (M2) of the Laravel/PHP semantic-index work — the **capture + data-model plumbing** for magic member sites. Invisible by design: no user-facing feature ships here, only the substrate M3 (resolve + classify) and M4 (reverse index → find-references) build on.

Two capture families, per the plan:
- **Call-form** (`->active()`, `User::whereEmail()`) is already captured as `BuilderChain`s — M2 adds nothing here.
- **Property-form** (`$user->email`, `$this->profile`, `$user?->name`) is the **new capture** this PR adds.

## What changed

**Capture layer** — `queries/php.scm`, `src/queries.rs`
- New `member_access_expression` / `nullsafe_member_access_expression` tree-sitter query, restricted to `name: (name)` so dynamic `$user->$prop` is excluded.
- `MemberAccessMatch` struct + `ExtractedPhpPatterns.member_accesses` + extraction arm. Reads the receiver expression + nullsafe-ness from the member node's parent.
- Method calls (`$user->posts()`) are **not** captured — those are `member_call_expression`, already covered by builder-chain extraction.

**Data model** — `src/salsa_impl.rs`
- `MemberAccessReferenceData`: raw capture (member, receiver text + byte range, nullsafe flag, member-name position) **plus a reserved resolution scaffold** (`declaring_fqcn`, `kind`, `confidence`) that M3 fills. `#[serde(default)]` keeps older disk-cache entries readable.
- `Confidence` (High/Medium/Low/Unresolved, default Unresolved) and `MagicMemberKind` (Scope/Accessor/Relationship/Column/DynamicFinder/PlainMember).
- `ParsedPatternsData.member_access_refs` + `PatternAtPosition::MemberAccess`, indexed at the member-name span in `build_position_index`.
- Populated in `handle_get_patterns` for plain `.php` files; scaffold left at defaults.

**Consumer arms** — `src/references.rs`, `src/main.rs`
- The new `PatternAtPosition` variant gets explicit arms in every consumer: no-ops in classify / hover / goto (armed in M4 / M6), and a real member-name range in `pattern_range_at`.

## Design notes for reviewers

- **Scaffold-now (Option 2):** the resolution fields are wired through the index once, in M2, so M3 is a pure "fill in resolution" diff with no structural churn. They sit at `None` / `Unresolved` until M3.
- **Deferred on purpose:** Blade-embedded member access (`{{ \$user->email }}`) is **not** captured yet — resolving Blade-scope receivers and shifting byte ranges across the snippet/outer-file tree boundary is M3's receiver-resolution work.
- **Transitional firehose:** M2 captures *every* `\$x->member` (incl. vendor) unfiltered — the plan's "capture, then M3 filters at classification." When M3 lands, `handle_get_patterns` resolves + filters before storing, so the firehose never persists. Behind this stacked (unmerged) branch, so nothing is released meanwhile.

## Test plan

- `cargo test` — **1230 lib + 225 + 79 pass / 0 fail** (12 new: 8 capture, 4 data-model/position-index/serde).
- `cargo clippy --all-targets` — clean. `cargo fmt --check` — clean. `cargo build --release` — compiles.
- No manual Zed test — M2 is invisible.

## Roadmap

- [x] **M1 — Class-hierarchy + member index** (#63)
- [x] **M2 — Capture magic call/property sites** *(this PR)*
- [ ] **M3 — Resolve + classify** (wire `var_type` + `ClassView`, widen receiver resolution, fill the scaffold)
- [ ] **M4 — Reverse reference index → find-references**
- [ ] **M5 — Code lens (all 5 types)**
- [ ] **M6 — Hover cards**
- [ ] **M7 — Magic-aware rename**