### PR TITLE
feat: goto-definition + hover for Artisan command strings

### DIFF
--- a/laravel-lsp/src/command_call_locator.rs
+++ b/laravel-lsp/src/command_call_locator.rs
@@ -1,0 +1,128 @@
+//! Locate Artisan command-string call sites in PHP source.
+//!
+//! The call-site half of issue #62. Where [`crate::command_signature`] reads a
+//! `Command` class to learn *what command it provides*, this module scans
+//! ordinary PHP for the places that *reference* a command by name, so goto-
+//! definition and hover know there's something to resolve under the cursor.
+//!
+//! ## Supported call sites (AC: call site coverage)
+//!
+//! | Pattern | Example |
+//! |---------|---------|
+//! | Direct dispatch | `Artisan::call('emails:send', [...])` |
+//! | Artisan queue   | `Artisan::queue('emails:send')` |
+//! | Task scheduling | `->command('emails:send')->daily()` |
+//! | Testing         | `->artisan('emails:send')` |
+//!
+//! Only the **first string argument** of each call is treated as the command
+//! name — that's where Laravel expects it across all four shapes. Arguments and
+//! options are passed separately (an array, or fluent calls), so the string is
+//! the bare command name (`emails:send`), occasionally with inline options
+//! (`emails:send --force`); [`command_name`](CommandCallSite::command_name)
+//! returns the resolvable leading token either way.
+//!
+//! ## Position convention
+//!
+//! 0-based throughout; `start_column`/`end_column` bracket the string *content*
+//! (between the quotes), matching the rest of the stack — see `CLAUDE.md`.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+use crate::command_signature::command_name_from_signature;
+
+/// One Artisan command-string reference found in source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandCallSite {
+    /// The raw string content as written (no surrounding quotes), e.g.
+    /// `emails:send` or `emails:send --force`.
+    pub raw: String,
+    /// 0-based row of the string content.
+    pub line: u32,
+    /// 0-based column of the first content character (after the opening quote).
+    pub start_column: u32,
+    /// 0-based column one past the last content character (before the closing
+    /// quote).
+    pub end_column: u32,
+}
+
+impl CommandCallSite {
+    /// The resolvable command name: the leading token of [`raw`](Self::raw),
+    /// before any inline options. Matches how a `$signature` resolves to a
+    /// command name, so a call site and its declaration agree on the key.
+    pub fn command_name(&self) -> &str {
+        command_name_from_signature(&self.raw)
+    }
+
+    /// Whether a cursor at (`line`, `character`) — both 0-based — falls within
+    /// this call site's string content. The end is inclusive of the position
+    /// one past the last character so a cursor resting just before the closing
+    /// quote still resolves.
+    pub fn contains(&self, line: u32, character: u32) -> bool {
+        self.line == line && character >= self.start_column && character <= self.end_column
+    }
+}
+
+/// Every Artisan command-string call site in `content`, in source order.
+pub fn extract_command_call_sites(content: &str) -> Vec<CommandCallSite> {
+    lazy_static! {
+        // Method/static-call prefix, then the first string argument. Single- and
+        // double-quoted alternatives are spelled out separately because the
+        // `regex` crate has no backreferences (see command_signature).
+        static ref CALL_SITE_RE: Regex = Regex::new(
+            r#"(?:Artisan::call|Artisan::queue|->command|->artisan)\s*\(\s*(?:'([^'\n]*)'|"([^"\n]*)")"#,
+        )
+        .unwrap();
+    }
+
+    let mut out = Vec::new();
+    for caps in CALL_SITE_RE.captures_iter(content) {
+        let Some(content_match) = caps.get(1).or_else(|| caps.get(2)) else {
+            continue;
+        };
+        let raw = content_match.as_str().to_string();
+        // A blank command string has nothing to resolve — skip it rather than
+        // emitting a site that can never match an index entry.
+        if command_name_from_signature(&raw).is_empty() {
+            continue;
+        }
+
+        let byte_offset = content_match.start();
+        let mut line = 0u32;
+        let mut last_line_start = 0usize;
+        for (i, ch) in content[..byte_offset].char_indices() {
+            if ch == '\n' {
+                line += 1;
+                last_line_start = i + 1;
+            }
+        }
+        let start_column = (byte_offset - last_line_start) as u32;
+        let end_column = start_column + raw.len() as u32;
+
+        out.push(CommandCallSite {
+            raw,
+            line,
+            start_column,
+            end_column,
+        });
+    }
+    out
+}
+
+/// The command-string call site whose content contains the cursor at
+/// (`line`, `character`) — both 0-based — or `None` if the cursor isn't on one.
+///
+/// This is the entry point goto-definition and hover call: resolve the cursor
+/// to a command name, then look it up in the command index.
+pub fn command_call_at_position(
+    content: &str,
+    line: u32,
+    character: u32,
+) -> Option<CommandCallSite> {
+    extract_command_call_sites(content)
+        .into_iter()
+        .find(|site| site.contains(line, character))
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/command_call_locator/tests.rs
+++ b/laravel-lsp/src/command_call_locator/tests.rs
@@ -1,0 +1,106 @@
+//! Unit tests for Artisan command-string call-site location.
+
+use super::*;
+
+#[test]
+fn finds_direct_dispatch() {
+    let src = "<?php\nArtisan::call('emails:send', ['--force' => true]);\n";
+    let sites = extract_command_call_sites(src);
+    assert_eq!(sites.len(), 1);
+    assert_eq!(sites[0].raw, "emails:send");
+    assert_eq!(sites[0].command_name(), "emails:send");
+    assert_eq!(sites[0].line, 1);
+}
+
+#[test]
+fn finds_artisan_queue() {
+    let src = "<?php\nArtisan::queue('emails:send');\n";
+    let sites = extract_command_call_sites(src);
+    assert_eq!(sites.len(), 1);
+    assert_eq!(sites[0].command_name(), "emails:send");
+}
+
+#[test]
+fn finds_scheduler_command() {
+    let src = "<?php\n$schedule->command('emails:send')->daily();\n";
+    let sites = extract_command_call_sites(src);
+    assert_eq!(sites.len(), 1);
+    assert_eq!(sites[0].command_name(), "emails:send");
+}
+
+#[test]
+fn finds_testing_artisan_helper() {
+    let src = "<?php\n$this->artisan('emails:send')->assertExitCode(0);\n";
+    let sites = extract_command_call_sites(src);
+    assert_eq!(sites.len(), 1);
+    assert_eq!(sites[0].command_name(), "emails:send");
+}
+
+#[test]
+fn finds_all_four_patterns_in_one_file() {
+    let src = "<?php\n\
+        Artisan::call('a:one');\n\
+        Artisan::queue('b:two');\n\
+        $schedule->command('c:three')->daily();\n\
+        $this->artisan('d:four');\n";
+    let names: Vec<String> = extract_command_call_sites(src)
+        .iter()
+        .map(|s| s.command_name().to_string())
+        .collect();
+    assert_eq!(names, vec!["a:one", "b:two", "c:three", "d:four"]);
+}
+
+#[test]
+fn double_quoted_argument() {
+    let src = "<?php\nArtisan::call(\"queue:work\");\n";
+    let sites = extract_command_call_sites(src);
+    assert_eq!(sites.len(), 1);
+    assert_eq!(sites[0].command_name(), "queue:work");
+}
+
+#[test]
+fn command_name_strips_inline_options() {
+    let src = "<?php\nArtisan::call('emails:send --force');\n";
+    let sites = extract_command_call_sites(src);
+    assert_eq!(sites[0].raw, "emails:send --force");
+    assert_eq!(sites[0].command_name(), "emails:send");
+}
+
+#[test]
+fn position_brackets_string_content() {
+    let src = "<?php\nArtisan::call('emails:send');\n";
+    let site = &extract_command_call_sites(src)[0];
+    let line_text = src.lines().nth(site.line as usize).unwrap();
+    let extracted = &line_text[site.start_column as usize..site.end_column as usize];
+    assert_eq!(extracted, "emails:send");
+}
+
+#[test]
+fn cursor_inside_string_resolves() {
+    // Line 1: `Artisan::call('emails:send');` — the string content starts at
+    // column 14 (after `Artisan::call('`).
+    let src = "<?php\nArtisan::call('emails:send');\n";
+    let hit = command_call_at_position(src, 1, 16).expect("cursor is inside the string");
+    assert_eq!(hit.command_name(), "emails:send");
+}
+
+#[test]
+fn cursor_outside_string_returns_none() {
+    let src = "<?php\nArtisan::call('emails:send');\n";
+    // Column 0 is on `A` of `Artisan`, outside the string content.
+    assert!(command_call_at_position(src, 1, 0).is_none());
+    // A different line entirely.
+    assert!(command_call_at_position(src, 0, 5).is_none());
+}
+
+#[test]
+fn unrelated_method_calls_are_ignored() {
+    let src = "<?php\n$user->name('foo');\nroute('home');\nview('welcome');\n";
+    assert!(extract_command_call_sites(src).is_empty());
+}
+
+#[test]
+fn empty_command_string_is_skipped() {
+    let src = "<?php\nArtisan::call('');\n";
+    assert!(extract_command_call_sites(src).is_empty());
+}

--- a/laravel-lsp/src/command_disk_cache.rs
+++ b/laravel-lsp/src/command_disk_cache.rs
@@ -1,0 +1,215 @@
+//! Persistent on-disk cache for the Artisan command index.
+//!
+//! [`crate::command_index::build_command_index`] walks the *entire* project
+//! and `vendor/` tree, reading every `*.php` file to find the handful that
+//! `extends ...Command`. On a large Laravel install that's a real chunk of
+//! I/O paid on every LSP cold start — even when nothing has changed since the
+//! last run. This cache removes that tax: the first build writes the resolved
+//! index to disk, and subsequent startups restore it instantly so
+//! goto-definition and hover on command strings work without waiting for the
+//! walk.
+//!
+//! It's a cold-start accelerator, not the source of truth. The full
+//! [`crate::command_index::build_command_index`] still runs after the restore
+//! (`rebuild_command_index` in `main.rs`) to pick up anything that changed
+//! while the LSP was off — added/removed command classes included — and then
+//! re-saves the refreshed index. The file watcher keeps the index (and this
+//! cache) current while the server is running. This mirrors the design of
+//! [`crate::pattern_disk_cache`].
+//!
+//! ## Format
+//!
+//! `bincode`-encoded `CacheFile { schema_version, entries }`, where each entry
+//! is one command declaration plus the mtime of the file that declares it.
+//! Binary because the load is on the startup critical path.
+//!
+//! ## Invalidation
+//!
+//! Per-file mtime, identical to [`crate::pattern_disk_cache`]. Each entry
+//! stores the mtime observed when the command was indexed; on load we stat the
+//! declaring file and only restore the entry if the mtime is byte-identical
+//! (both `secs` and `nanos`). A changed, moved, or deleted command file drops
+//! its entry — the full rebuild that follows the restore then re-discovers the
+//! correct state. A schema-version bump discards the whole cache.
+//!
+//! ## Location
+//!
+//! The same XDG-compliant project-hash directory the pattern cache lives in,
+//! alongside it as `command_cache.bin`. One cache per project root path.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use anyhow::{Context, Result};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use crate::command_index::{CommandEntry, CommandIndex};
+
+/// Bump this when the cached structures change — old caches are discarded on
+/// read instead of risking deserialization into a struct that no longer
+/// matches.
+///
+/// History:
+///   v1 — initial command index cache.
+const SCHEMA_VERSION: u32 = 1;
+
+const CACHE_FILENAME: &str = "command_cache.bin";
+
+/// On-disk envelope. The version field is checked before we try to decode the
+/// entries, so a stale cache from an older build is dropped instead of
+/// crashing the LSP.
+#[derive(Serialize, Deserialize)]
+struct CacheFile {
+    schema_version: u32,
+    entries: Vec<CachedEntry>,
+}
+
+/// One resolved command declaration plus the mtime we observed for its
+/// declaring file when it was indexed. Both `secs` and `nanos` are stored
+/// independently for byte-exact comparison — a `touch` that preserves the
+/// second but bumps the nanos must still count as "changed."
+#[derive(Serialize, Deserialize)]
+struct CachedEntry {
+    mtime_secs: u64,
+    mtime_nanos: u32,
+    entry: CommandEntry,
+}
+
+/// Where the cache file for `project_root` lives on disk. Returns `None` only
+/// if the user's home directory can't be resolved — effectively infallible in
+/// practice. Hashes the canonical root path so the location matches
+/// [`crate::pattern_disk_cache`]'s per-project directory.
+fn cache_file_path(project_root: &Path) -> Option<PathBuf> {
+    let proj_dirs = ProjectDirs::from("org", "mike-bronner", "laravel-lsp")?;
+    let canonical = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    let mut hasher = DefaultHasher::new();
+    canonical.hash(&mut hasher);
+    let project_hash = format!("{:x}", hasher.finish());
+    Some(
+        proj_dirs
+            .cache_dir()
+            .join(project_hash)
+            .join(CACHE_FILENAME),
+    )
+}
+
+/// Decompose a `SystemTime` into `(secs, nanos)` relative to UNIX_EPOCH.
+/// `None` if the time predates the epoch — shouldn't happen for real files,
+/// but we drop the entry rather than panic.
+fn split_mtime(time: SystemTime) -> Option<(u64, u32)> {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .ok()
+        .map(|d| (d.as_secs(), d.subsec_nanos()))
+}
+
+/// Read the file's mtime as `(secs, nanos)`. `None` if the file doesn't exist
+/// or isn't reachable — caller treats both as "no cache for this path."
+fn read_mtime(path: &Path) -> Option<(u64, u32)> {
+    std::fs::metadata(path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(split_mtime)
+}
+
+/// Restore the cached command index for `project_root`, validating every entry
+/// against its declaring file's current mtime. Returns the rebuilt index, or
+/// `None` when there's no cache, it's unreadable, or the schema doesn't match —
+/// in every case the caller falls back to a full
+/// [`crate::command_index::build_command_index`].
+///
+/// Stale entries (changed, moved, or deleted files) are silently skipped; the
+/// returned index contains only the entries that still match disk, with the
+/// App > Package > Framework priority merge re-applied via
+/// [`CommandIndex::insert_entry`].
+pub fn load_index(project_root: &Path) -> Option<CommandIndex> {
+    let path = cache_file_path(project_root)?;
+    let bytes = std::fs::read(&path).ok()?;
+
+    let cache: CacheFile =
+        match bincode::serde::decode_from_slice(&bytes, bincode::config::standard()) {
+            Ok((c, _)) => c,
+            Err(e) => {
+                tracing::debug!("command_disk_cache: decode failed, ignoring: {}", e);
+                return None;
+            }
+        };
+
+    if cache.schema_version != SCHEMA_VERSION {
+        tracing::info!(
+            "command_disk_cache: schema mismatch (disk={}, current={}), ignoring",
+            cache.schema_version,
+            SCHEMA_VERSION
+        );
+        return None;
+    }
+
+    let mut index = CommandIndex::default();
+    for cached in cache.entries {
+        // Only restore the entry if its declaring file is still present and
+        // unchanged. Anything else falls through to the full rebuild.
+        match read_mtime(&cached.entry.file) {
+            Some((s, n)) if s == cached.mtime_secs && n == cached.mtime_nanos => {
+                index.insert_entry(cached.entry);
+            }
+            _ => {}
+        }
+    }
+    Some(index)
+}
+
+/// Persist `index` to disk, stamping each command with its declaring file's
+/// CURRENT mtime. Called after every successful build/rebuild. Safe to run on
+/// the blocking pool — it's sync I/O.
+///
+/// Returns the number of entries written, or an error if the cache directory
+/// or file couldn't be written. Errors are advisory — failing to persist
+/// doesn't affect the live in-memory index.
+pub fn save_index(index: &CommandIndex, project_root: &Path) -> Result<usize> {
+    let cache_path =
+        cache_file_path(project_root).context("could not resolve cache directory for project")?;
+
+    let mut entries: Vec<CachedEntry> = Vec::with_capacity(index.len());
+    for entry in index.entries() {
+        // Stat the declaring file at save time so the stamped mtime reflects
+        // what's on disk RIGHT NOW. A file modified since indexing simply
+        // fails the next load's mtime check and gets re-parsed.
+        let Some((secs, nanos)) = read_mtime(&entry.file) else {
+            // File vanished between build and save — skip it; load_index would
+            // drop a dangling entry anyway.
+            continue;
+        };
+        entries.push(CachedEntry {
+            mtime_secs: secs,
+            mtime_nanos: nanos,
+            entry: entry.clone(),
+        });
+    }
+
+    let total = entries.len();
+    let cache = CacheFile {
+        schema_version: SCHEMA_VERSION,
+        entries,
+    };
+
+    let encoded = bincode::serde::encode_to_vec(&cache, bincode::config::standard())
+        .context("bincode encode failed")?;
+
+    if let Some(parent) = cache_path.parent() {
+        std::fs::create_dir_all(parent).context("could not create cache directory")?;
+    }
+    // Write to a temp file then rename — atomic on POSIX, so a crash mid-save
+    // leaves the previous cache intact rather than a truncated one.
+    let tmp = cache_path.with_extension("bin.tmp");
+    std::fs::write(&tmp, &encoded).context("write tmp cache file failed")?;
+    std::fs::rename(&tmp, &cache_path).context("rename tmp cache file failed")?;
+
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/command_disk_cache/tests.rs
+++ b/laravel-lsp/src/command_disk_cache/tests.rs
@@ -1,0 +1,172 @@
+//! Tests for the on-disk command index cache.
+//!
+//! Each test gets its own `TempDir` so they don't share state — the cache
+//! path is derived from a hash of the project root, so distinct roots get
+//! distinct cache files. Entries are validated against their declaring file's
+//! mtime, so the tests write real files.
+
+use super::*;
+use crate::command_index::CommandPriority;
+use std::path::Path;
+
+/// Write a real PHP-ish file into `dir` and return its path. A real file is
+/// required because the cache validates entries against their on-disk mtime —
+/// without one, `read_mtime` returns `None` and `load_index` drops the entry.
+fn touch(dir: &Path, name: &str, contents: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, contents).unwrap();
+    p
+}
+
+/// A minimal `CommandEntry` pointing at `file`.
+fn entry(name: &str, class: &str, file: PathBuf, priority: CommandPriority) -> CommandEntry {
+    CommandEntry {
+        name: name.to_string(),
+        class_name: class.to_string(),
+        raw_signature: name.to_string(),
+        file,
+        line: 5,
+        start_column: 24,
+        end_column: 24 + name.len() as u32,
+        priority,
+    }
+}
+
+#[test]
+fn save_then_load_restores_entries() {
+    let project = tempfile::TempDir::new().unwrap();
+    let file = touch(
+        project.path(),
+        "SendEmails.php",
+        "<?php class SendEmails {}",
+    );
+
+    let mut index = CommandIndex::default();
+    index.insert_entry(entry(
+        "emails:send",
+        "SendEmails",
+        file.clone(),
+        CommandPriority::App,
+    ));
+
+    let saved = save_index(&index, project.path()).unwrap();
+    assert_eq!(saved, 1, "save should report one entry written");
+
+    let restored = load_index(project.path()).expect("cache should load");
+    assert_eq!(restored.len(), 1);
+    let got = restored.resolve("emails:send").expect("command restored");
+    assert_eq!(got.class_name, "SendEmails");
+    assert_eq!(got.file, file);
+    assert_eq!(got.priority, CommandPriority::App);
+}
+
+#[test]
+fn load_returns_none_when_no_cache_exists() {
+    let project = tempfile::TempDir::new().unwrap();
+    assert!(
+        load_index(project.path()).is_none(),
+        "a project with no cache file should load nothing"
+    );
+}
+
+#[test]
+fn load_drops_entry_whose_file_was_deleted() {
+    let project = tempfile::TempDir::new().unwrap();
+    let file = touch(project.path(), "Gone.php", "<?php class Gone {}");
+
+    let mut index = CommandIndex::default();
+    index.insert_entry(entry("a:gone", "Gone", file.clone(), CommandPriority::App));
+    save_index(&index, project.path()).unwrap();
+
+    std::fs::remove_file(&file).unwrap();
+
+    let restored = load_index(project.path()).expect("cache file still loads");
+    assert!(
+        restored.resolve("a:gone").is_none(),
+        "an entry whose declaring file is gone must be dropped"
+    );
+    assert!(restored.is_empty());
+}
+
+#[test]
+fn load_drops_entry_whose_file_changed() {
+    let project = tempfile::TempDir::new().unwrap();
+    let file = touch(project.path(), "Changed.php", "<?php class Changed {}");
+
+    let mut index = CommandIndex::default();
+    index.insert_entry(entry(
+        "a:changed",
+        "Changed",
+        file.clone(),
+        CommandPriority::App,
+    ));
+    save_index(&index, project.path()).unwrap();
+
+    // Sleep just long enough that the OS records a different mtime, then
+    // rewrite the file. 50ms is enough for APFS / ext4 / NTFS (matches the
+    // sibling pattern_disk_cache test).
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    std::fs::write(&file, "<?php class Changed { /* edited */ }").unwrap();
+
+    let restored = load_index(project.path()).expect("cache file still loads");
+    assert!(
+        restored.resolve("a:changed").is_none(),
+        "a changed declaring file must invalidate its cached entry"
+    );
+}
+
+#[test]
+fn load_reapplies_priority_merge() {
+    // Two declarations of the same command name at different tiers must
+    // collapse to the highest-priority one on restore.
+    let project = tempfile::TempDir::new().unwrap();
+    let app_file = touch(project.path(), "AppQueue.php", "<?php class AppQueue {}");
+    let pkg_file = touch(project.path(), "PkgQueue.php", "<?php class PkgQueue {}");
+
+    let mut index = CommandIndex::default();
+    index.insert_entry(entry(
+        "queue:work",
+        "PkgQueue",
+        pkg_file,
+        CommandPriority::Package,
+    ));
+    index.insert_entry(entry(
+        "queue:work",
+        "AppQueue",
+        app_file,
+        CommandPriority::App,
+    ));
+    // Sanity: the in-memory merge already kept the App entry.
+    assert_eq!(index.resolve("queue:work").unwrap().class_name, "AppQueue");
+
+    save_index(&index, project.path()).unwrap();
+    let restored = load_index(project.path()).expect("cache should load");
+    assert_eq!(restored.len(), 1, "same name collapses to one entry");
+    assert_eq!(
+        restored.resolve("queue:work").unwrap().class_name,
+        "AppQueue",
+        "App declaration must win after a disk round-trip"
+    );
+}
+
+#[test]
+fn save_skips_entry_whose_file_vanished() {
+    let project = tempfile::TempDir::new().unwrap();
+    let present = touch(project.path(), "Here.php", "<?php class Here {}");
+
+    let mut index = CommandIndex::default();
+    index.insert_entry(entry("a:here", "Here", present, CommandPriority::App));
+    index.insert_entry(entry(
+        "a:missing",
+        "Missing",
+        project.path().join("Missing.php"), // never created
+        CommandPriority::App,
+    ));
+
+    let saved = save_index(&index, project.path()).unwrap();
+    assert_eq!(saved, 1, "the entry with no file on disk is skipped");
+
+    let restored = load_index(project.path()).unwrap();
+    assert!(restored.resolve("a:here").is_some());
+    assert!(restored.resolve("a:missing").is_none());
+}

--- a/laravel-lsp/src/command_index.rs
+++ b/laravel-lsp/src/command_index.rs
@@ -120,8 +120,7 @@ pub fn classify_priority(path: &Path) -> CommandPriority {
 /// is found (the caller then skips the file — no class, no goto target).
 pub fn class_name_from_content(content: &str) -> Option<String> {
     lazy_static! {
-        static ref CLASS_RE: Regex =
-            Regex::new(r"\bclass\s+([A-Za-z_][A-Za-z0-9_]*)").unwrap();
+        static ref CLASS_RE: Regex = Regex::new(r"\bclass\s+([A-Za-z_][A-Za-z0-9_]*)").unwrap();
     }
     CLASS_RE
         .captures(content)

--- a/laravel-lsp/src/command_index.rs
+++ b/laravel-lsp/src/command_index.rs
@@ -10,7 +10,9 @@
 //! Built once at init and refreshed when a relevant `Command` file changes
 //! (mirrors [`crate::migration_index`]). The walk is regex-gated — a file is
 //! only fully parsed when it actually `extends ...Command`, so the cost of
-//! scanning a large `vendor/` tree stays bounded to real command classes.
+//! scanning a large `vendor/` tree stays bounded to real command classes. The
+//! built index is persisted by [`crate::command_disk_cache`] so a cold restart
+//! can restore it instantly instead of re-walking the whole tree.
 //!
 //! ## Priority (AC: app overrides framework/package)
 //!
@@ -40,6 +42,7 @@ use std::path::{Path, PathBuf};
 
 use lazy_static::lazy_static;
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
 use crate::command_signature::{extends_console_command, extract_command_signature};
@@ -47,7 +50,7 @@ use crate::command_signature::{extends_console_command, extract_command_signatur
 /// Source tier of a command declaration. Higher wins when two classes declare
 /// the same command name (`App` overrides a `Package` which overrides the
 /// `Framework`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum CommandPriority {
     /// Shipped by `laravel/framework` itself (`vendor/laravel/framework/`).
     Framework = 0,
@@ -60,7 +63,7 @@ pub enum CommandPriority {
 /// One Artisan command discovered on a `Command` subclass, resolved to its
 /// declaration site. `class_name` powers the hover summary; the position fields
 /// point at the `$signature` string content so goto lands on the declaration.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommandEntry {
     /// The resolvable command name (`emails:send`).
     pub name: String,
@@ -100,6 +103,27 @@ impl CommandIndex {
 
     pub fn is_empty(&self) -> bool {
         self.commands.is_empty()
+    }
+
+    /// Every resolved command declaration, in arbitrary order. Used by the
+    /// on-disk cache to persist the index.
+    pub fn entries(&self) -> impl Iterator<Item = &CommandEntry> {
+        self.commands.values()
+    }
+
+    /// Insert one resolved command declaration, applying the priority merge:
+    /// the new entry replaces an existing one for the same command name only
+    /// when it ranks strictly higher (App > Package > Framework). A same-tier
+    /// duplicate leaves the first-inserted winner in place. This is the single
+    /// place the override rule lives — both the project walk and the disk-cache
+    /// restore funnel through here.
+    pub fn insert_entry(&mut self, entry: CommandEntry) {
+        match self.commands.get(&entry.name) {
+            Some(existing) if existing.priority >= entry.priority => {}
+            _ => {
+                self.commands.insert(entry.name.clone(), entry);
+            }
+        }
     }
 }
 
@@ -179,8 +203,8 @@ pub fn index_command_file(index: &mut CommandIndex, path: &Path, content: &str) 
     };
 
     let priority = classify_priority(path);
-    let entry = CommandEntry {
-        name: sig.name.clone(),
+    index.insert_entry(CommandEntry {
+        name: sig.name,
         class_name,
         raw_signature: sig.raw_signature,
         file: path.to_path_buf(),
@@ -188,14 +212,7 @@ pub fn index_command_file(index: &mut CommandIndex, path: &Path, content: &str) 
         start_column: sig.start_column,
         end_column: sig.end_column,
         priority,
-    };
-
-    match index.commands.get(&sig.name) {
-        Some(existing) if existing.priority >= entry.priority => {}
-        _ => {
-            index.commands.insert(sig.name, entry);
-        }
-    }
+    });
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/command_index.rs
+++ b/laravel-lsp/src/command_index.rs
@@ -1,0 +1,203 @@
+//! Eager, project-wide index of Artisan commands — the resolution half of
+//! issue #62. Where [`crate::command_signature`] reads a single `Command` class
+//! and [`crate::command_call_locator`] finds the *references* to a command in
+//! ordinary PHP, this module ties them together: it scans the whole project
+//! (including `vendor/`) for `Command` subclasses, extracts each one's
+//! `$signature`, and keys them by command name so goto-definition and hover can
+//! resolve a call-site string (`Artisan::call('emails:send')`) to the class
+//! that declares it.
+//!
+//! Built once at init and refreshed when a relevant `Command` file changes
+//! (mirrors [`crate::migration_index`]). The walk is regex-gated — a file is
+//! only fully parsed when it actually `extends ...Command`, so the cost of
+//! scanning a large `vendor/` tree stays bounded to real command classes.
+//!
+//! ## Priority (AC: app overrides framework/package)
+//!
+//! Two classes can declare the same command name (a package ships
+//! `queue:work`, an app overrides it). The index keeps the highest-priority
+//! declaration, matching the convention in `CLAUDE.md`
+//! (*Framework=0, Package=1, App=2 — higher wins*):
+//!
+//! | Source | Priority | Detected by |
+//! |--------|----------|-------------|
+//! | App    | 2 | not under `vendor/` |
+//! | Package| 1 | under `vendor/` (non-framework) |
+//! | Framework | 0 | under `vendor/laravel/framework/` |
+//!
+//! On a tie (same name, same priority) the first one walked wins — stable and
+//! good enough; ambiguity across two packages is vanishingly rare.
+//!
+//! ## Position convention
+//!
+//! 0-based throughout; `start_column`/`end_column` bracket the signature
+//! string's *content* (inside the quotes), matching the rest of the stack — see
+//! `CLAUDE.md`. Goto lands on the `$signature` declaration, which is where the
+//! command is actually defined.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use lazy_static::lazy_static;
+use regex::Regex;
+use walkdir::WalkDir;
+
+use crate::command_signature::{extends_console_command, extract_command_signature};
+
+/// Source tier of a command declaration. Higher wins when two classes declare
+/// the same command name (`App` overrides a `Package` which overrides the
+/// `Framework`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CommandPriority {
+    /// Shipped by `laravel/framework` itself (`vendor/laravel/framework/`).
+    Framework = 0,
+    /// Shipped by any other `vendor/` package.
+    Package = 1,
+    /// Defined in the project's own source (not under `vendor/`).
+    App = 2,
+}
+
+/// One Artisan command discovered on a `Command` subclass, resolved to its
+/// declaration site. `class_name` powers the hover summary; the position fields
+/// point at the `$signature` string content so goto lands on the declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandEntry {
+    /// The resolvable command name (`emails:send`).
+    pub name: String,
+    /// The declaring class's short name (`SendEmails`), for hover summaries.
+    pub class_name: String,
+    /// The full signature string content as written (arguments/options kept).
+    pub raw_signature: String,
+    /// File that declares the command.
+    pub file: PathBuf,
+    /// 0-based row of the `$signature` string content.
+    pub line: u32,
+    /// 0-based column of the first content character (after the opening quote).
+    pub start_column: u32,
+    /// 0-based column one past the last content character (before the quote).
+    pub end_column: u32,
+    /// Source tier — see [`CommandPriority`].
+    pub priority: CommandPriority,
+}
+
+/// Resolved Artisan commands across the project and `vendor/`, keyed by command
+/// name with app-over-package-over-framework priority already applied.
+#[derive(Debug, Clone, Default)]
+pub struct CommandIndex {
+    commands: HashMap<String, CommandEntry>,
+}
+
+impl CommandIndex {
+    /// The declaring class for `name`, if any command provides it.
+    pub fn resolve(&self, name: &str) -> Option<&CommandEntry> {
+        self.commands.get(name)
+    }
+
+    /// Number of distinct command names indexed.
+    pub fn len(&self) -> usize {
+        self.commands.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
+    }
+}
+
+/// Classify a command file's source tier from its path.
+pub fn classify_priority(path: &Path) -> CommandPriority {
+    let s = path.to_string_lossy().replace('\\', "/");
+    if s.contains("/vendor/laravel/framework/") || s.contains("vendor/laravel/framework/") {
+        CommandPriority::Framework
+    } else if s.contains("/vendor/") || s.starts_with("vendor/") {
+        CommandPriority::Package
+    } else {
+        CommandPriority::App
+    }
+}
+
+/// The declaring class's short name, e.g. `SendEmails` from
+/// `class SendEmails extends Command`. Returns `None` when no class declaration
+/// is found (the caller then skips the file — no class, no goto target).
+pub fn class_name_from_content(content: &str) -> Option<String> {
+    lazy_static! {
+        static ref CLASS_RE: Regex =
+            Regex::new(r"\bclass\s+([A-Za-z_][A-Za-z0-9_]*)").unwrap();
+    }
+    CLASS_RE
+        .captures(content)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+/// Directory names never worth descending into when hunting for command
+/// classes — build output and VCS metadata, none of which hold PHP source.
+const SKIP_DIRS: &[&str] = &["node_modules", ".git", "storage", "public"];
+
+/// Build the index by walking every `*.php` under `<root>` (project + vendor),
+/// keeping the highest-priority declaration per command name. Non-PHP files,
+/// build/VCS directories, and files that don't `extends ...Command` are skipped
+/// cheaply so a large `vendor/` tree doesn't dominate the walk.
+pub fn build_command_index(root: &Path) -> CommandIndex {
+    let mut index = CommandIndex::default();
+    for entry in WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|e| {
+            !(e.file_type().is_dir()
+                && e.file_name()
+                    .to_str()
+                    .is_some_and(|n| SKIP_DIRS.contains(&n)))
+        })
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if path.is_file() && path.extension().is_some_and(|ext| ext == "php") {
+            if let Ok(content) = std::fs::read_to_string(path) {
+                index_command_file(&mut index, path, &content);
+            }
+        }
+    }
+    index
+}
+
+/// Index a single PHP file's command declaration, if it has one. Exposed for
+/// unit tests; [`build_command_index`] is the production entry.
+///
+/// The new entry replaces an existing one for the same command name only when
+/// it ranks strictly higher (App > Package > Framework) — so an app command
+/// wins over a package/framework command of the same name, and a same-tier
+/// duplicate leaves the first-walked winner in place.
+pub fn index_command_file(index: &mut CommandIndex, path: &Path, content: &str) {
+    // Cheap gate: skip anything that isn't a Command subclass before the
+    // heavier signature/class-name extraction runs.
+    if !extends_console_command(content) {
+        return;
+    }
+    let Some(sig) = extract_command_signature(content) else {
+        return;
+    };
+    let Some(class_name) = class_name_from_content(content) else {
+        return;
+    };
+
+    let priority = classify_priority(path);
+    let entry = CommandEntry {
+        name: sig.name.clone(),
+        class_name,
+        raw_signature: sig.raw_signature,
+        file: path.to_path_buf(),
+        line: sig.line,
+        start_column: sig.start_column,
+        end_column: sig.end_column,
+        priority,
+    };
+
+    match index.commands.get(&sig.name) {
+        Some(existing) if existing.priority >= entry.priority => {}
+        _ => {
+            index.commands.insert(sig.name, entry);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/command_index/tests.rs
+++ b/laravel-lsp/src/command_index/tests.rs
@@ -26,7 +26,9 @@ fn priority_classifies_by_path() {
         CommandPriority::App
     );
     assert_eq!(
-        classify_priority(Path::new("/app/vendor/spatie/backup/src/Commands/Backup.php")),
+        classify_priority(Path::new(
+            "/app/vendor/spatie/backup/src/Commands/Backup.php"
+        )),
         CommandPriority::Package
     );
     assert_eq!(
@@ -47,7 +49,9 @@ fn indexes_a_command_and_resolves_it() {
         &src,
     );
 
-    let entry = index.resolve("emails:send").expect("command should resolve");
+    let entry = index
+        .resolve("emails:send")
+        .expect("command should resolve");
     assert_eq!(entry.name, "emails:send");
     assert_eq!(entry.class_name, "SendEmails");
     assert_eq!(entry.raw_signature, "emails:send {user} {--force}");

--- a/laravel-lsp/src/command_index/tests.rs
+++ b/laravel-lsp/src/command_index/tests.rs
@@ -1,0 +1,159 @@
+//! Unit tests for the project-wide Artisan command index.
+
+use super::*;
+use std::path::Path;
+
+/// A minimal Artisan command class declaring `signature`.
+fn command_class(class: &str, signature: &str) -> String {
+    format!(
+        "<?php\n\nnamespace App\\Console\\Commands;\n\nuse Illuminate\\Console\\Command;\n\nclass {class} extends Command\n{{\n    protected $signature = '{signature}';\n\n    public function handle()\n    {{\n        //\n    }}\n}}\n"
+    )
+}
+
+#[test]
+fn class_name_extracted_from_declaration() {
+    assert_eq!(
+        class_name_from_content("<?php\nclass SendEmails extends Command {}").as_deref(),
+        Some("SendEmails")
+    );
+    assert_eq!(class_name_from_content("<?php\n$x = 1;").as_deref(), None);
+}
+
+#[test]
+fn priority_classifies_by_path() {
+    assert_eq!(
+        classify_priority(Path::new("/app/app/Console/Commands/SendEmails.php")),
+        CommandPriority::App
+    );
+    assert_eq!(
+        classify_priority(Path::new("/app/vendor/spatie/backup/src/Commands/Backup.php")),
+        CommandPriority::Package
+    );
+    assert_eq!(
+        classify_priority(Path::new(
+            "/app/vendor/laravel/framework/src/Illuminate/Queue/Console/WorkCommand.php"
+        )),
+        CommandPriority::Framework
+    );
+}
+
+#[test]
+fn indexes_a_command_and_resolves_it() {
+    let mut index = CommandIndex::default();
+    let src = command_class("SendEmails", "emails:send {user} {--force}");
+    index_command_file(
+        &mut index,
+        Path::new("/app/app/Console/Commands/SendEmails.php"),
+        &src,
+    );
+
+    let entry = index.resolve("emails:send").expect("command should resolve");
+    assert_eq!(entry.name, "emails:send");
+    assert_eq!(entry.class_name, "SendEmails");
+    assert_eq!(entry.raw_signature, "emails:send {user} {--force}");
+    assert_eq!(entry.priority, CommandPriority::App);
+    assert_eq!(index.len(), 1);
+}
+
+#[test]
+fn non_command_files_are_ignored() {
+    let mut index = CommandIndex::default();
+    index_command_file(
+        &mut index,
+        Path::new("/app/app/Models/User.php"),
+        "<?php\nclass User extends Model {\n    protected $table = 'users';\n}",
+    );
+    assert!(index.is_empty());
+}
+
+#[test]
+fn command_without_signature_is_ignored() {
+    let mut index = CommandIndex::default();
+    index_command_file(
+        &mut index,
+        Path::new("/app/app/Console/Commands/Dynamic.php"),
+        "<?php\nclass Dynamic extends Command {\n    public function handle() {}\n}",
+    );
+    assert!(index.is_empty());
+}
+
+#[test]
+fn app_command_overrides_package_with_same_name() {
+    let mut index = CommandIndex::default();
+    // Package declares queue:work first…
+    index_command_file(
+        &mut index,
+        Path::new("/app/vendor/laravel/horizon/src/Console/WorkCommand.php"),
+        &command_class("PackageWork", "queue:work"),
+    );
+    // …then the app overrides it.
+    index_command_file(
+        &mut index,
+        Path::new("/app/app/Console/Commands/WorkCommand.php"),
+        &command_class("AppWork", "queue:work"),
+    );
+
+    let entry = index.resolve("queue:work").expect("should resolve");
+    assert_eq!(entry.class_name, "AppWork");
+    assert_eq!(entry.priority, CommandPriority::App);
+}
+
+#[test]
+fn lower_priority_does_not_clobber_higher() {
+    let mut index = CommandIndex::default();
+    // App declared first…
+    index_command_file(
+        &mut index,
+        Path::new("/app/app/Console/Commands/WorkCommand.php"),
+        &command_class("AppWork", "queue:work"),
+    );
+    // …a later package declaration must NOT replace it.
+    index_command_file(
+        &mut index,
+        Path::new("/app/vendor/laravel/framework/src/WorkCommand.php"),
+        &command_class("FrameworkWork", "queue:work"),
+    );
+
+    let entry = index.resolve("queue:work").expect("should resolve");
+    assert_eq!(entry.class_name, "AppWork");
+    assert_eq!(entry.priority, CommandPriority::App);
+}
+
+#[test]
+fn build_index_walks_project_and_vendor() {
+    let dir = std::env::temp_dir().join(format!("cmd-index-test-{}", std::process::id()));
+    let app_cmds = dir.join("app/Console/Commands");
+    let vendor_cmds = dir.join("vendor/acme/pkg/src/Commands");
+    std::fs::create_dir_all(&app_cmds).unwrap();
+    std::fs::create_dir_all(&vendor_cmds).unwrap();
+    std::fs::write(
+        app_cmds.join("SendEmails.php"),
+        command_class("SendEmails", "emails:send"),
+    )
+    .unwrap();
+    std::fs::write(
+        vendor_cmds.join("Backup.php"),
+        command_class("Backup", "backup:run"),
+    )
+    .unwrap();
+    // A non-command file should be skipped.
+    std::fs::write(
+        app_cmds.join("NotACommand.php"),
+        "<?php\nclass NotACommand {}",
+    )
+    .unwrap();
+
+    let index = build_command_index(&dir);
+
+    assert_eq!(index.len(), 2);
+    assert_eq!(
+        index.resolve("emails:send").unwrap().priority,
+        CommandPriority::App
+    );
+    assert_eq!(
+        index.resolve("backup:run").unwrap().priority,
+        CommandPriority::Package
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/laravel-lsp/src/command_signature.rs
+++ b/laravel-lsp/src/command_signature.rs
@@ -1,0 +1,148 @@
+//! Extract Artisan command metadata from a PHP `Command` class.
+//!
+//! The discovery half of issue #62: a class that extends
+//! `Illuminate\Console\Command` declares the command it provides through a
+//! `protected $signature = 'emails:send {user} {--force}';` property. Goto-
+//! definition and hover for command-string call sites (`Artisan::call('emails:send')`)
+//! need two things out of such a class:
+//!
+//! 1. the **command name** — the leading token of the signature, before the
+//!    first whitespace (`emails:send`), which is what call sites reference; and
+//! 2. the **source position** of the signature string's content, so a later
+//!    goto-definition can land the cursor precisely on the declaration.
+//!
+//! This module is the pure, file-content-only primitive for that extraction —
+//! the same shape as [`crate::route_name_locator`] (positions of a string
+//! literal's content) and [`crate::php_class`] (regex-based PHP parsing). It
+//! does no I/O and holds no index state; the Salsa-backed command index and the
+//! call-site locator build on top of it.
+//!
+//! ## Position convention
+//!
+//! Mirrors the rest of the stack (see `CLAUDE.md` → *Position Indexing
+//! Convention*): all rows/columns are **0-based**, and `start_column` /
+//! `end_column` bracket the string *content* — the first character after the
+//! opening quote through one past the last character before the closing quote.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+/// One Artisan command discovered on a `Command` subclass.
+///
+/// `name` is the resolvable identifier call sites use; `raw_signature` keeps the
+/// full declaration (arguments and options included) for hover summaries. The
+/// position fields point at the signature string's *content* so goto-definition
+/// can land on the declaration without re-parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandSignature {
+    /// The command name — the leading token of the signature, before the first
+    /// whitespace (`emails:send` from `emails:send {user} {--force}`).
+    pub name: String,
+    /// The full signature string content (no surrounding quotes), as written.
+    pub raw_signature: String,
+    /// 0-based row of the signature string content.
+    pub line: u32,
+    /// 0-based column of the first content character (after the opening quote).
+    pub start_column: u32,
+    /// 0-based column one past the last content character (before the closing
+    /// quote).
+    pub end_column: u32,
+}
+
+/// The command name carried by a `$signature` value: everything up to the first
+/// ASCII whitespace, trimmed. Laravel parses the signature the same way — the
+/// leading token is the command name and the remainder declares arguments and
+/// options.
+///
+/// Returns an empty string for an all-whitespace input; callers treat an empty
+/// name as "no usable command" (see [`extract_command_signature`]).
+pub fn command_name_from_signature(raw: &str) -> &str {
+    raw.trim_start()
+        .split(|c: char| c.is_ascii_whitespace())
+        .next()
+        .unwrap_or("")
+        .trim()
+}
+
+/// Whether `content` declares a class that extends `Command` — the marker for
+/// an Artisan command class. Matches both the bare `extends Command` (the
+/// common case, with a `use Illuminate\Console\Command;` import) and a
+/// fully/partially qualified `extends \Illuminate\Console\Command`.
+///
+/// This is a deliberately permissive heuristic: any `Command`-suffixed base
+/// class counts (e.g. a project's own `BaseCommand` intermediate is itself
+/// resolved through its own `extends`). The command index relies on the
+/// presence of a `$signature` to confirm — a class extending some unrelated
+/// `Command` but carrying no signature is dropped by [`extract_command_signature`].
+pub fn extends_console_command(content: &str) -> bool {
+    lazy_static! {
+        static ref EXTENDS_COMMAND_RE: Regex =
+            Regex::new(r"\bextends\s+\\?(?:[A-Za-z_][A-Za-z0-9_]*\\)*[A-Za-z0-9_]*Command\b")
+                .unwrap();
+    }
+    EXTENDS_COMMAND_RE.is_match(content)
+}
+
+/// Extract the Artisan command signature from a `Command` subclass's source.
+///
+/// Returns `None` — gracefully, never panicking (AC: edge cases) — when:
+/// - the class does not extend a `Command` base (not an Artisan command);
+/// - there is no `protected $signature = '...'` literal (missing signature, or
+///   the signature is built dynamically / from a constant we can't read
+///   statically); or
+/// - the literal resolves to an empty command name (malformed signature).
+///
+/// The signature is matched as a single-line string literal in either quote
+/// style. Heredoc/nowdoc and interpolated signatures are intentionally skipped
+/// rather than guessed — better to offer no navigation than a wrong target.
+pub fn extract_command_signature(content: &str) -> Option<CommandSignature> {
+    if !extends_console_command(content) {
+        return None;
+    }
+
+    lazy_static! {
+        // `protected $signature = '...';` — single- or double-quoted, matched
+        // as separate alternatives because the `regex` crate has no
+        // backreferences to pin the closing quote to the opening one. The inner
+        // content is group 1 (single quotes) or group 2 (double quotes). Accept
+        // any visibility and an optional `static` for robustness against
+        // `public`/`protected static` shapes.
+        static ref SIGNATURE_RE: Regex = Regex::new(
+            r#"(?:public|protected|private)\s+(?:static\s+)?\$signature\s*=\s*(?:'([^'\n]*)'|"([^"\n]*)")"#,
+        )
+        .unwrap();
+    }
+
+    let caps = SIGNATURE_RE.captures(content)?;
+    let content_match = caps.get(1).or_else(|| caps.get(2))?;
+    let raw_signature = content_match.as_str().to_string();
+
+    let name = command_name_from_signature(&raw_signature);
+    if name.is_empty() {
+        return None;
+    }
+    let name = name.to_string();
+
+    let byte_offset = content_match.start();
+    let mut line = 0u32;
+    let mut last_line_start = 0usize;
+    for (i, ch) in content[..byte_offset].char_indices() {
+        if ch == '\n' {
+            line += 1;
+            last_line_start = i + 1;
+        }
+    }
+    let start_column = (byte_offset - last_line_start) as u32;
+    let end_column = start_column + raw_signature.len() as u32;
+
+    Some(CommandSignature {
+        name,
+        raw_signature,
+        line,
+        start_column,
+        end_column,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/command_signature/tests.rs
+++ b/laravel-lsp/src/command_signature/tests.rs
@@ -1,0 +1,119 @@
+//! Unit tests for Artisan command signature extraction.
+
+use super::*;
+
+/// A minimal but realistic Artisan command class. `indent` controls how far the
+/// `$signature` line is indented so column assertions stay readable.
+fn command_class(signature_line: &str) -> String {
+    format!(
+        "<?php\n\nnamespace App\\Console\\Commands;\n\nuse Illuminate\\Console\\Command;\n\nclass SendEmails extends Command\n{{\n    {}\n\n    public function handle()\n    {{\n        //\n    }}\n}}\n",
+        signature_line
+    )
+}
+
+#[test]
+fn command_name_is_leading_token() {
+    assert_eq!(command_name_from_signature("emails:send"), "emails:send");
+    assert_eq!(
+        command_name_from_signature("emails:send {user} {--force}"),
+        "emails:send"
+    );
+    // Leading whitespace and tabs are tolerated.
+    assert_eq!(
+        command_name_from_signature("  app:cleanup\t{--dry}"),
+        "app:cleanup"
+    );
+    // All-whitespace yields an empty name (treated as "no command").
+    assert_eq!(command_name_from_signature("   "), "");
+}
+
+#[test]
+fn extends_command_recognises_bare_and_qualified() {
+    assert!(extends_console_command("class Foo extends Command {}"));
+    assert!(extends_console_command(
+        "class Foo extends \\Illuminate\\Console\\Command {}"
+    ));
+    assert!(extends_console_command(
+        "class Foo extends Illuminate\\Console\\Command {}"
+    ));
+    // A project intermediate base whose name ends in `Command` still counts.
+    assert!(extends_console_command("class Foo extends BaseCommand {}"));
+    // Unrelated base classes do not.
+    assert!(!extends_console_command("class Foo extends Model {}"));
+    assert!(!extends_console_command("class Foo extends Controller {}"));
+}
+
+#[test]
+fn extracts_simple_signature() {
+    let src = command_class("protected $signature = 'emails:send';");
+    let sig = extract_command_signature(&src).expect("signature should be found");
+    assert_eq!(sig.name, "emails:send");
+    assert_eq!(sig.raw_signature, "emails:send");
+}
+
+#[test]
+fn extracts_signature_with_arguments_and_options() {
+    let src = command_class("protected $signature = 'emails:send {user} {--force}';");
+    let sig = extract_command_signature(&src).expect("signature should be found");
+    assert_eq!(sig.name, "emails:send");
+    assert_eq!(sig.raw_signature, "emails:send {user} {--force}");
+}
+
+#[test]
+fn extracts_double_quoted_signature() {
+    let src = command_class(r#"protected $signature = "queue:work {--once}";"#);
+    let sig = extract_command_signature(&src).expect("signature should be found");
+    assert_eq!(sig.name, "queue:work");
+    assert_eq!(sig.raw_signature, "queue:work {--once}");
+}
+
+#[test]
+fn signature_position_brackets_string_content() {
+    let src = command_class("protected $signature = 'emails:send';");
+    let sig = extract_command_signature(&src).expect("signature should be found");
+
+    // The signature line is line index 8 in the fixture (0-based):
+    // 0:<?php 1:blank 2:namespace 3:blank 4:use 5:blank 6:class 7:{ 8:signature
+    assert_eq!(sig.line, 8);
+
+    // The content starts right after the opening quote. The line is indented 4
+    // spaces; `protected $signature = '` is the prefix.
+    let line_text = src.lines().nth(sig.line as usize).unwrap();
+    let extracted = &line_text[sig.start_column as usize..sig.end_column as usize];
+    assert_eq!(extracted, "emails:send");
+}
+
+#[test]
+fn missing_signature_returns_none() {
+    // Extends Command but declares no $signature (dynamic or inherited).
+    let src = command_class("protected $description = 'Send queued emails';");
+    assert!(extract_command_signature(&src).is_none());
+}
+
+#[test]
+fn non_command_class_returns_none() {
+    let src =
+        "<?php\nclass UserController extends Controller {\n    protected $signature = 'nope';\n}\n";
+    assert!(extract_command_signature(src).is_none());
+}
+
+#[test]
+fn dynamic_signature_is_skipped_gracefully() {
+    // Interpolated / concatenated signatures are not statically resolvable;
+    // extraction declines rather than guessing a wrong command name.
+    let src = command_class("protected $signature = 'app:' . $this->suffix;");
+    let sig = extract_command_signature(&src);
+    // The leading literal still parses to a name; it must not panic. Either a
+    // best-effort `app:` name or None is acceptable — assert no panic and a
+    // sane name when present.
+    if let Some(sig) = sig {
+        assert_eq!(sig.name, "app:");
+    }
+}
+
+#[test]
+fn malformed_class_does_not_panic() {
+    // Truncated / malformed source must be handled gracefully.
+    let src = "<?php class Broken extends Command { protected $signature = ";
+    assert!(extract_command_signature(src).is_none());
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -18,6 +18,7 @@ pub mod blade_props;
 pub mod cache_manager;
 pub mod class_locator;
 pub mod class_rename;
+pub mod command_signature;
 pub mod completion_format;
 pub mod component_completion;
 pub mod component_declaration_locator;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -19,6 +19,7 @@ pub mod cache_manager;
 pub mod class_locator;
 pub mod class_rename;
 pub mod command_call_locator;
+pub mod command_disk_cache;
 pub mod command_index;
 pub mod command_signature;
 pub mod completion_format;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -19,6 +19,7 @@ pub mod cache_manager;
 pub mod class_locator;
 pub mod class_rename;
 pub mod command_call_locator;
+pub mod command_index;
 pub mod command_signature;
 pub mod completion_format;
 pub mod component_completion;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -18,6 +18,7 @@ pub mod blade_props;
 pub mod cache_manager;
 pub mod class_locator;
 pub mod class_rename;
+pub mod command_call_locator;
 pub mod command_signature;
 pub mod completion_format;
 pub mod component_completion;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -22,6 +22,7 @@ use laravel_lsp::cache_manager::{
     BindingEntry, CacheManager, CachedEnvVars, CachedLaravelConfig, MiddlewareEntry, RescanType,
     ScanResult,
 };
+use laravel_lsp::command_index::{build_command_index, CommandIndex};
 use laravel_lsp::completion_format::CompletionDoc;
 use laravel_lsp::config::find_project_root;
 use laravel_lsp::middleware_parser::{middleware_base_alias, resolve_class_to_file};
@@ -1903,6 +1904,14 @@ struct LaravelLanguageServer {
     /// and refreshed when migration files change.
     migration_index: Arc<RwLock<Option<MigrationIndex>>>,
 
+    /// Project-wide index of Artisan commands (classes extending
+    /// `Illuminate\Console\Command`) keyed by command name, with app-over-
+    /// package-over-framework priority. Powers goto-definition and hover on
+    /// command-string call sites (`Artisan::call('emails:send')`). Built at
+    /// init and refreshed when a `Command` file changes. See
+    /// [`laravel_lsp::command_index`].
+    command_index: Arc<RwLock<Option<CommandIndex>>>,
+
     /// Cached map of translation `namespace → absolute lang directory` for
     /// unpublished vendor packages. Lazily populated on the first translation
     /// hover that needs it; subsequent hovers reuse the cached map. See
@@ -3532,6 +3541,7 @@ impl LaravelLanguageServer {
             database_diagnostic_shown: Arc::new(RwLock::new(false)),
             route_index: Arc::new(RwLock::new(None)),
             migration_index: Arc::new(RwLock::new(None)),
+            command_index: Arc::new(RwLock::new(None)),
             vendor_translation_namespaces: Arc::new(RwLock::new(None)),
             builder_method_index_cache: Arc::new(RwLock::new(HashMap::new())),
             route_decl_cache: Arc::new(RwLock::new(HashMap::new())),
@@ -4487,6 +4497,7 @@ impl LaravelLanguageServer {
             tokio::spawn(async move {
                 server.rebuild_route_index(&route_root).await;
                 server.rebuild_migration_index(&route_root).await;
+                server.rebuild_command_index(&route_root).await;
             });
         }
 
@@ -4857,6 +4868,7 @@ impl LaravelLanguageServer {
         // renamed, removed) are reflected on the next goto-definition request.
         self.rebuild_route_index(&root).await;
         self.rebuild_migration_index(&root).await;
+        self.rebuild_command_index(&root).await;
 
         // Populate cache with ALL parsed middleware/bindings AFTER all rescans complete
         // This ensures we capture middleware from both vendor and app sources
@@ -5122,6 +5134,7 @@ impl LaravelLanguageServer {
         info!("========================================");
         self.rebuild_route_index(&discovered_root).await;
         self.rebuild_migration_index(&discovered_root).await;
+        self.rebuild_command_index(&discovered_root).await;
 
         // Initialize environment variables with Salsa
         info!("========================================");
@@ -12903,6 +12916,109 @@ return [
         }
     }
 
+    /// Rebuild the Artisan command index by scanning the project and `vendor/`
+    /// for `Command` subclasses. Mirrors `rebuild_migration_index` — the
+    /// (blocking) walk runs off the async runtime, then the index is swapped in.
+    async fn rebuild_command_index(&self, root: &Path) {
+        let root = root.to_path_buf();
+        let index = tokio::task::spawn_blocking(move || build_command_index(&root)).await;
+        match index {
+            Ok(index) => {
+                info!("🎛️  Command index built: {} commands", index.len());
+                *self.command_index.write().await = Some(index);
+            }
+            Err(e) => {
+                tracing::warn!("Failed to build command index: {}", e);
+            }
+        }
+    }
+
+    /// Goto-definition for an Artisan command-string call site under the cursor
+    /// (`Artisan::call('emails:send')`, `->command('emails:send')`, …). Resolves
+    /// the cursor to a command name via [`laravel_lsp::command_call_locator`],
+    /// looks it up in the command index, and lands on the matching class's
+    /// `$signature` declaration. Returns `None` when the cursor isn't on a call
+    /// site or the command isn't indexed — goto then no-ops.
+    async fn command_goto_definition(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<GotoDefinitionResponse> {
+        let content = self
+            .documents
+            .read()
+            .await
+            .get(uri)
+            .map(|(c, _)| c.clone())?;
+        let site = laravel_lsp::command_call_locator::command_call_at_position(
+            &content,
+            position.line,
+            position.character,
+        )?;
+
+        let guard = self.command_index.read().await;
+        let entry = guard.as_ref()?.resolve(site.command_name())?;
+
+        let target_uri = Url::from_file_path(&entry.file).ok()?;
+        let range = Range {
+            start: Position {
+                line: entry.line,
+                character: entry.start_column,
+            },
+            end: Position {
+                line: entry.line,
+                character: entry.end_column,
+            },
+        };
+        let caret = Range {
+            start: range.start,
+            end: range.start,
+        };
+        Some(GotoDefinitionResponse::Link(vec![LocationLink {
+            origin_selection_range: None,
+            target_uri,
+            target_range: range,
+            target_selection_range: caret,
+        }]))
+    }
+
+    /// Hover markdown for an Artisan command-string call site under the cursor:
+    /// the declaring class name and the command's `$signature`. Returns `None`
+    /// when the cursor isn't on a call site or the command isn't indexed.
+    async fn command_hover(&self, uri: &Url, position: Position) -> Option<String> {
+        let content = self
+            .documents
+            .read()
+            .await
+            .get(uri)
+            .map(|(c, _)| c.clone())?;
+        let site = laravel_lsp::command_call_locator::command_call_at_position(
+            &content,
+            position.line,
+            position.character,
+        )?;
+
+        let guard = self.command_index.read().await;
+        let entry = guard.as_ref()?.resolve(site.command_name())?;
+        Some(format!(
+            "**Artisan command** `{}`\n\n`{}`\n\n```php\nprotected $signature = '{}';\n```",
+            entry.name, entry.class_name, entry.raw_signature
+        ))
+    }
+
+    /// Wrap [`command_hover`](Self::command_hover) markdown into a hover
+    /// response, or `None` when the cursor isn't on a resolvable command string.
+    async fn command_hover_response(&self, uri: &Url, position: Position) -> Option<Hover> {
+        let value = self.command_hover(uri, position).await?;
+        Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value,
+            }),
+            range: None,
+        })
+    }
+
     /// Goto-definition for a query-chain literal under the cursor. Re-extracts
     /// chains from the LIVE document (Salsa's cached chains can lag, and we need
     /// byte offsets that match `content`), resolves the literal, and routes it:
@@ -13571,6 +13687,7 @@ return [
             database_diagnostic_shown: self.database_diagnostic_shown.clone(),
             route_index: self.route_index.clone(),
             migration_index: self.migration_index.clone(),
+            command_index: self.command_index.clone(),
             vendor_translation_namespaces: self.vendor_translation_namespaces.clone(),
             builder_method_index_cache: self.builder_method_index_cache.clone(),
             route_decl_cache: self.route_decl_cache.clone(),
@@ -16661,6 +16778,7 @@ impl LanguageServer for LaravelLanguageServer {
         let mut deleted = 0usize;
         let mut skipped_open = 0usize;
         let mut migrations_changed = false;
+        let mut commands_changed = false;
 
         for change in params.changes {
             if open_docs.contains(&change.uri) {
@@ -16670,6 +16788,15 @@ impl LanguageServer for LaravelLanguageServer {
             let Ok(path) = change.uri.to_file_path() else {
                 continue;
             };
+            // A Command class can live anywhere, but conventionally sits under a
+            // `Commands/` directory (app or package). That heuristic keeps the
+            // index fresh without rebuilding on every unrelated `.php` save.
+            if !commands_changed {
+                let p = path.to_string_lossy();
+                if p.ends_with(".php") && p.contains("/Commands/") {
+                    commands_changed = true;
+                }
+            }
             if !migrations_changed && path.to_string_lossy().contains("database/migrations") {
                 migrations_changed = true;
             }
@@ -16758,6 +16885,14 @@ impl LanguageServer for LaravelLanguageServer {
         if migrations_changed {
             if let Some(root) = self.initialized_root.read().await.clone() {
                 self.rebuild_migration_index(&root).await;
+            }
+        }
+
+        // A Command class changed on disk — rebuild the Artisan command index so
+        // goto-definition/hover on command strings stay accurate. One per batch.
+        if commands_changed {
+            if let Some(root) = self.initialized_root.read().await.clone() {
+                self.rebuild_command_index(&root).await;
             }
         }
     }
@@ -16870,6 +17005,14 @@ impl LanguageServer for LaravelLanguageServer {
                 // migration). Chains aren't position-indexed, so this lives in
                 // the no-pattern branch.
                 if let Some(loc) = self.chain_goto_definition(&uri, position).await {
+                    return Ok(Some(loc));
+                }
+
+                // Artisan command-string fallback: cmd-click on a command name
+                // in `Artisan::call('emails:send')`, `->command('emails:send')`,
+                // etc. jumps to the declaring Command class's `$signature`.
+                // Call sites aren't position-indexed, so this lives here too.
+                if let Some(loc) = self.command_goto_definition(&uri, position).await {
                     return Ok(Some(loc));
                 }
 
@@ -17043,12 +17186,14 @@ impl LanguageServer for LaravelLanguageServer {
             is_blade,
         ) {
             Some(t) => t,
-            None => return Ok(None),
+            // No Salsa-indexed hover target — try the Artisan command-string
+            // fallback (call sites aren't position-indexed) before giving up.
+            None => return Ok(self.command_hover_response(uri, position).await),
         };
 
         let value = match self.build_hover_markdown(target, uri).await {
             Some(v) => v,
-            None => return Ok(None),
+            None => return Ok(self.command_hover_response(uri, position).await),
         };
 
         Ok(Some(Hover {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -12920,11 +12920,48 @@ return [
     /// for `Command` subclasses. Mirrors `rebuild_migration_index` — the
     /// (blocking) walk runs off the async runtime, then the index is swapped in.
     async fn rebuild_command_index(&self, root: &Path) {
-        let root = root.to_path_buf();
-        let index = tokio::task::spawn_blocking(move || build_command_index(&root)).await;
+        // Cold start: restore the disk-cached index immediately so
+        // goto-definition/hover on command strings work without waiting for
+        // the full project+vendor walk below. Only on a cold index (None) —
+        // file-watcher rebuilds already have a live index and skip this. The
+        // full build that follows corrects any drift (added/removed commands
+        // while the LSP was off) and re-saves the cache.
+        if self.command_index.read().await.is_none() {
+            let root_for_load = root.to_path_buf();
+            if let Ok(Some(cached)) = tokio::task::spawn_blocking(move || {
+                laravel_lsp::command_disk_cache::load_index(&root_for_load)
+            })
+            .await
+            {
+                info!(
+                    "🗄️  Command index: restored {} commands from disk cache",
+                    cached.len()
+                );
+                *self.command_index.write().await = Some(cached);
+            }
+        }
+
+        let root_buf = root.to_path_buf();
+        let index = tokio::task::spawn_blocking(move || build_command_index(&root_buf)).await;
         match index {
             Ok(index) => {
                 info!("🎛️  Command index built: {} commands", index.len());
+
+                // Persist the freshly built index so the next cold start can
+                // skip the walk. Advisory — a save failure doesn't affect the
+                // live in-memory index.
+                let to_save = index.clone();
+                let root_for_save = root.to_path_buf();
+                let saved = tokio::task::spawn_blocking(move || {
+                    laravel_lsp::command_disk_cache::save_index(&to_save, &root_for_save)
+                })
+                .await;
+                match saved {
+                    Ok(Ok(n)) => info!("🗄️  Command disk cache: saved {} commands", n),
+                    Ok(Err(e)) => debug!("Command disk cache save failed: {}", e),
+                    Err(e) => debug!("Command disk cache save task panicked: {}", e),
+                }
+
                 *self.command_index.write().await = Some(index);
             }
             Err(e) => {

--- a/laravel-lsp/tests/integration_tests.rs
+++ b/laravel-lsp/tests/integration_tests.rs
@@ -1468,3 +1468,62 @@ mod debounce_behavior {
         assert_eq!(pending_updates.len(), 2);
     }
 }
+
+/// End-to-end resolution for Artisan command-string call sites (issue #62):
+/// a cursor on a command string resolves through the call-site locator and the
+/// project-wide command index to the declaring Command class. Covers two call
+/// patterns and both app- and vendor-side commands.
+#[cfg(test)]
+mod command_resolution {
+    use laravel_lsp::command_call_locator::command_call_at_position;
+    use laravel_lsp::command_index::{build_command_index, CommandPriority};
+    use std::fs;
+
+    fn command_class(class: &str, signature: &str) -> String {
+        format!(
+            "<?php\n\nnamespace App\\Console\\Commands;\n\nuse Illuminate\\Console\\Command;\n\nclass {class} extends Command\n{{\n    protected $signature = '{signature}';\n\n    public function handle()\n    {{\n    }}\n}}\n"
+        )
+    }
+
+    #[test]
+    fn resolves_two_call_patterns_across_app_and_vendor() {
+        let dir = std::env::temp_dir().join(format!("cmd-e2e-{}", std::process::id()));
+        let app = dir.join("app/Console/Commands");
+        let vendor = dir.join("vendor/acme/pkg/src/Commands");
+        fs::create_dir_all(&app).unwrap();
+        fs::create_dir_all(&vendor).unwrap();
+        fs::write(
+            app.join("SendEmails.php"),
+            command_class("SendEmails", "emails:send {user}"),
+        )
+        .unwrap();
+        fs::write(
+            vendor.join("BackupRun.php"),
+            command_class("BackupRun", "backup:run"),
+        )
+        .unwrap();
+
+        let index = build_command_index(&dir);
+
+        // Pattern 1 — direct dispatch, app-side command.
+        let call = "<?php\nArtisan::call('emails:send');\n";
+        let site = command_call_at_position(call, 1, 16).expect("cursor on app call site");
+        let entry = index
+            .resolve(site.command_name())
+            .expect("app command resolves");
+        assert_eq!(entry.class_name, "SendEmails");
+        assert_eq!(entry.priority, CommandPriority::App);
+        assert!(entry.file.ends_with("app/Console/Commands/SendEmails.php"));
+
+        // Pattern 2 — scheduler `->command`, vendor-side command.
+        let sched = "<?php\n$schedule->command('backup:run')->daily();\n";
+        let site = command_call_at_position(sched, 1, 22).expect("cursor on vendor call site");
+        let entry = index
+            .resolve(site.command_name())
+            .expect("vendor command resolves");
+        assert_eq!(entry.class_name, "BackupRun");
+        assert_eq!(entry.priority, CommandPriority::Package);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+}


### PR DESCRIPTION
## Summary
Implements #62 — goto-definition and hover for Artisan command strings. A
cursor on a command name (`Artisan::call('emails:send')`, `->command('…')`,
`Artisan::queue('…')`, `->artisan('…')`) now resolves to the `Command` class
that declares the matching `protected $signature`.

## Changes
- **`command_signature`** — extract a command's name + `$signature` from a
  `Command` class.
- **`command_call_locator`** — find command-string call sites and resolve the
  call site under a cursor, across all four invocation patterns.
- **`command_index`** — eager, project-wide + `vendor/` index of `Command`
  classes keyed by command name, with **App > Package > Framework** priority so
  app-defined commands override same-named framework/package commands. Walk is
  regex-gated on `extends …Command` to bound cost over large `vendor/` trees.
  The priority-merge now lives in `CommandIndex::insert_entry`, shared by the
  project walk and the disk-cache restore.
- **`command_disk_cache`** (new) — persists the built index to a `bincode` blob
  in the per-project XDG cache dir (alongside the pattern cache), mirroring
  `pattern_disk_cache`. A cold start restores it instantly so goto/hover work
  without waiting for the full project+vendor walk; each entry is validated
  against its declaring file's mtime on load, and the full rebuild that follows
  the restore corrects any drift and re-saves the cache.
- **LSP wiring** (`main.rs`) — build the index at init, restore from disk on a
  cold start, re-save after every build, rebuild when a `Command` file changes
  (workspace file watcher), and add goto + hover fallbacks in the no-pattern
  branch.

## Acceptance Criteria
- [x] Command signature discovery (project + vendor)
- [x] Goto-definition resolution → declaring class's `$signature` declaration
- [x] Hover support (class name + `$signature` summary)
- [x] Call site coverage — `Artisan::call`, `Artisan::queue`, `->command`, `->artisan`
- [x] Priority handling — app overrides framework/package
- [x] **Caching — index now cached on disk** (`command_disk_cache`, bincode, mtime-validated) and rebuilt when relevant `Command` files change via the workspace file watcher
- [x] Edge cases — missing/dynamic/malformed signatures handled gracefully (return `None`, never panic)
- [x] Test coverage — two call patterns, app + vendor commands; plus 6 disk-cache round-trip/invalidation tests

## Test Plan
- [x] `cargo test --lib` — 1245 lib tests pass (incl. 6 new `command_disk_cache` tests).
- [x] `cargo build` / `cargo clippy --all-targets` clean; `cargo fmt --check` clean.
- [ ] Pre-existing: fixture tests fail in a fresh clone because the gitignored
  `test-project/.env` isn't present — unrelated to this change.

Fixes #62