### PR TITLE
fix: 🐛 Resolve namespaced Blade components across all registration shapes

### DIFF
--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -482,43 +482,9 @@ fn extract_provider_blade_aliases(source: &str, aliases: &mut HashMap<String, St
 /// pulling out single-quoted alias/view pairs. Skips entries whose value is a
 /// `Class::class` reference (those are PHP component classes, not view paths).
 fn parse_component_aliases(source: &str, aliases: &mut HashMap<String, String>) {
-    // Find the start of the aliases block: 'aliases' => [
-    let Some(aliases_pos) = source
-        .find("'aliases'")
-        .or_else(|| source.find("\"aliases\""))
-    else {
+    let Some(block) = php_array_block(source, "aliases") else {
         return;
     };
-
-    // Find the opening bracket of the alias array after 'aliases' =>
-    let after_key = &source[aliases_pos..];
-    let Some(open_bracket_rel) = after_key.find('[') else {
-        return;
-    };
-
-    // Walk character-by-character to find the matching close bracket so we
-    // don't pick up entries from sibling top-level config keys.
-    let block_start = aliases_pos + open_bracket_rel + 1;
-    let mut depth: i32 = 1;
-    let mut block_end = block_start;
-    for (idx, ch) in source[block_start..].char_indices() {
-        match ch {
-            '[' => depth += 1,
-            ']' => {
-                depth -= 1;
-                if depth == 0 {
-                    block_end = block_start + idx;
-                    break;
-                }
-            }
-            _ => {}
-        }
-    }
-    if depth != 0 {
-        return;
-    }
-
-    let block = &source[block_start..block_end];
 
     for raw_line in block.lines() {
         let line = raw_line.trim();
@@ -548,6 +514,35 @@ fn parse_component_aliases(source: &str, aliases: &mut HashMap<String, String>) 
 
         aliases.insert(alias_name.to_string(), view_path.to_string());
     }
+}
+
+/// Find the contents of the PHP array literal assigned to `key` in a config
+/// source: `'{key}' => [ ... ]`. Walks character-by-character to the matching
+/// close bracket so entries from sibling top-level config keys are never
+/// picked up. Returns the text between the brackets.
+fn php_array_block<'a>(source: &'a str, key: &str) -> Option<&'a str> {
+    let key_pos = source
+        .find(&format!("'{key}'"))
+        .or_else(|| source.find(&format!("\"{key}\"")))?;
+
+    let after_key = &source[key_pos..];
+    let open_bracket_rel = after_key.find('[')?;
+
+    let block_start = key_pos + open_bracket_rel + 1;
+    let mut depth: i32 = 1;
+    for (idx, ch) in source[block_start..].char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&source[block_start..block_start + idx]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Split a PHP array entry like `'alias' => 'view.path',` into (key, value).

--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -543,19 +543,25 @@ pub fn livewire_component_namespaces(root: &Path) -> Vec<(String, PathBuf)> {
         let Ok(source) = fs::read_to_string(&config_path) else {
             continue;
         };
-        let parsed = parse_livewire_component_namespaces(&source, root);
-        if !parsed.is_empty() {
+        // A present key is authoritative even when its array is empty —
+        // `'component_namespaces' => []` is how an app *disables* Livewire's
+        // defaults (Laravel's config merge replaces the array wholesale).
+        // Only a missing key falls through to the vendor defaults.
+        if let Some(parsed) = parse_livewire_component_namespaces(&source, root) {
             return parsed;
         }
     }
     Vec::new()
 }
 
-fn parse_livewire_component_namespaces(source: &str, root: &Path) -> Vec<(String, PathBuf)> {
+/// Returns `None` when the `component_namespaces` key is absent from the
+/// source, `Some(entries)` (possibly empty) when it is present.
+fn parse_livewire_component_namespaces(
+    source: &str,
+    root: &Path,
+) -> Option<Vec<(String, PathBuf)>> {
     let mut namespaces = Vec::new();
-    let Some(block) = php_array_block(source, "component_namespaces") else {
-        return namespaces;
-    };
+    let block = php_array_block(source, "component_namespaces")?;
 
     for raw_line in block.lines() {
         let line = raw_line.trim();
@@ -579,7 +585,7 @@ fn parse_livewire_component_namespaces(source: &str, root: &Path) -> Vec<(String
         namespaces.push((namespace.to_string(), path));
     }
 
-    namespaces
+    Some(namespaces)
 }
 
 /// Resolve a PHP path expression from a config value to an absolute path.

--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -516,6 +516,106 @@ fn parse_component_aliases(source: &str, aliases: &mut HashMap<String, String>) 
     }
 }
 
+// ============================================================================
+// Livewire component namespaces (Livewire v4)
+// ============================================================================
+
+/// Anonymous component namespaces Livewire v4 registers at boot.
+///
+/// Livewire v4's service provider loops over
+/// `config('livewire.component_namespaces')` — defaulting to
+/// `['layouts' => resource_path('views/layouts'), 'pages' =>
+/// resource_path('views/pages')]` — calling
+/// `Blade::anonymousComponentPath($location, $namespace)` for each entry,
+/// which is what makes `<x-layouts::app>` resolve to
+/// `resources/views/layouts/app.blade.php`. The registration is config-driven
+/// and runs in a loop, so provider parsing never sees it; reconstruct it from
+/// the config instead: the app's `config/livewire.php` when it defines the
+/// key, else the package's own config (Livewire merges vendor defaults
+/// underneath the app's). Livewire v3 has no such key, so this is a no-op
+/// there.
+pub fn livewire_component_namespaces(root: &Path) -> Vec<(String, PathBuf)> {
+    let candidates = [
+        root.join("config/livewire.php"),
+        root.join("vendor/livewire/livewire/config/livewire.php"),
+    ];
+    for config_path in candidates {
+        let Ok(source) = fs::read_to_string(&config_path) else {
+            continue;
+        };
+        let parsed = parse_livewire_component_namespaces(&source, root);
+        if !parsed.is_empty() {
+            return parsed;
+        }
+    }
+    Vec::new()
+}
+
+fn parse_livewire_component_namespaces(source: &str, root: &Path) -> Vec<(String, PathBuf)> {
+    let mut namespaces = Vec::new();
+    let Some(block) = php_array_block(source, "component_namespaces") else {
+        return namespaces;
+    };
+
+    for raw_line in block.lines() {
+        let line = raw_line.trim();
+        if line.is_empty()
+            || line.starts_with("//")
+            || line.starts_with('#')
+            || line.starts_with("/*")
+        {
+            continue;
+        }
+
+        let Some((key, value)) = split_arrow_pair(line) else {
+            continue;
+        };
+        let Some(namespace) = unquote(key) else {
+            continue;
+        };
+        let Some(path) = resolve_php_path_expression(value, root) else {
+            continue;
+        };
+        namespaces.push((namespace.to_string(), path));
+    }
+
+    namespaces
+}
+
+/// Resolve a PHP path expression from a config value to an absolute path.
+/// Handles the Laravel path helpers (`resource_path('x')`, `base_path('x')`,
+/// `app_path('x')`) and plain string literals (absolute, or root-relative).
+fn resolve_php_path_expression(value: &str, root: &Path) -> Option<PathBuf> {
+    let value = value.trim();
+
+    for (helper, base) in [
+        ("resource_path", Some("resources")),
+        ("base_path", None),
+        ("app_path", Some("app")),
+    ] {
+        if let Some(rest) = value.strip_prefix(helper) {
+            let inner = rest.trim().strip_prefix('(')?.rsplit_once(')')?.0;
+            let arg = unquote(inner.trim()).unwrap_or("");
+            let mut path = root.to_path_buf();
+            if let Some(base) = base {
+                path.push(base);
+            }
+            if !arg.is_empty() {
+                path.push(arg);
+            }
+            return Some(path);
+        }
+    }
+
+    let literal = unquote(value)?;
+    let path = PathBuf::from(literal);
+    Some(if path.is_absolute() {
+        path
+    } else {
+        root.join(literal)
+    })
+}
+
 /// Find the contents of the PHP array literal assigned to `key` in a config
 /// source: `'{key}' => [ ... ]`. Walks character-by-character to the matching
 /// close bracket so entries from sibling top-level config keys are never

--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -588,6 +588,103 @@ fn parse_livewire_component_namespaces(
     Some(namespaces)
 }
 
+/// Resolve a dotted config key (`mary.prefix`) to its string value the way
+/// Laravel would at boot: the app's `config/{file}.php` wins; otherwise the
+/// registering package's own bundled `config/{file}.php` default (packages
+/// `mergeConfigFrom` their config under the same key). The package config is
+/// located by walking up from the provider file to the nearest `config/`
+/// sibling, stopping at the project root. Returns `None` when neither
+/// defines the key — PHP's `config()` would yield null there.
+pub fn resolve_config_string_for_package(
+    root: &Path,
+    dotted_key: &str,
+    provider_path: &Path,
+) -> Option<String> {
+    let (file, key) = dotted_key.split_once('.')?;
+    let config_file = format!("{file}.php");
+
+    // App override.
+    if let Ok(source) = fs::read_to_string(root.join("config").join(&config_file)) {
+        if let Some(value) = php_top_level_string_value(&source, key) {
+            return Some(value);
+        }
+    }
+
+    // Package default: provider at `<pkg>/src/FooServiceProvider.php` →
+    // `<pkg>/config/{file}.php`.
+    let mut dir = provider_path.parent();
+    while let Some(d) = dir {
+        let candidate = d.join("config").join(&config_file);
+        if candidate.exists() {
+            let source = fs::read_to_string(&candidate).ok()?;
+            return php_top_level_string_value(&source, key);
+        }
+        if d == root {
+            break;
+        }
+        dir = d.parent();
+    }
+
+    None
+}
+
+/// Find the string value of a **top-level** key in a PHP config file
+/// (`return ['prefix' => 'mary-', ...]`), ignoring same-named keys nested
+/// inside sub-arrays. Handles plain string literals and the
+/// `env('NAME', 'default')` form (the default is taken — .env overrides are
+/// out of static reach).
+pub fn php_top_level_string_value(source: &str, key: &str) -> Option<String> {
+    let return_pos = source.find("return")?;
+    let open_rel = source[return_pos..].find('[')?;
+    let block_start = return_pos + open_rel + 1;
+
+    let mut depth: i32 = 1;
+    let mut block_end = None;
+    for (idx, ch) in source[block_start..].char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    block_end = Some(block_start + idx);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let block = &source[block_start..block_end?];
+
+    let needle_sq = format!("'{key}'");
+    let needle_dq = format!("\"{key}\"");
+    let mut rel_depth: i32 = 0;
+    for line in block.lines() {
+        let trimmed = line.trim();
+        if rel_depth == 0 && (trimmed.starts_with(&needle_sq) || trimmed.starts_with(&needle_dq)) {
+            let (_, value) = split_arrow_pair(trimmed)?;
+            if let Some(literal) = unquote(value) {
+                return Some(literal.to_string());
+            }
+            // env('NAME', 'default') → the default argument.
+            if let Some(rest) = value.strip_prefix("env(") {
+                let inner = rest.rsplit_once(')')?.0;
+                let default = inner.split_once(',')?.1.trim();
+                return unquote(default).map(str::to_string);
+            }
+            return None;
+        }
+        for ch in line.chars() {
+            match ch {
+                '[' => rel_depth += 1,
+                ']' => rel_depth -= 1,
+                _ => {}
+            }
+        }
+    }
+
+    None
+}
+
 /// Resolve a PHP path expression from a config value to an absolute path.
 /// Handles the Laravel path helpers (`resource_path('x')`, `base_path('x')`,
 /// `app_path('x')`) and plain string literals (absolute, or root-relative).

--- a/laravel-lsp/src/config/tests.rs
+++ b/laravel-lsp/src/config/tests.rs
@@ -529,3 +529,31 @@ fn resolve_php_path_expression_handles_helpers_and_literals() {
     // Unparseable expressions are skipped, not mangled.
     assert_eq!(resolve_php_path_expression("env('SOME_DIR')", root), None);
 }
+
+#[test]
+fn livewire_empty_app_override_disables_vendor_defaults() {
+    // 'component_namespaces' => [] in the app config is a deliberate
+    // disable — it must NOT fall through to the vendor defaults.
+    let tmp = std::env::temp_dir().join(format!(
+        "laravel-lsp-test-lw-empty-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&tmp);
+    let vendor_dir = tmp.join("vendor/livewire/livewire/config");
+    std::fs::create_dir_all(&vendor_dir).unwrap();
+    std::fs::write(vendor_dir.join("livewire.php"), LIVEWIRE_VENDOR_CONFIG).unwrap();
+    let app_dir = tmp.join("config");
+    std::fs::create_dir_all(&app_dir).unwrap();
+    std::fs::write(
+        app_dir.join("livewire.php"),
+        "<?php return ['component_namespaces' => []];",
+    )
+    .unwrap();
+
+    assert!(
+        livewire_component_namespaces(&tmp).is_empty(),
+        "an explicit empty override must disable the vendor defaults"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/laravel-lsp/src/config/tests.rs
+++ b/laravel-lsp/src/config/tests.rs
@@ -429,3 +429,103 @@ return [
     assert!(aliases.contains_key("light-button"));
     assert!(!aliases.contains_key("unrelated-alias"));
 }
+
+// ─── Livewire v4 component namespaces (issue #79, case 3) ────────────────
+
+const LIVEWIRE_VENDOR_CONFIG: &str = r#"<?php
+return [
+    'component_namespaces' => [
+        'layouts' => resource_path('views/layouts'),
+        'pages' => resource_path('views/pages'),
+    ],
+];
+"#;
+
+#[test]
+fn livewire_component_namespaces_reads_vendor_defaults() {
+    let tmp =
+        std::env::temp_dir().join(format!("laravel-lsp-test-lw-vendor-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    let config_dir = tmp.join("vendor/livewire/livewire/config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(config_dir.join("livewire.php"), LIVEWIRE_VENDOR_CONFIG).unwrap();
+
+    let namespaces = livewire_component_namespaces(&tmp);
+    assert_eq!(
+        namespaces,
+        vec![
+            ("layouts".to_string(), tmp.join("resources/views/layouts")),
+            ("pages".to_string(), tmp.join("resources/views/pages")),
+        ]
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn livewire_app_config_overrides_vendor_defaults() {
+    let tmp = std::env::temp_dir().join(format!("laravel-lsp-test-lw-app-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    let vendor_dir = tmp.join("vendor/livewire/livewire/config");
+    std::fs::create_dir_all(&vendor_dir).unwrap();
+    std::fs::write(vendor_dir.join("livewire.php"), LIVEWIRE_VENDOR_CONFIG).unwrap();
+    let app_dir = tmp.join("config");
+    std::fs::create_dir_all(&app_dir).unwrap();
+    std::fs::write(
+        app_dir.join("livewire.php"),
+        r#"<?php
+return [
+    'component_namespaces' => [
+        'shells' => base_path('themes/shells'),
+    ],
+];
+"#,
+    )
+    .unwrap();
+
+    let namespaces = livewire_component_namespaces(&tmp);
+    assert_eq!(
+        namespaces,
+        vec![("shells".to_string(), tmp.join("themes/shells"))]
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn livewire_component_namespaces_empty_without_livewire() {
+    let tmp = std::env::temp_dir().join(format!("laravel-lsp-test-lw-none-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).unwrap();
+
+    assert!(livewire_component_namespaces(&tmp).is_empty());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn resolve_php_path_expression_handles_helpers_and_literals() {
+    let root = Path::new("/proj");
+    assert_eq!(
+        resolve_php_path_expression("resource_path('views/layouts')", root),
+        Some(PathBuf::from("/proj/resources/views/layouts"))
+    );
+    assert_eq!(
+        resolve_php_path_expression("base_path('themes')", root),
+        Some(PathBuf::from("/proj/themes"))
+    );
+    assert_eq!(
+        resolve_php_path_expression("app_path('Views')", root),
+        Some(PathBuf::from("/proj/app/Views"))
+    );
+    assert_eq!(
+        resolve_php_path_expression("'relative/dir'", root),
+        Some(PathBuf::from("/proj/relative/dir"))
+    );
+    assert_eq!(
+        resolve_php_path_expression("'/absolute/dir'", root),
+        Some(PathBuf::from("/absolute/dir"))
+    );
+    // Unparseable expressions are skipped, not mangled.
+    assert_eq!(resolve_php_path_expression("env('SOME_DIR')", root), None);
+}

--- a/laravel-lsp/src/config/tests.rs
+++ b/laravel-lsp/src/config/tests.rs
@@ -534,10 +534,8 @@ fn resolve_php_path_expression_handles_helpers_and_literals() {
 fn livewire_empty_app_override_disables_vendor_defaults() {
     // 'component_namespaces' => [] in the app config is a deliberate
     // disable — it must NOT fall through to the vendor defaults.
-    let tmp = std::env::temp_dir().join(format!(
-        "laravel-lsp-test-lw-empty-{}",
-        std::process::id()
-    ));
+    let tmp =
+        std::env::temp_dir().join(format!("laravel-lsp-test-lw-empty-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&tmp);
     let vendor_dir = tmp.join("vendor/livewire/livewire/config");
     std::fs::create_dir_all(&vendor_dir).unwrap();
@@ -553,6 +551,87 @@ fn livewire_empty_app_override_disables_vendor_defaults() {
     assert!(
         livewire_component_namespaces(&tmp).is_empty(),
         "an explicit empty override must disable the vendor defaults"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+// ─── Config string value resolution (MaryUI prefix, issue #79) ────────────
+
+#[test]
+fn php_top_level_string_value_ignores_nested_keys() {
+    let source = r#"<?php
+return [
+    'components' => [
+        'prefix' => 'nested-should-not-match',
+    ],
+    'prefix' => 'mary-',
+];
+"#;
+    assert_eq!(
+        php_top_level_string_value(source, "prefix"),
+        Some("mary-".to_string())
+    );
+}
+
+#[test]
+fn php_top_level_string_value_takes_env_default() {
+    let source = r#"<?php
+return [
+    'prefix' => env('MARY_PREFIX', 'mary-'),
+];
+"#;
+    assert_eq!(
+        php_top_level_string_value(source, "prefix"),
+        Some("mary-".to_string())
+    );
+}
+
+#[test]
+fn php_top_level_string_value_handles_empty_string() {
+    let source = "<?php\nreturn [\n    'prefix' => '',\n];\n";
+    assert_eq!(
+        php_top_level_string_value(source, "prefix"),
+        Some(String::new())
+    );
+}
+
+#[test]
+fn resolve_config_string_app_override_wins_over_package_default() {
+    let tmp = std::env::temp_dir().join(format!("laravel-lsp-test-cfgstr-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    let pkg_config = tmp.join("vendor/robsontenorio/mary/config");
+    std::fs::create_dir_all(&pkg_config).unwrap();
+    std::fs::write(
+        pkg_config.join("mary.php"),
+        "<?php return ['prefix' => ''];",
+    )
+    .unwrap();
+    let provider_path = tmp.join("vendor/robsontenorio/mary/src/MaryServiceProvider.php");
+
+    // Package default only.
+    assert_eq!(
+        resolve_config_string_for_package(&tmp, "mary.prefix", &provider_path),
+        Some(String::new())
+    );
+
+    // App override wins.
+    let app_config = tmp.join("config");
+    std::fs::create_dir_all(&app_config).unwrap();
+    std::fs::write(
+        app_config.join("mary.php"),
+        "<?php return ['prefix' => 'mary-'];",
+    )
+    .unwrap();
+    assert_eq!(
+        resolve_config_string_for_package(&tmp, "mary.prefix", &provider_path),
+        Some("mary-".to_string())
+    );
+
+    // Unknown key resolves to None (PHP null).
+    assert_eq!(
+        resolve_config_string_for_package(&tmp, "mary.nonexistent", &provider_path),
+        None
     );
 
     let _ = std::fs::remove_dir_all(&tmp);

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2880,17 +2880,34 @@ impl LaravelConfigData {
         let component_path = actual_component.replace('.', "/");
 
         if let Some(ns) = namespace {
+            // Markdown mail components are hardcoded in Laravel's
+            // ComponentTagCompiler: `<x-mail::message>` maps straight to view
+            // `mail::message`, and at render time `Markdown` points the `mail`
+            // namespace at `{path}/html` for each configured path — the
+            // published `resources/views/vendor/mail` first, then the
+            // framework's bundled views. There is no `components/` segment.
+            // Pushed first so the published path is `paths.first()` — the
+            // diagnostic reports that as the "Expected at:" location.
+            if ns == "mail" {
+                let mut published = self
+                    .root
+                    .join("resources/views/vendor/mail/html")
+                    .join(&component_path);
+                published.set_extension("blade.php");
+                paths.push(published);
+                let mut framework = self
+                    .root
+                    .join("vendor/laravel/framework/src/Illuminate/Mail/resources/views/html")
+                    .join(&component_path);
+                framework.set_extension("blade.php");
+                paths.push(framework);
+            }
+
             // Anonymous component path (Blade::anonymousComponentPath): the
             // registered directory IS the components directory, so resolve
-            // directly with no `components/` segment. Both the flat file and
-            // Laravel's `{component}/index.blade.php` index convention are valid.
-            // Pushed first so the correct path is `paths.first()` — the
-            // diagnostic reports that as the "Expected at:" location.
+            // directly with no `components/` segment.
             if let Some(dir) = self.anonymous_component_paths.get(ns) {
-                let mut direct = dir.join(&component_path);
-                direct.set_extension("blade.php");
-                paths.push(direct);
-                paths.push(dir.join(&component_path).join("index.blade.php"));
+                push_component_file_candidates(&mut paths, dir.join(&component_path));
             }
 
             // Anonymous component namespace (Blade::anonymousComponentNamespace):
@@ -2898,19 +2915,17 @@ impl LaravelConfigData {
             if let Some(dir) = self.anonymous_component_namespaces.get(ns) {
                 for view_path in &self.view_paths {
                     let base = self.root.join(view_path).join(dir);
-                    let mut direct = base.join(&component_path);
-                    direct.set_extension("blade.php");
-                    paths.push(direct);
-                    paths.push(base.join(&component_path).join("index.blade.php"));
+                    push_component_file_candidates(&mut paths, base.join(&component_path));
                 }
             }
 
             // Package component - check package view path first
             if let Some(package_view_path) = self.view_namespaces.get(ns) {
                 // Anonymous package component: {package_views}/components/{component}.blade.php
-                let mut full_path = package_view_path.join("components").join(&component_path);
-                full_path.set_extension("blade.php");
-                paths.push(full_path);
+                push_component_file_candidates(
+                    &mut paths,
+                    package_view_path.join("components").join(&component_path),
+                );
             }
 
             // Also check component namespace (Blade::componentNamespace)
@@ -2930,14 +2945,14 @@ impl LaravelConfigData {
             }
 
             // Check vendor published components: resources/views/vendor/{namespace}/components/
-            let mut vendor_path = self
-                .root
-                .join("resources/views/vendor")
-                .join(ns)
-                .join("components")
-                .join(&component_path);
-            vendor_path.set_extension("blade.php");
-            paths.push(vendor_path);
+            push_component_file_candidates(
+                &mut paths,
+                self.root
+                    .join("resources/views/vendor")
+                    .join(ns)
+                    .join("components")
+                    .join(&component_path),
+            );
         } else {
             // Regular component - check each component path
             for (_namespace, base_path) in &self.component_paths {
@@ -2987,6 +3002,24 @@ impl LaravelConfigData {
         }
 
         Some(path)
+    }
+}
+
+/// Push the three file shapes Laravel accepts for an anonymous component at
+/// `base` (the component's path under its directory, *without* extension),
+/// mirroring `ComponentTagCompiler`'s guess order:
+///   1. `{base}.blade.php`            — flat file
+///   2. `{base}/index.blade.php`      — directory-index convention
+///   3. `{base}/{last}.blade.php`     — directory-self convention
+///      (`<x-ns::button>` → `button/button.blade.php`)
+fn push_component_file_candidates(paths: &mut Vec<PathBuf>, base: PathBuf) {
+    let mut direct = base.clone();
+    direct.set_extension("blade.php");
+    paths.push(direct);
+    paths.push(base.join("index.blade.php"));
+    if let Some(last) = base.file_name().and_then(|s| s.to_str()) {
+        let self_named = format!("{last}.blade.php");
+        paths.push(base.join(self_named));
     }
 }
 
@@ -6557,6 +6590,18 @@ impl SalsaActor {
                     .entry(tag.clone())
                     .or_insert_with(|| (data.priority, file.clone()));
             }
+        }
+
+        // Livewire v4 registers an anonymous component path for every entry
+        // of config('livewire.component_namespaces') at boot (`layouts` and
+        // `pages` by default) — a config-driven loop no provider parse can
+        // see. Merged last so explicit Blade::anonymousComponentPath
+        // registrations win. Not gated on `has_livewire`: that flag only
+        // sees direct composer.json requires, while Livewire commonly
+        // arrives transitively (Flux, Filament, MaryUI); the loader
+        // self-gates on the config files existing.
+        for (ns, dir) in crate::config::livewire_component_namespaces(&root) {
+            anonymous_component_paths.entry(ns).or_insert(dir);
         }
 
         // Convert to data transfer type

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -1627,6 +1627,20 @@ pub fn parse_service_provider_source<'db>(
             r#"(?:Blade::|\$\w+->)component\s*\(\s*\\?([A-Za-z0-9_\\]+)::class\s*,\s*['"]([^'"]+)['"]\s*\)"#
         ).unwrap();
 
+        /// Matches a class-backed registration whose tag is a config-driven
+        /// prefix concatenation: `Blade::component($prefix . 'card', Card::class)`.
+        /// MaryUI registers its whole catalog this way, reading the prefix
+        /// from `config('mary.prefix')` once at the top of the method.
+        static ref BLADE_COMPONENT_PREFIXED_RE: Regex = Regex::new(
+            r#"(?:Blade::|\$\w+->)component\s*\(\s*\$(\w+)\s*\.\s*['"]([^'"]+)['"]\s*,\s*\\?([A-Za-z0-9_\\]+)::class\s*\)"#
+        ).unwrap();
+
+        /// Matches the prefix-variable assignment feeding the form above:
+        /// `$prefix = config('mary.prefix');` (with or without a default arg).
+        static ref CONFIG_VAR_ASSIGN_RE: Regex = Regex::new(
+            r#"\$(\w+)\s*=\s*config\(\s*['"]([\w.-]+)['"]\s*[,)]"#
+        ).unwrap();
+
         /// Matches Blade::componentNamespace('Namespace\\Path', 'prefix')
         static ref COMPONENT_NAMESPACE_RE: Regex = Regex::new(
             r#"Blade::componentNamespace\s*\(\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]+)['"]\s*\)"#
@@ -1959,36 +1973,67 @@ pub fn parse_service_provider_source<'db>(
     // the file's `use` statements before file resolution, mirroring how PHP
     // itself resolves the reference.
     {
-        let mut push_blade_component = |tag_match: regex::Match, class_match: regex::Match| {
-            let tag_name_str = tag_match.as_str();
-            let class_str = expand_class_via_use_statements(
-                class_match.as_str().trim_start_matches('\\'),
-                text,
-            );
+        let mut push_blade_component =
+            |tag_name_str: &str, tag_offset: usize, class_match: regex::Match| {
+                let class_str = expand_class_via_use_statements(
+                    class_match.as_str().trim_start_matches('\\'),
+                    text,
+                );
 
-            let line = text[..tag_match.start()].lines().count() as u32;
-            let file_path = resolve_class_to_file_internal(&class_str, &root);
+                let line = text[..tag_offset].lines().count() as u32;
+                let file_path = resolve_class_to_file_internal(&class_str, &root);
 
-            let component_name = ComponentName::new(db, tag_name_str.to_string());
-            blade_components.push(ParsedBladeComponentReg::new(
-                db,
-                component_name,
-                class_str,
-                file_path,
-                line,
-                priority,
-                path.clone(),
-            ));
-        };
+                let component_name = ComponentName::new(db, tag_name_str.to_string());
+                blade_components.push(ParsedBladeComponentReg::new(
+                    db,
+                    component_name,
+                    class_str,
+                    file_path,
+                    line,
+                    priority,
+                    path.clone(),
+                ));
+            };
 
         for cap in BLADE_COMPONENT_RE.captures_iter(text) {
             if let (Some(tag_name), Some(class)) = (cap.get(1), cap.get(2)) {
-                push_blade_component(tag_name, class);
+                push_blade_component(tag_name.as_str(), tag_name.start(), class);
             }
         }
         for cap in BLADE_COMPONENT_CLASS_FIRST_RE.captures_iter(text) {
             if let (Some(class), Some(tag_name)) = (cap.get(1), cap.get(2)) {
-                push_blade_component(tag_name, class);
+                push_blade_component(tag_name.as_str(), tag_name.start(), class);
+            }
+        }
+
+        // Prefix-computed registrations (MaryUI's catalog form):
+        //   $prefix = config('mary.prefix');
+        //   Blade::component($prefix . 'card', Card::class);
+        // The tag only exists after concatenating a config value, so resolve
+        // the variable's config key from the same file and read the value the
+        // way Laravel would at boot — the app's config override wins, else the
+        // package's bundled config default. A key neither defines is PHP null,
+        // which string-concatenates to '' (MaryUI's actual default).
+        let config_vars: HashMap<&str, &str> = CONFIG_VAR_ASSIGN_RE
+            .captures_iter(text)
+            .filter_map(|cap| match (cap.get(1), cap.get(2)) {
+                (Some(var), Some(key)) => Some((var.as_str(), key.as_str())),
+                _ => None,
+            })
+            .collect();
+        if !config_vars.is_empty() {
+            for cap in BLADE_COMPONENT_PREFIXED_RE.captures_iter(text) {
+                if let (Some(var), Some(suffix), Some(class)) = (cap.get(1), cap.get(2), cap.get(3))
+                {
+                    let Some(key) = config_vars.get(var.as_str()) else {
+                        continue;
+                    };
+                    let prefix =
+                        crate::config::resolve_config_string_for_package(&root, key, path)
+                            .unwrap_or_default();
+                    let tag = format!("{prefix}{}", suffix.as_str());
+                    push_blade_component(&tag, suffix.start(), class);
+                }
             }
         }
     }
@@ -2309,6 +2354,19 @@ fn expand_class_via_use_statements(class_name: &str, source: &str) -> String {
 
 /// Resolve a class name to a file path using PSR-4 conventions
 fn resolve_class_to_file_internal(class_name: &str, root_path: &Path) -> Option<PathBuf> {
+    // PSR-4 via the composer autoload map first — the authoritative answer
+    // for any installed package (vendor or app). The legacy prefix mappings
+    // below stay as fallbacks for projects without a readable autoload map.
+    if let Some((namespace, class)) = class_name.rsplit_once('\\') {
+        let autoload = crate::composer_autoload::ComposerAutoload::for_project(root_path);
+        for dir in autoload.resolve_namespace_dirs(namespace) {
+            let file = dir.join(class).with_extension("php");
+            if file.exists() {
+                return Some(file);
+            }
+        }
+    }
+
     // Common namespace to directory mappings
     let mappings = [
         ("App\\", "app/"),

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -951,6 +951,128 @@ fn missing_namespaced_component_still_reports_not_found() {
     );
 }
 
+#[test]
+fn package_view_namespace_resolves_directory_component_shapes() {
+    // Laravel's ComponentTagCompiler accepts three file shapes for an
+    // anonymous component; package view namespaces (loadViewsFrom /
+    // fluent ->hasViews()) must honor the directory conventions too.
+    // Filament 5 ships `<x-filament::button>` as `button/index.blade.php`
+    // (issue #79, case 1).
+    let (_dir, root) = project_with_files(&[
+        ("vendor/composer/installed.json", r#"{"packages": []}"#),
+        (
+            "vendor/filament/support/resources/views/components/button/index.blade.php",
+            "<button></button>",
+        ),
+        (
+            "vendor/filament/support/resources/views/components/dropdown/dropdown.blade.php",
+            "<div></div>",
+        ),
+        (
+            "vendor/filament/support/resources/views/components/badge.blade.php",
+            "<span></span>",
+        ),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let mut config = config_with_component_namespaces(&root, &[]);
+    config.view_namespaces.insert(
+        "filament".to_string(),
+        root.join("vendor/filament/support/resources/views"),
+    );
+
+    for component in ["filament::button", "filament::dropdown", "filament::badge"] {
+        assert!(
+            resolves(component, &config, &autoload),
+            "{component} must resolve via a directory-component shape: {:#?}",
+            component_candidate_paths(component, &config, &autoload),
+        );
+    }
+    assert!(
+        !resolves("filament::does-not-exist", &config, &autoload),
+        "a missing namespaced component must still report not-found",
+    );
+}
+
+#[test]
+fn vendor_published_component_resolves_directory_index() {
+    // Published package views (`resources/views/vendor/{ns}/components/`)
+    // get the same directory-index treatment.
+    let (_dir, root) = project_with_files(&[
+        ("vendor/composer/installed.json", r#"{"packages": []}"#),
+        (
+            "resources/views/vendor/courier/components/alert/index.blade.php",
+            "<div></div>",
+        ),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let config = config_with_component_namespaces(&root, &[]);
+
+    assert!(
+        resolves("courier::alert", &config, &autoload),
+        "published vendor component must resolve via index.blade.php: {:#?}",
+        component_candidate_paths("courier::alert", &config, &autoload),
+    );
+}
+
+#[test]
+fn markdown_mail_components_resolve_html_paths() {
+    // `<x-mail::message>` is hardcoded in Laravel's ComponentTagCompiler to
+    // the `mail::` view namespace, which Markdown points at `{path}/html` —
+    // the published vendor dir first, then the framework's bundled views.
+    // There is no `components/` segment (issue #79, case 2).
+    let (_dir, root) = project_with_files(&[
+        ("vendor/composer/installed.json", r#"{"packages": []}"#),
+        (
+            "vendor/laravel/framework/src/Illuminate/Mail/resources/views/html/message.blade.php",
+            "<html></html>",
+        ),
+        (
+            "resources/views/vendor/mail/html/header.blade.php",
+            "<tr></tr>",
+        ),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let config = config_with_component_namespaces(&root, &[]);
+
+    assert!(
+        resolves("mail::message", &config, &autoload),
+        "mail::message must resolve to the framework's html view: {:#?}",
+        component_candidate_paths("mail::message", &config, &autoload),
+    );
+    assert!(
+        resolves("mail::header", &config, &autoload),
+        "mail::header must resolve to the published html view: {:#?}",
+        component_candidate_paths("mail::header", &config, &autoload),
+    );
+    assert!(
+        !resolves("mail::does-not-exist", &config, &autoload),
+        "a missing mail component must still report not-found",
+    );
+}
+
+#[test]
+fn anonymous_component_path_resolves_livewire_layout_namespace() {
+    // The shape Livewire v4's config-driven registration produces:
+    // anonymous_component_paths['layouts'] → resources/views/layouts, so
+    // `<x-layouts::app>` resolves to resources/views/layouts/app.blade.php
+    // (issue #79, case 3).
+    let (_dir, root) = project_with_files(&[
+        ("vendor/composer/installed.json", r#"{"packages": []}"#),
+        ("resources/views/layouts/app.blade.php", "<html></html>"),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let mut config = config_with_component_namespaces(&root, &[]);
+    config
+        .anonymous_component_paths
+        .insert("layouts".to_string(), root.join("resources/views/layouts"));
+
+    assert!(
+        resolves("layouts::app", &config, &autoload),
+        "layouts::app must resolve via the anonymous component path: {:#?}",
+        component_candidate_paths("layouts::app", &config, &autoload),
+    );
+}
+
 // ─── Member-access capture data model (M2) ──────────────────────────────
 
 /// A captured property-form access with the capture-time defaults (the

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -1736,6 +1736,205 @@ class AppServiceProvider
 }
 
 #[test]
+fn vendor_literal_registration_resolves_class_via_psr4() {
+    // MaryUI's literal form: `Blade::component('mary-card', Card::class)` in
+    // a vendor provider. The class file must resolve through the composer
+    // PSR-4 map — `Mary\` is in no hardcoded namespace mapping (issue #79,
+    // the <x-mary-card> case).
+    let provider = r#"<?php
+namespace Mary;
+
+use Mary\View\Components\Card;
+
+class MaryServiceProvider
+{
+    public function registerComponents()
+    {
+        Blade::component('mary-card', Card::class);
+    }
+}
+"#;
+    let installed = r#"{
+        "packages": [
+            {
+                "name": "robsontenorio/mary",
+                "autoload": { "psr-4": { "Mary\\": "src/" } },
+                "install-path": "../robsontenorio/mary"
+            }
+        ]
+    }"#;
+    let (_dir, root) = project_with_files(&[
+        ("vendor/composer/installed.json", installed),
+        (
+            "vendor/robsontenorio/mary/src/View/Components/Card.php",
+            "<?php namespace Mary\\View\\Components; class Card {}",
+        ),
+    ]);
+
+    let found = parsed_blade_components(
+        provider,
+        root.join("vendor/robsontenorio/mary/src/MaryServiceProvider.php"),
+        root.clone(),
+    );
+
+    assert!(
+        found.iter().any(|(tag, class, file)| {
+            tag == "mary-card"
+                && class == "Mary\\View\\Components\\Card"
+                && file
+                    .as_ref()
+                    .is_some_and(|f| f.ends_with("src/View/Components/Card.php"))
+        }),
+        "vendor literal registration must resolve its class via PSR-4, got {found:?}"
+    );
+}
+
+#[test]
+fn prefix_computed_registration_resolves_config_prefix() {
+    // MaryUI's catalog form: the tag is computed from a config value.
+    //   $prefix = config('mary.prefix');
+    //   Blade::component($prefix . 'card', Card::class);
+    // With the package's bundled default ('') the tag is `card`; an app
+    // config override ('mary-') changes it to `mary-card`.
+    let provider = r#"<?php
+namespace Mary;
+
+use Mary\View\Components\Card;
+
+class MaryServiceProvider
+{
+    public function registerComponents()
+    {
+        $prefix = config('mary.prefix');
+
+        Blade::component($prefix . 'card', Card::class);
+    }
+}
+"#;
+    let installed = r#"{
+        "packages": [
+            {
+                "name": "robsontenorio/mary",
+                "autoload": { "psr-4": { "Mary\\": "src/" } },
+                "install-path": "../robsontenorio/mary"
+            }
+        ]
+    }"#;
+    let package_config = r#"<?php
+return [
+    'prefix' => '',
+];
+"#;
+
+    // Package default prefix: ''.
+    let (_dir, root) = project_with_files(&[
+        ("vendor/composer/installed.json", installed),
+        ("vendor/robsontenorio/mary/config/mary.php", package_config),
+        (
+            "vendor/robsontenorio/mary/src/View/Components/Card.php",
+            "<?php namespace Mary\\View\\Components; class Card {}",
+        ),
+    ]);
+    let found = parsed_blade_components(
+        provider,
+        root.join("vendor/robsontenorio/mary/src/MaryServiceProvider.php"),
+        root.clone(),
+    );
+    assert!(
+        found
+            .iter()
+            .any(|(tag, _, file)| tag == "card" && file.is_some()),
+        "default '' prefix must register the bare tag, got {found:?}"
+    );
+
+    // App config override: 'mary-'.
+    let (_dir2, root2) = project_with_files(&[
+        ("vendor/composer/installed.json", installed),
+        ("vendor/robsontenorio/mary/config/mary.php", package_config),
+        ("config/mary.php", "<?php return ['prefix' => 'mary-'];"),
+        (
+            "vendor/robsontenorio/mary/src/View/Components/Card.php",
+            "<?php namespace Mary\\View\\Components; class Card {}",
+        ),
+    ]);
+    let found = parsed_blade_components(
+        provider,
+        root2.join("vendor/robsontenorio/mary/src/MaryServiceProvider.php"),
+        root2.clone(),
+    );
+    assert!(
+        found
+            .iter()
+            .any(|(tag, _, file)| tag == "mary-card" && file.is_some()),
+        "app config prefix override must win, got {found:?}"
+    );
+}
+
+#[tokio::test]
+async fn livewire_config_namespaces_merge_into_laravel_config() {
+    // The SalsaActor assembly wiring (the `or_insert` merge): a vendor
+    // Livewire v4 config's component_namespaces must surface in
+    // LaravelConfigData.anonymous_component_paths, and an explicit
+    // Blade::anonymousComponentPath registration for the same namespace
+    // must win over the Livewire-derived entry.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let lw_config = root.join("vendor/livewire/livewire/config/livewire.php");
+    std::fs::create_dir_all(lw_config.parent().unwrap()).unwrap();
+    std::fs::write(
+        &lw_config,
+        "<?php return ['component_namespaces' => ['layouts' => resource_path('views/layouts')]];",
+    )
+    .unwrap();
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    let config = handle
+        .get_laravel_config()
+        .await
+        .unwrap()
+        .expect("config should build");
+    assert_eq!(
+        config.anonymous_component_paths.get("layouts"),
+        Some(&root.join("resources/views/layouts")),
+        "Livewire config namespaces must merge into anonymous_component_paths"
+    );
+
+    // Explicit registration wins.
+    let provider = r#"<?php
+class AppServiceProvider
+{
+    public function boot()
+    {
+        Blade::anonymousComponentPath(resource_path('views/custom-layouts'), 'layouts');
+    }
+}
+"#;
+    handle
+        .register_service_provider_source(
+            root.join("app/Providers/AppServiceProvider.php"),
+            provider.to_string(),
+            2,
+            root.clone(),
+        )
+        .await
+        .unwrap();
+    let config = handle
+        .get_laravel_config()
+        .await
+        .unwrap()
+        .expect("config should rebuild");
+    assert_eq!(
+        config.anonymous_component_paths.get("layouts"),
+        Some(&root.join("resources/views/custom-layouts")),
+        "an explicit anonymousComponentPath registration must win over the Livewire default"
+    );
+}
+
+#[test]
 fn class_component_registration_resolves_via_candidate_paths() {
     // End of the chain: a tag present in `class_component_files` must surface
     // from `component_candidate_paths`, so the shared diagnostic/goto resolver

--- a/scripts/lsp-probe.py
+++ b/scripts/lsp-probe.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Drive the laravel-lsp binary against a real project and print the
+diagnostics it publishes for one file — a verification harness for changes
+that affect diagnostics, without needing Zed in the loop.
+
+Usage:
+    scripts/lsp-probe.py [PROJECT_ROOT] [RELATIVE_FILE] [DEADLINE_SECS]
+
+Defaults probe the in-repo fixture:
+    scripts/lsp-probe.py test-project resources/views/namespaced-component-test.blade.php
+
+The client performs the handshake the server expects from Zed: it answers
+server->client requests (with empty results), sends
+workspace/didChangeConfiguration after initialized (the server defers its
+background vendor scan until then), and re-sends the document every 20s so
+validation re-runs as background scans land. The final publish before the
+deadline is printed.
+"""
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BINARY = os.path.join(REPO_ROOT, "laravel-lsp/target/release/laravel-lsp")
+ROOT = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else os.path.join(REPO_ROOT, "test-project")
+FILE = os.path.join(ROOT, sys.argv[2] if len(sys.argv) > 2
+                    else "resources/views/namespaced-component-test.blade.php")
+DEADLINE_SECS = int(sys.argv[3]) if len(sys.argv) > 3 else 300
+
+if not os.path.exists(BINARY):
+    sys.exit(f"binary not found: {BINARY} — run `cargo build --release` first")
+
+proc = subprocess.Popen([BINARY], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                        stderr=open("/tmp/lsp-probe.log", "wb"))
+killer = threading.Timer(DEADLINE_SECS, proc.kill)
+killer.start()
+
+write_lock = threading.Lock()
+
+
+def send(msg):
+    data = json.dumps(msg).encode()
+    with write_lock:
+        proc.stdin.write(b"Content-Length: %d\r\n\r\n%s" % (len(data), data))
+        proc.stdin.flush()
+
+
+def read_msg():
+    headers = {}
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            return None
+        if line == b"\r\n":
+            break
+        if b":" in line:
+            key, value = line.decode().split(":", 1)
+            headers[key.strip().lower()] = value.strip()
+    length = int(headers.get("content-length", 0))
+    if length == 0:
+        return None
+    return json.loads(proc.stdout.read(length))
+
+
+send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
+    "processId": os.getpid(),
+    "rootUri": "file://" + ROOT,
+    "capabilities": {"workspace": {"configuration": True}},
+    "workspaceFolders": [{"uri": "file://" + ROOT, "name": os.path.basename(ROOT)}],
+}})
+
+content = open(FILE).read()
+publishes = []
+version = 1
+stop_nudges = threading.Event()
+
+
+def nudge():
+    """Periodically re-send the document text to re-trigger validation."""
+    global version
+    while not stop_nudges.wait(20):
+        version += 1
+        try:
+            send({"jsonrpc": "2.0", "method": "textDocument/didChange", "params": {
+                "textDocument": {"uri": "file://" + FILE, "version": version},
+                "contentChanges": [{"text": content}]}})
+        except Exception:
+            return
+
+
+while True:
+    msg = read_msg()
+    if msg is None:
+        break
+    if msg.get("id") == 1 and "result" in msg:
+        send({"jsonrpc": "2.0", "method": "initialized", "params": {}})
+        send({"jsonrpc": "2.0", "method": "workspace/didChangeConfiguration",
+              "params": {"settings": {}}})
+        send({"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {
+            "textDocument": {"uri": "file://" + FILE, "languageId": "blade",
+                              "version": 1, "text": content}}})
+        threading.Thread(target=nudge, daemon=True).start()
+    elif "method" in msg and "id" in msg:
+        # Server->client request: answer with an empty/null result so the
+        # server never blocks awaiting a response.
+        method = msg["method"]
+        result = [None] * len(msg.get("params", {}).get("items", [])) \
+            if method == "workspace/configuration" else None
+        send({"jsonrpc": "2.0", "id": msg["id"], "result": result})
+    elif msg.get("method") == "textDocument/publishDiagnostics":
+        params = msg["params"]
+        if params["uri"] == "file://" + FILE:
+            publishes.append(params["diagnostics"])
+            ts = time.strftime("%H:%M:%S")
+            print(f"[{ts}] publish #{len(publishes)}: {len(params['diagnostics'])} diagnostics",
+                  flush=True)
+
+if publishes:
+    diags = publishes[-1]
+    print(f"--- final publish: {len(diags)} diagnostics ---")
+    for d in diags:
+        lines = d["message"].splitlines()
+        line_no = d["range"]["start"]["line"] + 1
+        detail = lines[1] if len(lines) > 1 else ""
+        print(f"  line {line_no}: {lines[0]} | {detail}")
+else:
+    print("no publishDiagnostics received for target file before deadline "
+          "(server log: /tmp/lsp-probe.log)")
+
+stop_nudges.set()
+killer.cancel()
+proc.kill()

--- a/test-project/.junie/guidelines.md
+++ b/test-project/.junie/guidelines.md
@@ -8,22 +8,22 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.16
+- php - 8.4.22
+- filament/filament (FILAMENT) - v5
 - laravel/fortify (FORTIFY) - v1
 - laravel/framework (LARAVEL) - v12
 - laravel/prompts (PROMPTS) - v0
 - livewire/flux (FLUXUI_FREE) - v2
-- livewire/livewire (LIVEWIRE) - v3
+- livewire/livewire (LIVEWIRE) - v4
 - livewire/volt (VOLT) - v1
 - laravel/mcp (MCP) - v0
 - laravel/pint (PINT) - v1
 - laravel/sail (SAIL) - v1
 - pestphp/pest (PEST) - v4
 - phpunit/phpunit (PHPUNIT) - v12
-- tailwindcss (TAILWINDCSS) - v4
 
 ## Conventions
-- You must follow all existing code conventions used in this application. When creating or editing a file, check sibling files for the correct structure, approach, naming.
+- You must follow all existing code conventions used in this application. When creating or editing a file, check sibling files for the correct structure, approach, and naming.
 - Use descriptive names for variables and methods. For example, `isRegisteredForDiscounts`, not `discount()`.
 - Check for existing components to reuse before writing a new one.
 
@@ -31,7 +31,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - Do not create verification scripts or tinker when tests cover that functionality and prove it works. Unit and feature tests are more important.
 
 ## Application Structure & Architecture
-- Stick to existing directory structure - don't create new base folders without approval.
+- Stick to existing directory structure; don't create new base folders without approval.
 - Do not change the application's dependencies without approval.
 
 ## Frontend Bundling
@@ -43,17 +43,16 @@ This application is a Laravel application and its main Laravel ecosystems packag
 ## Documentation Files
 - You must only create documentation files if explicitly requested by the user.
 
-
 === boost rules ===
 
 ## Laravel Boost
 - Laravel Boost is an MCP server that comes with powerful tools designed specifically for this application. Use them.
 
 ## Artisan
-- Use the `list-artisan-commands` tool when you need to call an Artisan command to double check the available parameters.
+- Use the `list-artisan-commands` tool when you need to call an Artisan command to double-check the available parameters.
 
 ## URLs
-- Whenever you share a project URL with the user you should use the `get-absolute-url` tool to ensure you're using the correct scheme, domain / IP, and port.
+- Whenever you share a project URL with the user, you should use the `get-absolute-url` tool to ensure you're using the correct scheme, domain/IP, and port.
 
 ## Tinker / Debugging
 - You should use the `tinker` tool when you need to execute PHP to debug code or query Eloquent models directly.
@@ -64,22 +63,21 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - Only recent browser logs will be useful - ignore old logs.
 
 ## Searching Documentation (Critically Important)
-- Boost comes with a powerful `search-docs` tool you should use before any other approaches. This tool automatically passes a list of installed packages and their versions to the remote Boost API, so it returns only version-specific documentation specific for the user's circumstance. You should pass an array of packages to filter on if you know you need docs for particular packages.
-- The 'search-docs' tool is perfect for all Laravel related packages, including Laravel, Inertia, Livewire, Filament, Tailwind, Pest, Nova, Nightwatch, etc.
-- You must use this tool to search for Laravel-ecosystem documentation before falling back to other approaches.
+- Boost comes with a powerful `search-docs` tool you should use before any other approaches when dealing with Laravel or Laravel ecosystem packages. This tool automatically passes a list of installed packages and their versions to the remote Boost API, so it returns only version-specific documentation for the user's circumstance. You should pass an array of packages to filter on if you know you need docs for particular packages.
+- The `search-docs` tool is perfect for all Laravel-related packages, including Laravel, Inertia, Livewire, Filament, Tailwind, Pest, Nova, Nightwatch, etc.
+- You must use this tool to search for Laravel ecosystem documentation before falling back to other approaches.
 - Search the documentation before making code changes to ensure we are taking the correct approach.
-- Use multiple, broad, simple, topic based queries to start. For example: `['rate limiting', 'routing rate limiting', 'routing']`.
-- Do not add package names to queries - package information is already shared. For example, use `test resource table`, not `filament 4 test resource table`.
+- Use multiple, broad, simple, topic-based queries to start. For example: `['rate limiting', 'routing rate limiting', 'routing']`.
+- Do not add package names to queries; package information is already shared. For example, use `test resource table`, not `filament 4 test resource table`.
 
 ### Available Search Syntax
 - You can and should pass multiple queries at once. The most relevant results will be returned first.
 
-1. Simple Word Searches with auto-stemming - query=authentication - finds 'authenticate' and 'auth'
-2. Multiple Words (AND Logic) - query=rate limit - finds knowledge containing both "rate" AND "limit"
-3. Quoted Phrases (Exact Position) - query="infinite scroll" - Words must be adjacent and in that order
-4. Mixed Queries - query=middleware "rate limit" - "middleware" AND exact phrase "rate limit"
-5. Multiple Queries - queries=["authentication", "middleware"] - ANY of these terms
-
+1. Simple Word Searches with auto-stemming - query=authentication - finds 'authenticate' and 'auth'.
+2. Multiple Words (AND Logic) - query=rate limit - finds knowledge containing both "rate" AND "limit".
+3. Quoted Phrases (Exact Position) - query="infinite scroll" - words must be adjacent and in that order.
+4. Mixed Queries - query=middleware "rate limit" - "middleware" AND exact phrase "rate limit".
+5. Multiple Queries - queries=["authentication", "middleware"] - ANY of these terms.
 
 === php rules ===
 
@@ -90,7 +88,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 ### Constructors
 - Use PHP 8 constructor property promotion in `__construct()`.
     - <code-snippet>public function __construct(public GitHub $github) { }</code-snippet>
-- Do not allow empty `__construct()` methods with zero parameters.
+- Do not allow empty `__construct()` methods with zero parameters unless the constructor is private.
 
 ### Type Declarations
 - Always use explicit return type declarations for methods and functions.
@@ -104,22 +102,13 @@ protected function isAccessible(User $user, ?string $path = null): bool
 </code-snippet>
 
 ## Comments
-- Prefer PHPDoc blocks over comments. Never use comments within the code itself unless there is something _very_ complex going on.
+- Prefer PHPDoc blocks over inline comments. Never use comments within the code itself unless there is something very complex going on.
 
 ## PHPDoc Blocks
 - Add useful array shape type definitions for arrays when appropriate.
 
 ## Enums
 - Typically, keys in an Enum should be TitleCase. For example: `FavoritePerson`, `BestLake`, `Monthly`.
-
-
-=== tests rules ===
-
-## Test Enforcement
-
-- Every change must be programmatically tested. Write a new test or update an existing test, then run the affected tests to make sure they pass.
-- Run the minimum number of tests needed to ensure code quality and speed. Use `php artisan test` with a specific filename or filter.
-
 
 === laravel/core rules ===
 
@@ -131,7 +120,7 @@ protected function isAccessible(User $user, ?string $path = null): bool
 
 ### Database
 - Always use proper Eloquent relationship methods with return type hints. Prefer relationship methods over raw queries or manual joins.
-- Use Eloquent models and relationships before suggesting raw database queries
+- Use Eloquent models and relationships before suggesting raw database queries.
 - Avoid `DB::`; prefer `Model::query()`. Generate code that leverages Laravel's ORM capabilities rather than bypassing them.
 - Generate code that prevents N+1 query problems by using eager loading.
 - Use Laravel's query builder for very complex database operations.
@@ -166,44 +155,42 @@ protected function isAccessible(User $user, ?string $path = null): bool
 ### Vite Error
 - If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
 
-
 === laravel/v12 rules ===
 
 ## Laravel 12
 
-- Use the `search-docs` tool to get version specific documentation.
+- Use the `search-docs` tool to get version-specific documentation.
 - Since Laravel 11, Laravel has a new streamlined file structure which this project uses.
 
 ### Laravel 12 Structure
-- No middleware files in `app/Http/Middleware/`.
+- In Laravel 12, middleware are no longer registered in `app/Http/Kernel.php`.
+- Middleware are configured declaratively in `bootstrap/app.php` using `Application::configure()->withMiddleware()`.
 - `bootstrap/app.php` is the file to register middleware, exceptions, and routing files.
 - `bootstrap/providers.php` contains application specific service providers.
-- **No app\Console\Kernel.php** - use `bootstrap/app.php` or `routes/console.php` for console configuration.
-- **Commands auto-register** - files in `app/Console/Commands/` are automatically available and do not require manual registration.
+- The `app\Console\Kernel.php` file no longer exists; use `bootstrap/app.php` or `routes/console.php` for console configuration.
+- Console commands in `app/Console/Commands/` are automatically available and do not require manual registration.
 
 ### Database
 - When modifying a column, the migration must include all of the attributes that were previously defined on the column. Otherwise, they will be dropped and lost.
-- Laravel 11 allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
+- Laravel 12 allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
 
 ### Models
 - Casts can and likely should be set in a `casts()` method on a model rather than the `$casts` property. Follow existing conventions from other models.
-
 
 === fluxui-free/core rules ===
 
 ## Flux UI Free
 
 - This project is using the free edition of Flux UI. It has full access to the free components and variants, but does not have access to the Pro components.
-- Flux UI is a component library for Livewire. Flux is a robust, hand-crafted, UI component library for your Livewire applications. It's built using Tailwind CSS and provides a set of components that are easy to use and customize.
+- Flux UI is a component library for Livewire. Flux is a robust, hand-crafted UI component library for your Livewire applications. It's built using Tailwind CSS and provides a set of components that are easy to use and customize.
 - You should use Flux UI components when available.
 - Fallback to standard Blade components if Flux is unavailable.
-- If available, use Laravel Boost's `search-docs` tool to get the exact documentation and code snippets available for this project.
+- If available, use the `search-docs` tool to get the exact documentation and code snippets available for this project.
 - Flux UI components look like this:
 
-<code-snippet name="Flux UI Component Usage Example" lang="blade">
+<code-snippet name="Flux UI Component Example" lang="blade">
     <flux:button variant="primary"/>
 </code-snippet>
-
 
 ### Available Components
 This is correct as of Boost installation, but there may be additional components within the codebase.
@@ -212,14 +199,14 @@ This is correct as of Boost installation, but there may be additional components
 avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, heading, icon, input, modal, navbar, otp-input, profile, radio, select, separator, skeleton, switch, text, textarea, tooltip
 </available-flux-components>
 
-
 === livewire/core rules ===
 
-## Livewire Core
-- Use the `search-docs` tool to find exact version specific documentation for how to write Livewire & Livewire tests.
-- Use the `php artisan make:livewire [Posts\CreatePost]` artisan command to create new components
+## Livewire
+
+- Use the `search-docs` tool to find exact version-specific documentation for how to write Livewire and Livewire tests.
+- Use the `php artisan make:livewire [Posts\CreatePost]` Artisan command to create new components.
 - State should live on the server, with the UI reflecting it.
-- All Livewire requests hit the Laravel backend, they're like regular HTTP requests. Always validate form data, and run authorization checks in Livewire actions.
+- All Livewire requests hit the Laravel backend; they're like regular HTTP requests. Always validate form data and run authorization checks in Livewire actions.
 
 ## Livewire Best Practices
 - Livewire components require a single root element.
@@ -236,15 +223,14 @@ avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, h
 
 - Prefer lifecycle hooks like `mount()`, `updatedFoo()` for initialization and reactive side effects:
 
-<code-snippet name="Lifecycle hook examples" lang="php">
+<code-snippet name="Lifecycle Hook Examples" lang="php">
     public function mount(User $user) { $this->user = $user; }
     public function updatedSearch() { $this->resetPage(); }
 </code-snippet>
 
-
 ## Testing Livewire
 
-<code-snippet name="Example Livewire component test" lang="php">
+<code-snippet name="Example Livewire Component Test" lang="php">
     Livewire::test(Counter::class)
         ->assertSet('count', 0)
         ->call('increment')
@@ -253,58 +239,20 @@ avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, h
         ->assertStatus(200);
 </code-snippet>
 
-
-    <code-snippet name="Testing a Livewire component exists within a page" lang="php">
-        $this->get('/posts/create')
-        ->assertSeeLivewire(CreatePost::class);
-    </code-snippet>
-
-
-=== livewire/v3 rules ===
-
-## Livewire 3
-
-### Key Changes From Livewire 2
-- These things changed in Livewire 2, but may not have been updated in this application. Verify this application's setup to ensure you conform with application conventions.
-    - Use `wire:model.live` for real-time updates, `wire:model` is now deferred by default.
-    - Components now use the `App\Livewire` namespace (not `App\Http\Livewire`).
-    - Use `$this->dispatch()` to dispatch events (not `emit` or `dispatchBrowserEvent`).
-    - Use the `components.layouts.app` view as the typical layout path (not `layouts.app`).
-
-### New Directives
-- `wire:show`, `wire:transition`, `wire:cloak`, `wire:offline`, `wire:target` are available for use. Use the documentation to find usage examples.
-
-### Alpine
-- Alpine is now included with Livewire, don't manually include Alpine.js.
-- Plugins included with Alpine: persist, intersect, collapse, and focus.
-
-### Lifecycle Hooks
-- You can listen for `livewire:init` to hook into Livewire initialization, and `fail.status === 419` for the page expiring:
-
-<code-snippet name="livewire:load example" lang="js">
-document.addEventListener('livewire:init', function () {
-    Livewire.hook('request', ({ fail }) => {
-        if (fail && fail.status === 419) {
-            alert('Your session expired');
-        }
-    });
-
-    Livewire.hook('message.failed', (message, component) => {
-        console.error(message);
-    });
-});
+<code-snippet name="Testing Livewire Component Exists on Page" lang="php">
+    $this->get('/posts/create')
+    ->assertSeeLivewire(CreatePost::class);
 </code-snippet>
-
 
 === volt/core rules ===
 
 ## Livewire Volt
 
-- This project uses Livewire Volt for interactivity within its pages. New pages requiring interactivity must also use Livewire Volt. There is documentation available for it.
-- Make new Volt components using `php artisan make:volt [name] [--test] [--pest]`
-- Volt is a **class-based** and **functional** API for Livewire that supports single-file components, allowing a component's PHP logic and Blade templates to co-exist in the same file
+- This project uses Livewire Volt for interactivity within its pages. New pages requiring interactivity must also use Livewire Volt.
+- Make new Volt components using `php artisan make:volt [name] [--test] [--pest]`.
+- Volt is a class-based and functional API for Livewire that supports single-file components, allowing a component's PHP logic and Blade templates to coexist in the same file.
 - Livewire Volt allows PHP logic and Blade templates in one file. Components use the `@volt` directive.
-- You must check existing Volt components to determine if they're functional or class based. If you can't detect that, ask the user which they prefer before writing a Volt component.
+- You must check existing Volt components to determine if they're functional or class-based. If you can't detect that, ask the user which they prefer before writing a Volt component.
 
 ### Volt Functional Component Example
 
@@ -330,10 +278,8 @@ $double = computed(fn () => $this->count * 2);
 @endvolt
 </code-snippet>
 
-
 ### Volt Class Based Component Example
 To get started, define an anonymous class that extends Livewire\Volt\Component. Within the class, you may utilize all of the features of Livewire using traditional Livewire syntax:
-
 
 <code-snippet name="Volt Class-based Volt Component Example" lang="php">
 use Livewire\Volt\Component;
@@ -353,7 +299,6 @@ new class extends Component {
 </div>
 </code-snippet>
 
-
 ### Testing Volt & Volt Components
 - Use the existing directory for tests if it already exists. Otherwise, fallback to `tests/Feature/Volt`.
 
@@ -367,7 +312,6 @@ test('counter increments', function () {
         ->assertSee('Count: 1');
 });
 </code-snippet>
-
 
 <code-snippet name="Volt Component Test Using Pest" lang="php">
 declare(strict_types=1);
@@ -390,9 +334,7 @@ test('product form creates product', function () {
 });
 </code-snippet>
 
-
 ### Common Patterns
-
 
 <code-snippet name="CRUD With Volt" lang="php">
 <?php
@@ -428,14 +370,12 @@ $delete = fn(Product $product) => $product->delete();
     </flux:button>
 </code-snippet>
 
-
 === pint/core rules ===
 
 ## Laravel Pint Code Formatter
 
-- You must run `vendor/bin/pint --dirty` before finalizing changes to ensure your code matches the project's expected style.
-- Do not run `vendor/bin/pint --test`, simply run `vendor/bin/pint` to fix any formatting issues.
-
+- You must run `vendor/bin/pint --dirty --format agent` before finalizing changes to ensure your code matches the project's expected style.
+- Do not run `vendor/bin/pint --test --format agent`, simply run `vendor/bin/pint --format agent` to fix any formatting issues.
 
 === pest/core rules ===
 
@@ -457,9 +397,9 @@ it('is true', function () {
 
 ### Running Tests
 - Run the minimal number of tests using an appropriate filter before finalizing code edits.
-- To run all tests: `php artisan test`.
-- To run all tests in a file: `php artisan test tests/Feature/ExampleTest.php`.
-- To filter on a particular test name: `php artisan test --filter=testName` (recommended after making a change to a related file).
+- To run all tests: `php artisan test --compact`.
+- To run all tests in a file: `php artisan test --compact tests/Feature/ExampleTest.php`.
+- To filter on a particular test name: `php artisan test --compact --filter=testName` (recommended after making a change to a related file).
 - When the tests relating to your changes are passing, ask the user if they would like to run the entire test suite to ensure everything is still passing.
 
 ### Pest Assertions
@@ -478,7 +418,7 @@ it('returns all', function () {
 - You can also create partial mocks using the same import or self method.
 
 ### Datasets
-- Use datasets in Pest to simplify tests which have a lot of duplicated data. This is often the case when testing validation rules, so consider going with this solution when writing tests for validation rules.
+- Use datasets in Pest to simplify tests that have a lot of duplicated data. This is often the case when testing validation rules, so consider this solution when writing tests for validation rules.
 
 <code-snippet name="Pest Dataset Example" lang="php">
 it('has emails', function (string $email) {
@@ -489,18 +429,17 @@ it('has emails', function (string $email) {
 ]);
 </code-snippet>
 
-
 === pest/v4 rules ===
 
 ## Pest 4
 
-- Pest v4 is a huge upgrade to Pest and offers: browser testing, smoke testing, visual regression testing, test sharding, and faster type coverage.
+- Pest 4 is a huge upgrade to Pest and offers: browser testing, smoke testing, visual regression testing, test sharding, and faster type coverage.
 - Browser testing is incredibly powerful and useful for this project.
 - Browser tests should live in `tests/Browser/`.
 - Use the `search-docs` tool for detailed guidance on utilizing these features.
 
 ### Browser Testing
-- You can use Laravel features like `Event::fake()`, `assertAuthenticated()`, and model factories within Pest v4 browser tests, as well as `RefreshDatabase` (when needed) to ensure a clean state for each test.
+- You can use Laravel features like `Event::fake()`, `assertAuthenticated()`, and model factories within Pest 4 browser tests, as well as `RefreshDatabase` (when needed) to ensure a clean state for each test.
 - Interact with the page (click, type, scroll, select, submit, drag-and-drop, touch gestures, etc.) when appropriate to complete the test.
 - If requested, test on multiple browsers (Chrome, Firefox, Safari).
 - If requested, test on different devices and viewports (like iPhone 14 Pro, tablets, or custom breakpoints).
@@ -533,100 +472,4 @@ $pages = visit(['/', '/about', '/contact']);
 
 $pages->assertNoJavascriptErrors()->assertNoConsoleLogs();
 </code-snippet>
-
-
-=== tailwindcss/core rules ===
-
-## Tailwind Core
-
-- Use Tailwind CSS classes to style HTML, check and use existing tailwind conventions within the project before writing your own.
-- Offer to extract repeated patterns into components that match the project's conventions (i.e. Blade, JSX, Vue, etc..)
-- Think through class placement, order, priority, and defaults - remove redundant classes, add classes to parent or child carefully to limit repetition, group elements logically
-- You can use the `search-docs` tool to get exact examples from the official documentation when needed.
-
-### Spacing
-- When listing items, use gap utilities for spacing, don't use margins.
-
-    <code-snippet name="Valid Flex Gap Spacing Example" lang="html">
-        <div class="flex gap-8">
-            <div>Superior</div>
-            <div>Michigan</div>
-            <div>Erie</div>
-        </div>
-    </code-snippet>
-
-
-### Dark Mode
-- If existing pages and components support dark mode, new pages and components must support dark mode in a similar way, typically using `dark:`.
-
-
-=== tailwindcss/v4 rules ===
-
-## Tailwind 4
-
-- Always use Tailwind CSS v4 - do not use the deprecated utilities.
-- `corePlugins` is not supported in Tailwind v4.
-- In Tailwind v4, configuration is CSS-first using the `@theme` directive — no separate `tailwind.config.js` file is needed.
-<code-snippet name="Extending Theme in CSS" lang="css">
-@theme {
-  --color-brand: oklch(0.72 0.11 178);
-}
-</code-snippet>
-
-- In Tailwind v4, you import Tailwind using a regular CSS `@import` statement, not using the `@tailwind` directives used in v3:
-
-<code-snippet name="Tailwind v4 Import Tailwind Diff" lang="diff">
-   - @tailwind base;
-   - @tailwind components;
-   - @tailwind utilities;
-   + @import "tailwindcss";
-</code-snippet>
-
-
-### Replaced Utilities
-- Tailwind v4 removed deprecated utilities. Do not use the deprecated option - use the replacement.
-- Opacity values are still numeric.
-
-| Deprecated |	Replacement |
-|------------+--------------|
-| bg-opacity-* | bg-black/* |
-| text-opacity-* | text-black/* |
-| border-opacity-* | border-black/* |
-| divide-opacity-* | divide-black/* |
-| ring-opacity-* | ring-black/* |
-| placeholder-opacity-* | placeholder-black/* |
-| flex-shrink-* | shrink-* |
-| flex-grow-* | grow-* |
-| overflow-ellipsis | text-ellipsis |
-| decoration-slice | box-decoration-slice |
-| decoration-clone | box-decoration-clone |
-
-
-=== laravel/fortify rules ===
-
-## Laravel Fortify
-
-Fortify is a headless authentication backend that provides authentication routes and controllers for Laravel applications.
-
-**Before implementing any authentication features, use the `search-docs` tool to get the latest docs for that specific feature.**
-
-### Configuration & Setup
-- Check `config/fortify.php` to see what's enabled. Use `search-docs` for detailed information on specific features.
-- Enable features by adding them to the `'features' => []` array: `Features::registration()`, `Features::resetPasswords()`, etc.
-- To see the all Fortify registered routes, use the `list-routes` tool with the `only_vendor: true` and `action: "Fortify"` parameters.
-- Fortify includes view routes by default (login, register). Set `'views' => false` in the configuration file to disable them if you're handling views yourself.
-
-### Customization
-- Views can be customized in `FortifyServiceProvider`'s `boot()` method using `Fortify::loginView()`, `Fortify::registerView()`, etc.
-- Customize authentication logic with `Fortify::authenticateUsing()` for custom user retrieval / validation.
-- Actions in `app/Actions/Fortify/` handle business logic (user creation, password reset, etc.). They're fully customizable, so you can modify them to change feature behavior.
-
-## Available Features
-- `Features::registration()` for user registration.
-- `Features::emailVerification()` to verify new user emails.
-- `Features::twoFactorAuthentication()` for 2FA with QR codes and recovery codes.
-  - Add options: `['confirmPassword' => true, 'confirm' => true]` to require password confirmation and OTP confirmation before enabling 2FA.
-- `Features::updateProfileInformation()` to let users update their profile.
-- `Features::updatePasswords()` to let users change their passwords.
-- `Features::resetPasswords()` for password reset via email.
 </laravel-boost-guidelines>

--- a/test-project/CLAUDE.md
+++ b/test-project/CLAUDE.md
@@ -8,22 +8,22 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.16
+- php - 8.4.22
+- filament/filament (FILAMENT) - v5
 - laravel/fortify (FORTIFY) - v1
 - laravel/framework (LARAVEL) - v12
 - laravel/prompts (PROMPTS) - v0
 - livewire/flux (FLUXUI_FREE) - v2
-- livewire/livewire (LIVEWIRE) - v3
+- livewire/livewire (LIVEWIRE) - v4
 - livewire/volt (VOLT) - v1
 - laravel/mcp (MCP) - v0
 - laravel/pint (PINT) - v1
 - laravel/sail (SAIL) - v1
 - pestphp/pest (PEST) - v4
 - phpunit/phpunit (PHPUNIT) - v12
-- tailwindcss (TAILWINDCSS) - v4
 
 ## Conventions
-- You must follow all existing code conventions used in this application. When creating or editing a file, check sibling files for the correct structure, approach, naming.
+- You must follow all existing code conventions used in this application. When creating or editing a file, check sibling files for the correct structure, approach, and naming.
 - Use descriptive names for variables and methods. For example, `isRegisteredForDiscounts`, not `discount()`.
 - Check for existing components to reuse before writing a new one.
 
@@ -31,7 +31,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - Do not create verification scripts or tinker when tests cover that functionality and prove it works. Unit and feature tests are more important.
 
 ## Application Structure & Architecture
-- Stick to existing directory structure - don't create new base folders without approval.
+- Stick to existing directory structure; don't create new base folders without approval.
 - Do not change the application's dependencies without approval.
 
 ## Frontend Bundling
@@ -43,17 +43,16 @@ This application is a Laravel application and its main Laravel ecosystems packag
 ## Documentation Files
 - You must only create documentation files if explicitly requested by the user.
 
-
 === boost rules ===
 
 ## Laravel Boost
 - Laravel Boost is an MCP server that comes with powerful tools designed specifically for this application. Use them.
 
 ## Artisan
-- Use the `list-artisan-commands` tool when you need to call an Artisan command to double check the available parameters.
+- Use the `list-artisan-commands` tool when you need to call an Artisan command to double-check the available parameters.
 
 ## URLs
-- Whenever you share a project URL with the user you should use the `get-absolute-url` tool to ensure you're using the correct scheme, domain / IP, and port.
+- Whenever you share a project URL with the user, you should use the `get-absolute-url` tool to ensure you're using the correct scheme, domain/IP, and port.
 
 ## Tinker / Debugging
 - You should use the `tinker` tool when you need to execute PHP to debug code or query Eloquent models directly.
@@ -64,22 +63,21 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - Only recent browser logs will be useful - ignore old logs.
 
 ## Searching Documentation (Critically Important)
-- Boost comes with a powerful `search-docs` tool you should use before any other approaches. This tool automatically passes a list of installed packages and their versions to the remote Boost API, so it returns only version-specific documentation specific for the user's circumstance. You should pass an array of packages to filter on if you know you need docs for particular packages.
-- The 'search-docs' tool is perfect for all Laravel related packages, including Laravel, Inertia, Livewire, Filament, Tailwind, Pest, Nova, Nightwatch, etc.
-- You must use this tool to search for Laravel-ecosystem documentation before falling back to other approaches.
+- Boost comes with a powerful `search-docs` tool you should use before any other approaches when dealing with Laravel or Laravel ecosystem packages. This tool automatically passes a list of installed packages and their versions to the remote Boost API, so it returns only version-specific documentation for the user's circumstance. You should pass an array of packages to filter on if you know you need docs for particular packages.
+- The `search-docs` tool is perfect for all Laravel-related packages, including Laravel, Inertia, Livewire, Filament, Tailwind, Pest, Nova, Nightwatch, etc.
+- You must use this tool to search for Laravel ecosystem documentation before falling back to other approaches.
 - Search the documentation before making code changes to ensure we are taking the correct approach.
-- Use multiple, broad, simple, topic based queries to start. For example: `['rate limiting', 'routing rate limiting', 'routing']`.
-- Do not add package names to queries - package information is already shared. For example, use `test resource table`, not `filament 4 test resource table`.
+- Use multiple, broad, simple, topic-based queries to start. For example: `['rate limiting', 'routing rate limiting', 'routing']`.
+- Do not add package names to queries; package information is already shared. For example, use `test resource table`, not `filament 4 test resource table`.
 
 ### Available Search Syntax
 - You can and should pass multiple queries at once. The most relevant results will be returned first.
 
-1. Simple Word Searches with auto-stemming - query=authentication - finds 'authenticate' and 'auth'
-2. Multiple Words (AND Logic) - query=rate limit - finds knowledge containing both "rate" AND "limit"
-3. Quoted Phrases (Exact Position) - query="infinite scroll" - Words must be adjacent and in that order
-4. Mixed Queries - query=middleware "rate limit" - "middleware" AND exact phrase "rate limit"
-5. Multiple Queries - queries=["authentication", "middleware"] - ANY of these terms
-
+1. Simple Word Searches with auto-stemming - query=authentication - finds 'authenticate' and 'auth'.
+2. Multiple Words (AND Logic) - query=rate limit - finds knowledge containing both "rate" AND "limit".
+3. Quoted Phrases (Exact Position) - query="infinite scroll" - words must be adjacent and in that order.
+4. Mixed Queries - query=middleware "rate limit" - "middleware" AND exact phrase "rate limit".
+5. Multiple Queries - queries=["authentication", "middleware"] - ANY of these terms.
 
 === php rules ===
 
@@ -90,7 +88,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 ### Constructors
 - Use PHP 8 constructor property promotion in `__construct()`.
     - <code-snippet>public function __construct(public GitHub $github) { }</code-snippet>
-- Do not allow empty `__construct()` methods with zero parameters.
+- Do not allow empty `__construct()` methods with zero parameters unless the constructor is private.
 
 ### Type Declarations
 - Always use explicit return type declarations for methods and functions.
@@ -104,22 +102,13 @@ protected function isAccessible(User $user, ?string $path = null): bool
 </code-snippet>
 
 ## Comments
-- Prefer PHPDoc blocks over comments. Never use comments within the code itself unless there is something _very_ complex going on.
+- Prefer PHPDoc blocks over inline comments. Never use comments within the code itself unless there is something very complex going on.
 
 ## PHPDoc Blocks
 - Add useful array shape type definitions for arrays when appropriate.
 
 ## Enums
 - Typically, keys in an Enum should be TitleCase. For example: `FavoritePerson`, `BestLake`, `Monthly`.
-
-
-=== tests rules ===
-
-## Test Enforcement
-
-- Every change must be programmatically tested. Write a new test or update an existing test, then run the affected tests to make sure they pass.
-- Run the minimum number of tests needed to ensure code quality and speed. Use `php artisan test` with a specific filename or filter.
-
 
 === laravel/core rules ===
 
@@ -131,7 +120,7 @@ protected function isAccessible(User $user, ?string $path = null): bool
 
 ### Database
 - Always use proper Eloquent relationship methods with return type hints. Prefer relationship methods over raw queries or manual joins.
-- Use Eloquent models and relationships before suggesting raw database queries
+- Use Eloquent models and relationships before suggesting raw database queries.
 - Avoid `DB::`; prefer `Model::query()`. Generate code that leverages Laravel's ORM capabilities rather than bypassing them.
 - Generate code that prevents N+1 query problems by using eager loading.
 - Use Laravel's query builder for very complex database operations.
@@ -166,44 +155,42 @@ protected function isAccessible(User $user, ?string $path = null): bool
 ### Vite Error
 - If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
 
-
 === laravel/v12 rules ===
 
 ## Laravel 12
 
-- Use the `search-docs` tool to get version specific documentation.
+- Use the `search-docs` tool to get version-specific documentation.
 - Since Laravel 11, Laravel has a new streamlined file structure which this project uses.
 
 ### Laravel 12 Structure
-- No middleware files in `app/Http/Middleware/`.
+- In Laravel 12, middleware are no longer registered in `app/Http/Kernel.php`.
+- Middleware are configured declaratively in `bootstrap/app.php` using `Application::configure()->withMiddleware()`.
 - `bootstrap/app.php` is the file to register middleware, exceptions, and routing files.
 - `bootstrap/providers.php` contains application specific service providers.
-- **No app\Console\Kernel.php** - use `bootstrap/app.php` or `routes/console.php` for console configuration.
-- **Commands auto-register** - files in `app/Console/Commands/` are automatically available and do not require manual registration.
+- The `app\Console\Kernel.php` file no longer exists; use `bootstrap/app.php` or `routes/console.php` for console configuration.
+- Console commands in `app/Console/Commands/` are automatically available and do not require manual registration.
 
 ### Database
 - When modifying a column, the migration must include all of the attributes that were previously defined on the column. Otherwise, they will be dropped and lost.
-- Laravel 11 allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
+- Laravel 12 allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
 
 ### Models
 - Casts can and likely should be set in a `casts()` method on a model rather than the `$casts` property. Follow existing conventions from other models.
-
 
 === fluxui-free/core rules ===
 
 ## Flux UI Free
 
 - This project is using the free edition of Flux UI. It has full access to the free components and variants, but does not have access to the Pro components.
-- Flux UI is a component library for Livewire. Flux is a robust, hand-crafted, UI component library for your Livewire applications. It's built using Tailwind CSS and provides a set of components that are easy to use and customize.
+- Flux UI is a component library for Livewire. Flux is a robust, hand-crafted UI component library for your Livewire applications. It's built using Tailwind CSS and provides a set of components that are easy to use and customize.
 - You should use Flux UI components when available.
 - Fallback to standard Blade components if Flux is unavailable.
-- If available, use Laravel Boost's `search-docs` tool to get the exact documentation and code snippets available for this project.
+- If available, use the `search-docs` tool to get the exact documentation and code snippets available for this project.
 - Flux UI components look like this:
 
-<code-snippet name="Flux UI Component Usage Example" lang="blade">
+<code-snippet name="Flux UI Component Example" lang="blade">
     <flux:button variant="primary"/>
 </code-snippet>
-
 
 ### Available Components
 This is correct as of Boost installation, but there may be additional components within the codebase.
@@ -212,14 +199,14 @@ This is correct as of Boost installation, but there may be additional components
 avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, heading, icon, input, modal, navbar, otp-input, profile, radio, select, separator, skeleton, switch, text, textarea, tooltip
 </available-flux-components>
 
-
 === livewire/core rules ===
 
-## Livewire Core
-- Use the `search-docs` tool to find exact version specific documentation for how to write Livewire & Livewire tests.
-- Use the `php artisan make:livewire [Posts\CreatePost]` artisan command to create new components
+## Livewire
+
+- Use the `search-docs` tool to find exact version-specific documentation for how to write Livewire and Livewire tests.
+- Use the `php artisan make:livewire [Posts\CreatePost]` Artisan command to create new components.
 - State should live on the server, with the UI reflecting it.
-- All Livewire requests hit the Laravel backend, they're like regular HTTP requests. Always validate form data, and run authorization checks in Livewire actions.
+- All Livewire requests hit the Laravel backend; they're like regular HTTP requests. Always validate form data and run authorization checks in Livewire actions.
 
 ## Livewire Best Practices
 - Livewire components require a single root element.
@@ -236,15 +223,14 @@ avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, h
 
 - Prefer lifecycle hooks like `mount()`, `updatedFoo()` for initialization and reactive side effects:
 
-<code-snippet name="Lifecycle hook examples" lang="php">
+<code-snippet name="Lifecycle Hook Examples" lang="php">
     public function mount(User $user) { $this->user = $user; }
     public function updatedSearch() { $this->resetPage(); }
 </code-snippet>
 
-
 ## Testing Livewire
 
-<code-snippet name="Example Livewire component test" lang="php">
+<code-snippet name="Example Livewire Component Test" lang="php">
     Livewire::test(Counter::class)
         ->assertSet('count', 0)
         ->call('increment')
@@ -253,58 +239,20 @@ avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, h
         ->assertStatus(200);
 </code-snippet>
 
-
-    <code-snippet name="Testing a Livewire component exists within a page" lang="php">
-        $this->get('/posts/create')
-        ->assertSeeLivewire(CreatePost::class);
-    </code-snippet>
-
-
-=== livewire/v3 rules ===
-
-## Livewire 3
-
-### Key Changes From Livewire 2
-- These things changed in Livewire 2, but may not have been updated in this application. Verify this application's setup to ensure you conform with application conventions.
-    - Use `wire:model.live` for real-time updates, `wire:model` is now deferred by default.
-    - Components now use the `App\Livewire` namespace (not `App\Http\Livewire`).
-    - Use `$this->dispatch()` to dispatch events (not `emit` or `dispatchBrowserEvent`).
-    - Use the `components.layouts.app` view as the typical layout path (not `layouts.app`).
-
-### New Directives
-- `wire:show`, `wire:transition`, `wire:cloak`, `wire:offline`, `wire:target` are available for use. Use the documentation to find usage examples.
-
-### Alpine
-- Alpine is now included with Livewire, don't manually include Alpine.js.
-- Plugins included with Alpine: persist, intersect, collapse, and focus.
-
-### Lifecycle Hooks
-- You can listen for `livewire:init` to hook into Livewire initialization, and `fail.status === 419` for the page expiring:
-
-<code-snippet name="livewire:load example" lang="js">
-document.addEventListener('livewire:init', function () {
-    Livewire.hook('request', ({ fail }) => {
-        if (fail && fail.status === 419) {
-            alert('Your session expired');
-        }
-    });
-
-    Livewire.hook('message.failed', (message, component) => {
-        console.error(message);
-    });
-});
+<code-snippet name="Testing Livewire Component Exists on Page" lang="php">
+    $this->get('/posts/create')
+    ->assertSeeLivewire(CreatePost::class);
 </code-snippet>
-
 
 === volt/core rules ===
 
 ## Livewire Volt
 
-- This project uses Livewire Volt for interactivity within its pages. New pages requiring interactivity must also use Livewire Volt. There is documentation available for it.
-- Make new Volt components using `php artisan make:volt [name] [--test] [--pest]`
-- Volt is a **class-based** and **functional** API for Livewire that supports single-file components, allowing a component's PHP logic and Blade templates to co-exist in the same file
+- This project uses Livewire Volt for interactivity within its pages. New pages requiring interactivity must also use Livewire Volt.
+- Make new Volt components using `php artisan make:volt [name] [--test] [--pest]`.
+- Volt is a class-based and functional API for Livewire that supports single-file components, allowing a component's PHP logic and Blade templates to coexist in the same file.
 - Livewire Volt allows PHP logic and Blade templates in one file. Components use the `@volt` directive.
-- You must check existing Volt components to determine if they're functional or class based. If you can't detect that, ask the user which they prefer before writing a Volt component.
+- You must check existing Volt components to determine if they're functional or class-based. If you can't detect that, ask the user which they prefer before writing a Volt component.
 
 ### Volt Functional Component Example
 
@@ -330,10 +278,8 @@ $double = computed(fn () => $this->count * 2);
 @endvolt
 </code-snippet>
 
-
 ### Volt Class Based Component Example
 To get started, define an anonymous class that extends Livewire\Volt\Component. Within the class, you may utilize all of the features of Livewire using traditional Livewire syntax:
-
 
 <code-snippet name="Volt Class-based Volt Component Example" lang="php">
 use Livewire\Volt\Component;
@@ -353,7 +299,6 @@ new class extends Component {
 </div>
 </code-snippet>
 
-
 ### Testing Volt & Volt Components
 - Use the existing directory for tests if it already exists. Otherwise, fallback to `tests/Feature/Volt`.
 
@@ -367,7 +312,6 @@ test('counter increments', function () {
         ->assertSee('Count: 1');
 });
 </code-snippet>
-
 
 <code-snippet name="Volt Component Test Using Pest" lang="php">
 declare(strict_types=1);
@@ -390,9 +334,7 @@ test('product form creates product', function () {
 });
 </code-snippet>
 
-
 ### Common Patterns
-
 
 <code-snippet name="CRUD With Volt" lang="php">
 <?php
@@ -428,14 +370,12 @@ $delete = fn(Product $product) => $product->delete();
     </flux:button>
 </code-snippet>
 
-
 === pint/core rules ===
 
 ## Laravel Pint Code Formatter
 
-- You must run `vendor/bin/pint --dirty` before finalizing changes to ensure your code matches the project's expected style.
-- Do not run `vendor/bin/pint --test`, simply run `vendor/bin/pint` to fix any formatting issues.
-
+- You must run `vendor/bin/pint --dirty --format agent` before finalizing changes to ensure your code matches the project's expected style.
+- Do not run `vendor/bin/pint --test --format agent`, simply run `vendor/bin/pint --format agent` to fix any formatting issues.
 
 === pest/core rules ===
 
@@ -457,9 +397,9 @@ it('is true', function () {
 
 ### Running Tests
 - Run the minimal number of tests using an appropriate filter before finalizing code edits.
-- To run all tests: `php artisan test`.
-- To run all tests in a file: `php artisan test tests/Feature/ExampleTest.php`.
-- To filter on a particular test name: `php artisan test --filter=testName` (recommended after making a change to a related file).
+- To run all tests: `php artisan test --compact`.
+- To run all tests in a file: `php artisan test --compact tests/Feature/ExampleTest.php`.
+- To filter on a particular test name: `php artisan test --compact --filter=testName` (recommended after making a change to a related file).
 - When the tests relating to your changes are passing, ask the user if they would like to run the entire test suite to ensure everything is still passing.
 
 ### Pest Assertions
@@ -478,7 +418,7 @@ it('returns all', function () {
 - You can also create partial mocks using the same import or self method.
 
 ### Datasets
-- Use datasets in Pest to simplify tests which have a lot of duplicated data. This is often the case when testing validation rules, so consider going with this solution when writing tests for validation rules.
+- Use datasets in Pest to simplify tests that have a lot of duplicated data. This is often the case when testing validation rules, so consider this solution when writing tests for validation rules.
 
 <code-snippet name="Pest Dataset Example" lang="php">
 it('has emails', function (string $email) {
@@ -489,18 +429,17 @@ it('has emails', function (string $email) {
 ]);
 </code-snippet>
 
-
 === pest/v4 rules ===
 
 ## Pest 4
 
-- Pest v4 is a huge upgrade to Pest and offers: browser testing, smoke testing, visual regression testing, test sharding, and faster type coverage.
+- Pest 4 is a huge upgrade to Pest and offers: browser testing, smoke testing, visual regression testing, test sharding, and faster type coverage.
 - Browser testing is incredibly powerful and useful for this project.
 - Browser tests should live in `tests/Browser/`.
 - Use the `search-docs` tool for detailed guidance on utilizing these features.
 
 ### Browser Testing
-- You can use Laravel features like `Event::fake()`, `assertAuthenticated()`, and model factories within Pest v4 browser tests, as well as `RefreshDatabase` (when needed) to ensure a clean state for each test.
+- You can use Laravel features like `Event::fake()`, `assertAuthenticated()`, and model factories within Pest 4 browser tests, as well as `RefreshDatabase` (when needed) to ensure a clean state for each test.
 - Interact with the page (click, type, scroll, select, submit, drag-and-drop, touch gestures, etc.) when appropriate to complete the test.
 - If requested, test on multiple browsers (Chrome, Firefox, Safari).
 - If requested, test on different devices and viewports (like iPhone 14 Pro, tablets, or custom breakpoints).
@@ -533,100 +472,4 @@ $pages = visit(['/', '/about', '/contact']);
 
 $pages->assertNoJavascriptErrors()->assertNoConsoleLogs();
 </code-snippet>
-
-
-=== tailwindcss/core rules ===
-
-## Tailwind Core
-
-- Use Tailwind CSS classes to style HTML, check and use existing tailwind conventions within the project before writing your own.
-- Offer to extract repeated patterns into components that match the project's conventions (i.e. Blade, JSX, Vue, etc..)
-- Think through class placement, order, priority, and defaults - remove redundant classes, add classes to parent or child carefully to limit repetition, group elements logically
-- You can use the `search-docs` tool to get exact examples from the official documentation when needed.
-
-### Spacing
-- When listing items, use gap utilities for spacing, don't use margins.
-
-    <code-snippet name="Valid Flex Gap Spacing Example" lang="html">
-        <div class="flex gap-8">
-            <div>Superior</div>
-            <div>Michigan</div>
-            <div>Erie</div>
-        </div>
-    </code-snippet>
-
-
-### Dark Mode
-- If existing pages and components support dark mode, new pages and components must support dark mode in a similar way, typically using `dark:`.
-
-
-=== tailwindcss/v4 rules ===
-
-## Tailwind 4
-
-- Always use Tailwind CSS v4 - do not use the deprecated utilities.
-- `corePlugins` is not supported in Tailwind v4.
-- In Tailwind v4, configuration is CSS-first using the `@theme` directive — no separate `tailwind.config.js` file is needed.
-<code-snippet name="Extending Theme in CSS" lang="css">
-@theme {
-  --color-brand: oklch(0.72 0.11 178);
-}
-</code-snippet>
-
-- In Tailwind v4, you import Tailwind using a regular CSS `@import` statement, not using the `@tailwind` directives used in v3:
-
-<code-snippet name="Tailwind v4 Import Tailwind Diff" lang="diff">
-   - @tailwind base;
-   - @tailwind components;
-   - @tailwind utilities;
-   + @import "tailwindcss";
-</code-snippet>
-
-
-### Replaced Utilities
-- Tailwind v4 removed deprecated utilities. Do not use the deprecated option - use the replacement.
-- Opacity values are still numeric.
-
-| Deprecated |	Replacement |
-|------------+--------------|
-| bg-opacity-* | bg-black/* |
-| text-opacity-* | text-black/* |
-| border-opacity-* | border-black/* |
-| divide-opacity-* | divide-black/* |
-| ring-opacity-* | ring-black/* |
-| placeholder-opacity-* | placeholder-black/* |
-| flex-shrink-* | shrink-* |
-| flex-grow-* | grow-* |
-| overflow-ellipsis | text-ellipsis |
-| decoration-slice | box-decoration-slice |
-| decoration-clone | box-decoration-clone |
-
-
-=== laravel/fortify rules ===
-
-## Laravel Fortify
-
-Fortify is a headless authentication backend that provides authentication routes and controllers for Laravel applications.
-
-**Before implementing any authentication features, use the `search-docs` tool to get the latest docs for that specific feature.**
-
-### Configuration & Setup
-- Check `config/fortify.php` to see what's enabled. Use `search-docs` for detailed information on specific features.
-- Enable features by adding them to the `'features' => []` array: `Features::registration()`, `Features::resetPasswords()`, etc.
-- To see the all Fortify registered routes, use the `list-routes` tool with the `only_vendor: true` and `action: "Fortify"` parameters.
-- Fortify includes view routes by default (login, register). Set `'views' => false` in the configuration file to disable them if you're handling views yourself.
-
-### Customization
-- Views can be customized in `FortifyServiceProvider`'s `boot()` method using `Fortify::loginView()`, `Fortify::registerView()`, etc.
-- Customize authentication logic with `Fortify::authenticateUsing()` for custom user retrieval / validation.
-- Actions in `app/Actions/Fortify/` handle business logic (user creation, password reset, etc.). They're fully customizable, so you can modify them to change feature behavior.
-
-## Available Features
-- `Features::registration()` for user registration.
-- `Features::emailVerification()` to verify new user emails.
-- `Features::twoFactorAuthentication()` for 2FA with QR codes and recovery codes.
-  - Add options: `['confirmPassword' => true, 'confirm' => true]` to require password confirmation and OTP confirmation before enabling 2FA.
-- `Features::updateProfileInformation()` to let users update their profile.
-- `Features::updatePasswords()` to let users change their passwords.
-- `Features::resetPasswords()` for password reset via email.
 </laravel-boost-guidelines>

--- a/test-project/composer.json
+++ b/test-project/composer.json
@@ -10,11 +10,13 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "filament/filament": "^5.6",
         "laravel/fortify": "^1.30",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "livewire/flux": "^2.9.0",
-        "livewire/volt": "^1.7.0"
+        "livewire/volt": "^1.7.0",
+        "robsontenorio/mary": "^2.8"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/test-project/resources/views/layouts/app.blade.php
+++ b/test-project/resources/views/layouts/app.blade.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{{ $title ?? config('app.name') }}</title>
+    </head>
+    <body>
+        {{ $slot }}
+    </body>
+</html>

--- a/test-project/resources/views/namespaced-component-test.blade.php
+++ b/test-project/resources/views/namespaced-component-test.blade.php
@@ -1,0 +1,28 @@
+{{-- Namespaced Blade component resolution fixtures (issue #79). --}}
+{{-- Each tag below resolves at runtime in Laravel; none should report --}}
+{{-- "Blade component not found". --}}
+
+{{-- Package view namespace + directory-index convention: --}}
+{{-- vendor/filament/support/resources/views/components/button/index.blade.php --}}
+<x-filament::button>Save</x-filament::button>
+
+{{-- Package view namespace, flat file: --}}
+{{-- vendor/filament/support/resources/views/components/badge.blade.php --}}
+<x-filament::badge>New</x-filament::badge>
+
+{{-- Markdown mail components live under html/, not components/: --}}
+{{-- vendor/laravel/framework/src/Illuminate/Mail/resources/views/html/message.blade.php --}}
+<x-mail::message>
+    Hello from the mail namespace.
+</x-mail::message>
+
+{{-- Livewire v4 default component namespace (config/livewire.php): --}}
+{{-- 'layouts' => resource_path('views/layouts') --}}
+<x-layouts::app>
+    {{-- MaryUI registers class components dynamically with a config prefix: --}}
+    {{-- vendor/robsontenorio/mary/src/View/Components/Card.php --}}
+    <x-mary-card title="A card" />
+
+    {{-- Negative fixture: must STILL report "component not found". --}}
+    <x-filament::does-not-exist />
+</x-layouts::app>

--- a/test-project/resources/views/namespaced-component-test.blade.php
+++ b/test-project/resources/views/namespaced-component-test.blade.php
@@ -19,9 +19,13 @@
 {{-- Livewire v4 default component namespace (config/livewire.php): --}}
 {{-- 'layouts' => resource_path('views/layouts') --}}
 <x-layouts::app>
-    {{-- MaryUI registers class components dynamically with a config prefix: --}}
-    {{-- vendor/robsontenorio/mary/src/View/Components/Card.php --}}
+    {{-- MaryUI literal class registration: Blade::component('mary-card', Card::class) --}}
+    {{-- → vendor/robsontenorio/mary/src/View/Components/Card.php (via PSR-4) --}}
     <x-mary-card title="A card" />
+
+    {{-- MaryUI prefix-computed registration: Blade::component($prefix . 'badge', Badge::class) --}}
+    {{-- with $prefix = config('mary.prefix') — '' by default in this project --}}
+    <x-badge value="New" />
 
     {{-- Negative fixture: must STILL report "component not found". --}}
     <x-filament::does-not-exist />


### PR DESCRIPTION
## Summary
Fixes all four reproducible false "Blade component not found" cases from #79. All were candidate-list or class-resolution gaps in the shared resolver — goto-definition and diagnostics stayed in agreement (the #71 invariant held); the resolution itself was incomplete.

## Root causes & changes
1. **Directory-form components** — Laravel's `ComponentTagCompiler` accepts three file shapes for an anonymous component: `{name}.blade.php`, `{name}/index.blade.php`, and `{name}/{name}.blade.php`. The package view-namespace and vendor-published branches only emitted the flat shape, so Filament 5's `<x-filament::button>` (`button/index.blade.php`) never resolved. A shared `push_component_file_candidates` helper now emits all three shapes in every anonymous branch.
2. **Markdown mail components** — `<x-mail::message>` is hardcoded in the framework (`ComponentTagCompiler` → `Markdown::htmlComponentPaths()`): it resolves under `{path}/html/`, not `components/`. Candidates now model the published `resources/views/vendor/mail/html/` dir first, then the framework's bundled views.
3. **Livewire v4 component namespaces** — Livewire v4 registers `Blade::anonymousComponentPath()` for every entry of `config('livewire.component_namespaces')` (defaults: `layouts`, `pages`) in a runtime loop no provider parse can see. A new `livewire_component_namespaces()` loader reads the app's `config/livewire.php`, falling back to the package's vendor defaults. Not gated on `has_livewire` — Livewire usually arrives transitively (Flux, Filament, MaryUI). An explicit empty app override (`'component_namespaces' => []`) disables the defaults, matching Laravel's wholesale array replacement on config merge.
4. **Vendor class registrations (MaryUI)** — `resolve_class_to_file_internal` resolved class files through a hardcoded three-namespace whitelist (`App\`, `Illuminate\`, `Laravel\`), so MaryUI's literal `Blade::component('mary-card', Card::class)` parsed and was then silently dropped. The composer PSR-4 autoload map is now consulted first. MaryUI's prefix-computed form (`Blade::component($prefix . 'card', Card::class)` with `$prefix = config('mary.prefix')`) is also parsed now — the config key resolves the way Laravel would at boot (app override → package bundled default → `''`).

## Acceptance criteria (from #79)
- [x] Vendor components (`<x-mail::message>`, `<x-filament::badge>`, `<x-filament::button>`, `<x-mary-card>`) no longer show false-positive diagnostics
- [x] `Blade::componentNamespace()` and fluent `->hasViews()` registrations both resolve
- [x] Diagnostics and goto-definition share resolution (`resolve_component_existing_file` → `component_candidate_paths`, unchanged invariant)
- [x] Genuinely missing components still report errors (negative fixture + regression tests)
- [x] Tested with multiple namespaces (`filament`, `courier`, `mail`, `layouts`) and registration forms
- [x] Published-view and class-based components both resolve

## Test plan
- [x] `cargo test --lib` — 1533 passed (15 new across both rounds: directory shapes, vendor-published index, mail html paths, Livewire config parsing incl. empty-override + app-override, PSR-4 literal + prefix-computed registrations, config string resolution, and a SalsaActor integration test proving the Livewire merge wiring with explicit-registration precedence)
- [x] `cargo fmt` / `cargo clippy --all-targets` clean
- [x] `scripts/lsp-probe.py` (new harness) against the in-repo fixture: 8 → 1 diagnostics (the sole survivor is the deliberate negative fixture)
- [x] Probe against a real Filament 5 project: 19 → 0 diagnostics
- [x] Manually verified in Zed

## Review
- Sherlock approved round 1; round 2 addresses his notes 1–3 (the MaryUI follow-up became an in-PR fix, the empty-override edge is closed, and the "hard to unit-test" Salsa merge wiring got its integration test).

Fixes #79