### PR TITLE
perf: Dependency-tracked incremental magic refresh (#80)

### DIFF
--- a/laravel-lsp/src/class_hierarchy_index.rs
+++ b/laravel-lsp/src/class_hierarchy_index.rs
@@ -74,6 +74,79 @@ pub struct ClassNode {
     pub properties: Vec<MemberDecl>,
 }
 
+impl ClassNode {
+    /// Position-blind fingerprint of this class's *surface* — the parts other
+    /// files' member resolution can observe: kind, inheritance edges, and
+    /// member names + staticness. Source spans are deliberately excluded
+    /// (a body edit shifts every later member's span without changing what
+    /// other files resolve against), and member order is normalized so
+    /// reordering declarations doesn't read as a surface change. The
+    /// save-time incremental path diffs these signatures to skip cross-file
+    /// re-resolution on body-only edits.
+    ///
+    /// Signatures are only comparable within one process lifetime —
+    /// `DefaultHasher` seeds per-process, so never persist them.
+    pub fn surface_signature(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let mut h = DefaultHasher::new();
+        self.fqcn.hash(&mut h);
+        (match self.kind {
+            PhpStructureKind::Class => 0u8,
+            PhpStructureKind::Interface => 1,
+            PhpStructureKind::Trait => 2,
+            PhpStructureKind::Enum => 3,
+        })
+        .hash(&mut h);
+        self.extends.hash(&mut h);
+        let mut implements: Vec<&str> = self.implements.iter().map(String::as_str).collect();
+        implements.sort_unstable();
+        implements.hash(&mut h);
+        let mut traits: Vec<&str> = self.trait_uses.iter().map(String::as_str).collect();
+        traits.sort_unstable();
+        traits.hash(&mut h);
+        let mut methods: Vec<(&str, bool)> = self
+            .methods
+            .iter()
+            .map(|m| (m.name.as_str(), m.is_static))
+            .collect();
+        methods.sort_unstable();
+        methods.hash(&mut h);
+        let mut properties: Vec<(&str, bool)> = self
+            .properties
+            .iter()
+            .map(|p| (p.name.as_str(), p.is_static))
+            .collect();
+        properties.sort_unstable();
+        properties.hash(&mut h);
+        h.finish()
+    }
+}
+
+/// FQCNs whose surface differs between `old` (a `file_surfaces` snapshot
+/// taken before re-indexing) and `new_nodes` (the freshly parsed
+/// replacements): changed signatures, plus classes added or removed
+/// entirely. Empty means a body-only edit — no other file's resolution
+/// can have been affected.
+pub fn surface_diff(old: &HashMap<String, u64>, new_nodes: &[ClassNode]) -> Vec<String> {
+    let mut affected = Vec::new();
+    let mut seen: HashSet<&str> = HashSet::with_capacity(new_nodes.len());
+    for node in new_nodes {
+        seen.insert(node.fqcn.as_str());
+        match old.get(&node.fqcn) {
+            Some(sig) if *sig == node.surface_signature() => {}
+            _ => affected.push(node.fqcn.clone()),
+        }
+    }
+    for fqcn in old.keys() {
+        if !seen.contains(fqcn.as_str()) {
+            affected.push(fqcn.clone());
+        }
+    }
+    affected
+}
+
 /// Inverted class-hierarchy index. Owned by the actor; never shared.
 #[derive(Default, Debug)]
 pub struct ClassHierarchyIndex {
@@ -254,6 +327,49 @@ impl ClassHierarchyIndex {
         }
         let new: HashSet<&str> = nodes.iter().map(|n| n.fqcn.as_str()).collect();
         old != new
+    }
+
+    /// fqcn → surface signature for every class `path` currently
+    /// contributes. The save flow snapshots this before re-indexing a saved
+    /// file, then runs [`surface_diff`] against the fresh parse to decide
+    /// whether any other file could be affected.
+    pub fn file_surfaces(&self, path: &Path) -> HashMap<String, u64> {
+        match self.by_file.get(path) {
+            Some(fqcns) => fqcns
+                .iter()
+                .filter_map(|f| {
+                    self.classes
+                        .get(f)
+                        .map(|n| (f.clone(), n.surface_signature()))
+                })
+                .collect(),
+            None => HashMap::new(),
+        }
+    }
+
+    /// `seeds` plus every transitive descendant (subclasses, implementers,
+    /// trait users). A surface change to a class changes the resolved member
+    /// surface of everything that inherits from it, so the save-time blast
+    /// radius must cover the whole subtree.
+    pub fn expand_with_descendants(&self, seeds: &[String]) -> HashSet<String> {
+        let mut out: HashSet<String> = HashSet::with_capacity(seeds.len());
+        let mut queue: Vec<&str> = seeds.iter().map(String::as_str).collect();
+        while let Some(fqcn) = queue.pop() {
+            if !out.insert(fqcn.to_string()) {
+                continue;
+            }
+            for child in self
+                .subclasses_of(fqcn)
+                .iter()
+                .chain(self.implementers_of(fqcn))
+                .chain(self.trait_users_of(fqcn))
+            {
+                if !out.contains(child.as_str()) {
+                    queue.push(child);
+                }
+            }
+        }
+        out
     }
 
     pub fn indexed_file_count(&self) -> usize {

--- a/laravel-lsp/src/class_hierarchy_index.rs
+++ b/laravel-lsp/src/class_hierarchy_index.rs
@@ -147,6 +147,25 @@ pub fn surface_diff(old: &HashMap<String, u64>, new_nodes: &[ClassNode]) -> Vec<
     affected
 }
 
+/// FQCNs whose surface differs between two `file_surfaces` snapshots taken
+/// before and after a save: changed signatures, plus classes added or
+/// removed. The map-vs-map sibling of [`surface_diff`] — the save flow
+/// snapshots both sides through the actor, so it never holds `ClassNode`s.
+pub fn surface_map_diff(old: &HashMap<String, u64>, new: &HashMap<String, u64>) -> Vec<String> {
+    let mut affected = Vec::new();
+    for (fqcn, sig) in new {
+        if old.get(fqcn) != Some(sig) {
+            affected.push(fqcn.clone());
+        }
+    }
+    for fqcn in old.keys() {
+        if !new.contains_key(fqcn) {
+            affected.push(fqcn.clone());
+        }
+    }
+    affected
+}
+
 /// Inverted class-hierarchy index. Owned by the actor; never shared.
 #[derive(Default, Debug)]
 pub struct ClassHierarchyIndex {

--- a/laravel-lsp/src/class_hierarchy_index/tests.rs
+++ b/laravel-lsp/src/class_hierarchy_index/tests.rs
@@ -204,3 +204,167 @@ fn contains_file_tracks_indexed_paths() {
     idx.remove_file(&path);
     assert!(!idx.contains_file(&path));
 }
+
+// ── Surface signatures (incremental save gate, #80) ─────────────────────
+
+#[test]
+fn surface_signature_ignores_body_edits_and_span_shifts() {
+    let original = r#"<?php
+namespace App\Models;
+class User {
+    public $name;
+    public function show() { return 1; }
+}
+"#;
+    // Same surface: a fatter body and extra blank lines shift every span.
+    let body_edit = r#"<?php
+namespace App\Models;
+
+
+class User {
+    public $name;
+    public function show() {
+        $value = compute();
+        return $value + 41;
+    }
+}
+"#;
+    let a = extract("/proj/app/Models/User.php", original);
+    let b = extract("/proj/app/Models/User.php", body_edit);
+    assert_eq!(a[0].surface_signature(), b[0].surface_signature());
+}
+
+#[test]
+fn surface_signature_ignores_member_order() {
+    let ab = r#"<?php
+class User {
+    public function alpha() {}
+    public function beta() {}
+}
+"#;
+    let ba = r#"<?php
+class User {
+    public function beta() {}
+    public function alpha() {}
+}
+"#;
+    let a = extract("/proj/User.php", ab);
+    let b = extract("/proj/User.php", ba);
+    assert_eq!(a[0].surface_signature(), b[0].surface_signature());
+}
+
+#[test]
+fn surface_signature_changes_on_surface_edits() {
+    let base = r#"<?php
+namespace App\Models;
+class User extends Base {
+    public $name;
+    public function show() {}
+}
+"#;
+    let base_sig = extract("/proj/User.php", base)[0].surface_signature();
+
+    // Added method.
+    let added = base.replace(
+        "public function show() {}",
+        "public function show() {}\n    public function hide() {}",
+    );
+    assert_ne!(
+        base_sig,
+        extract("/proj/User.php", &added)[0].surface_signature()
+    );
+
+    // Changed parent.
+    let reparented = base.replace("extends Base", "extends Other");
+    assert_ne!(
+        base_sig,
+        extract("/proj/User.php", &reparented)[0].surface_signature()
+    );
+
+    // Static-ness flip on a member.
+    let statified = base.replace("public function show()", "public static function show()");
+    assert_ne!(
+        base_sig,
+        extract("/proj/User.php", &statified)[0].surface_signature()
+    );
+
+    // Added trait use.
+    let traited = base.replace("public $name;", "use Sluggable;\n    public $name;");
+    assert_ne!(
+        base_sig,
+        extract("/proj/User.php", &traited)[0].surface_signature()
+    );
+}
+
+#[test]
+fn surface_diff_reports_changed_added_and_removed() {
+    let mut idx = ClassHierarchyIndex::default();
+    let path = PathBuf::from("/proj/app/Models/User.php");
+    let original = r#"<?php
+namespace App\Models;
+class User { public function show() {} }
+class Profile { public $bio; }
+"#;
+    idx.insert_file(&path, extract("/proj/app/Models/User.php", original));
+    let old = idx.file_surfaces(&path);
+    assert_eq!(old.len(), 2);
+
+    // Body-only edit → empty diff.
+    let body_edit = r#"<?php
+namespace App\Models;
+class User { public function show() { return 7; } }
+class Profile { public $bio; }
+"#;
+    let nodes = extract("/proj/app/Models/User.php", body_edit);
+    assert!(surface_diff(&old, &nodes).is_empty());
+
+    // User gains a method (changed), Profile is dropped (removed),
+    // Avatar appears (added) → all three FQCNs reported.
+    let reshaped = r#"<?php
+namespace App\Models;
+class User { public function show() {} public function hide() {} }
+class Avatar {}
+"#;
+    let nodes = extract("/proj/app/Models/User.php", reshaped);
+    let mut diff = surface_diff(&old, &nodes);
+    diff.sort();
+    assert_eq!(
+        diff,
+        vec![
+            "App\\Models\\Avatar".to_string(),
+            "App\\Models\\Profile".to_string(),
+            "App\\Models\\User".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn expand_with_descendants_walks_all_edge_kinds_transitively() {
+    let mut idx = ClassHierarchyIndex::default();
+    let src = r#"<?php
+namespace App;
+interface Contract {}
+trait Helper {}
+class Base {}
+class Child extends Base {}
+class GrandChild extends Child {}
+class Impl implements Contract {}
+class Uses { use Helper; }
+"#;
+    idx.insert_file(
+        &PathBuf::from("/proj/app/All.php"),
+        extract("/proj/app/All.php", src),
+    );
+
+    let radius = idx.expand_with_descendants(&["App\\Base".to_string()]);
+    assert!(radius.contains("App\\Base"));
+    assert!(radius.contains("App\\Child"));
+    assert!(radius.contains("App\\GrandChild"));
+    assert!(!radius.contains("App\\Impl"));
+
+    let radius = idx.expand_with_descendants(&["App\\Contract".to_string()]);
+    assert!(radius.contains("App\\Impl"));
+
+    let radius = idx.expand_with_descendants(&["App\\Helper".to_string()]);
+    assert!(radius.contains("App\\Uses"));
+}

--- a/laravel-lsp/src/class_hierarchy_index/tests.rs
+++ b/laravel-lsp/src/class_hierarchy_index/tests.rs
@@ -368,3 +368,28 @@ class Uses { use Helper; }
     let radius = idx.expand_with_descendants(&["App\\Helper".to_string()]);
     assert!(radius.contains("App\\Uses"));
 }
+
+#[test]
+fn surface_map_diff_matches_node_diff_semantics() {
+    let mut old = HashMap::new();
+    old.insert("App\\A".to_string(), 1u64);
+    old.insert("App\\B".to_string(), 2u64);
+
+    // Unchanged → empty.
+    assert!(surface_map_diff(&old, &old.clone()).is_empty());
+
+    // Changed signature + removed class + added class all report.
+    let mut new = HashMap::new();
+    new.insert("App\\A".to_string(), 9u64); // changed
+    new.insert("App\\C".to_string(), 3u64); // added
+    let mut diff = surface_map_diff(&old, &new);
+    diff.sort();
+    assert_eq!(
+        diff,
+        vec![
+            "App\\A".to_string(),
+            "App\\B".to_string(),
+            "App\\C".to_string(),
+        ]
+    );
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -48,6 +48,7 @@ pub mod middleware_parser;
 pub mod migration_index;
 // model_analyzer was consolidated into `laravel_introspector::model_metadata`.
 // Public API is re-exported as `laravel_introspector::ModelMetadata`.
+pub mod magic_dependency_index;
 pub mod magic_disk_cache;
 pub mod naming;
 pub mod parser;

--- a/laravel-lsp/src/magic_dependency_index.rs
+++ b/laravel-lsp/src/magic_dependency_index.rs
@@ -1,0 +1,103 @@
+//! Reverse dependency index for the magic-member system: which files
+//! resolved member-access receivers against which classes.
+//!
+//! This is what makes the save-time refresh *incremental* (#80). When a
+//! saved file changes a class's surface, the old behavior re-resolved the
+//! entire project; this index answers "which files actually reference that
+//! class?" so only the genuine blast radius re-resolves.
+//!
+//! **Populated from attempts, not successes.** The resolvers record every
+//! receiver FQCN they *try* to classify against — including lookups where
+//! the member doesn't (yet) exist on the class. That asymmetry is the
+//! point: if `$user->avatar` fails today because `User` has no `avatar`,
+//! the file still depends on `User` — adding the member tomorrow must
+//! re-resolve this file or the new reference stays invisible until a full
+//! rebuild. Receiver FQCNs come from use-statements and type-hints, so
+//! they're recordable even when the class isn't indexed at all.
+//!
+//! Mirrors `symbol_index` ownership: actor-owned, no internal locking,
+//! all access serialized through the actor queue.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+#[derive(Default, Debug)]
+pub struct MagicDependencyIndex {
+    /// fqcn → files that resolved a receiver against it.
+    dependents: HashMap<String, HashSet<PathBuf>>,
+    /// file → FQCNs it referenced (for eviction on re-index).
+    by_file: HashMap<PathBuf, HashSet<String>>,
+}
+
+impl MagicDependencyIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace `path`'s recorded dependencies with `fqcns`
+    /// (evict-then-insert, same contract as the other actor indexes).
+    pub fn replace_file(&mut self, path: &Path, fqcns: HashSet<String>) {
+        self.remove_file(path);
+        if fqcns.is_empty() {
+            return;
+        }
+        for fqcn in &fqcns {
+            self.dependents
+                .entry(fqcn.clone())
+                .or_default()
+                .insert(path.to_path_buf());
+        }
+        self.by_file.insert(path.to_path_buf(), fqcns);
+    }
+
+    /// Drop `path`'s contribution entirely (file deleted or re-indexing).
+    pub fn remove_file(&mut self, path: &Path) {
+        let Some(fqcns) = self.by_file.remove(path) else {
+            return;
+        };
+        for fqcn in fqcns {
+            if let Some(files) = self.dependents.get_mut(&fqcn) {
+                files.remove(path);
+                if files.is_empty() {
+                    self.dependents.remove(&fqcn);
+                }
+            }
+        }
+    }
+
+    /// Union of files that reference any of `fqcns`. The save flow feeds
+    /// this the surface-changed classes plus their transitive descendants
+    /// and re-resolves exactly the returned set.
+    pub fn dependents_of<'a, I>(&self, fqcns: I) -> HashSet<PathBuf>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        let mut out = HashSet::new();
+        for fqcn in fqcns {
+            if let Some(files) = self.dependents.get(fqcn) {
+                out.extend(files.iter().cloned());
+            }
+        }
+        out
+    }
+
+    /// Drop everything — paired with the full-rebuild path, which
+    /// repopulates from scratch.
+    pub fn clear(&mut self) {
+        self.dependents.clear();
+        self.by_file.clear();
+    }
+
+    /// Number of files with recorded dependencies. For logs.
+    pub fn file_count(&self) -> usize {
+        self.by_file.len()
+    }
+
+    /// Number of distinct FQCNs referenced. For logs.
+    pub fn class_count(&self) -> usize {
+        self.dependents.len()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/magic_dependency_index.rs
+++ b/laravel-lsp/src/magic_dependency_index.rs
@@ -88,6 +88,15 @@ impl MagicDependencyIndex {
         self.by_file.clear();
     }
 
+    /// Snapshot every file's recorded dependencies — the persistence side
+    /// of the incremental magic-cache re-save (#80).
+    pub fn export(&self) -> Vec<(PathBuf, HashSet<String>)> {
+        self.by_file
+            .iter()
+            .map(|(path, fqcns)| (path.clone(), fqcns.clone()))
+            .collect()
+    }
+
     /// Number of files with recorded dependencies. For logs.
     pub fn file_count(&self) -> usize {
         self.by_file.len()

--- a/laravel-lsp/src/magic_dependency_index/tests.rs
+++ b/laravel-lsp/src/magic_dependency_index/tests.rs
@@ -1,0 +1,95 @@
+//! Tests for the magic-member reverse dependency index.
+
+use super::*;
+
+fn set(items: &[&str]) -> HashSet<String> {
+    items.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn dependents_union_across_classes() {
+    let mut idx = MagicDependencyIndex::new();
+    idx.replace_file(
+        Path::new("/proj/app/Http/Controllers/UserController.php"),
+        set(&["App\\Models\\User", "App\\Models\\Profile"]),
+    );
+    idx.replace_file(
+        Path::new("/proj/app/Jobs/SyncUsers.php"),
+        set(&["App\\Models\\User"]),
+    );
+    idx.replace_file(
+        Path::new("/proj/app/Services/Billing.php"),
+        set(&["App\\Models\\Invoice"]),
+    );
+
+    let deps = idx.dependents_of(["App\\Models\\User"].iter().copied());
+    assert_eq!(deps.len(), 2);
+    assert!(deps.contains(Path::new("/proj/app/Http/Controllers/UserController.php")));
+    assert!(deps.contains(Path::new("/proj/app/Jobs/SyncUsers.php")));
+
+    let deps = idx.dependents_of(
+        ["App\\Models\\User", "App\\Models\\Invoice"]
+            .iter()
+            .copied(),
+    );
+    assert_eq!(deps.len(), 3);
+
+    let deps = idx.dependents_of(["App\\Models\\Unknown"].iter().copied());
+    assert!(deps.is_empty());
+}
+
+#[test]
+fn replace_file_evicts_stale_dependencies() {
+    let mut idx = MagicDependencyIndex::new();
+    let path = Path::new("/proj/app/Services/Billing.php");
+    idx.replace_file(path, set(&["App\\Models\\Invoice", "App\\Models\\User"]));
+
+    // The file stops referencing User — the old edge must disappear.
+    idx.replace_file(path, set(&["App\\Models\\Invoice"]));
+    assert!(idx
+        .dependents_of(["App\\Models\\User"].iter().copied())
+        .is_empty());
+    assert_eq!(
+        idx.dependents_of(["App\\Models\\Invoice"].iter().copied())
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn replace_with_empty_set_removes_file() {
+    let mut idx = MagicDependencyIndex::new();
+    let path = Path::new("/proj/app/Services/Billing.php");
+    idx.replace_file(path, set(&["App\\Models\\Invoice"]));
+    assert_eq!(idx.file_count(), 1);
+
+    idx.replace_file(path, HashSet::new());
+    assert_eq!(idx.file_count(), 0);
+    assert_eq!(idx.class_count(), 0);
+}
+
+#[test]
+fn remove_file_prunes_empty_class_entries() {
+    let mut idx = MagicDependencyIndex::new();
+    let a = Path::new("/proj/a.php");
+    let b = Path::new("/proj/b.php");
+    idx.replace_file(a, set(&["App\\X"]));
+    idx.replace_file(b, set(&["App\\X", "App\\Y"]));
+
+    idx.remove_file(a);
+    // X still has b as a dependent; removing b empties both.
+    assert_eq!(idx.dependents_of(["App\\X"].iter().copied()).len(), 1);
+    idx.remove_file(b);
+    assert_eq!(idx.class_count(), 0);
+    assert_eq!(idx.file_count(), 0);
+}
+
+#[test]
+fn clear_resets_everything() {
+    let mut idx = MagicDependencyIndex::new();
+    idx.replace_file(Path::new("/proj/a.php"), set(&["App\\X"]));
+    idx.clear();
+    assert_eq!(idx.file_count(), 0);
+    assert_eq!(idx.class_count(), 0);
+    assert!(idx.dependents_of(["App\\X"].iter().copied()).is_empty());
+}

--- a/laravel-lsp/src/magic_disk_cache.rs
+++ b/laravel-lsp/src/magic_disk_cache.rs
@@ -15,13 +15,19 @@
 //! ## Validity
 //!
 //! Magic-member resolution is **cross-file**: file A's `$user->email` resolves
-//! through the User class hierarchy, which may live in file B. So a per-file
-//! mtime check isn't sufficient — a change to B can invalidate A's cached
-//! entry. The caller therefore only restores this cache when the project is
-//! unchanged since the last save (the pattern cache validated every file, i.e.
-//! zero files needed re-parsing). Any change → the caller rebuilds from
-//! scratch. That keeps the cache correct by construction while making the
-//! common reload-without-edits case instant.
+//! through the User class hierarchy, which may live in file B. A per-file
+//! mtime check alone is therefore insufficient — a change to B can invalidate
+//! A's cached entry. The restore handles this granularly (#80): everything is
+//! restored as-is, then the files the pattern cache flagged as changed are
+//! re-resolved **along with their recorded blast radius** — dependents of
+//! their classes and transitive descendants (from the persisted dependency
+//! sets), plus Blade files of views they render (from the persisted render
+//! sites). An earlier revision used an all-or-nothing guard instead,
+//! re-resolving the whole project after any edit-then-restart.
+//!
+//! The cache is also re-saved (debounced) after live incremental refreshes,
+//! so it tracks the in-memory index across a working session instead of
+//! going stale at the first edit.
 //!
 //! ## Format
 //!
@@ -29,6 +35,7 @@
 //! XDG project-hash directory the pattern cache uses, as `magic_cache.bin`.
 
 use std::collections::hash_map::DefaultHasher;
+use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
@@ -37,22 +44,38 @@ use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 
 use crate::symbol_index::MagicMemberEntry;
+use crate::view_var_index::ViewRender;
 
 /// Bump when `MagicMemberEntry`'s shape (or this file's layout) changes, so a
 /// stale cache from an older build is discarded on read rather than
 /// mis-deserialized. v2: call-form usages (#77) — a v1 cache holds only
 /// property-form entries for unchanged files, which would leave scope /
 /// finder references invisible until an unrelated edit; discard wholesale.
-const SCHEMA_VERSION: u32 = 2;
+/// v3: per-file receiver dependencies + controller view renders (#80) — the
+/// incremental save flow needs both alive after a cache-warm restart, where
+/// the resolution pass that would otherwise populate them never runs.
+const SCHEMA_VERSION: u32 = 3;
 
 const CACHE_FILENAME: &str = "magic_cache.bin";
+
+/// Everything the warm path needs to restore the magic-member system without
+/// re-resolving: per-file resolved entries, per-file receiver dependencies
+/// (for the incremental save flow's blast-radius lookups), and per-controller
+/// view renders (to rebuild the persistent view-variable index).
+#[derive(Default, Serialize, Deserialize)]
+pub struct MagicCacheData {
+    /// One entry per file that contributed resolved magic members or receiver
+    /// dependencies: (path, resolved entries, attempted receiver FQCNs).
+    pub entries: Vec<(PathBuf, Vec<MagicMemberEntry>, HashSet<String>)>,
+    /// One entry per controller with `view()` render sites, for rebuilding
+    /// the view-variable index on restore.
+    pub view_renders: Vec<(PathBuf, Vec<ViewRender>)>,
+}
 
 #[derive(Serialize, Deserialize)]
 struct CacheFile {
     schema_version: u32,
-    /// One entry per file that contributed resolved magic members, paired with
-    /// that file's full resolved entry list.
-    entries: Vec<(PathBuf, Vec<MagicMemberEntry>)>,
+    data: MagicCacheData,
 }
 
 /// Where the magic cache for `project_root` lives. Mirrors the pattern cache's
@@ -74,13 +97,13 @@ fn cache_file_path(project_root: &Path) -> Option<PathBuf> {
     )
 }
 
-/// Load the resolved magic-member entries previously saved for `project_root`.
+/// Load the resolved magic-member data previously saved for `project_root`.
 ///
 /// Returns `None` — meaning "no usable cache, resolve fresh" — for any of:
 /// missing file, decode failure, or schema-version mismatch. The caller is
 /// responsible for deciding the cache is still *valid* for the current project
 /// state (see the module-level validity note); this just reads it back.
-pub fn load(project_root: &Path) -> Option<Vec<(PathBuf, Vec<MagicMemberEntry>)>> {
+pub fn load(project_root: &Path) -> Option<MagicCacheData> {
     let path = cache_file_path(project_root)?;
     let bytes = std::fs::read(&path).ok()?;
     let (cache, _): (CacheFile, _) =
@@ -88,20 +111,23 @@ pub fn load(project_root: &Path) -> Option<Vec<(PathBuf, Vec<MagicMemberEntry>)>
     if cache.schema_version != SCHEMA_VERSION {
         return None;
     }
-    Some(cache.entries)
+    Some(cache.data)
 }
 
-/// Persist the resolved magic-member `entries` for `project_root`. Written via
+/// Persist the resolved magic-member `data` for `project_root`. Written via
 /// a temp-file rename so a crash mid-write leaves the previous cache intact.
-/// Returns the number of files written. Errors are advisory — failing to
-/// persist doesn't affect the in-memory index.
-pub fn save(project_root: &Path, entries: &[(PathBuf, Vec<MagicMemberEntry>)]) -> Result<usize> {
+/// Returns the number of entry files written. Errors are advisory — failing
+/// to persist doesn't affect the in-memory index.
+pub fn save(project_root: &Path, data: &MagicCacheData) -> Result<usize> {
     let cache_path =
         cache_file_path(project_root).context("could not resolve cache directory for project")?;
-    let total = entries.len();
+    let total = data.entries.len();
     let cache = CacheFile {
         schema_version: SCHEMA_VERSION,
-        entries: entries.to_vec(),
+        data: MagicCacheData {
+            entries: data.entries.clone(),
+            view_renders: data.view_renders.clone(),
+        },
     };
     let encoded = bincode::serde::encode_to_vec(&cache, bincode::config::standard())
         .context("bincode encode failed")?;
@@ -112,4 +138,74 @@ pub fn save(project_root: &Path, entries: &[(PathBuf, Vec<MagicMemberEntry>)]) -
     std::fs::write(&tmp, &encoded).context("write tmp magic cache failed")?;
     std::fs::rename(&tmp, &cache_path).context("rename tmp magic cache failed")?;
     Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip the v3 schema — entries with deps, dep-only files, and
+    /// view renders all survive save → load.
+    #[test]
+    fn v3_cache_round_trips_entries_deps_and_renders() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path();
+
+        let entry = MagicMemberEntry {
+            fqcn: "App\\Models\\User".to_string(),
+            member: "email".to_string(),
+            line: 10,
+            column: 4,
+            end_column: 12,
+        };
+        let mut deps = std::collections::HashSet::new();
+        deps.insert("App\\Models\\User".to_string());
+        let mut dep_only = std::collections::HashSet::new();
+        dep_only.insert("App\\Models\\Invoice".to_string());
+        let mut vars = std::collections::HashMap::new();
+        vars.insert("user".to_string(), "App\\Models\\User".to_string());
+
+        let data = MagicCacheData {
+            entries: vec![
+                (
+                    PathBuf::from("/proj/app/Http/Controllers/A.php"),
+                    vec![entry.clone()],
+                    deps.clone(),
+                ),
+                // Dep-only file: failed classifications recorded, no entries.
+                (
+                    PathBuf::from("/proj/app/Services/B.php"),
+                    Vec::new(),
+                    dep_only,
+                ),
+            ],
+            view_renders: vec![(
+                PathBuf::from("/proj/app/Http/Controllers/A.php"),
+                vec![ViewRender {
+                    view_name: "users.show".to_string(),
+                    vars,
+                }],
+            )],
+        };
+
+        assert_eq!(save(root, &data).unwrap(), 2);
+        let loaded = load(root).expect("cache must load back");
+        assert_eq!(loaded.entries.len(), 2);
+        let a = loaded
+            .entries
+            .iter()
+            .find(|(p, _, _)| p.ends_with("A.php"))
+            .unwrap();
+        assert_eq!(a.1, vec![entry]);
+        assert!(a.2.contains("App\\Models\\User"));
+        let b = loaded
+            .entries
+            .iter()
+            .find(|(p, _, _)| p.ends_with("B.php"))
+            .unwrap();
+        assert!(b.1.is_empty());
+        assert!(b.2.contains("App\\Models\\Invoice"));
+        assert_eq!(loaded.view_renders.len(), 1);
+        assert_eq!(loaded.view_renders[0].1[0].view_name, "users.show");
+    }
 }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3038,6 +3038,7 @@ async fn build_magic_member_entries(
                     &*class_files,
                     &mut classviews,
                     &root,
+                    None, // deps recorded once the actor ingests them (#80)
                 );
                 // Volt SFC `.php` components: index `$this->member` reads under
                 // the component's synthetic key (no-op for plain/model .php).
@@ -3149,6 +3150,7 @@ async fn build_magic_member_entries(
                             &*class_files,
                             &mut classviews,
                             &root,
+                            None, // deps recorded once the actor ingests them (#80)
                         )
                     } else {
                         let view_name =
@@ -3161,6 +3163,7 @@ async fn build_magic_member_entries(
                             &*class_files,
                             &mut classviews,
                             &root,
+                            None, // deps recorded once the actor ingests them (#80)
                         )
                     };
                     // Component `$this->member` references (SFC own class, or MFC
@@ -5501,6 +5504,7 @@ impl LaravelLanguageServer {
                 &*class_files,
                 &mut classviews,
                 &root,
+                None, // deps recorded once the actor ingests them (#80)
             )
         } else {
             laravel_lsp::member_resolver::resolve_member_access_entries(
@@ -5509,6 +5513,7 @@ impl LaravelLanguageServer {
                 &*class_files,
                 &mut classviews,
                 &root,
+                None, // deps recorded once the actor ingests them (#80)
             )
         };
         // Component `$this->member` references (Volt SFC `.php` or Blade SFC).

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -1977,6 +1977,30 @@ struct LaravelLanguageServer {
             >,
         >,
     >,
+
+    /// Reverse dependency map for the magic-member system: which files
+    /// resolved receivers against which classes. The incremental save flow
+    /// (#80) uses it to re-resolve only a surface change's actual blast
+    /// radius instead of the whole project. `std::sync::RwLock`, not tokio:
+    /// it's read/written inside `spawn_blocking` closures where `.await`
+    /// isn't available, and every critical section is a short map op.
+    magic_deps: Arc<std::sync::RwLock<laravel_lsp::magic_dependency_index::MagicDependencyIndex>>,
+
+    /// Persistent view-variable index (view name → var → FQCN types from
+    /// every render site). Previously rebuilt as a local inside each full
+    /// magic rebuild; the incremental save flow needs it long-lived so a
+    /// saved controller can update just its own render contribution and
+    /// affected Blade files can re-resolve without a project pass.
+    /// `std::sync::RwLock` for the same blocking-closure reason as
+    /// `magic_deps`.
+    view_vars: Arc<std::sync::RwLock<laravel_lsp::view_var_index::ViewVarIndex>>,
+
+    /// Handle for the debounced magic-cache re-save. Incremental refreshes
+    /// mutate the in-memory indexes; without re-persisting them the next
+    /// startup would discard the cache and re-resolve the project. Each
+    /// schedule call cancels the previous timer, so a burst of saves
+    /// produces one disk write after the burst settles.
+    magic_cache_save_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 /// Default Salsa debounce delay in milliseconds
@@ -2942,12 +2966,16 @@ async fn build_magic_member_entries(
     // on a cache-warm start, so the bar otherwise sits frozen). `None` on the
     // incremental save-refresh path, which has no progress UI.
     mut progress: Option<&mut laravel_lsp::indexing_progress::IndexingProgress>,
-) -> Vec<(PathBuf, Vec<laravel_lsp::symbol_index::MagicMemberEntry>)> {
+    // Shared persistent view-var index. The pass-1 build publishes into it
+    // wholesale so the incremental save flow (#80) can later update single
+    // files and resolve Blade accesses without another project pass.
+    shared_view_vars: &Arc<std::sync::RwLock<laravel_lsp::view_var_index::ViewVarIndex>>,
+) -> laravel_lsp::magic_disk_cache::MagicCacheData {
     // `snapshot_class_files` already hands back a shared `Arc` (cached actor-
     // side), so the per-rebuild full-map clone is gone — just reuse it.
     let class_files = salsa.snapshot_class_files().await.unwrap_or_default();
     if class_files.is_empty() {
-        return Vec::new();
+        return Default::default();
     }
     let root = root.to_path_buf();
 
@@ -2964,6 +2992,7 @@ async fn build_magic_member_entries(
         .map(|e| e.key().clone())
         .collect();
     let mut view_var_index = laravel_lsp::view_var_index::ViewVarIndex::new();
+    let mut view_renders: Vec<(PathBuf, Vec<laravel_lsp::view_var_index::ViewRender>)> = Vec::new();
     {
         let vv_sem = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
         let mut vv_handles = Vec::with_capacity(view_targets.len());
@@ -2991,9 +3020,16 @@ async fn build_magic_member_entries(
         }
         for h in vv_handles {
             if let Ok(Some((path, renders))) = h.await {
-                view_var_index.insert_file(path, &renders);
+                view_var_index.insert_file(path.clone(), &renders);
+                view_renders.push((path, renders));
             }
         }
+    }
+    // Publish the fresh index for the incremental save flow, then keep an
+    // `Arc` of the same content for this build's pass 3 (blocking closures
+    // can't hold the lock across a project-sized pass).
+    if let Ok(mut shared) = shared_view_vars.write() {
+        *shared = view_var_index.clone();
     }
     let view_var_index = Arc::new(view_var_index);
 
@@ -3032,13 +3068,14 @@ async fn build_magic_member_entries(
             tokio::task::spawn_blocking(move || {
                 let source = std::fs::read_to_string(&path).ok()?;
                 let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
+                let mut deps = HashSet::new();
                 let mut entries = laravel_lsp::member_resolver::resolve_member_access_entries(
                     &source,
                     &data.member_access_refs,
                     &*class_files,
                     &mut classviews,
                     &root,
-                    None, // deps recorded once the actor ingests them (#80)
+                    Some(&mut deps),
                 );
                 // Volt SFC `.php` components: index `$this->member` reads under
                 // the component's synthetic key (no-op for plain/model .php).
@@ -3049,7 +3086,11 @@ async fn build_magic_member_entries(
                         &data.member_access_refs,
                     ),
                 );
-                (!entries.is_empty()).then_some((path, entries))
+                // Keep dep-only files: a file whose every classification
+                // failed still *depends* on those classes — dropping it here
+                // would blind the incremental save flow to exactly the
+                // "member added later" case the deps exist for.
+                (!entries.is_empty() || !deps.is_empty()).then_some((path, entries, deps))
             })
             .await
             .ok()
@@ -3142,6 +3183,7 @@ async fn build_magic_member_entries(
                         None
                     };
 
+                    let mut deps = HashSet::new();
                     let mut entries = if let Some(prop_types) = volt_props {
                         laravel_lsp::view_var_index::resolve_volt_member_accesses(
                             &data.member_access_refs,
@@ -3150,7 +3192,7 @@ async fn build_magic_member_entries(
                             &*class_files,
                             &mut classviews,
                             &root,
-                            None, // deps recorded once the actor ingests them (#80)
+                            Some(&mut deps),
                         )
                     } else {
                         let view_name =
@@ -3163,7 +3205,7 @@ async fn build_magic_member_entries(
                             &*class_files,
                             &mut classviews,
                             &root,
-                            None, // deps recorded once the actor ingests them (#80)
+                            Some(&mut deps),
                         )
                     };
                     // Component `$this->member` references (SFC own class, or MFC
@@ -3178,7 +3220,8 @@ async fn build_magic_member_entries(
                             ),
                         );
                     }
-                    (!entries.is_empty()).then_some((path, entries))
+                    // Dep-only files stay — see the pass-2 comment.
+                    (!entries.is_empty() || !deps.is_empty()).then_some((path, entries, deps))
                 })
                 .await
                 .ok()
@@ -3192,7 +3235,48 @@ async fn build_magic_member_entries(
         }
     }
 
-    magic_entries
+    laravel_lsp::magic_disk_cache::MagicCacheData {
+        entries: magic_entries,
+        view_renders,
+    }
+}
+
+/// Fold a magic build's (or disk restore's) per-file entries into the live
+/// indexes: replace the dependency index contents and bulk-import the
+/// resolved entries into the actor's symbol index. Returns the imported
+/// entry count.
+///
+/// The deps lock is scoped to drop before the actor await — `magic_deps` is
+/// a `std::sync::RwLock` and must never be held across a suspension point.
+async fn import_magic_data(
+    salsa: &SalsaHandle,
+    magic_deps: &Arc<std::sync::RwLock<laravel_lsp::magic_dependency_index::MagicDependencyIndex>>,
+    entries: Vec<(
+        PathBuf,
+        Vec<laravel_lsp::symbol_index::MagicMemberEntry>,
+        HashSet<String>,
+    )>,
+) -> Result<usize, &'static str> {
+    let mut import = Vec::with_capacity(entries.len());
+    if let Ok(mut deps_lock) = magic_deps.write() {
+        // Full replace: a build/restore is authoritative for the whole
+        // project, and clearing first drops entries for since-deleted files.
+        deps_lock.clear();
+        for (path, file_entries, deps) in entries {
+            deps_lock.replace_file(&path, deps);
+            if !file_entries.is_empty() {
+                import.push((path, file_entries));
+            }
+        }
+    } else {
+        // Poisoned lock — skip deps, still import entries so references work.
+        for (path, file_entries, _) in entries {
+            if !file_entries.is_empty() {
+                import.push((path, file_entries));
+            }
+        }
+    }
+    salsa.bulk_import_magic_members(import).await
 }
 
 impl LaravelLanguageServer {
@@ -3878,6 +3962,13 @@ impl LaravelLanguageServer {
             vendor_translation_namespaces: Arc::new(RwLock::new(None)),
             builder_method_index_cache: Arc::new(RwLock::new(HashMap::new())),
             route_decl_cache: Arc::new(RwLock::new(HashMap::new())),
+            magic_deps: Arc::new(std::sync::RwLock::new(
+                laravel_lsp::magic_dependency_index::MagicDependencyIndex::new(),
+            )),
+            view_vars: Arc::new(std::sync::RwLock::new(
+                laravel_lsp::view_var_index::ViewVarIndex::new(),
+            )),
+            magic_cache_save_handle: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -4228,6 +4319,14 @@ impl LaravelLanguageServer {
         // again here so the warming task can (a) skip files already in
         // cache from the load and (b) hand the same map to save_from.
         let pattern_cache_for_warm = pattern_cache.clone();
+        // Incremental save flow state (#80): the warm task populates both —
+        // from the disk cache on a clean restore, from the fresh build
+        // otherwise — so save-time blast-radius lookups work either way.
+        let magic_deps_for_warm = self.magic_deps.clone();
+        let view_vars_for_warm = self.view_vars.clone();
+        // For the granular restore's per-file re-resolution (it reuses the
+        // same machinery as the save-time dependents pass).
+        let server_for_warm = self.clone_for_spawn();
         tokio::spawn(async move {
             // `progress` moves into this task — when warming finishes (or
             // hits an early return) we call `end` to clear the status bar.
@@ -4274,6 +4373,9 @@ impl LaravelLanguageServer {
                 .into_iter()
                 .filter(|p| !pattern_cache_for_warm.contains_key(p))
                 .collect();
+            // The granular magic restore below re-resolves exactly these
+            // changed files plus their recorded blast radius.
+            let changed_paths = paths_to_parse.clone();
             let to_parse = paths_to_parse.len();
             let cached_hits = total - to_parse;
             if cached_hits > 0 {
@@ -4463,15 +4565,17 @@ impl LaravelLanguageServer {
             // every captured member access (PHP/Blade/Volt) against the class
             // hierarchy + view-variable index — the dominant warm cost.
             //
-            // Restore it from disk when the project is UNCHANGED since the last
-            // save (`to_parse == 0` → the pattern cache validated every file).
-            // Because resolution is cross-file, this all-or-nothing guard keeps
-            // the restored index correct: if even one file changed, the cached
-            // resolution could be stale, so we resolve fresh. The common
-            // reload-without-edits case becomes instant instead of ~30s.
+            // Granular restore (#80): the cache is restored whenever it
+            // exists; only the files that changed since it was saved — plus
+            // their recorded blast radius (dependents of their classes and
+            // descendants, plus Blade files of views they render) — are
+            // re-resolved through the per-file machinery. An earlier
+            // revision discarded the whole cache when even one file had
+            // changed, re-resolving every member access in the project
+            // (~135s on a real app) after any edit-then-restart.
             // Disk read on the blocking pool so it never stalls the async
             // runtime (the file can be large on a big project).
-            let restored = if to_parse == 0 {
+            let restored = {
                 let root_for_load = root_for_save.clone();
                 tokio::task::spawn_blocking(move || {
                     laravel_lsp::magic_disk_cache::load(&root_for_load)
@@ -4479,53 +4583,134 @@ impl LaravelLanguageServer {
                 .await
                 .ok()
                 .flatten()
-            } else {
-                None
             };
-            if let Some(entries) = restored {
-                match salsa.bulk_import_magic_members(entries).await {
+            if let Some(data) = restored {
+                let laravel_lsp::magic_disk_cache::MagicCacheData {
+                    entries,
+                    view_renders,
+                } = data;
+                // Rebuild the persistent view-var index from the persisted
+                // renders — the resolution pass that would otherwise build it
+                // never runs on a restore, and the incremental save flow
+                // needs it alive (#80).
+                if let Ok(mut vv) = view_vars_for_warm.write() {
+                    *vv = laravel_lsp::view_var_index::ViewVarIndex::new();
+                    for (path, renders) in &view_renders {
+                        vv.insert_file(path.clone(), renders);
+                    }
+                }
+                // Views rendered by since-changed controllers may pass
+                // different variable types now — their Blade files join the
+                // re-resolve set below.
+                let changed_set: HashSet<&PathBuf> = changed_paths.iter().collect();
+                let changed_views: HashSet<String> = view_renders
+                    .iter()
+                    .filter(|(path, _)| changed_set.contains(path))
+                    .flat_map(|(_, renders)| renders.iter().map(|r| r.view_name.clone()))
+                    .collect();
+                match import_magic_data(&salsa, &magic_deps_for_warm, entries).await {
                     Ok(n) => info!("🪄 Magic-member index: {} entries (restored from disk)", n),
                     Err(e) => debug!("Magic-member restore import failed: {}", e),
+                }
+
+                if !changed_paths.is_empty() {
+                    // Class-level blast radius of the changed files. The
+                    // surfaces reflect the files' *current* classes; a class
+                    // deleted since the cache was saved keeps its stale
+                    // dependents until their next touch — the same
+                    // self-healing trade-off as the live incremental path.
+                    let mut seeds: Vec<String> = Vec::new();
+                    for path in &changed_paths {
+                        if let Ok(surfaces) = salsa.file_class_surfaces(path.clone()).await {
+                            seeds.extend(surfaces.into_keys());
+                        }
+                    }
+                    let radius = salsa
+                        .expand_class_descendants(seeds)
+                        .await
+                        .unwrap_or_default();
+                    // Changed files themselves (vendor excluded — the magic
+                    // index deliberately skips vendor usage sites, and a
+                    // composer update would otherwise re-resolve thousands
+                    // of files nobody references from).
+                    let mut work: HashSet<PathBuf> = changed_paths
+                        .iter()
+                        .filter(|p| {
+                            p.to_string_lossy().ends_with(".php")
+                                && !p.components().any(|c| c.as_os_str() == "vendor")
+                        })
+                        .cloned()
+                        .collect();
+                    if let Ok(deps) = magic_deps_for_warm.read() {
+                        work.extend(deps.dependents_of(radius.iter().map(String::as_str)));
+                    }
+                    if !changed_views.is_empty() {
+                        for entry in pattern_cache_for_warm.iter() {
+                            let p = entry.key();
+                            if !p.to_string_lossy().ends_with(".blade.php")
+                                || p.components().any(|c| c.as_os_str() == "vendor")
+                            {
+                                continue;
+                            }
+                            if let Some(name) = laravel_lsp::view_var_index::view_name_for_path(
+                                p,
+                                &view_paths_for_warm,
+                            ) {
+                                if changed_views.contains(name.as_str()) {
+                                    work.insert(p.clone());
+                                }
+                            }
+                        }
+                    }
+                    if !work.is_empty() {
+                        info!(
+                            "🪄 Granular magic restore: re-resolving {} changed/dependent file(s)",
+                            work.len()
+                        );
+                        server_for_warm.refresh_files_magic(work).await;
+                    }
                 }
             } else {
                 // Resolve fresh, drive progress (the file-parse loop had nothing
                 // to report on a cache-warm start), persist for next time, then
                 // import. `build_magic_member_entries` is shared with the
-                // incremental save-refresh path.
-                let magic_entries = build_magic_member_entries(
+                // incremental save-refresh path. It publishes the view-var
+                // index into `view_vars_for_warm` itself.
+                let magic_data = build_magic_member_entries(
                     &salsa,
                     &pattern_cache_for_warm,
                     &root_for_save,
                     &view_paths_for_warm,
                     MAX_CONCURRENT_PARSES,
                     progress.as_mut(),
+                    &view_vars_for_warm,
                 )
                 .await;
-                if !magic_entries.is_empty() {
+                if !magic_data.entries.is_empty() {
                     // Persist on the blocking pool (sync I/O), handing the
-                    // entries back so the import below still owns them — no clone.
+                    // data back so the import below still owns it — no clone.
                     let root_for_msave = root_for_save.clone();
-                    let magic_entries = match tokio::task::spawn_blocking(move || {
-                        let res =
-                            laravel_lsp::magic_disk_cache::save(&root_for_msave, &magic_entries);
-                        (res, magic_entries)
+                    let magic_data = match tokio::task::spawn_blocking(move || {
+                        let res = laravel_lsp::magic_disk_cache::save(&root_for_msave, &magic_data);
+                        (res, magic_data)
                     })
                     .await
                     {
-                        Ok((Ok(n), entries)) => {
+                        Ok((Ok(n), data)) => {
                             info!("🗄️  Magic-member index: saved {} files to disk", n);
-                            entries
+                            data
                         }
-                        Ok((Err(e), entries)) => {
+                        Ok((Err(e), data)) => {
                             debug!("Magic-member disk save failed: {}", e);
-                            entries
+                            data
                         }
                         Err(e) => {
                             debug!("Magic-member disk save task panicked: {}", e);
-                            Vec::new()
+                            Default::default()
                         }
                     };
-                    match salsa.bulk_import_magic_members(magic_entries).await {
+                    match import_magic_data(&salsa, &magic_deps_for_warm, magic_data.entries).await
+                    {
                         Ok(n) => info!("🪄 Magic-member index: {} entries", n),
                         Err(e) => debug!("Magic-member index build failed: {}", e),
                     }
@@ -5394,11 +5579,20 @@ impl LaravelLanguageServer {
 
     /// Refresh the magic-member index when a source file is saved — the single
     /// entry point for incremental updates (typing-pause edits deliberately do
-    /// no magic work). Pushes the saved buffer into Salsa so resolution sees
-    /// current content, runs the instant per-file refresh (which also covers
-    /// very large projects where the full rebuild is gated off), then schedules
-    /// the debounced project-wide reconverge for cross-file ripples. Volt pages
-    /// are self-contained, so they skip the project-wide pass.
+    /// no magic work). The flow (#80):
+    ///
+    /// 1. Snapshot the file's pre-save class surfaces (the hierarchy still
+    ///    holds them — nothing has re-parsed yet).
+    /// 2. Push the saved buffer into Salsa, run the instant per-file refresh
+    ///    (which re-parses, updates the hierarchy, records receiver deps, and
+    ///    updates the file's view-render contribution).
+    /// 3. Diff pre/post surfaces and view renders. A body-only edit — the
+    ///    overwhelming majority of saves — diffs empty and stops here: no
+    ///    other file's resolution can have changed.
+    /// 4. Otherwise re-resolve only the actual blast radius (dependents of
+    ///    the changed classes + their descendants, plus Blade files of views
+    ///    whose variable types changed) in the background, at bounded
+    ///    concurrency, whatever the radius size.
     async fn refresh_magic_on_save(&self, uri: &Url, text: &str) {
         let Ok(path) = uri.to_file_path() else {
             return;
@@ -5408,6 +5602,14 @@ impl LaravelLanguageServer {
         if !path_str.ends_with(".php") {
             return;
         }
+
+        // Pre-save surface snapshot — MUST precede the Salsa update below,
+        // which is what eventually replaces the hierarchy's nodes.
+        let old_surfaces = self
+            .salsa
+            .file_class_surfaces(path.clone())
+            .await
+            .unwrap_or_default();
 
         // Ensure Salsa reflects the saved buffer before resolving — a pending
         // did_change debounce may not have fired yet. Use the buffer's version
@@ -5427,69 +5629,231 @@ impl LaravelLanguageServer {
             debug!("Failed to update Salsa on save for {}: {}", path_str, e);
         }
 
-        self.refresh_file_magic(&path, text).await;
+        let changed_views = self.refresh_file_magic(&path, text).await;
 
-        let is_volt_blade = path_str.ends_with(".blade.php")
-            && laravel_lsp::livewire_resolver::source_contains_volt_signature(text);
-        if !is_volt_blade {
-            self.schedule_magic_rebuild().await;
+        let new_surfaces = self
+            .salsa
+            .file_class_surfaces(path.clone())
+            .await
+            .unwrap_or_default();
+        let changed_classes =
+            laravel_lsp::class_hierarchy_index::surface_map_diff(&old_surfaces, &new_surfaces);
+
+        // The per-file refresh above already mutated the live indexes —
+        // keep the disk cache converging regardless of ripple size.
+        self.schedule_magic_cache_save().await;
+
+        if changed_classes.is_empty() && changed_views.is_empty() {
+            return; // body-only edit — nothing beyond this file can change
         }
+
+        // The ripple runs in the background so did_save returns promptly.
+        let server = self.clone_for_spawn();
+        tokio::spawn(async move {
+            server
+                .refresh_magic_dependents(&path, changed_classes, changed_views)
+                .await;
+        });
+    }
+
+    /// Re-resolve the blast radius of a surface or render change: dependents
+    /// of the changed classes (and their transitive descendants) from the
+    /// dependency index, plus the Blade files of views whose variable types
+    /// changed. The set is processed incrementally whatever its size — even
+    /// a base-class change rippling to thousands of files is cheaper than
+    /// the full three-pass rebuild a fallback would trigger, and the
+    /// semaphore keeps CPU bounded throughout. (An earlier revision fell
+    /// back to the full rebuild above 500 dependents; on a real project
+    /// that fallback *was* the long re-index it existed to prevent.)
+    async fn refresh_magic_dependents(
+        &self,
+        saved: &Path,
+        changed_classes: Vec<String>,
+        changed_views: Vec<String>,
+    ) {
+        let mut work: HashSet<PathBuf> = HashSet::new();
+
+        if !changed_classes.is_empty() {
+            let radius = self
+                .salsa
+                .expand_class_descendants(changed_classes)
+                .await
+                .unwrap_or_default();
+            if let Ok(deps) = self.magic_deps.read() {
+                work.extend(deps.dependents_of(radius.iter().map(String::as_str)));
+            }
+        }
+
+        if !changed_views.is_empty() {
+            let view_paths = self
+                .cached_config
+                .read()
+                .await
+                .as_ref()
+                .map(|c| c.view_paths.clone())
+                .unwrap_or_default();
+            let changed: HashSet<&str> = changed_views.iter().map(String::as_str).collect();
+            for entry in self.salsa.pattern_cache().iter() {
+                let p = entry.key();
+                if !p.to_string_lossy().ends_with(".blade.php")
+                    || p.components().any(|c| c.as_os_str() == "vendor")
+                {
+                    continue;
+                }
+                if let Some(name) = laravel_lsp::view_var_index::view_name_for_path(p, &view_paths)
+                {
+                    if changed.contains(name.as_str()) {
+                        work.insert(p.clone());
+                    }
+                }
+            }
+        }
+
+        work.remove(saved); // already refreshed by the per-file pass
+        if work.is_empty() {
+            return;
+        }
+        info!(
+            "🪄 Incremental magic refresh: re-resolving {} dependent file(s)",
+            work.len()
+        );
+        self.refresh_files_magic(work).await;
+    }
+
+    /// Re-resolve a set of files through the per-file magic refresh at
+    /// bounded concurrency. Shared by the save-time dependents pass and the
+    /// granular startup restore (#80). Open buffers are authoritative;
+    /// everything else reads from disk on the blocking pool.
+    async fn refresh_files_magic(&self, work: HashSet<PathBuf>) {
+        let sem = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_MAGIC_PARSES));
+        let mut handles = Vec::with_capacity(work.len());
+        for dep in work {
+            let server = self.clone_for_spawn();
+            let permit_owner = sem.clone();
+            handles.push(tokio::spawn(async move {
+                let _permit = permit_owner.acquire_owned().await.ok()?;
+                let buffered = match Url::from_file_path(&dep) {
+                    Ok(url) => server
+                        .documents
+                        .read()
+                        .await
+                        .get(&url)
+                        .map(|(content, _)| content.clone()),
+                    Err(()) => None,
+                };
+                let content = match buffered {
+                    Some(c) => c,
+                    None => {
+                        let dep_for_read = dep.clone();
+                        tokio::task::spawn_blocking(move || {
+                            std::fs::read_to_string(&dep_for_read).ok()
+                        })
+                        .await
+                        .ok()
+                        .flatten()?
+                    }
+                };
+                server.refresh_file_magic(&dep, &content).await;
+                Some(())
+            }));
+        }
+        for h in handles {
+            let _ = h.await;
+        }
+        // Reference counts may have changed project-wide.
+        let _ = self.client.code_lens_refresh().await;
+        self.schedule_magic_cache_save().await;
     }
 
     /// Instant per-file magic-member refresh (the "instant" half of the
-    /// save-time refresh). Re-resolves just the saved file's member accesses
-    /// against the current hierarchy and replaces its entries in the reverse
-    /// index, so find-references on that file is current the moment the
-    /// project-wide reconverge is gated off (large projects) or still pending.
+    /// save-time refresh). Re-resolves the file's member accesses against the
+    /// current hierarchy, replaces its entries in the reverse index, records
+    /// its receiver dependencies, and (for controllers) updates its view-
+    /// render contribution in the persistent view-var index.
     ///
-    /// Handles PHP files and self-contained Volt pages. Controller-rendered
-    /// Blade needs the project-wide view-variable index (it must know which
-    /// controllers feed this view), so it is left to the debounced full rebuild.
-    async fn refresh_file_magic(&self, path: &Path, content: &str) {
+    /// Handles PHP, self-contained Volt pages, AND controller-rendered Blade
+    /// (resolved against the persistent view-var index — previously deferred
+    /// to the full rebuild, which #80 retired from the per-save path).
+    ///
+    /// Returns the view names whose variable types changed because of this
+    /// file's render sites — the caller feeds those into the Blade ripple.
+    async fn refresh_file_magic(&self, path: &Path, content: &str) -> Vec<String> {
         let path_str = path.to_string_lossy();
         // `.blade.php` also ends with `.php`, so this covers both.
         if !path_str.ends_with(".php") {
-            return;
+            return Vec::new();
         }
         let is_blade = path_str.ends_with(".blade.php");
         let Some(root) = self.root_path.read().await.clone() else {
-            return;
+            return Vec::new();
         };
 
         // Fresh parsed patterns for the edited file. `get_patterns` also updates
         // the class hierarchy for this file, so its own class is resolvable.
         let patterns = match self.salsa.get_patterns(path.to_path_buf()).await {
             Ok(Some(p)) => p,
-            _ => return,
+            _ => return Vec::new(),
         };
 
+        let class_files = self.salsa.snapshot_class_files().await.unwrap_or_default();
+
+        // View-render diff (controllers): recompute this file's render sites
+        // and replace its contribution. Runs BEFORE the member-access early
+        // return — a controller can pass variables to views without reading
+        // any `->member` itself.
+        let mut changed_views: Vec<String> = Vec::new();
+        if !is_blade && !class_files.is_empty() {
+            let had_renders = self
+                .view_vars
+                .read()
+                .map(|vv| vv.renders_for(path).is_some())
+                .unwrap_or(false);
+            if !patterns.views.is_empty() || had_renders {
+                let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
+                let renders = laravel_lsp::view_var_index::view_renders_in_file(
+                    content,
+                    &*class_files,
+                    &mut classviews,
+                    &root,
+                );
+                if let Ok(mut vv) = self.view_vars.write() {
+                    let old = vv.renders_for(path).map(|r| r.to_vec()).unwrap_or_default();
+                    if old != renders {
+                        let mut views: HashSet<String> = old
+                            .iter()
+                            .chain(renders.iter())
+                            .map(|r| r.view_name.clone())
+                            .collect();
+                        vv.insert_file(path.to_path_buf(), &renders);
+                        changed_views.extend(views.drain());
+                    }
+                }
+            }
+        }
+
         // No member accesses → nothing to resolve. Still re-index with an empty
-        // set so a *removed* last access clears its stale entry; this skips the
-        // class-files snapshot and the resolver entirely (the common edit on a
-        // file with no `->member` reads, e.g. a config or a plain function).
+        // set so a *removed* last access clears its stale entry, and clear the
+        // file's recorded dependencies for the same reason.
         if patterns.member_access_refs.is_empty() {
             let _ = self
                 .salsa
                 .reindex_file_magic(path.to_path_buf(), Vec::new())
                 .await;
-            return;
+            if let Ok(mut deps) = self.magic_deps.write() {
+                deps.remove_file(path);
+            }
+            return changed_views;
         }
 
-        // Controller-rendered Blade needs the project-wide view-variable index —
-        // defer it to the debounced full rebuild. Self-contained Volt resolves
-        // locally below.
+        if class_files.is_empty() {
+            return changed_views;
+        }
+
         let is_volt =
             is_blade && laravel_lsp::livewire_resolver::source_contains_volt_signature(content);
-        if is_blade && !is_volt {
-            return;
-        }
-
-        let class_files = self.salsa.snapshot_class_files().await.unwrap_or_default();
-        if class_files.is_empty() {
-            return;
-        }
 
         let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
+        let mut deps: HashSet<String> = HashSet::new();
         let mut entries = if is_volt {
             let prop_types = laravel_lsp::view_var_index::volt_property_types(
                 content,
@@ -5504,8 +5868,35 @@ impl LaravelLanguageServer {
                 &*class_files,
                 &mut classviews,
                 &root,
-                None, // deps recorded once the actor ingests them (#80)
+                Some(&mut deps),
             )
+        } else if is_blade {
+            // Controller-rendered Blade: resolve against the persistent
+            // view-var index. The read guard spans only this sync call —
+            // no awaits while held.
+            let view_paths = self
+                .cached_config
+                .read()
+                .await
+                .as_ref()
+                .map(|c| c.view_paths.clone())
+                .unwrap_or_default();
+            match laravel_lsp::view_var_index::view_name_for_path(path, &view_paths) {
+                Some(view_name) => match self.view_vars.read() {
+                    Ok(vv) => laravel_lsp::view_var_index::resolve_blade_member_accesses(
+                        &patterns.member_access_refs,
+                        &view_name,
+                        &vv,
+                        &patterns.blade_loops,
+                        &*class_files,
+                        &mut classviews,
+                        &root,
+                        Some(&mut deps),
+                    ),
+                    Err(_) => Vec::new(),
+                },
+                None => Vec::new(),
+            }
         } else {
             laravel_lsp::member_resolver::resolve_member_access_entries(
                 content,
@@ -5513,7 +5904,7 @@ impl LaravelLanguageServer {
                 &*class_files,
                 &mut classviews,
                 &root,
-                None, // deps recorded once the actor ingests them (#80)
+                Some(&mut deps),
             )
         };
         // Component `$this->member` references (Volt SFC `.php` or Blade SFC).
@@ -5532,13 +5923,92 @@ impl LaravelLanguageServer {
         {
             debug!("Per-file magic refresh failed for {}: {}", path_str, e);
         }
+        if let Ok(mut deps_lock) = self.magic_deps.write() {
+            deps_lock.replace_file(path, deps);
+        }
+
+        changed_views
     }
 
-    /// Schedule the debounced project-wide magic-member reconverge (the "full"
-    /// half of the save-time refresh). Coalesces rapid saves (save-all, format-
-    /// on-save bursts): each call cancels the previous pending rebuild and
-    /// starts a fresh timer, so cross-file ripples (controller→Blade,
-    /// model→usages) reconverge shortly after the save settles.
+    /// Schedule the debounced re-save of the magic disk cache. Call after
+    /// anything that mutates the in-memory magic state (per-file refresh,
+    /// dependents pass, full reconverge) — the debounce coalesces a burst
+    /// of saves into one disk write, and the export runs against whatever
+    /// the indexes hold when the timer fires.
+    async fn schedule_magic_cache_save(&self) {
+        const MAGIC_CACHE_SAVE_DEBOUNCE_MS: u64 = 10_000;
+        if let Some(handle) = self.magic_cache_save_handle.write().await.take() {
+            handle.abort();
+        }
+        let server = self.clone_for_spawn();
+        let handle = tokio::spawn(async move {
+            sleep(Duration::from_millis(MAGIC_CACHE_SAVE_DEBOUNCE_MS)).await;
+            server.save_magic_cache().await;
+        });
+        *self.magic_cache_save_handle.write().await = Some(handle);
+    }
+
+    /// Export the live magic state (resolved entries from the actor's
+    /// symbol index, receiver deps, view renders) and persist it. Keeping
+    /// the cache current after incremental refreshes is what lets the next
+    /// startup restore instead of re-resolving (#80) — without this, any
+    /// edit invalidated the cache for the whole next session.
+    async fn save_magic_cache(&self) {
+        let Some(root) = self.root_path.read().await.clone() else {
+            return;
+        };
+        let Ok(entries_by_file) = self.salsa.export_magic_members().await else {
+            return;
+        };
+        let deps = self
+            .magic_deps
+            .read()
+            .map(|d| d.export())
+            .unwrap_or_default();
+        let view_renders = self
+            .view_vars
+            .read()
+            .map(|v| v.export())
+            .unwrap_or_default();
+
+        // Merge entries and deps per file — a file can have either without
+        // the other (dep-only files matter; see magic_dependency_index).
+        let mut by_file: HashMap<
+            PathBuf,
+            (
+                Vec<laravel_lsp::symbol_index::MagicMemberEntry>,
+                HashSet<String>,
+            ),
+        > = HashMap::new();
+        for (path, entries) in entries_by_file {
+            by_file.entry(path).or_default().0 = entries;
+        }
+        for (path, dep_set) in deps {
+            by_file.entry(path).or_default().1 = dep_set;
+        }
+        let data = laravel_lsp::magic_disk_cache::MagicCacheData {
+            entries: by_file
+                .into_iter()
+                .map(|(path, (entries, dep_set))| (path, entries, dep_set))
+                .collect(),
+            view_renders,
+        };
+
+        match tokio::task::spawn_blocking(move || laravel_lsp::magic_disk_cache::save(&root, &data))
+            .await
+        {
+            Ok(Ok(n)) => info!("🗄️  Magic cache re-saved: {} files", n),
+            Ok(Err(e)) => debug!("Magic cache re-save failed: {}", e),
+            Err(e) => debug!("Magic cache re-save task panicked: {}", e),
+        }
+    }
+
+    /// Schedule the debounced project-wide magic-member reconverge. No longer
+    /// part of the per-save path (#80 — saves use the dependency-tracked
+    /// incremental refresh); this remains the reconverge after external
+    /// (watched-file) changes, whose ripples the save-time diff never saw.
+    /// The debounce coalesces bursts (git checkout touching hundreds of
+    /// files) into one rebuild.
     async fn schedule_magic_rebuild(&self) {
         if let Some(handle) = self.magic_rebuild_handle.write().await.take() {
             handle.abort();
@@ -5582,21 +6052,23 @@ impl LaravelLanguageServer {
             debug!("Symbol index rebuild failed: {}", e);
             return;
         }
-        let entries = build_magic_member_entries(
+        let data = build_magic_member_entries(
             &self.salsa,
             &pattern_cache,
             &root,
             &view_paths,
             MAX_CONCURRENT_MAGIC_PARSES,
             None, // save-refresh path has no first-load progress UI
+            &self.view_vars,
         )
         .await;
-        match self.salsa.bulk_import_magic_members(entries).await {
+        match import_magic_data(&self.salsa, &self.magic_deps, data.entries).await {
             Ok(n) => info!("🪄 Magic-member index reconverged: {} entries", n),
             Err(e) => debug!("Magic reconverge failed: {}", e),
         }
         // Counts changed — ask the client to re-resolve code lenses.
         let _ = self.client.code_lens_refresh().await;
+        self.schedule_magic_cache_save().await;
     }
 
     /// Execute all pending rescans
@@ -14571,6 +15043,9 @@ return [
             vendor_translation_namespaces: self.vendor_translation_namespaces.clone(),
             builder_method_index_cache: self.builder_method_index_cache.clone(),
             route_decl_cache: self.route_decl_cache.clone(),
+            magic_deps: self.magic_deps.clone(),
+            view_vars: self.view_vars.clone(),
+            magic_cache_save_handle: self.magic_cache_save_handle.clone(),
         }
     }
 
@@ -18983,6 +19458,17 @@ impl LanguageServer for LaravelLanguageServer {
             if let Some(root) = self.initialized_root.read().await.clone() {
                 self.rebuild_command_index(&root).await;
             }
+        }
+
+        // External PHP changes (git pull, formatter outside Zed) bypass the
+        // save-time incremental refresh entirely — their surface diffs were
+        // never computed, so the dependency-tracked path can't see their
+        // ripples. The debounced full reconverge (still gated on project
+        // size) restores the old guarantee that the magic index converges
+        // after disk-level changes. Saves no longer trigger this (#80);
+        // external edits are the one remaining caller.
+        if created_or_changed + deleted > 0 {
+            self.schedule_magic_rebuild().await;
         }
     }
 

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -24,7 +24,7 @@ use crate::query_chain::flow;
 use crate::query_chain::use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};
 use crate::salsa_impl::{Confidence, MagicMemberKind, MemberAccessReferenceData};
 use crate::symbol_index::MagicMemberEntry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tree_sitter::Node;
@@ -205,12 +205,19 @@ impl ClassViewCache {
 ///
 /// `classviews` is reused across files by the caller so each model is analyzed
 /// once per build pass.
+///
+/// `deps`, when provided, accumulates every receiver FQCN resolution
+/// *attempted* — including accesses whose member classification fails — for
+/// the magic dependency index (see `magic_dependency_index`). Recording
+/// attempts rather than successes is what lets a later "member added to
+/// class" save re-resolve the files that were waiting on it.
 pub fn resolve_member_access_entries(
     source: &str,
     member_refs: &[Arc<MemberAccessReferenceData>],
     resolver: &impl ClassFileResolver,
     classviews: &mut ClassViewCache,
     project_root: &Path,
+    mut deps: Option<&mut HashSet<String>>,
 ) -> Vec<MagicMemberEntry> {
     if member_refs.is_empty() {
         return Vec::new();
@@ -238,6 +245,7 @@ pub fn resolve_member_access_entries(
             resolver,
             classviews,
             project_root,
+            deps.as_deref_mut(),
         ) else {
             continue;
         };
@@ -275,6 +283,10 @@ pub fn resolve_member_access_entries(
 ///
 /// This is the M3 engine; M4 calls it during the reverse-index build and
 /// writes the result into each site's reserved scaffold.
+///
+/// `deps`, when provided, records the receiver FQCN(s) this access resolves
+/// to — *before* member classification, so failed lookups still register a
+/// dependency on the receiver's class.
 #[allow(clippy::too_many_arguments)]
 pub fn resolve_and_classify(
     receiver: Node,
@@ -285,6 +297,7 @@ pub fn resolve_and_classify(
     resolver: &impl ClassFileResolver,
     classviews: &mut ClassViewCache,
     project_root: &Path,
+    mut deps: Option<&mut HashSet<String>>,
 ) -> Option<ResolvedMemberAccess> {
     let (fqcn, confidence) =
         match resolve_receiver(receiver, bytes, aliases, resolver, classviews, project_root) {
@@ -306,6 +319,10 @@ pub fn resolve_and_classify(
             )?,
             None => return None,
         };
+
+    if let Some(d) = deps.as_deref_mut() {
+        d.insert(fqcn.clone());
+    }
 
     if let Some(resolved) = classify_against(
         &fqcn,
@@ -332,6 +349,9 @@ pub fn resolve_and_classify(
     // the actual safety here.
     if form.is_call() && is_eloquent_builder(&fqcn) && is_scope_param_receiver(receiver, bytes) {
         let model = enclosing_class_fqcn(receiver, bytes)?;
+        if let Some(d) = deps {
+            d.insert(model.clone());
+        }
         let resolved = classify_against(
             &model,
             member,

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -347,6 +347,7 @@ fn resolve_in(p: &Project, caller: &str, member: &str) -> Option<ResolvedMemberA
         &p.index,
         &mut cache,
         &p.root,
+        None,
     )
 }
 
@@ -878,8 +879,14 @@ class C {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         has_entry(&entries, "App\\Models\\User", "email"),
         "{entries:?}"
@@ -907,6 +914,7 @@ function show($mystery) {
         &p.index,
         &mut ClassViewCache::new(),
         &p.root,
+        None,
     );
     assert!(
         entries.is_empty(),
@@ -933,6 +941,7 @@ class C {
         &p.index,
         &mut ClassViewCache::new(),
         &p.root,
+        None,
     );
     assert!(entries.is_empty(), "{entries:?}");
 }
@@ -941,7 +950,7 @@ class C {
 fn population_empty_refs_is_empty() {
     let p = project("app/Models/User.php", USER_MODEL);
     let entries =
-        resolve_member_access_entries("", &[], &p.index, &mut ClassViewCache::new(), &p.root);
+        resolve_member_access_entries("", &[], &p.index, &mut ClassViewCache::new(), &p.root, None);
     assert!(entries.is_empty());
 }
 
@@ -993,6 +1002,7 @@ class User extends Model {
         &snapshot,
         &mut ClassViewCache::new(),
         dir.path(),
+        None,
     );
     assert!(
         entries
@@ -1071,6 +1081,7 @@ class User extends Authenticatable {
         &snapshot,
         &mut ClassViewCache::new(),
         dir.path(),
+        None,
     );
     assert!(
         entries
@@ -1170,7 +1181,14 @@ fn resolve_auth_caller(
     caller: &str,
 ) -> Vec<MagicMemberEntry> {
     let refs = member_refs_of(caller);
-    resolve_member_access_entries(caller, &refs, index, &mut ClassViewCache::new(), dir.path())
+    resolve_member_access_entries(
+        caller,
+        &refs,
+        index,
+        &mut ClassViewCache::new(),
+        dir.path(),
+        None,
+    )
 }
 
 #[test]
@@ -1311,8 +1329,14 @@ class C {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         has_entry(&entries, "App\\Models\\User", "active"),
         "static scope call should index under its usage name; got {entries:?}"
@@ -1332,8 +1356,14 @@ class C {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         has_entry(&entries, "App\\Models\\User", "active"),
         "instance scope call should index; got {entries:?}"
@@ -1353,8 +1383,14 @@ class C {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         has_entry(&entries, "App\\Models\\User", "posts"),
         "relationship call should index under the same key as property reads; got {entries:?}"
@@ -1374,8 +1410,14 @@ class C {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         has_entry(&entries, "App\\Models\\User", "whereEmail"),
         "dynamic finder call should index; got {entries:?}"
@@ -1396,8 +1438,14 @@ class C {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     // `count()` (unresolvable/plain) and `helperMethod()` (not on the model)
     // must not index; only the relationship call survives.
     assert!(
@@ -1425,8 +1473,14 @@ class C {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         has_entry(&entries, "App\\Models\\User", "active"),
         "aliased static receiver should resolve through use-imports; got {entries:?}"
@@ -1442,8 +1496,14 @@ use Illuminate\Support\Str;
 $slug = Str::slug('Laravel');
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(entries.is_empty(), "{entries:?}");
 }
 
@@ -1462,8 +1522,14 @@ class Order extends Model {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         has_entry(&entries, "App\\Models\\User", "active"),
         "same-namespace unimported static receiver should resolve; got {entries:?}"
@@ -1488,8 +1554,14 @@ class C {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     let active_count = entries
         .iter()
         .filter(|e| e.fqcn == "App\\Models\\User" && e.member == "active")
@@ -1521,8 +1593,14 @@ class User extends Model {
 "#;
     let p = project("app/Models/User.php", model);
     let refs = member_refs_of(model);
-    let entries =
-        resolve_member_access_entries(model, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        model,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         has_entry(&entries, "App\\Models\\User", "active"),
         "builder-typed `$query->active()` must resolve via the enclosing model; got {entries:?}"
@@ -1546,8 +1624,14 @@ class User extends Model {
 "#;
     let p = project("app/Models/User.php", model);
     let refs = member_refs_of(model);
-    let entries =
-        resolve_member_access_entries(model, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        model,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         has_entry(&entries, "App\\Models\\User", "active"),
         "mid-chain `$query->where(…)->active()` must index; got {entries:?}"
@@ -1565,8 +1649,14 @@ use Illuminate\Support\Str;
 $x = Str::of('laravel')->upper();
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(entries.is_empty(), "{entries:?}");
 }
 
@@ -1583,8 +1673,14 @@ class C {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         !has_entry(&entries, "App\\Models\\User", "first"),
         "plain chain terminals must not index; got {entries:?}"
@@ -1611,8 +1707,14 @@ class UserTest {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         !has_entry(&entries, "App\\Models\\User", "active"),
         "factory-state calls must not index as scope references; got {entries:?}"
@@ -1636,8 +1738,14 @@ class User extends Model {
 "#;
     let p = project("app/Models/User.php", model);
     let refs = member_refs_of(model);
-    let entries =
-        resolve_member_access_entries(model, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        model,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     let active_count = entries
         .iter()
         .filter(|e| e.fqcn == "App\\Models\\User" && e.member == "active")
@@ -1669,8 +1777,14 @@ class User extends Model {
 "#;
     let p = project("app/Models/User.php", model);
     let refs = member_refs_of(model);
-    let entries =
-        resolve_member_access_entries(model, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        model,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         !has_entry(&entries, "App\\Models\\User", "published"),
         "a whereHas-closure builder call must not attribute to the enclosing model; got {entries:?}"
@@ -1704,12 +1818,95 @@ class C {
 }
 "#;
     let refs = member_refs_of(caller);
-    let entries =
-        resolve_member_access_entries(caller, &refs, &p.index, &mut ClassViewCache::new(), &p.root);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        None,
+    );
     assert!(
         !has_entry(&entries, "App\\Models\\User", "active"),
         "a relation-hopped scope call must not attribute to the root model; got {entries:?}"
     );
     // The relationship CALL itself still indexes (it is User's member).
     assert!(has_entry(&entries, "App\\Models\\User", "posts"));
+}
+
+// ─── Dependency recording (incremental save, #80) ──────────────────────────
+
+#[test]
+fn deps_record_receiver_fqcn_on_successful_classification() {
+    let p = project("app/Models/User.php", USER_MODEL);
+    let caller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+class C {
+    public function show(User $user) {
+        return $user->email;
+    }
+}
+"#;
+    let mut deps = std::collections::HashSet::new();
+    let entries = resolve_member_access_entries(
+        caller,
+        &member_refs_of(caller),
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        Some(&mut deps),
+    );
+    assert!(!entries.is_empty());
+    assert!(deps.contains("App\\Models\\User"), "{deps:?}");
+}
+
+#[test]
+fn deps_record_receiver_fqcn_even_when_member_classification_fails() {
+    let p = project("app/Models/User.php", USER_MODEL);
+    // `notAColumn` doesn't exist on User → no index entry, but the file
+    // still depends on User: adding the member later must re-resolve it.
+    let caller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+class C {
+    public function show(User $user) {
+        return $user->notAColumn;
+    }
+}
+"#;
+    let mut deps = std::collections::HashSet::new();
+    let entries = resolve_member_access_entries(
+        caller,
+        &member_refs_of(caller),
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        Some(&mut deps),
+    );
+    assert!(entries.is_empty(), "{entries:?}");
+    assert!(
+        deps.contains("App\\Models\\User"),
+        "failed classification must still record the receiver dependency, got {deps:?}"
+    );
+}
+
+#[test]
+fn deps_record_nothing_for_unresolvable_receivers() {
+    let p = project("app/Models/User.php", USER_MODEL);
+    let caller = r#"<?php
+function show($mystery) {
+    return $mystery->email;
+}
+"#;
+    let mut deps = std::collections::HashSet::new();
+    resolve_member_access_entries(
+        caller,
+        &member_refs_of(caller),
+        &p.index,
+        &mut ClassViewCache::new(),
+        &p.root,
+        Some(&mut deps),
+    );
+    assert!(deps.is_empty(), "{deps:?}");
 }

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -3818,6 +3818,28 @@ pub enum SalsaRequest {
             std::collections::HashMap<PathBuf, Vec<crate::class_hierarchy_index::ClassNode>>,
         >,
     },
+    /// Surface signatures (`fqcn → u64`) for every class `path` declares.
+    /// The save flow snapshots this *before* pushing the saved buffer into
+    /// Salsa, then diffs against the re-parse to decide whether the edit
+    /// could affect other files (incremental refresh, #80).
+    FileClassSurfaces {
+        path: PathBuf,
+        reply: oneshot::Sender<std::collections::HashMap<String, u64>>,
+    },
+    /// Expand `seeds` to include every transitive descendant (subclasses,
+    /// implementers, trait users) — the class-level blast radius of a
+    /// surface change.
+    ExpandClassDescendants {
+        seeds: Vec<String>,
+        reply: oneshot::Sender<std::collections::HashSet<String>>,
+    },
+    /// Export every magic-member entry grouped by usage file, for the
+    /// incremental magic-cache re-save (#80).
+    ExportMagicMembers {
+        reply: oneshot::Sender<
+            std::collections::HashMap<PathBuf, Vec<crate::symbol_index::MagicMemberEntry>>,
+        >,
+    },
     /// Bulk-import resolved magic-member occurrences into the symbol index
     /// (M4). Appends to each path's existing (literal-symbol) entries.
     BulkImportMagicMembers {
@@ -4445,6 +4467,63 @@ impl SalsaHandle {
     /// Snapshot every indexed class grouped by declaring file, so warming can
     /// persist the hierarchy to the disk cache (it survives a warm restart
     /// only if persisted — fresh parses are the sole other populator).
+    /// Surface signatures for every class `path` currently declares (empty
+    /// if the file is unknown to the hierarchy). Snapshot side of the
+    /// save-time surface diff (#80).
+    pub async fn file_class_surfaces(
+        &self,
+        path: PathBuf,
+    ) -> Result<std::collections::HashMap<String, u64>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::FileClassSurfaces {
+                path,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// `seeds` plus every transitive descendant — the class-level blast
+    /// radius of a surface change (#80).
+    pub async fn expand_class_descendants(
+        &self,
+        seeds: Vec<String>,
+    ) -> Result<std::collections::HashSet<String>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::ExpandClassDescendants {
+                seeds,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Export every magic-member entry grouped by usage file — the live
+    /// index contents, for the incremental magic-cache re-save (#80).
+    pub async fn export_magic_members(
+        &self,
+    ) -> Result<
+        std::collections::HashMap<PathBuf, Vec<crate::symbol_index::MagicMemberEntry>>,
+        &'static str,
+    > {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::ExportMagicMembers { reply: reply_tx })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
     pub async fn snapshot_hierarchy_nodes(
         &self,
     ) -> Result<
@@ -5565,6 +5644,15 @@ impl SalsaActor {
                 }
                 SalsaRequest::SnapshotHierarchyNodes { reply } => {
                     let _ = reply.send(self.class_hierarchy_index.nodes_by_file());
+                }
+                SalsaRequest::FileClassSurfaces { path, reply } => {
+                    let _ = reply.send(self.class_hierarchy_index.file_surfaces(&path));
+                }
+                SalsaRequest::ExpandClassDescendants { seeds, reply } => {
+                    let _ = reply.send(self.class_hierarchy_index.expand_with_descendants(&seeds));
+                }
+                SalsaRequest::ExportMagicMembers { reply } => {
+                    let _ = reply.send(self.symbol_index.magic_members_by_file());
                 }
                 SalsaRequest::BulkImportMagicMembers { entries, reply } => {
                     // Append-only: `build_symbol_index` already inserted this

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -7130,6 +7130,7 @@ impl SalsaActor {
                 &self.class_hierarchy_index,
                 &mut classviews,
                 &project_root,
+                None, // query-time path — no dependency recording
             ) {
                 // find-references threshold: HIGH + MEDIUM.
                 if matches!(resolved.confidence, Confidence::High | Confidence::Medium) {
@@ -7204,6 +7205,7 @@ impl SalsaActor {
                 &self.class_hierarchy_index,
                 &mut classviews,
                 &project_root,
+                None, // query-time path — no dependency recording
             ) {
                 Some(r) if matches!(r.confidence, Confidence::High | Confidence::Medium) => {
                     (r.declaring_fqcn, r.kind, r.confidence, false)
@@ -7307,6 +7309,7 @@ impl SalsaActor {
             &self.class_hierarchy_index,
             &mut classviews,
             &project_root,
+            None, // query-time path — no dependency recording
         )?;
         if !matches!(resolved.confidence, Confidence::High | Confidence::Medium) {
             return None;

--- a/laravel-lsp/src/symbol_index.rs
+++ b/laravel-lsp/src/symbol_index.rs
@@ -332,6 +332,37 @@ impl SymbolIndex {
     }
 
     /// Total entry count across all symbols. Useful for logging.
+    /// Reconstruct every magic-member entry grouped by usage file — the
+    /// inverse of [`insert_magic_members`](Self::insert_magic_members).
+    /// Powers the incremental magic-cache persistence (#80): after a save
+    /// updates a file's entries in place, the cache re-save exports the
+    /// whole live index rather than re-resolving anything.
+    pub fn magic_members_by_file(&self) -> HashMap<PathBuf, Vec<MagicMemberEntry>> {
+        let mut out: HashMap<PathBuf, Vec<MagicMemberEntry>> = HashMap::new();
+        for (key, locations) in &self.forward {
+            if key.kind != SymbolKind::MagicMember {
+                continue;
+            }
+            // Key format is `<fqcn>#<member>` (see `magic_member_key_name`);
+            // FQCNs never contain `#`, so the first split is unambiguous.
+            let Some((fqcn, member)) = key.name.split_once('#') else {
+                continue;
+            };
+            for loc in locations {
+                out.entry(loc.file_path.clone())
+                    .or_default()
+                    .push(MagicMemberEntry {
+                        fqcn: fqcn.to_string(),
+                        member: member.to_string(),
+                        line: loc.line,
+                        column: loc.column,
+                        end_column: loc.end_column,
+                    });
+            }
+        }
+        out
+    }
+
     pub fn entry_count(&self) -> usize {
         self.forward.values().map(|v| v.len()).sum()
     }

--- a/laravel-lsp/src/symbol_index/tests.rs
+++ b/laravel-lsp/src/symbol_index/tests.rs
@@ -511,3 +511,31 @@ fn remove_literal_entries_drops_by_file_when_no_magic_remains() {
     assert_eq!(idx.indexed_file_count(), 0);
     assert!(idx.find(&SymbolRefData::View("welcome".into())).is_empty());
 }
+
+#[test]
+fn magic_members_export_round_trips_insert() {
+    let mut idx = SymbolIndex::default();
+    let a = PathBuf::from("/proj/app/Http/Controllers/UserController.php");
+    let b = PathBuf::from("/proj/app/Jobs/SyncUsers.php");
+    let entry = |member: &str, line: u32| MagicMemberEntry {
+        fqcn: "App\\Models\\User".to_string(),
+        member: member.to_string(),
+        line,
+        column: 4,
+        end_column: 12,
+    };
+    idx.insert_magic_members(&a, &[entry("email", 10), entry("posts", 20)]);
+    idx.insert_magic_members(&b, &[entry("email", 5)]);
+    // Literal symbols must NOT leak into the magic export.
+    idx.insert_file(&a, &fixture("welcome", "home"));
+
+    let export = idx.magic_members_by_file();
+    assert_eq!(export.len(), 2);
+    let mut a_entries = export.get(&a).unwrap().clone();
+    a_entries.sort_by_key(|e| e.line);
+    assert_eq!(a_entries.len(), 2);
+    assert_eq!(a_entries[0].fqcn, "App\\Models\\User");
+    assert_eq!(a_entries[0].member, "email");
+    assert_eq!(a_entries[1].member, "posts");
+    assert_eq!(export.get(&b).unwrap().len(), 1);
+}

--- a/laravel-lsp/src/view_var_index.rs
+++ b/laravel-lsp/src/view_var_index.rs
@@ -29,7 +29,9 @@ use crate::symbol_index::MagicMemberEntry;
 
 /// One `view('name', …)` render site: the rendered view and the variable →
 /// FQCN types it passes in (only the variables whose type resolved).
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// `Serialize`/`Deserialize` so the magic disk cache can persist renders and
+/// rebuild the view-variable index on a cache-warm restart (#80).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ViewRender {
     pub view_name: String,
     pub vars: HashMap<String, String>,
@@ -47,12 +49,15 @@ pub struct ViewRender {
 /// **No persistence.** This index is rebuilt every warm from re-read source +
 /// the (already-persisted) hierarchy, so it never hits the empty-on-restart
 /// trap. `by_file` exists only for incremental eviction within a live session.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ViewVarIndex {
     /// view name → (variable name → set of FQCN types).
     forward: HashMap<String, HashMap<String, HashSet<String>>>,
-    /// file → the view names it contributed render sites for (for eviction).
-    by_file: HashMap<PathBuf, Vec<String>>,
+    /// file → the full render sites it contributed. Keeping whole renders
+    /// (not just view names) gives `remove_file` per-file type provenance
+    /// for a precise rebuild, and lets the incremental save flow (#80) diff
+    /// a saved controller's renders against its previous contribution.
+    by_file: HashMap<PathBuf, Vec<ViewRender>>,
 }
 
 impl ViewVarIndex {
@@ -65,35 +70,55 @@ impl ViewVarIndex {
     /// edited controller doesn't leave stale types behind.
     pub fn insert_file(&mut self, path: PathBuf, renders: &[ViewRender]) {
         self.remove_file(&path);
-        let mut contributed = Vec::new();
         for render in renders {
             let view = self.forward.entry(render.view_name.clone()).or_default();
             for (var, fqcn) in &render.vars {
                 view.entry(var.clone()).or_default().insert(fqcn.clone());
             }
-            contributed.push(render.view_name.clone());
         }
-        if !contributed.is_empty() {
-            self.by_file.insert(path, contributed);
+        if !renders.is_empty() {
+            self.by_file.insert(path, renders.to_vec());
         }
     }
 
     /// Drop a file's contribution. Because `forward` is a union across files,
-    /// eviction does a targeted rebuild of only the affected views from the
-    /// surviving files — correct, if not the cheapest possible.
+    /// eviction rebuilds only the affected views from the surviving files'
+    /// stored renders — precise, at O(files × renders) for the touched views.
     pub fn remove_file(&mut self, path: &Path) {
-        let Some(views) = self.by_file.remove(path) else {
+        let Some(renders) = self.by_file.remove(path) else {
             return;
         };
-        for view in views {
-            // Clearing the whole view entry is imprecise (other files may feed
-            // it), but a per-file rebuild needs per-file type provenance we
-            // don't keep. The warm rebuild clears the whole index anyway; this
-            // path only matters for live single-session edits, where dropping
-            // the view's vars and letting the still-open renderers re-add them
-            // on their next parse is acceptable.
-            self.forward.remove(&view);
+        let affected: HashSet<&str> = renders.iter().map(|r| r.view_name.as_str()).collect();
+        for view in &affected {
+            self.forward.remove(*view);
         }
+        for other_renders in self.by_file.values() {
+            for render in other_renders {
+                if !affected.contains(render.view_name.as_str()) {
+                    continue;
+                }
+                let view = self.forward.entry(render.view_name.clone()).or_default();
+                for (var, fqcn) in &render.vars {
+                    view.entry(var.clone()).or_default().insert(fqcn.clone());
+                }
+            }
+        }
+    }
+
+    /// The render sites `path` currently contributes, if any. The save flow
+    /// diffs this against a fresh `view_renders_in_file` to decide whether
+    /// the saved controller's Blade views need re-resolution (#80).
+    pub fn renders_for(&self, path: &Path) -> Option<&[ViewRender]> {
+        self.by_file.get(path).map(Vec::as_slice)
+    }
+
+    /// Snapshot every file's render contribution — the persistence side of
+    /// the incremental magic-cache re-save (#80).
+    pub fn export(&self) -> Vec<(PathBuf, Vec<ViewRender>)> {
+        self.by_file
+            .iter()
+            .map(|(path, renders)| (path.clone(), renders.clone()))
+            .collect()
     }
 
     /// All FQCN types observed for `var` in `view_name`, across every render

--- a/laravel-lsp/src/view_var_index.rs
+++ b/laravel-lsp/src/view_var_index.rs
@@ -169,6 +169,7 @@ pub fn view_name_for_path(file: &Path, view_roots: &[PathBuf]) -> Option<String>
 /// Positions come straight from the captured refs (already mapped to outer
 /// Blade-file coordinates by the capture pass), so entries point at the member
 /// name in the `.blade.php`. Sites that don't resolve are dropped.
+#[allow(clippy::too_many_arguments)]
 pub fn resolve_blade_member_accesses(
     member_refs: &[Arc<MemberAccessReferenceData>],
     view_name: &str,
@@ -177,6 +178,7 @@ pub fn resolve_blade_member_accesses(
     resolver: &impl ClassFileResolver,
     classviews: &mut ClassViewCache,
     project_root: &Path,
+    mut deps: Option<&mut HashSet<String>>,
 ) -> Vec<MagicMemberEntry> {
     let mut out: Vec<MagicMemberEntry> = Vec::new();
     let mut seen: HashSet<(String, u32, u32)> = HashSet::new();
@@ -209,6 +211,12 @@ pub fn resolve_blade_member_accesses(
             var_types(var, m.line)
                 .into_iter()
                 .filter_map(|fqcn| {
+                    // Attempted receiver type → dependency, even when the
+                    // member classification below fails (see
+                    // `magic_dependency_index` for why attempts matter).
+                    if let Some(d) = deps.as_deref_mut() {
+                        d.insert(fqcn.clone());
+                    }
                     classify_fqcn_member(
                         &fqcn,
                         &m.member,
@@ -228,6 +236,7 @@ pub fn resolve_blade_member_accesses(
                 resolver,
                 classviews,
                 project_root,
+                deps.as_deref_mut(),
             )
             .map(|c| vec![c.declaring_fqcn])
             .unwrap_or_default()
@@ -280,6 +289,7 @@ fn classify_fqcn_member(
 /// by parsing it as a standalone PHP expression and running the shared receiver
 /// resolver, then classify `member`. Only HIGH/MEDIUM receiver confidence is
 /// accepted — the find-references gate.
+#[allow(clippy::too_many_arguments)]
 fn resolve_chain_receiver(
     receiver_text: &str,
     member: &str,
@@ -287,6 +297,7 @@ fn resolve_chain_receiver(
     resolver: &impl ClassFileResolver,
     classviews: &mut ClassViewCache,
     project_root: &Path,
+    deps: Option<&mut HashSet<String>>,
 ) -> Option<ClassifiedMember> {
     let snippet = format!("<?php {receiver_text};");
     let tree = parse_php(&snippet).ok()?;
@@ -297,6 +308,9 @@ fn resolve_chain_receiver(
         resolve_expression_type(expr, bytes, &aliases, resolver, classviews, project_root)?;
     if !matches!(confidence, Confidence::High | Confidence::Medium) {
         return None;
+    }
+    if let Some(d) = deps {
+        d.insert(fqcn.clone());
     }
     classify_fqcn_member(&fqcn, member, form, resolver, classviews, project_root)
 }
@@ -765,6 +779,7 @@ pub fn mfc_volt_property_types(
 /// types. Receivers `$this->prop` and bare `$prop` are typed from `prop_types`;
 /// other shapes (`auth()->user()->email`) fall back to standalone resolution.
 /// Entries land in the same reverse index as PHP/Blade accesses.
+#[allow(clippy::too_many_arguments)]
 pub fn resolve_volt_member_accesses(
     member_refs: &[Arc<MemberAccessReferenceData>],
     prop_types: &HashMap<String, String>,
@@ -772,6 +787,7 @@ pub fn resolve_volt_member_accesses(
     resolver: &impl ClassFileResolver,
     classviews: &mut ClassViewCache,
     project_root: &Path,
+    mut deps: Option<&mut HashSet<String>>,
 ) -> Vec<MagicMemberEntry> {
     let mut out: Vec<MagicMemberEntry> = Vec::new();
     let mut seen: HashSet<(String, u32, u32)> = HashSet::new();
@@ -781,6 +797,11 @@ pub fn resolve_volt_member_accesses(
         let declaring: Option<String> = if let Some(prop) = volt_base_prop(receiver) {
             // Direct prop read (`$this->user`, or a bare public-prop/state read).
             let direct = prop_types.get(prop).and_then(|fqcn| {
+                // Attempted receiver type → dependency, even when member
+                // classification fails (see `magic_dependency_index`).
+                if let Some(d) = deps.as_deref_mut() {
+                    d.insert(fqcn.clone());
+                }
                 classify_fqcn_member(fqcn, &m.member, m.form, resolver, classviews, project_root)
                     .map(|c| c.declaring_fqcn)
             });
@@ -792,6 +813,9 @@ pub fn resolve_volt_member_accesses(
                 let iter = enclosing_loop_iterable(blade_loops, var, m.line)?;
                 let iter_prop = volt_base_prop(iter)?;
                 prop_types.get(iter_prop).and_then(|fqcn| {
+                    if let Some(d) = deps.as_deref_mut() {
+                        d.insert(fqcn.clone());
+                    }
                     classify_fqcn_member(
                         fqcn,
                         &m.member,
@@ -811,6 +835,7 @@ pub fn resolve_volt_member_accesses(
                 resolver,
                 classviews,
                 project_root,
+                deps.as_deref_mut(),
             )
             .map(|c| c.declaring_fqcn)
         };

--- a/laravel-lsp/src/view_var_index/tests.rs
+++ b/laravel-lsp/src/view_var_index/tests.rs
@@ -305,6 +305,7 @@ fn blade_var_resolves_via_view_index() {
         &p.index,
         &mut cache,
         &p.root,
+        None,
     );
 
     assert_eq!(entries.len(), 1, "got {entries:?}");
@@ -333,6 +334,7 @@ fn blade_unknown_member_is_dropped() {
         &p.index,
         &mut cache,
         &p.root,
+        None,
     );
     assert!(entries.is_empty(), "got {entries:?}");
 }
@@ -351,6 +353,7 @@ fn blade_var_with_no_inferred_type_is_dropped() {
         &p.index,
         &mut cache,
         &p.root,
+        None,
     );
     assert!(entries.is_empty(), "got {entries:?}");
 }
@@ -374,6 +377,7 @@ fn blade_relationship_resolves() {
         &p.index,
         &mut cache,
         &p.root,
+        None,
     );
     assert_eq!(entries.len(), 1, "got {entries:?}");
     assert_eq!(entries[0].fqcn, "App\\Models\\User");
@@ -581,7 +585,8 @@ fn volt_resolves_this_property_access() {
     // `{{ $this->user->email }}` — receiver captured as `$this->user`.
     let refs = vec![member_ref("$this->user", "email", 5, 18)];
     let mut cache = ClassViewCache::new();
-    let entries = resolve_volt_member_accesses(&refs, &types, &[], &p.index, &mut cache, &p.root);
+    let entries =
+        resolve_volt_member_accesses(&refs, &types, &[], &p.index, &mut cache, &p.root, None);
     assert_eq!(entries.len(), 1, "got {entries:?}");
     assert_eq!(entries[0].fqcn, "App\\Models\\User");
     assert_eq!(entries[0].member, "email");
@@ -596,7 +601,8 @@ fn volt_resolves_bare_public_property_access() {
     // Public properties are also readable bare in the template: `{{ $user->email }}`.
     let refs = vec![member_ref("$user", "email", 1, 0)];
     let mut cache = ClassViewCache::new();
-    let entries = resolve_volt_member_accesses(&refs, &types, &[], &p.index, &mut cache, &p.root);
+    let entries =
+        resolve_volt_member_accesses(&refs, &types, &[], &p.index, &mut cache, &p.root, None);
     assert_eq!(entries.len(), 1, "got {entries:?}");
     assert_eq!(entries[0].fqcn, "App\\Models\\User");
 }
@@ -607,7 +613,8 @@ fn volt_unknown_property_is_dropped() {
     let types = HashMap::new(); // nothing inferred
     let refs = vec![member_ref("$this->user", "email", 1, 0)];
     let mut cache = ClassViewCache::new();
-    let entries = resolve_volt_member_accesses(&refs, &types, &[], &p.index, &mut cache, &p.root);
+    let entries =
+        resolve_volt_member_accesses(&refs, &types, &[], &p.index, &mut cache, &p.root, None);
     assert!(entries.is_empty(), "got {entries:?}");
 }
 
@@ -653,7 +660,7 @@ fn volt_foreach_loop_var_resolves_from_this_computed() {
     let refs = vec![member_ref("$user", "email", 7, 40)];
     let mut cache = ClassViewCache::new();
     let entries =
-        resolve_volt_member_accesses(&refs, &types, &loops, &p.index, &mut cache, &p.root);
+        resolve_volt_member_accesses(&refs, &types, &loops, &p.index, &mut cache, &p.root, None);
     assert_eq!(entries.len(), 1, "got {entries:?}");
     assert_eq!(entries[0].fqcn, "App\\Models\\User");
     assert_eq!(entries[0].member, "email");
@@ -685,6 +692,7 @@ fn blade_foreach_loop_var_resolves_from_view_var() {
         &p.index,
         &mut cache,
         &p.root,
+        None,
     );
     assert_eq!(entries.len(), 1, "got {entries:?}");
     assert_eq!(entries[0].fqcn, "App\\Models\\User");
@@ -705,7 +713,7 @@ fn loop_var_outside_loop_range_is_dropped() {
     let refs = vec![member_ref("$user", "email", 30, 0)];
     let mut cache = ClassViewCache::new();
     let entries =
-        resolve_volt_member_accesses(&refs, &types, &loops, &p.index, &mut cache, &p.root);
+        resolve_volt_member_accesses(&refs, &types, &loops, &p.index, &mut cache, &p.root, None);
     assert!(entries.is_empty(), "got {entries:?}");
 }
 
@@ -781,4 +789,55 @@ fn volt_component_key_variants() {
         ),
         None
     );
+}
+
+// ─── Dependency recording (incremental save, #80) ──────────────────────────
+
+#[test]
+fn blade_deps_record_attempted_var_types_even_on_unknown_member() {
+    let p = blade_project();
+    let mut idx = ViewVarIndex::new();
+    idx.insert_file(
+        p.root.join("app/Http/Controllers/UserController.php"),
+        &[render("users.show", &[("user", "App\\Models\\User")])],
+    );
+
+    // `notAColumn` doesn't classify — the dependency must still register.
+    let refs = vec![member_ref("$user", "notAColumn", 3, 15)];
+    let mut cache = ClassViewCache::new();
+    let mut deps = HashSet::new();
+    let entries = resolve_blade_member_accesses(
+        &refs,
+        "users.show",
+        &idx,
+        &[],
+        &p.index,
+        &mut cache,
+        &p.root,
+        Some(&mut deps),
+    );
+    assert!(entries.is_empty(), "got {entries:?}");
+    assert!(deps.contains("App\\Models\\User"), "{deps:?}");
+}
+
+#[test]
+fn volt_deps_record_attempted_prop_types_even_on_unknown_member() {
+    let p = blade_project();
+    let mut types = HashMap::new();
+    types.insert("user".to_string(), "App\\Models\\User".to_string());
+
+    let refs = vec![member_ref("$this->user", "notAColumn", 1, 0)];
+    let mut cache = ClassViewCache::new();
+    let mut deps = HashSet::new();
+    let entries = resolve_volt_member_accesses(
+        &refs,
+        &types,
+        &[],
+        &p.index,
+        &mut cache,
+        &p.root,
+        Some(&mut deps),
+    );
+    assert!(entries.is_empty(), "got {entries:?}");
+    assert!(deps.contains("App\\Models\\User"), "{deps:?}");
 }

--- a/laravel-lsp/src/view_var_index/tests.rs
+++ b/laravel-lsp/src/view_var_index/tests.rs
@@ -841,3 +841,35 @@ fn volt_deps_record_attempted_prop_types_even_on_unknown_member() {
     assert!(entries.is_empty(), "got {entries:?}");
     assert!(deps.contains("App\\Models\\User"), "{deps:?}");
 }
+
+#[test]
+fn remove_file_preserves_other_files_contributions() {
+    let mut idx = ViewVarIndex::new();
+    let a = PathBuf::from("/proj/app/Http/Controllers/A.php");
+    let b = PathBuf::from("/proj/app/Http/Controllers/B.php");
+    // Both controllers feed the same view with different types for `user`.
+    idx.insert_file(
+        a.clone(),
+        &[render("users.show", &[("user", "App\\Models\\User")])],
+    );
+    idx.insert_file(
+        b,
+        &[render("users.show", &[("user", "App\\Models\\Admin")])],
+    );
+
+    idx.remove_file(&a);
+    // B's contribution must survive A's eviction (the old implementation
+    // dropped the whole view).
+    let types = idx.var_types("users.show", "user");
+    assert_eq!(types, vec!["App\\Models\\Admin".to_string()]);
+}
+
+#[test]
+fn renders_for_returns_current_contribution() {
+    let mut idx = ViewVarIndex::new();
+    let a = PathBuf::from("/proj/app/Http/Controllers/A.php");
+    assert!(idx.renders_for(&a).is_none());
+    let r = render("users.show", &[("user", "App\\Models\\User")]);
+    idx.insert_file(a.clone(), std::slice::from_ref(&r));
+    assert_eq!(idx.renders_for(&a), Some(std::slice::from_ref(&r)));
+}


### PR DESCRIPTION
Addresses the sustained-CPU report in #80. Every save previously triggered a full three-pass re-resolution of all non-vendor PHP/Blade files (204k member accesses on the reporter's scale of project).

- **Body-only edits** (the overwhelming majority of saves) now do zero cross-file work — class surfaces and view renders are diffed before/after each save.
- **Surface/render changes** re-resolve only the recorded blast radius: dependents of the changed classes and their transitive descendants, plus Blade files of affected views, at bounded (8-way) concurrency.
- **Startup** restores the magic cache granularly (schema v3 persists dependency sets and view renders): only changed files plus their blast radius re-resolve. Measured: 135.8s → 6.1s on a 39k-file project with edits since last run.
- The cache is re-saved (debounced) after incremental refreshes, so it tracks the session.
- External watched-file changes (`git pull`, outside formatters) keep the debounced full reconverge — their ripples bypass the save-time diff.

Known minor races (documented in code): saves during a cold full warm get no ripple until the build imports; stale dependents of a *deleted* class self-heal on next touch.

## Test plan

- 1,865 unit/integration tests passing (`cargo test`), clippy clean
- Live-verified on a 39k-file project: body-edit saves silent, controller render change re-resolved exactly 2 Blade files, restart-after-edit warmed in 6.1s with `Granular magic restore: re-resolving 322 changed/dependent file(s)`

Addresses #80 (the save-time CPU; the reporter's memory observations remain open pending their diagnostics).