### PR TITLE
fix: 🐛 Prove duck-typed framework reads via interface-package consumer scan.

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18037,12 +18037,14 @@ impl LaravelLanguageServer {
                 continue;
             }
             // A member with zero project references may still be read by the
-            // framework through inheritance — a model's `$timestamps` is read by
-            // `HasTimestamps`, never by app code. Prove that across the chain
-            // (parents + traits, including vendor) before flagging it. Runs only
-            // for the already-zero-reference case (a handful of members per
-            // file) and off the async worker, since the walk does FS IO +
-            // parsing.
+            // framework — through inheritance (a model's `$timestamps` is read
+            // by `HasTimestamps`) or duck-typed by a consumer of an interface
+            // the class implements (a job's `$tries` is read by
+            // `Illuminate\Queue\Queue` via the ShouldQueue contract). Prove
+            // that across the chain and the interface packages before flagging
+            // it. Runs only for the already-zero-reference case (a handful of
+            // members per file) and off the async worker, since the walk does
+            // FS IO + parsing.
             if self.any_member_framework_read(&root, &item.symbols).await {
                 continue;
             }
@@ -18072,11 +18074,12 @@ impl LaravelLanguageServer {
     }
 
     /// Whether any `MagicMember` in `symbols` is read across its inheritance
-    /// chain (parents + traits, including vendor) — i.e. framework-read rather
-    /// than dead. Spares configuration properties like a model's `$timestamps`
-    /// from the unused-symbol warning. Each check runs on a blocking thread so
-    /// the filesystem IO + parsing never stalls the async worker or other
-    /// in-flight requests.
+    /// chain (parents + traits, including vendor) or by a vendor package
+    /// consuming an interface the chain implements — i.e. framework-read
+    /// rather than dead. Spares configuration properties like a model's
+    /// `$timestamps` and a queued job's `$tries` from the unused-symbol
+    /// warning. Each check runs on a blocking thread so the filesystem IO +
+    /// parsing never stalls the async worker or other in-flight requests.
     async fn any_member_framework_read(
         &self,
         root: &Path,

--- a/laravel-lsp/src/vendor_member_prover.rs
+++ b/laravel-lsp/src/vendor_member_prover.rs
@@ -1,38 +1,64 @@
-//! Prove that a class member is *read* somewhere in its inheritance chain —
-//! including parent classes and used traits that live in `vendor/`.
+//! Prove that a class member is *read* by framework code — either through the
+//! class's own inheritance chain, or by a vendor package consuming the class
+//! through an interface it implements.
 //!
 //! ## Why this exists
 //!
 //! The unused-symbol diagnostic flags a code-lensed member with zero project
 //! references as "possibly dead code". That's wrong for **framework-read
-//! configuration properties**: a model's `public $timestamps = false;` is never
-//! referenced by *app* code, but `Illuminate\Database\Eloquent\Concerns\
-//! HasTimestamps` reads `$this->timestamps`. The property isn't dead — the
-//! framework reads it via inheritance.
+//! configuration properties**, which come in two structural flavors:
 //!
-//! Rather than maintain a hand-written allowlist of Eloquent's config
-//! properties (a heuristic that drifts with each Laravel release), this module
-//! *proves* the read deterministically: it walks the class's `extends` parents
-//! and `use`d traits — resolving each FQCN (app **or** vendor) to a file — and
-//! checks whether any of them reads `$this->member` (or `self::$member` /
-//! `static::$member`). If something in the chain reads it, it isn't dead.
+//! 1. **Chain reads**: a model's `public $timestamps = false;` is never
+//!    referenced by *app* code, but `Illuminate\Database\Eloquent\Concerns\
+//!    HasTimestamps` — a trait in the model's own chain — reads
+//!    `$this->timestamps`.
+//! 2. **Consumer reads**: a queued job's `public $tries = 1;` is read by
+//!    `Illuminate\Queue\Queue::getJobTries()` as `$job->tries ?? $job->tries()`
+//!    — a duck-typed read on an object the framework was *handed*. Nothing in
+//!    the job's chain (`Queueable`, `InteractsWithQueue`, …) ever touches
+//!    `$tries`; the read lives in the package that consumes the
+//!    `ShouldQueue` contract the job implements.
+//!
+//! Rather than maintain a hand-written allowlist of these properties (a
+//! heuristic that drifts with each Laravel release), this module *proves* the
+//! read deterministically:
+//!
+//! - **Chain walk**: resolve the class's `extends` parents and `use`d traits
+//!   (app **or** vendor) to files and check whether any of them reads
+//!   `$this->member` (or `self::$member` / `static::$member`).
+//! - **Consumer scan**: if the chain proves nothing, take every interface the
+//!   chain `implements`, resolve each to its `vendor/<vendor>/<package>/`
+//!   root, and scan that package's PHP files for a property access
+//!   `->member` on *any* receiver. The contract and its consumer normally
+//!   share a package (`ShouldQueue` and `Queue` both live in
+//!   `laravel/framework`), so the scan is bounded to one package tree.
 //!
 //! ## Scope — we do NOT index all of `vendor/`
 //!
-//! Only the files actually *in the chain* are resolved and parsed. For a real
-//! Eloquent model that's `Model` plus its concern traits — roughly two dozen
-//! small files — resolved lazily and parsed once. The full `vendor/` tree
-//! (often 10k+ files) is never walked.
+//! The chain walk only resolves the files actually *in the chain* — for a real
+//! Eloquent model that's `Model` plus its concern traits, roughly two dozen
+//! small files. The consumer scan walks at most the packages owning the
+//! chain's interfaces (typically just `laravel/framework`), with a cheap
+//! `->member` substring prefilter so tree-sitter only parses candidate files,
+//! and memoizes the per-`(package, member)` verdict for the process lifetime
+//! (vendor trees don't change mid-session; a `composer update` warrants a
+//! server restart anyway). The full `vendor/` tree (often 10k+ files across
+//! dozens of packages) is never walked.
 //!
 //! ## Concurrency
 //!
-//! [`member_read_in_chain`] is pure and **synchronous**: it does filesystem IO
-//! and tree-sitter parsing inline. Call it from `spawn_blocking`, never from
+//! [`member_read_in_chain`] is **synchronous**: it does filesystem IO and
+//! tree-sitter parsing inline. Call it from `spawn_blocking`, never from
 //! inside the Salsa actor — a slow walk there would serialize with every other
-//! in-flight LSP request.
+//! in-flight LSP request. The memo cache behind the consumer scan is a
+//! `Mutex`ed map; contention is negligible (the lock is held only for a
+//! lookup/insert, never across IO).
 
-use std::collections::HashSet;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
+
+use walkdir::WalkDir;
 
 use tree_sitter::Node;
 
@@ -46,14 +72,24 @@ use crate::parser::parse_php;
 /// resolution cycle the visited-set somehow doesn't catch).
 const MAX_CHAIN_VISITS: usize = 256;
 
+/// Safety bound on how many files a single package consumer scan will visit.
+/// `laravel/framework` — by far the largest package this scan ever meets — is
+/// ~3k PHP files; 8192 is generous headroom while still capping a pathological
+/// vendor tree (a package that bundles fixtures, generated code, etc.).
+const MAX_PACKAGE_FILES: usize = 8192;
+
 /// Whether `member` is read as `$this->member` — or `self::$member` /
 /// `static::$member` / `Foo::$member` — in `fqcn`'s own source or in any class
-/// or trait reachable by walking its `extends` parents and `use`d traits.
+/// or trait reachable by walking its `extends` parents and `use`d traits; or,
+/// failing that, whether a vendor package owning an interface the chain
+/// `implements` reads `->member` on any receiver (a duck-typed consumer read —
+/// see the module docs for the `$tries` example).
 ///
 /// Each FQCN (app or vendor) is resolved to a file via
 /// [`find_php_class_file_in_app_or_vendor`], parsed, and scanned; its parent and
 /// traits are then enqueued. The walk is cycle-safe (each FQCN visited once) and
-/// bounded by [`MAX_CHAIN_VISITS`].
+/// bounded by [`MAX_CHAIN_VISITS`]. Interfaces collected along the way feed the
+/// consumer scan, which runs only if the chain walk proves nothing.
 ///
 /// Returns `false` for inputs that don't name a resolvable class — an empty
 /// FQCN, or a synthetic key like `volt::/path/to/file` (which carries `::`) —
@@ -70,6 +106,9 @@ pub fn member_read_in_chain(root: &Path, fqcn: &str, member: &str) -> bool {
 
     let mut visited: HashSet<String> = HashSet::new();
     let mut queue: Vec<String> = vec![normalize(fqcn)];
+    // Interfaces implemented anywhere in the chain (the class itself or a
+    // vendor parent), for the consumer scan after the chain walk comes up dry.
+    let mut interfaces: HashSet<String> = HashSet::new();
 
     while let Some(current) = queue.pop() {
         if visited.len() >= MAX_CHAIN_VISITS {
@@ -98,9 +137,105 @@ pub fn member_read_in_chain(root: &Path, fqcn: &str, member: &str) -> bool {
             for tr in node.trait_uses {
                 queue.push(normalize(&tr));
             }
+            for iface in node.implements {
+                interfaces.insert(normalize(&iface));
+            }
         }
     }
-    false
+
+    member_read_by_interface_consumers(root, &interfaces, member)
+}
+
+/// Whether any vendor package owning one of `interfaces` reads `->member` on
+/// any receiver. This is the duck-typed half of the proof: the framework reads
+/// `$job->tries` in `Illuminate\Queue\Queue`, which is in NO job's inheritance
+/// chain — but it IS in the package that owns the `ShouldQueue` contract the
+/// job implements.
+///
+/// Interfaces that resolve outside `vendor/` (app-side contracts) are skipped:
+/// app-side consumer reads are ordinary project references the index already
+/// counts. Each package is scanned at most once per (package, member) — see
+/// [`package_reads_member`] for the memoization.
+fn member_read_by_interface_consumers(
+    root: &Path,
+    interfaces: &HashSet<String>,
+    member: &str,
+) -> bool {
+    let mut packages: HashSet<PathBuf> = HashSet::new();
+    for iface in interfaces {
+        let Some(path) = find_php_class_file_in_app_or_vendor(iface, root) else {
+            continue;
+        };
+        if let Some(pkg) = vendor_package_root(root, &path) {
+            packages.insert(pkg);
+        }
+    }
+    packages.iter().any(|pkg| package_reads_member(pkg, member))
+}
+
+/// `<root>/vendor/<vendor>/<package>` for a file under it, or `None` for any
+/// path not inside the project's `vendor/` tree.
+fn vendor_package_root(root: &Path, file: &Path) -> Option<PathBuf> {
+    let rel = file.strip_prefix(root).ok()?;
+    let mut comps = rel.components();
+    if comps.next()?.as_os_str() != "vendor" {
+        return None;
+    }
+    let vendor = comps.next()?;
+    let package = comps.next()?;
+    // A file directly under vendor/<v>/ has no package segment to own it.
+    comps.next()?;
+    Some(root.join("vendor").join(vendor).join(package))
+}
+
+/// Process-lifetime memo of consumer-scan verdicts, keyed by
+/// `(package root, member)`. Vendor packages don't change mid-session, and the
+/// diagnostics pass re-proves the same handful of members on every debounced
+/// edit — without this, each keystroke batch would re-walk `laravel/framework`.
+static PACKAGE_MEMBER_READS: LazyLock<Mutex<HashMap<(PathBuf, String), bool>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Whether any PHP file in the package tree reads `->member` on any receiver.
+/// Memoized in [`PACKAGE_MEMBER_READS`]. Files are prefiltered with a cheap
+/// `->member` substring check so tree-sitter only parses candidates; the walk
+/// is bounded by [`MAX_PACKAGE_FILES`].
+fn package_reads_member(package_root: &Path, member: &str) -> bool {
+    let key = (package_root.to_path_buf(), member.to_string());
+    if let Some(&hit) = PACKAGE_MEMBER_READS.lock().unwrap().get(&key) {
+        return hit;
+    }
+
+    let needle = format!("->{member}");
+    let mut seen = 0usize;
+    let mut found = false;
+    let walker = WalkDir::new(package_root).into_iter().filter_entry(|e| {
+        let name = e.file_name().to_string_lossy();
+        !matches!(name.as_ref(), "node_modules" | ".git")
+    });
+    for entry in walker.filter_map(|e| e.ok()) {
+        if !entry.file_type().is_file()
+            || entry.path().extension().and_then(|e| e.to_str()) != Some("php")
+        {
+            continue;
+        }
+        seen += 1;
+        if seen > MAX_PACKAGE_FILES {
+            break;
+        }
+        let Ok(content) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        if !content.contains(&needle) {
+            continue;
+        }
+        if source_reads_member_any_receiver(&content, member) {
+            found = true;
+            break;
+        }
+    }
+
+    PACKAGE_MEMBER_READS.lock().unwrap().insert(key, found);
+    found
 }
 
 /// Strip a leading `\` and surrounding whitespace so FQCNs compare/dedup
@@ -120,6 +255,41 @@ fn source_reads_member(source: &str, member: &str) -> bool {
     while let Some(n) = stack.pop() {
         if node_reads_member(n, bytes, member) {
             return true;
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    false
+}
+
+/// Whether `source` contains a property access `->member` (or `?->member`) on
+/// ANY receiver — `$job->tries`, `$this->tries`, `$x?->tries`. Used by the
+/// consumer scan, where the framework reads the property off an object it was
+/// handed, so the receiver variable can be anything. Method calls
+/// (`$job->tries()`) are a different tree-sitter node kind
+/// (`member_call_expression`) and intentionally do NOT match: the diagnostic
+/// only lenses properties, so only property reads count as proof.
+fn source_reads_member_any_receiver(source: &str, member: &str) -> bool {
+    let Ok(tree) = parse_php(source) else {
+        return false;
+    };
+    let bytes = source.as_bytes();
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        if matches!(
+            n.kind(),
+            "member_access_expression" | "nullsafe_member_access_expression"
+        ) {
+            let matched = n
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(bytes).ok())
+                .map(|t| t.trim_start_matches('$') == member)
+                .unwrap_or(false);
+            if matched {
+                return true;
+            }
         }
         let mut c = n.walk();
         for ch in n.children(&mut c) {

--- a/laravel-lsp/src/vendor_member_prover.rs
+++ b/laravel-lsp/src/vendor_member_prover.rs
@@ -45,6 +45,19 @@
 //! server restart anyway). The full `vendor/` tree (often 10k+ files across
 //! dozens of packages) is never walked.
 //!
+//! ## Known trade-off — suppression strength scales inversely with name rarity
+//!
+//! The consumer scan matches `->member` on ANY receiver, because the
+//! framework's read sites don't reliably type-hint the contract
+//! (`Queue::getJobTries($job)` takes an untyped parameter — requiring the
+//! interface to be named in the reading file would regress the very case this
+//! module exists for). The cost: a zero-reference property with a *common*
+//! name (`$name`, `$id`) on a class whose chain implements any framework
+//! interface is effectively never flagged — some file in `laravel/framework`
+//! touches `->name`. That is the safe failure direction for a WARNING-level
+//! hint: a false negative hides a nudge, a false positive nags about live
+//! code.
+//!
 //! ## Concurrency
 //!
 //! [`member_read_in_chain`] is **synchronous**: it does filesystem IO and
@@ -146,31 +159,63 @@ pub fn member_read_in_chain(root: &Path, fqcn: &str, member: &str) -> bool {
     member_read_by_interface_consumers(root, &interfaces, member)
 }
 
-/// Whether any vendor package owning one of `interfaces` reads `->member` on
-/// any receiver. This is the duck-typed half of the proof: the framework reads
-/// `$job->tries` in `Illuminate\Queue\Queue`, which is in NO job's inheritance
-/// chain — but it IS in the package that owns the `ShouldQueue` contract the
-/// job implements.
+/// Whether any vendor package owning one of `interfaces` — or a parent
+/// contract one of them `extends` — touches `->member` on any receiver. This
+/// is the duck-typed half of the proof: the framework reads `$job->tries` in
+/// `Illuminate\Queue\Queue`, which is in NO job's inheritance chain — but it
+/// IS in the package that owns the `ShouldQueue` contract the job implements.
+///
+/// Parent contracts are followed because an interface may `extends` one from a
+/// *different* package, and the consumer reads can live with the parent. The
+/// hop walk reuses the chain walk's visited-set + bound discipline. (The
+/// structure extractor captures one `extends` parent per declaration — a
+/// pre-existing walker limitation — so multi-parent interfaces contribute
+/// their first parent only.)
 ///
 /// Interfaces that resolve outside `vendor/` (app-side contracts) are skipped:
 /// app-side consumer reads are ordinary project references the index already
 /// counts. Each package is scanned at most once per (package, member) — see
-/// [`package_reads_member`] for the memoization.
+/// [`package_touches_member`] for the memoization.
 fn member_read_by_interface_consumers(
     root: &Path,
     interfaces: &HashSet<String>,
     member: &str,
 ) -> bool {
     let mut packages: HashSet<PathBuf> = HashSet::new();
-    for iface in interfaces {
-        let Some(path) = find_php_class_file_in_app_or_vendor(iface, root) else {
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: Vec<String> = interfaces.iter().cloned().collect();
+
+    while let Some(iface) = queue.pop() {
+        if visited.len() >= MAX_CHAIN_VISITS {
+            break;
+        }
+        if iface.is_empty() || !visited.insert(iface.clone()) {
+            continue;
+        }
+        let Some(path) = find_php_class_file_in_app_or_vendor(&iface, root) else {
             continue;
         };
         if let Some(pkg) = vendor_package_root(root, &path) {
             packages.insert(pkg);
         }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        // `interface A extends B` lands in `extends`; `implements` is taken
+        // too in case a basename-fallback resolution landed on a class.
+        for node in classes_in_file(&path, &content) {
+            if let Some(parent) = node.extends {
+                queue.push(normalize(&parent));
+            }
+            for parent in node.implements {
+                queue.push(normalize(&parent));
+            }
+        }
     }
-    packages.iter().any(|pkg| package_reads_member(pkg, member))
+
+    packages
+        .iter()
+        .any(|pkg| package_touches_member(pkg, member))
 }
 
 /// `<root>/vendor/<vendor>/<package>` for a file under it, or `None` for any
@@ -195,11 +240,11 @@ fn vendor_package_root(root: &Path, file: &Path) -> Option<PathBuf> {
 static PACKAGE_MEMBER_READS: LazyLock<Mutex<HashMap<(PathBuf, String), bool>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Whether any PHP file in the package tree reads `->member` on any receiver.
-/// Memoized in [`PACKAGE_MEMBER_READS`]. Files are prefiltered with a cheap
-/// `->member` substring check so tree-sitter only parses candidates; the walk
-/// is bounded by [`MAX_PACKAGE_FILES`].
-fn package_reads_member(package_root: &Path, member: &str) -> bool {
+/// Whether any PHP file in the package tree touches `->member` on any
+/// receiver. Memoized in [`PACKAGE_MEMBER_READS`]. Files are prefiltered with
+/// a cheap `->member` substring check so tree-sitter only parses candidates;
+/// the walk is bounded by [`MAX_PACKAGE_FILES`].
+fn package_touches_member(package_root: &Path, member: &str) -> bool {
     let key = (package_root.to_path_buf(), member.to_string());
     if let Some(&hit) = PACKAGE_MEMBER_READS.lock().unwrap().get(&key) {
         return hit;
@@ -228,7 +273,7 @@ fn package_reads_member(package_root: &Path, member: &str) -> bool {
         if !content.contains(&needle) {
             continue;
         }
-        if source_reads_member_any_receiver(&content, member) {
+        if source_touches_member_any_receiver(&content, member) {
             found = true;
             break;
         }
@@ -267,11 +312,13 @@ fn source_reads_member(source: &str, member: &str) -> bool {
 /// Whether `source` contains a property access `->member` (or `?->member`) on
 /// ANY receiver — `$job->tries`, `$this->tries`, `$x?->tries`. Used by the
 /// consumer scan, where the framework reads the property off an object it was
-/// handed, so the receiver variable can be anything. Method calls
-/// (`$job->tries()`) are a different tree-sitter node kind
+/// handed, so the receiver variable can be anything. "Touches", not "reads":
+/// an access on an assignment's left side matches too, and that's deliberate —
+/// a framework that *writes* the property is equally proof the member isn't
+/// dead. Method calls (`$job->tries()`) are a different tree-sitter node kind
 /// (`member_call_expression`) and intentionally do NOT match: the diagnostic
-/// only lenses properties, so only property reads count as proof.
-fn source_reads_member_any_receiver(source: &str, member: &str) -> bool {
+/// only lenses properties, so only property accesses count as proof.
+fn source_touches_member_any_receiver(source: &str, member: &str) -> bool {
     let Ok(tree) = parse_php(source) else {
         return false;
     };

--- a/laravel-lsp/src/vendor_member_prover/tests.rs
+++ b/laravel-lsp/src/vendor_member_prover/tests.rs
@@ -129,6 +129,119 @@ fn empty_inputs_return_false() {
     assert!(!member_read_in_chain(&root, "App\\Models\\Widget", ""));
 }
 
+// ── consumer scan (interface package reads the member duck-typed) ──────────
+
+#[test]
+fn proves_read_via_interface_package_consumer() {
+    // Mike's SyncRedshiftFromQueue case: the job's `$tries` is read by NOTHING
+    // in its chain — the framework reads `$job->tries` in the package that
+    // owns the ShouldQueue contract the job implements.
+    let (_dir, root) = project_with_files(&[
+        (
+            "app/Jobs/SyncJob.php",
+            "<?php\nnamespace App\\Jobs;\nuse Acme\\Queue\\Contracts\\ShouldQueue;\nclass SyncJob implements ShouldQueue { public int $tries = 1; }\n",
+        ),
+        (
+            "vendor/acme/queue/src/Contracts/ShouldQueue.php",
+            "<?php\nnamespace Acme\\Queue\\Contracts;\ninterface ShouldQueue {}\n",
+        ),
+        (
+            "vendor/acme/queue/src/Queue.php",
+            "<?php\nnamespace Acme\\Queue;\nclass Queue { public function getJobTries($job) { return $job->tries ?? null; } }\n",
+        ),
+    ]);
+    assert!(member_read_in_chain(&root, "App\\Jobs\\SyncJob", "tries"));
+}
+
+#[test]
+fn proves_read_via_interface_implemented_by_vendor_parent() {
+    // The interface comes from a vendor PARENT in the chain, not the app class
+    // itself — interfaces must be collected across the whole walk.
+    let (_dir, root) = project_with_files(&[
+        (
+            "app/Jobs/SyncJob.php",
+            "<?php\nnamespace App\\Jobs;\nuse Acme\\Queue\\BaseJob;\nclass SyncJob extends BaseJob { public int $timeout = 30; }\n",
+        ),
+        (
+            "vendor/acme/queue/src/BaseJob.php",
+            "<?php\nnamespace Acme\\Queue;\nuse Acme\\Queue\\Contracts\\ShouldQueue;\nabstract class BaseJob implements ShouldQueue {}\n",
+        ),
+        (
+            "vendor/acme/queue/src/Contracts/ShouldQueue.php",
+            "<?php\nnamespace Acme\\Queue\\Contracts;\ninterface ShouldQueue {}\n",
+        ),
+        (
+            "vendor/acme/queue/src/Worker.php",
+            "<?php\nnamespace Acme\\Queue;\nclass Worker { public function run($job) { return $job?->timeout; } }\n",
+        ),
+    ]);
+    assert!(member_read_in_chain(&root, "App\\Jobs\\SyncJob", "timeout"));
+}
+
+#[test]
+fn member_unread_by_interface_package_is_not_proven() {
+    // The package owns the interface but never touches the member — the scan
+    // must not turn "implements a vendor interface" into blanket immunity.
+    let (_dir, root) = project_with_files(&[
+        (
+            "app/Jobs/SyncJob.php",
+            "<?php\nnamespace App\\Jobs;\nuse Acme\\Queue\\Contracts\\ShouldQueue;\nclass SyncJob implements ShouldQueue { public $orphan = true; }\n",
+        ),
+        (
+            "vendor/acme/queue/src/Contracts/ShouldQueue.php",
+            "<?php\nnamespace Acme\\Queue\\Contracts;\ninterface ShouldQueue {}\n",
+        ),
+        (
+            "vendor/acme/queue/src/Queue.php",
+            "<?php\nnamespace Acme\\Queue;\nclass Queue { public function getJobTries($job) { return $job->tries ?? null; } }\n",
+        ),
+    ]);
+    assert!(!member_read_in_chain(&root, "App\\Jobs\\SyncJob", "orphan"));
+}
+
+#[test]
+fn method_call_in_consumer_is_not_a_property_read() {
+    // `$job->retry()` is a method call, not a property access — it must not
+    // prove a PROPERTY named `retry`.
+    let (_dir, root) = project_with_files(&[
+        (
+            "app/Jobs/SyncJob.php",
+            "<?php\nnamespace App\\Jobs;\nuse Acme\\Queue\\Contracts\\ShouldQueue;\nclass SyncJob implements ShouldQueue { public $retry = 3; }\n",
+        ),
+        (
+            "vendor/acme/queue/src/Contracts/ShouldQueue.php",
+            "<?php\nnamespace Acme\\Queue\\Contracts;\ninterface ShouldQueue {}\n",
+        ),
+        (
+            "vendor/acme/queue/src/Queue.php",
+            "<?php\nnamespace Acme\\Queue;\nclass Queue { public function run($job) { return $job->retry(); } }\n",
+        ),
+    ]);
+    assert!(!member_read_in_chain(&root, "App\\Jobs\\SyncJob", "retry"));
+}
+
+#[test]
+fn app_side_interface_does_not_trigger_consumer_scan() {
+    // The interface resolves into app/, not vendor/ — app-side consumer reads
+    // are ordinary project references the index already counts, so the prover
+    // must not claim them.
+    let (_dir, root) = project_with_files(&[
+        (
+            "app/Jobs/SyncJob.php",
+            "<?php\nnamespace App\\Jobs;\nuse App\\Contracts\\Trackable;\nclass SyncJob implements Trackable { public $steps = 5; }\n",
+        ),
+        (
+            "app/Contracts/Trackable.php",
+            "<?php\nnamespace App\\Contracts;\ninterface Trackable {}\n",
+        ),
+        (
+            "app/Services/Tracker.php",
+            "<?php\nnamespace App\\Services;\nclass Tracker { public function f($t) { return $t->steps; } }\n",
+        ),
+    ]);
+    assert!(!member_read_in_chain(&root, "App\\Jobs\\SyncJob", "steps"));
+}
+
 #[test]
 fn extends_cycle_terminates() {
     // A extends B, B extends A — the visited-set must break the cycle and the

--- a/laravel-lsp/src/vendor_member_prover/tests.rs
+++ b/laravel-lsp/src/vendor_member_prover/tests.rs
@@ -273,6 +273,29 @@ fn app_side_interface_does_not_trigger_consumer_scan() {
 }
 
 #[test]
+fn interface_extends_cycle_terminates() {
+    // A extends B, B extends A — the hop walk in the consumer scan has its own
+    // visited-set + bound, textually separate from the chain walk's, so it
+    // needs its own termination pin (this test failing = an infinite loop /
+    // hang in `member_read_by_interface_consumers`).
+    let (_dir, root) = project_with_files(&[
+        (
+            "app/Jobs/SyncJob.php",
+            "<?php\nnamespace App\\Jobs;\nuse Acme\\Queue\\Contracts\\A;\nclass SyncJob implements A { public $x = 1; }\n",
+        ),
+        (
+            "vendor/acme/queue/src/Contracts/A.php",
+            "<?php\nnamespace Acme\\Queue\\Contracts;\ninterface A extends B {}\n",
+        ),
+        (
+            "vendor/acme/queue/src/Contracts/B.php",
+            "<?php\nnamespace Acme\\Queue\\Contracts;\ninterface B extends A {}\n",
+        ),
+    ]);
+    assert!(!member_read_in_chain(&root, "App\\Jobs\\SyncJob", "x"));
+}
+
+#[test]
 fn extends_cycle_terminates() {
     // A extends B, B extends A — the visited-set must break the cycle and the
     // walk must return (this test failing = an infinite loop / hang).

--- a/laravel-lsp/src/vendor_member_prover/tests.rs
+++ b/laravel-lsp/src/vendor_member_prover/tests.rs
@@ -179,6 +179,36 @@ fn proves_read_via_interface_implemented_by_vendor_parent() {
 }
 
 #[test]
+fn proves_read_via_parent_contract_in_different_package() {
+    // The implemented interface extends a contract in a DIFFERENT package, and
+    // the consumer read lives with the parent — the hop walk must follow
+    // `interface A extends B` across package boundaries.
+    let (_dir, root) = project_with_files(&[
+        (
+            "app/Jobs/SyncJob.php",
+            "<?php\nnamespace App\\Jobs;\nuse Acme\\Queue\\Contracts\\ShouldQueue;\nclass SyncJob implements ShouldQueue { public int $attempts = 2; }\n",
+        ),
+        (
+            "vendor/acme/queue/src/Contracts/ShouldQueue.php",
+            "<?php\nnamespace Acme\\Queue\\Contracts;\nuse Base\\Contracts\\Job;\ninterface ShouldQueue extends Job {}\n",
+        ),
+        (
+            "vendor/base/contracts/src/Job.php",
+            "<?php\nnamespace Base\\Contracts;\ninterface Job {}\n",
+        ),
+        (
+            "vendor/base/contracts/src/Runner.php",
+            "<?php\nnamespace Base\\Contracts;\nclass Runner { public function f($j) { return $j->attempts; } }\n",
+        ),
+    ]);
+    assert!(member_read_in_chain(
+        &root,
+        "App\\Jobs\\SyncJob",
+        "attempts"
+    ));
+}
+
+#[test]
 fn member_unread_by_interface_package_is_not_proven() {
     // The package owns the interface but never touches the member — the scan
     // must not turn "implements a vendor interface" into blanket immunity.


### PR DESCRIPTION
## Summary

The unused-symbol diagnostic flagged framework-read queue properties (`$tries`, `$timeout`, `$backoff`, …) as "possibly dead code". The existing chain prover only detects reads through the class's own inheritance chain (parents + traits) — but the framework reads these properties **duck-typed**, off an object it was handed: `Illuminate\Queue\Queue::getJobTries()` does `$job->tries ?? $job->tries()`, and `Queue` is in no job's chain.

## Approach

When the chain walk proves nothing, the prover now:

1. Collects every interface the chain `implements` (already resolved to FQCNs by the hierarchy extractor — previously discarded).
2. Resolves each interface to its `vendor/<vendor>/<package>/` root; app-side interfaces are skipped (app consumer reads are ordinary indexed references).
3. Scans that package for a property access `->member` on **any** receiver — substring prefilter, tree-sitter confirmation, so only candidate files are parsed. Method calls intentionally don't match (only properties are lensed).
4. Memoizes the verdict per `(package, member)` for the process lifetime (`LazyLock<Mutex<HashMap>>`), so debounced re-diagnostics never re-walk `laravel/framework`.

The contract and its consumer normally share a package (`ShouldQueue` and `Queue` both ship in `laravel/framework`), which keeps the scan bounded to one package tree, capped at 8192 files.

## Tests

- 5 new prover tests: the `$tries` reproduction, interface-via-vendor-parent, unread member stays flagged, method-call-only doesn't count, app-side interface skipped.
- Full suite green: 1558 + 232 unit, 80 integration.
- Verified the framework read site against laravel/framework 11.x (`Queue::getJobTries()`).

## Notes

- Known limitation, documented in the module docs: split `illuminate/*` installs (contract and consumer in different packages) won't be proven — standard Laravel apps ship the monolithic `laravel/framework`, which is.
- Suppression direction is safe: a false negative hides a warning; a false positive nags about live code.