### PR TITLE
fix: references code lens anchors at line 0 on PHP class files instead of the class declaration

### DIFF
--- a/laravel-lsp/src/code_lens.rs
+++ b/laravel-lsp/src/code_lens.rs
@@ -467,5 +467,20 @@ pub fn class_declaration_position(source: &str) -> Option<(u32, u32, u32)> {
     best
 }
 
+/// Select the compound file-level lens anchor for a file. A `.blade.php` view
+/// has no class declaration to attach to, so it anchors at line 0 (`None` here
+/// — the caller substitutes a zero-width top-of-file range). Any other file is
+/// treated as a PHP source: a named class anchors on its `class` declaration
+/// (#78), while an anonymous or class-less file falls back to line 0 (also
+/// `None`). Returning `None` for both the Blade and class-less cases lets the
+/// caller share a single zero-anchor fallback.
+pub fn compound_lens_anchor(file_name: &str, source: &str) -> Option<(u32, u32, u32)> {
+    if file_name.ends_with(".blade.php") {
+        None
+    } else {
+        class_declaration_position(source)
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/laravel-lsp/src/code_lens.rs
+++ b/laravel-lsp/src/code_lens.rs
@@ -437,5 +437,35 @@ fn first_class_fqcn(root: Node, bytes: &[u8]) -> Option<String> {
     })
 }
 
+/// The earliest named `class_declaration`'s name position (0-based row, start
+/// col, end col), or `None` for a file with no named class — an anonymous class
+/// (`new class extends Component`) or no class at all. Used to anchor the
+/// compound file-level lens on the `class` declaration line for a PHP class
+/// file (#78) instead of line 0, which is only correct for declaration-less
+/// Blade views. Reuses [`name_position`], the same machinery
+/// [`component_targets`] anchors member lenses with.
+pub fn class_declaration_position(source: &str) -> Option<(u32, u32, u32)> {
+    let tree = parse_php(source).ok()?;
+    let bytes = source.as_bytes();
+    let mut best: Option<(u32, u32, u32)> = None;
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "class_declaration" {
+            if let Some((_, line, col, end)) = name_position(n, bytes) {
+                // Keep the earliest by source position — DFS pop order isn't
+                // source order, so compare rather than take the first popped.
+                if best.is_none_or(|(bl, bc, _)| (line, col) < (bl, bc)) {
+                    best = Some((line, col, end));
+                }
+            }
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    best
+}
+
 #[cfg(test)]
 mod tests;

--- a/laravel-lsp/src/code_lens/tests.rs
+++ b/laravel-lsp/src/code_lens/tests.rs
@@ -365,3 +365,66 @@ fn file_level_symbols_empty_for_non_blade() {
     let config = lens_config(&root);
     assert!(file_level_symbols(&root.join("app/Models/User.php"), &config).is_empty());
 }
+
+#[test]
+fn class_declaration_position_anchors_on_the_class_name() {
+    // A Livewire component class file — the compound lens must anchor on the
+    // `class` declaration, not line 0 (#78).
+    let src = r#"<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class Counter extends Component
+{
+    public int $count = 0;
+}
+"#;
+    let (line, col, end) = class_declaration_position(src).expect("named class has a position");
+    // `class Counter` sits on line 6 (0-based).
+    assert_eq!(line, 6);
+    let text = src.lines().nth(line as usize).unwrap();
+    // The anchor spans the class name `Counter`, not the `class` keyword.
+    assert_eq!(col, text.find("Counter").unwrap() as u32);
+    assert_eq!(end, col + "Counter".len() as u32);
+}
+
+#[test]
+fn class_declaration_position_none_for_anonymous_class() {
+    // An anonymous Volt component (`new class extends Component`) has no name
+    // node — the caller falls back to the line-0 anchor.
+    let src = r#"<?php
+
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public int $count = 0;
+};
+"#;
+    assert!(class_declaration_position(src).is_none());
+}
+
+#[test]
+fn class_declaration_position_none_without_a_class() {
+    // A class-less PHP file (e.g. a plain config array) has nothing to anchor.
+    let src = "<?php\n\nreturn ['name' => 'Laravel'];\n";
+    assert!(class_declaration_position(src).is_none());
+}
+
+#[test]
+fn class_declaration_position_takes_the_earliest_class() {
+    // Two top-level classes — the anchor is the first by source position.
+    let src = r#"<?php
+
+namespace App;
+
+class First {}
+
+class Second {}
+"#;
+    let (line, col, _) = class_declaration_position(src).expect("a named class exists");
+    assert_eq!(line, 4);
+    let text = src.lines().nth(line as usize).unwrap();
+    assert_eq!(col, text.find("First").unwrap() as u32);
+}

--- a/laravel-lsp/src/code_lens/tests.rs
+++ b/laravel-lsp/src/code_lens/tests.rs
@@ -428,3 +428,51 @@ class Second {}
     let text = src.lines().nth(line as usize).unwrap();
     assert_eq!(col, text.find("First").unwrap() as u32);
 }
+
+#[test]
+fn compound_lens_anchor_blade_view_anchors_at_line_zero() {
+    // A Blade view has no class declaration to attach to — the compound lens
+    // must keep the line-0 anchor (#78). `None` tells the caller to use the
+    // zero-width top-of-file range.
+    let src = "<div>{{ $count }}</div>\n";
+    assert!(
+        compound_lens_anchor("counter.blade.php", src).is_none(),
+        "a Blade view must anchor at line 0, never on a class declaration"
+    );
+}
+
+#[test]
+fn compound_lens_anchor_php_class_anchors_on_the_declaration() {
+    // A Livewire-style PHP class file routes to the `class` declaration
+    // position, not line 0 (#78).
+    let src = r#"<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class Counter extends Component
+{
+    public int $count = 0;
+}
+"#;
+    let (line, col, end) =
+        compound_lens_anchor("Counter.php", src).expect("a named PHP class produces an anchor");
+    // Identical to `class_declaration_position` — the helper routes straight
+    // through for a non-Blade file. `class Counter` sits on line 6 (0-based).
+    assert_eq!((line, col, end), class_declaration_position(src).unwrap());
+    assert_eq!(line, 6);
+    let text = src.lines().nth(line as usize).unwrap();
+    assert_eq!(col, text.find("Counter").unwrap() as u32);
+}
+
+#[test]
+fn compound_lens_anchor_class_less_php_falls_back_to_line_zero() {
+    // A class-less `.php` file (e.g. a plain config array or an anonymous Volt
+    // component) has nothing to anchor — fall back to line 0.
+    let src = "<?php\n\nreturn ['name' => 'Laravel'];\n";
+    assert!(
+        compound_lens_anchor("config.php", src).is_none(),
+        "a class-less PHP file must fall back to the line-0 anchor"
+    );
+}

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18351,6 +18351,21 @@ fn symbol_entry_kind_to_lsp(kind: laravel_lsp::document_symbols::SymbolEntryKind
     }
 }
 
+/// A zero-width range at the top of the file — the compound file-level lens
+/// anchor for a declaration-less Blade view (or a class-less PHP fallback).
+fn zero_anchor() -> Range {
+    Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    }
+}
+
 impl LaravelLanguageServer {
     /// Collect every code-lens item for a file — each a `(range, symbols)` pair.
     /// Position lenses (magic members, routes, env, config, translation) carry
@@ -18446,17 +18461,30 @@ impl LaravelLanguageServer {
                 }
             }
             if !file_symbols.is_empty() {
+                // Anchor the compound lens. A Blade view has no declaration to
+                // attach to, so it keeps the line-0 anchor. A PHP class file
+                // anchors on its `class` declaration so the lens renders above
+                // the class name, not at line 0 (#78); a class-less `.php`
+                // (e.g. an anonymous Volt component) falls back to line 0.
+                let range = if file_name.ends_with(".blade.php") {
+                    zero_anchor()
+                } else {
+                    match laravel_lsp::code_lens::class_declaration_position(source) {
+                        Some((line, column, end_column)) => Range {
+                            start: Position {
+                                line,
+                                character: column,
+                            },
+                            end: Position {
+                                line,
+                                character: end_column,
+                            },
+                        },
+                        None => zero_anchor(),
+                    }
+                };
                 items.push(LensItem {
-                    range: Range {
-                        start: Position {
-                            line: 0,
-                            character: 0,
-                        },
-                        end: Position {
-                            line: 0,
-                            character: 0,
-                        },
-                    },
+                    range,
                     symbols: file_symbols,
                 });
             }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18465,23 +18465,21 @@ impl LaravelLanguageServer {
                 // attach to, so it keeps the line-0 anchor. A PHP class file
                 // anchors on its `class` declaration so the lens renders above
                 // the class name, not at line 0 (#78); a class-less `.php`
-                // (e.g. an anonymous Volt component) falls back to line 0.
-                let range = if file_name.ends_with(".blade.php") {
-                    zero_anchor()
-                } else {
-                    match laravel_lsp::code_lens::class_declaration_position(source) {
-                        Some((line, column, end_column)) => Range {
-                            start: Position {
-                                line,
-                                character: column,
-                            },
-                            end: Position {
-                                line,
-                                character: end_column,
-                            },
+                // (e.g. an anonymous Volt component) falls back to line 0. The
+                // routing decision lives in `compound_lens_anchor` so it can be
+                // unit-tested independently of this async server method.
+                let range = match laravel_lsp::code_lens::compound_lens_anchor(file_name, source) {
+                    Some((line, column, end_column)) => Range {
+                        start: Position {
+                            line,
+                            character: column,
                         },
-                        None => zero_anchor(),
-                    }
+                        end: Position {
+                            line,
+                            character: end_column,
+                        },
+                    },
+                    None => zero_anchor(),
                 };
                 items.push(LensItem {
                     range,


### PR DESCRIPTION
## Summary
Implements #78 — the compound file-level **references** code lens was hard-anchored at `Position { line: 0, character: 0 }` for any `.php` file with a file-level identity (e.g. a Livewire class). That line-0 anchor is correct only for declaration-less Blade views; on a class file the lens rendered at the very top instead of above the `class` declaration.

## Changes
- Add `code_lens::class_declaration_position()` — reuses the existing `name_position()` machinery to locate the earliest named `class_declaration` name node (0-based row/col/end-col). Returns `None` for anonymous classes (`new class extends Component`) and class-less files.
- Add `code_lens::compound_lens_anchor(file_name, source)` — owns the anchor-routing decision (Blade → line 0, named PHP class → declaration position, class-less → line-0 fallback) so it can be unit-tested independently of the async server method. `collect_lens_items()` in `laravel-lsp/src/main.rs` now routes through it.
- Extracted a small `zero_anchor()` helper for the top-of-file range.
- Unit tests for `class_declaration_position` (named class, anonymous class, no class, earliest-of-two) **and** for `compound_lens_anchor` (Blade view → line 0, PHP class → declaration, class-less → line-0 fallback).

## Acceptance Criteria
- [x] Identify the class declaration line in PHP class files using tree-sitter `class_declaration` name node (via existing `name_position()` machinery)
- [x] Modify `collect_lens_items()` to anchor the compound file-level lens at the class declaration position for `.php` files and `0,0` only for `.blade.php` files
- [x] Covered by test: compound lens anchors on the `class` name for a Livewire-style class file, not line 0 (`compound_lens_anchor_php_class_anchors_on_the_declaration`)
- [x] Covered by test: Blade view keeps the top (line 0) anchor (`compound_lens_anchor_blade_view_anchors_at_line_zero`)
- [x] Per-member lenses remain unaffected — they anchor on their own symbols via `code_lens_targets()`, untouched here

## Test Plan
- [x] `cargo test --lib --bins` — 1595 lib + 232 bin tests pass, including 3 new `compound_lens_anchor_*` tests and 4 `class_declaration_position_*` tests
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- Note: 8 pre-existing integration-test failures in `tests/integration_tests.rs` are environmental (they require gitignored `test-project/.env` fixtures absent from a fresh clone) and fail identically on the base commit — unrelated to this change.

Fixes #78