### PR TITLE
feat: hover cards for Laravel helper functions + Eloquent/query-builder methods

### DIFF
--- a/docs/hover.md
+++ b/docs/hover.md
@@ -52,6 +52,19 @@ Artisan::call('emails:send');
 //                                  protected $signature = 'emails:send {--queue}'
 ```
 
-**Hovered patterns:** views, Blade components (anonymous *and* class-backed), Livewire components, routes, config keys, env vars, translations (including `vendor::namespace.key`), middleware aliases, container bindings, assets (`asset()`, `Vite::asset()`, `mix()`, `public_path()`, …), `url()`, Blade variables, Eloquent magic members, and Artisan command strings. The bottom-line source path renders as a `file://` link, so the whole card is click-to-open in any LSP client that supports markdown links.
+**Laravel helper functions** get a card on the **function name itself** (not just the string argument) — a Laravel-aware one-line synopsis plus a source link:
+
+```php
+route('home');
+// ^^^^^ hover →  route — Generate a URL for a named route.
+//                (link into vendor's helpers.php, or the laravel.com docs)
+
+config('app.name');
+// ^^^^^^ hover →  config — Get / set the value of a configuration variable.
+```
+
+This is a deliberately **curated allow-list** of seven helpers — `route`, `view`, `config`, `auth`, `app`, `session`, `cache` — chosen because their framework docblock is thin or generic, so a Laravel-aware synopsis adds value over what Intelephense already shows. That narrow set *is* the dedup policy: every other helper (`bcrypt`, `abort`, `collect`, `str`, …) is simply never indexed, so we never emit a duplicate card next to Intelephense's — no runtime detection needed. The source link points into the vendored framework `helpers.php` when it's present under the workspace root, and falls back to the canonical `laravel.com/docs/helpers` anchor otherwise. (The string *argument* still hovers as before — `route('home')`'s `'home'` resolves to the route definition; the two spans are independent.)
+
+**Hovered patterns:** views, Blade components (anonymous *and* class-backed), Livewire components, routes, config keys, env vars, translations (including `vendor::namespace.key`), middleware aliases, container bindings, assets (`asset()`, `Vite::asset()`, `mix()`, `public_path()`, …), `url()`, Blade variables, Eloquent magic members, Artisan command strings, and curated Laravel helper-function identifiers. The bottom-line source path renders as a `file://` link, so the whole card is click-to-open in any LSP client that supports markdown links.
 
 Class-backed components and Livewire components show the `class Foo extends Component` signature and link to the PHP class; anonymous components fall back to the `@props([...])` declaration from the `.blade.php` template. Patterns without a meaningful target (directives, controller actions, Pennant features) stay silent rather than showing an empty card.

--- a/laravel-lsp/queries/php.scm
+++ b/laravel-lsp/queries/php.scm
@@ -2271,3 +2271,28 @@
 
 (scoped_call_expression
   name: (name) @scoped_call_name)
+
+; ============================================================================
+; Pattern 42: Curated Laravel helper-function IDENTIFIERS (hover on the name)
+; ============================================================================
+; Matches the FUNCTION-NAME token of a curated global helper call — `route` in
+; route('home'), `config` in config('app.name'), `auth` in auth(), etc. This is
+; the identifier span, NOT the string argument (that is captured by the
+; pattern-specific rules above). Both fire on the same call; their column ranges
+; are disjoint, so the cursor position selects the right one at hover time.
+;
+; The allow-list is the seven helpers whose framework docblock is thin/generic
+; and where a Laravel-aware card adds value (#58). Keeping the set narrow IS the
+; dedup policy — everything else is left to Intelephense, never indexed, so no
+; runtime duplicate-card detection is needed. The canonical allow-list lives in
+; `hover::HELPER_CARDS`; this query mirrors it as a parse-time pre-filter.
+;
+; Bare `(name)` only — `$obj->route()` (member_call_expression) and
+; `Route::route()` (scoped_call_expression) are different node kinds and never
+; match here. No `arguments:` constraint, so arg-less forms like `auth()` and
+; `app()` are captured alongside `cache('key')` / `session('k')`.
+
+(function_call_expression
+  function: (name) @helper_identifier
+  (#any-of? @helper_identifier
+    "route" "view" "config" "auth" "app" "session" "cache"))

--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -210,6 +210,124 @@ pub fn magic_member_card(
     })
 }
 
+// ============================================================================
+// Curated helper-function hover (#58)
+// ============================================================================
+
+/// A curated hover card for one Laravel global helper function.
+///
+/// The seven curated helpers are exactly those whose framework `helpers.php`
+/// docblock is thin or generic, so a Laravel-aware synopsis adds value over
+/// what Intelephense already shows. Keeping the set narrow IS the dedup policy:
+/// every other helper is simply never indexed, so we never emit a duplicate
+/// card — no runtime Intelephense detection needed.
+#[derive(Debug, Clone, Copy)]
+pub struct HelperCard {
+    /// One-line, Laravel-aware synopsis (the hover's detail line).
+    pub synopsis: &'static str,
+    /// Path, relative to the workspace root, of the framework file that DEFINES
+    /// this helper. All seven curated helpers live in Foundation's `helpers.php`
+    /// (`Support/helpers.php` holds the lower-level `collect`/`str`/… helpers).
+    /// Used to build the `file://` source link when the framework is vendored.
+    pub vendor_path: &'static str,
+    /// Canonical laravel.com docs anchor — the source-link fallback used when
+    /// the framework file above isn't present under the workspace root.
+    pub docs_url: &'static str,
+}
+
+/// All seven curated framework helpers live in this one file.
+const FOUNDATION_HELPERS: &str = "vendor/laravel/framework/src/Illuminate/Foundation/helpers.php";
+
+/// The curated allow-list of Laravel helper identifiers we provide hover cards
+/// for, keyed by helper name. This is the canonical allow-list; the `#any-of?`
+/// predicate in `queries/php.scm` mirrors it as a parse-time pre-filter.
+pub static HELPER_CARDS: &[(&str, HelperCard)] = &[
+    (
+        "route",
+        HelperCard {
+            synopsis: "Generate a URL for a named route.",
+            vendor_path: FOUNDATION_HELPERS,
+            docs_url: "https://laravel.com/docs/helpers#method-route",
+        },
+    ),
+    (
+        "view",
+        HelperCard {
+            synopsis: "Get the evaluated view contents for the given view.",
+            vendor_path: FOUNDATION_HELPERS,
+            docs_url: "https://laravel.com/docs/helpers#method-view",
+        },
+    ),
+    (
+        "config",
+        HelperCard {
+            synopsis: "Get / set the value of a configuration variable.",
+            vendor_path: FOUNDATION_HELPERS,
+            docs_url: "https://laravel.com/docs/helpers#method-config",
+        },
+    ),
+    (
+        "auth",
+        HelperCard {
+            synopsis: "Get the available auth guard / authenticator instance.",
+            vendor_path: FOUNDATION_HELPERS,
+            docs_url: "https://laravel.com/docs/helpers#method-auth",
+        },
+    ),
+    (
+        "app",
+        HelperCard {
+            synopsis: "Get the container instance, or resolve a binding from it.",
+            vendor_path: FOUNDATION_HELPERS,
+            docs_url: "https://laravel.com/docs/helpers#method-app",
+        },
+    ),
+    (
+        "session",
+        HelperCard {
+            synopsis: "Get / set a session value, or the session store instance.",
+            vendor_path: FOUNDATION_HELPERS,
+            docs_url: "https://laravel.com/docs/helpers#method-session",
+        },
+    ),
+    (
+        "cache",
+        HelperCard {
+            synopsis: "Get / set a cache value, or the cache store instance.",
+            vendor_path: FOUNDATION_HELPERS,
+            docs_url: "https://laravel.com/docs/helpers#method-cache",
+        },
+    ),
+];
+
+/// Look up the curated card for a helper name. `None` for anything outside the
+/// allow-list (the caller then renders no card).
+pub fn helper_card(name: &str) -> Option<&'static HelperCard> {
+    HELPER_CARDS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, card)| card)
+}
+
+/// Build a hover card for a curated Laravel helper identifier (`route`, `view`,
+/// `config`, …). `header` is the function name, `detail` the curated synopsis
+/// (both from [`HELPER_CARDS`]). `source_link` is the pre-resolved markdown link
+/// — built caller-side because it needs the workspace root to decide between a
+/// `file://` link into the vendored framework `helpers.php` and the docs-URL
+/// fallback.
+///
+/// Returns `None` when `name` isn't in the curated allow-list, so the caller
+/// renders nothing (the structural dedup policy — Intelephense owns the rest).
+pub fn helper_identifier_card(name: &str, source_link: Option<&str>) -> Option<String> {
+    let card = helper_card(name)?;
+    Some(render(&HoverContent {
+        header: Some(name),
+        detail: Some(card.synopsis),
+        source_link,
+        ..Default::default()
+    }))
+}
+
 /// The declaring method names a magic-member usage name could map to, by kind.
 /// Relationships/finders are accessed under their method name verbatim
 /// (`$user->account` ← `account()`); scopes and accessors transform

--- a/laravel-lsp/src/hover/tests.rs
+++ b/laravel-lsp/src/hover/tests.rs
@@ -381,3 +381,67 @@ fn magic_member_card_without_link_omits_source_section() {
         "**Database column**\n\n`email` on `App\\Models\\User`\n\nType `string`"
     );
 }
+
+// ============================================================================
+// helper-function hover (#58) — curated allow-list + card rendering
+// ============================================================================
+
+#[test]
+fn helper_card_covers_exactly_the_seven_curated_helpers() {
+    for name in ["route", "view", "config", "auth", "app", "session", "cache"] {
+        assert!(
+            helper_card(name).is_some(),
+            "`{name}` should be in the curated allow-list"
+        );
+    }
+    assert_eq!(HELPER_CARDS.len(), 7, "exactly seven curated helpers");
+    // Non-curated helpers are Intelephense's job — never carded.
+    for name in ["bcrypt", "abort", "collect", "str", "dd", "tap"] {
+        assert!(
+            helper_card(name).is_none(),
+            "`{name}` must not be in the curated allow-list"
+        );
+    }
+}
+
+#[test]
+fn helper_card_synopsis_and_links_are_populated() {
+    for (name, card) in HELPER_CARDS {
+        assert!(!card.synopsis.is_empty(), "{name} needs a synopsis");
+        assert!(
+            card.docs_url.starts_with("https://laravel.com/docs/"),
+            "{name} docs_url should be a canonical laravel.com anchor"
+        );
+        assert!(
+            card.vendor_path.ends_with("helpers.php"),
+            "{name} vendor_path should point at a framework helpers.php"
+        );
+    }
+}
+
+#[test]
+fn helper_identifier_card_renders_header_detail_and_link() {
+    let link = "[Laravel documentation](https://laravel.com/docs/helpers#method-route)";
+    let out = helper_identifier_card("route", Some(link)).expect("curated helper");
+    assert_eq!(
+        out,
+        format!("**route**\n\nGenerate a URL for a named route.\n\n{link}")
+    );
+}
+
+#[test]
+fn helper_identifier_card_omits_link_section_when_absent() {
+    let out = helper_identifier_card("config", None).expect("curated helper");
+    assert_eq!(
+        out,
+        "**config**\n\nGet / set the value of a configuration variable."
+    );
+}
+
+#[test]
+fn helper_identifier_card_is_none_for_non_curated_helper() {
+    assert!(
+        helper_identifier_card("bcrypt", None).is_none(),
+        "non-curated helpers render no card"
+    );
+}

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -16383,6 +16383,9 @@ return [
             PatternAtPosition::Component(comp) => self.hover_for_component(&comp.name).await,
             PatternAtPosition::Livewire(lw) => self.hover_for_livewire(&lw.name).await,
             PatternAtPosition::Route(route) => self.hover_for_route(&route.name).await,
+            PatternAtPosition::HelperIdentifier(helper) => {
+                self.hover_for_helper(&helper.name, root.as_deref()).await
+            }
             PatternAtPosition::ConfigRef(cfg) => {
                 self.hover_for_config(&cfg.key, root.as_deref()).await
             }
@@ -17379,6 +17382,38 @@ return [
         })
     }
 
+    /// Curated Laravel helper identifier (`route`, `view`, `config`, …) — a
+    /// Laravel-aware synopsis from [`hover::HELPER_CARDS`] plus a source link.
+    /// The link points into the vendored framework `helpers.php` when it exists
+    /// under the workspace root (a single existence stat — no vendor scan),
+    /// falling back to the canonical laravel.com docs anchor otherwise.
+    ///
+    /// Returns `""` for any name outside the curated allow-list, which the
+    /// parser never produces — the `helper_card` guard is purely defensive.
+    async fn hover_for_helper(&self, name: &str, root: Option<&Path>) -> String {
+        use laravel_lsp::hover;
+        let Some(card) = hover::helper_card(name) else {
+            return String::new();
+        };
+        // Prefer a file:// link into the vendored framework source; fall back to
+        // the docs URL when the framework isn't vendored under the workspace.
+        let vendored = match root {
+            Some(r) => {
+                let p = r.join(card.vendor_path);
+                tokio::fs::try_exists(&p)
+                    .await
+                    .unwrap_or(false)
+                    .then_some(p)
+            }
+            None => None,
+        };
+        let link = match vendored {
+            Some(p) => self.source_link(&p, None).await,
+            None => hover::source_link("Laravel documentation", card.docs_url, None),
+        };
+        hover::helper_identifier_card(name, Some(&link)).unwrap_or_default()
+    }
+
     /// Config — resolved value as a `php` code block, link to the
     /// `config/<group>.php` file.
     async fn hover_for_config(&self, key: &str, root: Option<&Path>) -> String {
@@ -17953,6 +17988,9 @@ fn pattern_range_at(
     let (l, start, end) = match pat {
         laravel_lsp::salsa_impl::PatternAtPosition::View(v) => (v.line, v.column, v.end_column),
         laravel_lsp::salsa_impl::PatternAtPosition::Route(r) => (r.line, r.column, r.end_column),
+        laravel_lsp::salsa_impl::PatternAtPosition::HelperIdentifier(h) => {
+            (h.line, h.column, h.end_column)
+        }
         laravel_lsp::salsa_impl::PatternAtPosition::ConfigRef(c) => {
             (c.line, c.column, c.end_column)
         }
@@ -19709,6 +19747,12 @@ impl LanguageServer for LaravelLanguageServer {
             PatternAtPosition::Route(route) => {
                 debug!("Laravel: Found route: {}", route.name);
                 self.create_route_location_from_salsa(&route).await
+            }
+            // Curated helper identifiers are a hover-only feature (#58) — no
+            // goto target (the synopsis card carries a source link instead).
+            PatternAtPosition::HelperIdentifier(helper) => {
+                debug!("Laravel: Found helper identifier: {}", helper.name);
+                None
             }
             PatternAtPosition::Url(url) => {
                 debug!("Laravel: Found url: {}", url.path);

--- a/laravel-lsp/src/pattern_indexer.rs
+++ b/laravel-lsp/src/pattern_indexer.rs
@@ -29,9 +29,9 @@ use crate::queries::{
 use crate::salsa_impl::{
     ActionReferenceData, AssetHelperType, AssetReferenceData, BindingReferenceData,
     ComponentReferenceData, Confidence, ConfigReferenceData, DirectiveReferenceData,
-    EnvReferenceData, FeatureReferenceData, LivewireReferenceData, MemberAccessReferenceData,
-    MiddlewareReferenceData, ParsedPatternsData, RouteReferenceData, TranslationReferenceData,
-    UrlReferenceData, ViewReferenceData,
+    EnvReferenceData, FeatureReferenceData, HelperReferenceData, LivewireReferenceData,
+    MemberAccessReferenceData, MiddlewareReferenceData, ParsedPatternsData, RouteReferenceData,
+    TranslationReferenceData, UrlReferenceData, ViewReferenceData,
 };
 
 /// Parse a file and return its `ParsedPatternsData` directly. Detects Blade
@@ -267,6 +267,15 @@ fn push_php_patterns(
         let (line, col, end_col) = xform(r.row, r.column, r.end_column);
         data.route_refs.push(Arc::new(RouteReferenceData {
             name: r.route_name.to_string(),
+            line,
+            column: col,
+            end_column: end_col,
+        }));
+    }
+    for h in &snippet.helper_identifiers {
+        let (line, col, end_col) = xform(h.row, h.column, h.end_column);
+        data.helper_refs.push(Arc::new(HelperReferenceData {
+            name: h.name.to_string(),
             line,
             column: col,
             end_column: end_col,

--- a/laravel-lsp/src/queries.rs
+++ b/laravel-lsp/src/queries.rs
@@ -292,6 +292,21 @@ pub struct RouteMatch<'a> {
     pub end_column: usize,
 }
 
+/// Represents the FUNCTION-NAME identifier of a curated Laravel helper call
+/// (`route` in `route('home')`, `config` in `config('app.name')`, …). Unlike
+/// [`RouteMatch`] / [`ConfigMatch`] — which capture the string ARGUMENT — this
+/// captures the identifier span so hover can fire on the helper name itself.
+/// Only the seven curated helpers (see `hover::HELPER_CARDS`) are matched.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HelperIdentifierMatch<'a> {
+    pub name: &'a str,
+    pub byte_start: usize,
+    pub byte_end: usize,
+    pub row: usize,
+    pub column: usize,
+    pub end_column: usize,
+}
+
 /// Represents a matched url('path') call in PHP code
 #[derive(Debug, Clone, PartialEq)]
 pub struct UrlMatch<'a> {
@@ -393,6 +408,9 @@ pub struct ExtractedPhpPatterns<'a> {
     pub asset_calls: Vec<AssetMatch<'a>>,
     pub binding_calls: Vec<BindingMatch<'a>>,
     pub route_calls: Vec<RouteMatch<'a>>,
+    /// Curated Laravel helper-function identifiers (`route`, `view`, `config`,
+    /// `auth`, `app`, `session`, `cache`) captured at their name span for hover.
+    pub helper_identifiers: Vec<HelperIdentifierMatch<'a>>,
     pub url_calls: Vec<UrlMatch<'a>>,
     pub action_calls: Vec<ActionMatch<'a>>,
     pub feature_calls: Vec<FeatureMatch<'a>>,
@@ -806,6 +824,20 @@ pub fn extract_all_php_patterns<'a>(
                 });
             }
 
+            // Curated helper-function identifier (the name token, e.g. `route`
+            // in `route('home')`). The `#any-of?` predicate in php.scm has
+            // already restricted this to the seven curated helpers.
+            "helper_identifier" => {
+                result.helper_identifiers.push(HelperIdentifierMatch {
+                    name: text,
+                    byte_start: node.start_byte(),
+                    byte_end: node.end_byte(),
+                    row: start_pos.row,
+                    column: start_pos.column,
+                    end_column: end_pos.column,
+                });
+            }
+
             // URL patterns
             "url_path" => {
                 result.url_calls.push(UrlMatch {
@@ -977,6 +1009,7 @@ pub fn extract_all_php_patterns<'a>(
         + result.asset_calls.len()
         + result.binding_calls.len()
         + result.route_calls.len()
+        + result.helper_identifiers.len()
         + result.url_calls.len()
         + result.action_calls.len()
         + result.feature_calls.len()

--- a/laravel-lsp/src/queries/tests/php_pattern_extraction.rs
+++ b/laravel-lsp/src/queries/tests/php_pattern_extraction.rs
@@ -90,3 +90,111 @@ fn test_extract_all_php_patterns_middleware() {
         "Should find 'verified' middleware"
     );
 }
+
+#[test]
+fn test_extract_helper_identifiers_fires_for_each_curated_helper() {
+    // Every curated helper's NAME token is captured — including arg-less forms
+    // (`auth()`, `app()`) and string-arg forms (`route('home')`).
+    let php_code = r#"<?php
+    route('home');
+    view('welcome');
+    config('app.name');
+    auth();
+    app('cache');
+    session('key');
+    cache('users');
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    let names: Vec<&str> = patterns.helper_identifiers.iter().map(|h| h.name).collect();
+
+    for helper in ["route", "view", "config", "auth", "app", "session", "cache"] {
+        assert!(
+            names.contains(&helper),
+            "Should capture the `{helper}` helper identifier, got {names:?}"
+        );
+    }
+    assert_eq!(
+        patterns.helper_identifiers.len(),
+        7,
+        "Exactly the seven curated helpers, got {names:?}"
+    );
+}
+
+#[test]
+fn test_extract_helper_identifiers_ignores_non_curated_helpers() {
+    // `bcrypt`/`abort` are real Laravel helpers but outside the curated set —
+    // Intelephense owns them, so we must not capture them (the dedup policy).
+    let php_code = r#"<?php
+    bcrypt('secret');
+    abort(404);
+    collect([1, 2, 3]);
+    str('x')->upper();
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    assert!(
+        patterns.helper_identifiers.is_empty(),
+        "Non-curated helpers must not be captured, got {:?}",
+        patterns
+            .helper_identifiers
+            .iter()
+            .map(|h| h.name)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_extract_helper_identifiers_skips_method_and_static_calls() {
+    // Only bare global calls match — `$obj->route()` (member call) and
+    // `Router::route()` (static call) are different node kinds.
+    let php_code = r#"<?php
+    $router->route('home');
+    Router::route('home');
+    $app->config('x');
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    assert!(
+        patterns.helper_identifiers.is_empty(),
+        "Method / static calls must not match the global-helper pattern, got {:?}",
+        patterns
+            .helper_identifiers
+            .iter()
+            .map(|h| h.name)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_extract_helper_identifier_position_is_the_name_span() {
+    // The captured span is the identifier itself, not the string argument —
+    // hover must fire on `route`, not on `'home'`.
+    let php_code = "<?php\nroute('home');\n";
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    let route = patterns
+        .helper_identifiers
+        .iter()
+        .find(|h| h.name == "route")
+        .expect("route helper identifier");
+    assert_eq!(route.row, 1, "on the second line (0-based)");
+    assert_eq!(route.column, 0, "starts at column 0");
+    assert_eq!(route.end_column, 5, "ends after the 5-char name `route`");
+}

--- a/laravel-lsp/src/references.rs
+++ b/laravel-lsp/src/references.rs
@@ -102,10 +102,13 @@ pub fn classify_pattern_at_cursor(
         // Patterns that don't yet participate in cross-file references.
         // `MemberAccess` is captured (M2) but not yet resolved/classified —
         // it gets armed for find-references in M4.
+        // `HelperIdentifier` is a hover-only feature (#58) — no cross-file
+        // rename / find-references participation.
         PatternAtPosition::Asset(_)
         | PatternAtPosition::Url(_)
         | PatternAtPosition::Action(_)
         | PatternAtPosition::Feature(_)
+        | PatternAtPosition::HelperIdentifier(_)
         | PatternAtPosition::MemberAccess(_) => None,
     }
 }

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2530,6 +2530,19 @@ pub struct UrlReferenceData {
     pub end_column: u32,
 }
 
+/// Curated-helper-identifier reference data for transfer across async
+/// boundaries. `name` is one of the seven curated global helpers (`route`,
+/// `view`, `config`, `auth`, `app`, `session`, `cache`); the position spans the
+/// function-NAME token (`route` in `route('home')`), not its string argument.
+/// Drives the Laravel-aware helper hover card (#58).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct HelperReferenceData {
+    pub name: String,
+    pub line: u32,
+    pub column: u32,
+    pub end_column: u32,
+}
+
 /// Action reference data for transfer across async boundaries
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ActionReferenceData {
@@ -3417,6 +3430,17 @@ pub struct ParsedPatternsData {
     pub asset_refs: Vec<Arc<AssetReferenceData>>,
     pub binding_refs: Vec<Arc<BindingReferenceData>>,
     pub route_refs: Vec<Arc<RouteReferenceData>>,
+    /// Curated Laravel helper-function identifiers (`route`, `view`, `config`,
+    /// `auth`, `app`, `session`, `cache`) at their name span — drives the
+    /// helper hover card (#58). Like `route_refs`, extracted in
+    /// `handle_get_patterns` rather than as a `ParsedPatterns` Salsa field
+    /// (that struct is at the 12-element tuple-Hash cap).
+    ///
+    /// `#[serde(default)]` so disk-cache entries written by older builds (which
+    /// lacked this field) deserialize with an empty list rather than failing
+    /// the whole entry; the next edit re-runs extraction and repopulates.
+    #[serde(default)]
+    pub helper_refs: Vec<Arc<HelperReferenceData>>,
     pub url_refs: Vec<Arc<UrlReferenceData>>,
     pub action_refs: Vec<Arc<ActionReferenceData>>,
     pub feature_refs: Vec<Arc<FeatureReferenceData>>,
@@ -3482,6 +3506,12 @@ pub enum PatternAtPosition {
     Asset(Arc<AssetReferenceData>),
     Binding(Arc<BindingReferenceData>),
     Route(Arc<RouteReferenceData>),
+    /// A curated global helper-function identifier (`route`, `view`, `config`,
+    /// `auth`, `app`, `session`, `cache`) under the cursor. Carries the helper
+    /// name (via `HelperReferenceData.name`, per the issue's `{ name }` intent)
+    /// plus the position the index and `pattern_range_at` need — matching the
+    /// `Arc<…ReferenceData>` shape every sibling variant uses.
+    HelperIdentifier(Arc<HelperReferenceData>),
     Url(Arc<UrlReferenceData>),
     Action(Arc<ActionReferenceData>),
     Feature(Arc<FeatureReferenceData>),
@@ -3591,6 +3621,15 @@ impl ParsedPatternsData {
                 column: route.column,
                 end_column: route.end_column,
                 pattern: PatternAtPosition::Route(route.clone()),
+            });
+        }
+
+        for helper in &self.helper_refs {
+            entries.push(PositionEntry {
+                line: helper.line,
+                column: helper.column,
+                end_column: helper.end_column,
+                pattern: PatternAtPosition::HelperIdentifier(helper.clone()),
             });
         }
 
@@ -6242,6 +6281,7 @@ impl SalsaActor {
 
         let text = file.text(&self.db);
         let mut route_refs = Vec::new();
+        let mut helper_refs: Vec<Arc<HelperReferenceData>> = Vec::new();
         let mut url_refs = Vec::new();
         let mut action_refs = Vec::new();
         let mut feature_refs = Vec::new();
@@ -6266,6 +6306,15 @@ impl SalsaActor {
                             line: r.row as u32,
                             column: r.column as u32,
                             end_column: r.end_column as u32,
+                        }));
+                    }
+
+                    for h in php_patterns.helper_identifiers {
+                        helper_refs.push(Arc::new(HelperReferenceData {
+                            name: h.name.to_string(),
+                            line: h.row as u32,
+                            column: h.column as u32,
+                            end_column: h.end_column as u32,
                         }));
                     }
 
@@ -6382,6 +6431,26 @@ impl SalsaActor {
                     );
                     route_refs.push(Arc::new(RouteReferenceData {
                         name: r.route_name.to_string(),
+                        line,
+                        column: col,
+                        end_column: end_col,
+                    }));
+                }
+                for h in snippet_patterns.helper_identifiers {
+                    let (line, col) = adjust_inner_position(
+                        h.row as u32,
+                        h.column as u32,
+                        region.row,
+                        region.column,
+                    );
+                    let (_, end_col) = adjust_inner_position(
+                        h.row as u32,
+                        h.end_column as u32,
+                        region.row,
+                        region.column,
+                    );
+                    helper_refs.push(Arc::new(HelperReferenceData {
+                        name: h.name.to_string(),
                         line,
                         column: col,
                         end_column: end_col,
@@ -6521,6 +6590,7 @@ impl SalsaActor {
             asset_refs,
             binding_refs,
             route_refs,
+            helper_refs,
             url_refs,
             action_refs,
             feature_refs,

--- a/laravel-lsp/src/tests/helper_identifier_hover.rs
+++ b/laravel-lsp/src/tests/helper_identifier_hover.rs
@@ -1,0 +1,104 @@
+//! Behavior tests for curated helper-function identifier hover (#58).
+//!
+//! Exercises the full parse → position-index → card path the LSP runs: a PHP
+//! snippet is parsed via [`parse_owned`], the cursor is placed on a helper's
+//! NAME token, and the resolved pattern + rendered card are asserted. Mirrors
+//! the example call sites in the issue's acceptance criteria.
+
+use laravel_lsp::hover;
+use laravel_lsp::pattern_indexer::parse_owned;
+use laravel_lsp::salsa_impl::PatternAtPosition;
+use std::path::Path;
+
+/// Parse a `.php` snippet the way the warming path does.
+fn parse(src: &str) -> std::sync::Arc<laravel_lsp::salsa_impl::ParsedPatternsData> {
+    parse_owned(Path::new("/project/app/Http/Controllers/Demo.php"), src)
+}
+
+#[test]
+fn hovering_route_identifier_resolves_a_helper_card() {
+    // `route('home')` — cursor on the `route` name (col 2), not the argument.
+    let data = parse("<?php\nroute('home');\n");
+
+    let pattern = data
+        .find_at_position(1, 2)
+        .expect("a pattern under the `route` identifier");
+    let PatternAtPosition::HelperIdentifier(helper) = pattern else {
+        panic!("expected HelperIdentifier, got {pattern:?}");
+    };
+    assert_eq!(helper.name, "route");
+
+    let card = hover::helper_identifier_card(&helper.name, None)
+        .expect("route is curated, so a card renders");
+    assert!(card.contains("**route**"), "card headers the helper name");
+    assert!(
+        card.contains("named route"),
+        "card carries the Laravel-aware synopsis"
+    );
+}
+
+#[test]
+fn hovering_config_identifier_resolves_a_helper_card() {
+    // `config('app.name')` — cursor on the `config` name (col 3).
+    let data = parse("<?php\nconfig('app.name');\n");
+
+    let pattern = data
+        .find_at_position(1, 3)
+        .expect("a pattern under the `config` identifier");
+    let PatternAtPosition::HelperIdentifier(helper) = pattern else {
+        panic!("expected HelperIdentifier, got {pattern:?}");
+    };
+    assert_eq!(helper.name, "config");
+    assert!(hover::helper_identifier_card(&helper.name, None).is_some());
+}
+
+#[test]
+fn hovering_the_string_argument_is_not_a_helper_identifier() {
+    // The identifier and the string argument occupy disjoint spans. Cursor on
+    // `home` inside `route('home')` must resolve to the route reference, never
+    // the helper-identifier card.
+    let data = parse("<?php\nroute('home');\n");
+
+    // `route(` is 6 chars, then the opening quote, so `home` starts at col 7.
+    let pattern = data
+        .find_at_position(1, 8)
+        .expect("a pattern under the string argument");
+    assert!(
+        matches!(pattern, PatternAtPosition::Route(_)),
+        "string arg should be the route reference, got {pattern:?}"
+    );
+}
+
+#[test]
+fn hovering_a_non_curated_helper_yields_no_card() {
+    // `bcrypt(...)` is a real helper but outside the curated set — Intelephense
+    // owns it, so we index nothing and render no card.
+    let data = parse("<?php\nbcrypt('secret');\n");
+
+    assert!(
+        data.find_at_position(1, 3).is_none(),
+        "non-curated helper produces no indexed pattern"
+    );
+    assert!(
+        hover::helper_identifier_card("bcrypt", None).is_none(),
+        "non-curated helper renders no card"
+    );
+}
+
+#[test]
+fn helper_identifier_hover_works_in_blade_embedded_php() {
+    // `route('home')` inside a Blade echo — the identifier is still carded so
+    // hover works in templates, not just `.php` files.
+    let data = parse_owned(
+        Path::new("/project/resources/views/nav.blade.php"),
+        "<a href=\"{{ route('home') }}\">Home</a>\n",
+    );
+
+    let route = data
+        .helper_refs
+        .iter()
+        .find(|h| h.name == "route")
+        .expect("route helper identifier captured in Blade-embedded PHP");
+    // The card renders the same regardless of host file type.
+    assert!(hover::helper_identifier_card(&route.name, None).is_some());
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod code_lens_opt_in;
 mod diagnostic_severity;
 mod dynamic_where_sparseness;
 mod generic_type_parsing;
+mod helper_identifier_hover;
 mod livewire_component_resolution;
 mod loop_variable_resolution;
 mod rename_integration;


### PR DESCRIPTION
## Summary
Implements #58. Hovering a **curated Laravel global helper's name token** —
`route`, `view`, `config`, `auth`, `app`, `session`, `cache` — now shows a
Laravel-aware synopsis card with a source link, complementing Intelephense
rather than duplicating it. Previously hover fired only on the string
*argument* (`'home'` in `route('home')`), never the identifier itself.

Scope follows Inspector Lestrade's re-triage: the Eloquent/member items
(dynamic `where{Column}`, relationship hover, member `PatternAtPosition`
extension, member dedup) were already satisfied by #63/#76/#80 — this PR is
**helper-function identifier hover only**, with Q1→curated allow-list and
Q2→curated static map.

## Changes
- **queries/php.scm**: capture curated helper name tokens (`#any-of?` prefilter).
- **queries.rs**: `HelperIdentifierMatch` + extraction + count.
- **salsa_impl.rs**: `HelperReferenceData`, `helper_refs`, `PatternAtPosition::HelperIdentifier`, position index, PHP + Blade-embedded extraction, struct construction.
- **pattern_indexer.rs**: helper extraction for the cache-warming path.
- **hover.rs**: `HELPER_CARDS` curated static map + `helper_identifier_card`.
- **main.rs**: hover dispatch + `hover_for_helper` (file:// vs docs-URL link), `pattern_range_at` arm, goto arm (hover-only → no goto target).
- **references.rs**: helper identifiers don't participate in find-references.
- **docs/hover.md**: document the section, the allow-list, and the dedup rationale.

## Decisions worth a reviewer's eye
- **Variant shape.** The AC names `PatternAtPosition::HelperIdentifier { name: String }`. I used `HelperIdentifier(Arc<HelperReferenceData>)` (name + position) — every one of the 15 sibling variants follows that shape, and `pattern_range_at` / `build_position_index` need the position fields. `.name` preserves the AC's intent.
- **Vendor path: `Foundation/helpers.php`, not `Support/helpers.php`.** The AC wrote `Support/helpers.php`, but all seven curated helpers are actually defined in `Illuminate/Foundation/helpers.php` (`Support/helpers.php` holds `collect`/`str`/…). Linking to `Support` would point at a file that doesn't contain them. Using the correct file keeps the link honest; the docs-URL fallback is unchanged. Flagging for ratification.

## Acceptance Criteria
- [x] `PatternAtPosition::HelperIdentifier` variant in `salsa_impl.rs` (carries name, per AC intent — see note above)
- [x] Position/indexing path records each curated helper call-site's name token for the allow-list (`route`, `view`, `config`, `auth`, `app`, `session`, `cache`)
- [x] Curated static map (`HELPER_CARDS`) name → synopsis; dedup is structural (only the seven are indexed; no runtime Intelephense detection)
- [x] Source link → vendored framework `helpers.php` when present under the workspace root, else canonical `laravel.com/docs` URL
- [x] `hover::helper_identifier_card` using the existing `HoverContent` template (header = name, detail = synopsis, source_link from map)
- [x] `PatternAtPosition::HelperIdentifier` wired into hover dispatch
- [x] Unit tests: detection fires for each of the 7; not for non-curated (`bcrypt`, `abort`)
- [x] Integration/behavior tests: hovering `route` in `route('home')` and `config` in `config('app.name')` show a card; `bcrypt(…)` produces none
- [x] `docs/hover.md` updated (section, allow-list, dedup rationale)

## Test Plan
- [x] `cargo test --lib --bins` — 266 passed (incl. new query/hover/behavior tests)
- [x] `cargo fmt --check` clean, `cargo clippy` clean on new code
- [ ] CI green
- Pre-existing `tests/integration_tests.rs` failures (8) are unrelated: they require a gitignored `test-project/.env` fixture absent on a clean clone.

Fixes #58