### PR TITLE
feat: rename — Blade variable rename (scope-aware + cross-file from controller)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Each feature has a focused reference under [`docs/`](docs/) — click through to
 | [🔗 Go-to-Definition](docs/go-to-definition.md) | Jump to views, components, routes, config, translations, env, assets, middleware, bindings, Artisan commands — plus query-chain columns / relations / tables and Eloquent magic members |
 | [ℹ️ Hover](docs/hover.md) | Intelephense-style summary cards for every recognised pattern, including semantic cards for Eloquent magic (scopes, accessors, relationships, cast-aware column types) |
 | [🔍 Find References](docs/find-references.md) | Every call site across the project, vendor packages included — including the magic-member usages Intelephense can't see |
-| [✏️ Rename](docs/rename.md) | Atomic rename of routes, configs, translations, env vars, views, components, Livewire, middleware, bindings, PHP classes (models, controllers, jobs, services, form requests), magic members — and database columns, migration included |
+| [✏️ Rename](docs/rename.md) | Atomic rename of routes, configs, translations, env vars, views, components, Livewire, middleware, bindings, PHP classes (models, controllers, jobs, services, form requests), magic members, database columns (migration included) — and scope-aware Blade template variables, including the controller→view `view('x', ['key' => …])` / `compact('key')` binding linkage |
 | [🔢 Code Lens](docs/code-lens.md) | Opt-in reference counts above magic members, routes, config / translation / env keys, and Blade templates — plus an unused-symbol warning |
 | [💡 Autocomplete](docs/autocomplete.md) | Cast types, model properties, query chains, builder methods, Blade / loop / slot variables, Pennant flags |
 | [❌ Diagnostics](docs/diagnostics.md) | Missing views / components / features, invalid rules, query-chain typos against your real schema |
@@ -228,9 +228,8 @@ After saving, restart Intelephense (`Cmd+Shift+P → lsp: restart`). For the lic
 
 ## 🚧 Planned Features
 
-**Rename — remaining work** (the class-backed kinds, the FQCN class-rename engine across all common PHP class kinds, magic members, and database columns shipped; variables didn't):
+**Rename — remaining work** (the class-backed kinds, the FQCN class-rename engine across all common PHP class kinds, magic members, database columns, and scope-aware Blade template variables shipped; PHP function-local variables didn't):
 
-- 📝 **Blade variable rename** — scope-aware within a template (`@foreach`, `@php`, etc.), plus cross-file via the `view('x', ['key' => …])` / `compact('key')` linkage from controller into view.
 - 🔧 **PHP variable rename** — scope-aware function-local. Class properties (`$this->foo`) are out of scope for this round and folded into a future class-property rename.
 
 **Framework integrations:**

--- a/docs/rename.md
+++ b/docs/rename.md
@@ -2,7 +2,7 @@
 
 [← Back to README](../README.md)
 
-Press `F2` (or right-click → **"Rename Symbol"**) on a route name, config key, translation key, environment variable, view, Blade component, Livewire component, middleware alias, container binding, PHP class (Eloquent model, controller, job, service, form request, or any other project class), magic member (relationship / scope / accessor), or database column. The extension rewrites every call site AND the declaration site (or moves the backing file, or generates the migration) in one atomic operation.
+Press `F2` (or right-click → **"Rename Symbol"**) on a route name, config key, translation key, environment variable, view, Blade component, Livewire component, middleware alias, container binding, PHP class (Eloquent model, controller, job, service, form request, or any other project class), magic member (relationship / scope / accessor), database column, scope-aware Blade template variable, or controller→view binding key. The extension rewrites every call site AND the declaration site (or moves the backing file, or generates the migration) in one atomic operation.
 
 You can also right-click a `.blade.php` file in Zed's file explorer → **Rename** → call sites update atomically with the file move.
 
@@ -104,10 +104,33 @@ The transforms run both ways: `active` ↔ `scopeActive`, `full_name` ↔ `getFu
 3. **Model array entries** — the `'email'` string in `$fillable`, `$casts`, `$hidden`, `$guarded`, `$dates`.
 4. **Query-chain column literals project-wide** — `where('email', …)`, `orderBy('email')`, `pluck('email')`, … rewritten *only* when the chain resolves to the column's table (with an enclosing-model fallback for local scopes). A qualified literal `'users.email'` rewrites only the `email` segment and only when the qualifier matches; the database itself is never touched — you review the diff, then run the migration.
 
+**Blade template variables** rename scope-aware, straight from the `.blade.php` file. Press `F2` on a `$variable` and only the occurrences in its *actual* scope are rewritten:
+
+```blade
+{{-- F2 on $item inside the loop renames only the loop's $item --}}
+@foreach ($items as $item)
+    {{ $item->name }}      {{-- renamed --}}
+@endforeach
+{{ $item }}                {{-- an unrelated, file-level $item — left alone --}}
+```
+
+A variable introduced by `@foreach` / `@forelse` / `@for` is block-scoped — the rewrite stops at the loop's open/close directives, and a nested loop that re-binds the same name is treated as a separate scope (rename one without clobbering the other). A variable that *isn't* loop-introduced (a controller-passed view variable, an inline `@php $x = …; @endphp`) is file-scoped, but still skips any nested loop that shadows the name. Occurrences inside `{{-- … --}}` comments and `@verbatim` blocks are never touched.
+
+**Controller → view binding rename** follows the data linkage so the key and its in-view usages move together. Press `F2` on the binding key in a controller:
+
+```php
+// F2 on 'name' in the controller:
+return view('users.profile', ['name' => $user->name]);
+//                             ^^^^ renamed to 'fullName'
+// → resources/views/users/profile.blade.php: every file-scoped $name becomes $fullName
+```
+
+The same works for `view('users.profile', compact('name'))` — the `compact('name')` string AND the enclosing method's local `$name` are renamed alongside the in-view usages, so the controller stays valid (compact binds the view key *by the local's name*). When a view is rendered from several controllers under different key names, each rename touches only its own key's usages — different key names never cross-contaminate. The array value expression (`$user->name` above) is the controller's own data and is left untouched.
+
 > ⚠️ **Intelephense overlap on relationship renames.** A relationship's usage name equals its method name, so Intelephense *also* understands `posts()` as a renameable method — on F2 both language servers may contribute edits for the declaration and the call-form sites. Scopes, accessors, and columns don't overlap (Intelephense can't connect `->active()` to `scopeActive()`), so this extension owns those cleanly. There's no surgical way to disable just Intelephense's rename — it has no `rename.enable` setting, and Zed has no per-capability toggle — though `intelephense.rename.exclude` can narrow its scope by glob. Tracked in [#74](https://github.com/mike-bronner/zed-laravel/issues/74).
 
 **Same parser-classified guarantee as [Find References](find-references.md)** — only positions the parser has tagged as the matching kind are mutated. A random string `'home'` in an unrelated literal is never touched.
 
 **Vendor-located files refuse to rename** — never moves a Composer-installed view, component, or Livewire class, and never rewrites a middleware alias or binding registered inside `vendor/`. You'll see a toast explaining why instead of a silent no-op.
 
-**Not yet renameable** (out of scope for this round, planned follow-up): Blade variables (`@foreach`, `@php` locals + the `view('x', ['key' => …])` / `compact('key')` linkage), PHP function-local variables. `prepare_rename` returns nothing for these so F2 silently does nothing.
+**Not yet renameable** (out of scope for this round, planned follow-up): PHP function-local variables (a plain `$local` in a controller method that isn't a view-binding key), and class properties (`$this->foo`). `prepare_rename` returns nothing for these so F2 silently does nothing.

--- a/laravel-lsp/src/blade_loops.rs
+++ b/laravel-lsp/src/blade_loops.rs
@@ -36,15 +36,21 @@ pub enum BladeLoopType {
 
 /// Parse variables from `@foreach` / `@forelse` directive arguments.
 /// Handles: `@foreach($items as $item)`, `@foreach($items as $key => $value)`,
-/// `@foreach($category->items as $item)`.
+/// `@foreach($category->items as $item)`, and iterables containing their own
+/// parens — `@foreach($users->where('active', true) as $user)`.
 pub fn parse_foreach_variables(arguments: &str) -> Vec<(String, String)> {
     lazy_static! {
-        static ref FOREACH_RE: Regex =
-            Regex::new(r#"\([^)]+\s+as\s+(?:\$(\w+)\s*=>\s*)?\$(\w+)\s*\)"#).unwrap();
+        // Match only the binding (right of the LAST ` as `), so a parenthesized
+        // iterable in the arg list can't truncate the capture.
+        static ref BINDING_RE: Regex =
+            Regex::new(r#"^\s*(?:\$(\w+)\s*=>\s*)?\$(\w+)\s*$"#).unwrap();
     }
 
     let mut vars = Vec::new();
-    if let Some(caps) = FOREACH_RE.captures(arguments) {
+    let Some(binding) = foreach_binding(arguments) else {
+        return vars;
+    };
+    if let Some(caps) = BINDING_RE.captures(binding) {
         if let Some(key_match) = caps.get(1) {
             vars.push((key_match.as_str().to_string(), "mixed".to_string()));
         }
@@ -56,16 +62,32 @@ pub fn parse_foreach_variables(arguments: &str) -> Vec<(String, String)> {
 }
 
 /// Parse the iterable expression from `@foreach` / `@forelse` arguments.
-/// e.g. `($this->audits as $audit)` -> `Some("$this->audits")`.
+/// e.g. `($this->audits as $audit)` -> `Some("$this->audits")`,
+/// `($users->where('active', true) as $user)` -> `Some("$users->where('active', true)")`.
 pub fn parse_foreach_iterable(arguments: &str) -> Option<String> {
-    lazy_static! {
-        static ref ITER_RE: Regex = Regex::new(r#"\(\s*(.+?)\s+as\s+\$"#).unwrap();
-    }
+    strip_outer_parens(arguments.trim())
+        .rsplit_once(" as ")
+        .map(|(iterable, _)| iterable.trim().to_string())
+}
 
-    ITER_RE
-        .captures(arguments)
-        .and_then(|c| c.get(1))
-        .map(|m| m.as_str().trim().to_string())
+/// Return the binding portion (right of the LAST ` as `) of a foreach argument
+/// list. Splitting on the last keyword — rather than regex-capturing the
+/// iterable with a `[^)]` run — keeps iterables that contain their own parens
+/// or `as` (method calls like `$users->where('active', true)`) intact, so the
+/// loop variable is still recovered. `None` when the directive has no ` as `.
+fn foreach_binding(arguments: &str) -> Option<&str> {
+    strip_outer_parens(arguments.trim())
+        .rsplit_once(" as ")
+        .map(|(_, binding)| binding)
+}
+
+/// Strip a single matching outer parenthesis pair, if both are present.
+/// Only the outermost pair is removed, so nested parens inside the iterable are
+/// preserved.
+fn strip_outer_parens(s: &str) -> &str {
+    s.strip_prefix('(')
+        .and_then(|inner| inner.strip_suffix(')'))
+        .unwrap_or(s)
 }
 
 /// Parse variables from `@for` directive arguments.
@@ -84,12 +106,78 @@ pub fn parse_for_variables(arguments: &str) -> Vec<(String, String)> {
     vars
 }
 
+/// Find every loop directive on a single line, returning
+/// `(directive_keyword, full_argument_substring_including_parens)` for each.
+///
+/// The argument list is captured by *balancing* parentheses rather than a
+/// `\([^)]*\)` regex, which stops at the first `)`. Without balancing, an
+/// iterable containing a call — `@foreach($users->where('active', true) as
+/// $user)` — truncates to `($users->where('active', true)`, the ` as $user`
+/// tail is lost, and the loop's variable goes unrecognized. That made the loop
+/// scope invisible and the rename clobber the whole file (issue #55). Parens
+/// inside single/double-quoted strings are ignored so a string argument can't
+/// throw off the depth count.
+fn loop_directives_on_line(line: &str) -> Vec<(&str, &str)> {
+    lazy_static! {
+        static ref LOOP_HEAD_RE: Regex =
+            Regex::new(r#"@(foreach|forelse|for|while)\s*\("#).unwrap();
+    }
+
+    let mut out = Vec::new();
+    for caps in LOOP_HEAD_RE.captures_iter(line) {
+        let Some(directive) = caps.get(1) else {
+            continue;
+        };
+        // The opening paren is the final byte of the whole match.
+        let open = caps.get(0).unwrap().end() - 1;
+        if let Some(close) = matching_paren(line, open) {
+            out.push((directive.as_str(), &line[open..=close]));
+        }
+    }
+    out
+}
+
+/// Given the byte index of an opening `(` in `s`, return the byte index of its
+/// matching `)`, balancing nested parens and ignoring any parens that sit
+/// inside single- or double-quoted string literals. Returns `None` when the
+/// parens are unbalanced on this line. `(`, `)`, `'`, `"`, `\` are ASCII, so
+/// the returned indices always land on char boundaries.
+fn matching_paren(s: &str, open: usize) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut depth = 0usize;
+    let mut quote: Option<u8> = None;
+    let mut i = open;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match quote {
+            Some(q) => {
+                if c == b'\\' {
+                    i += 1; // skip the escaped byte
+                } else if c == q {
+                    quote = None;
+                }
+            }
+            None => match c {
+                b'\'' | b'"' => quote = Some(c),
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(i);
+                    }
+                }
+                _ => {}
+            },
+        }
+        i += 1;
+    }
+    None
+}
+
 /// Find all loop blocks in Blade content and their boundaries.
 /// Returns a list of loop blocks with start/end lines and extracted variables.
 pub fn find_loop_blocks(content: &str) -> Vec<BladeLoopBlock> {
     lazy_static! {
-        static ref LOOP_START_RE: Regex =
-            Regex::new(r#"@(foreach|forelse|for|while)\s*(\([^)]*\))"#).unwrap();
         static ref LOOP_END_RE: Regex =
             Regex::new(r#"@(endforeach|endforelse|endfor|endwhile)"#).unwrap();
     }
@@ -99,10 +187,7 @@ pub fn find_loop_blocks(content: &str) -> Vec<BladeLoopBlock> {
         Vec::new();
 
     for (line_idx, line) in content.lines().enumerate() {
-        for caps in LOOP_START_RE.captures_iter(line) {
-            let directive = caps.get(1).map(|m| m.as_str()).unwrap_or("");
-            let arguments = caps.get(2).map(|m| m.as_str()).unwrap_or("");
-
+        for (directive, arguments) in loop_directives_on_line(line) {
             let (loop_type, variables, iterable) = match directive {
                 "foreach" => (
                     BladeLoopType::Foreach,

--- a/laravel-lsp/src/blade_loops.rs
+++ b/laravel-lsp/src/blade_loops.rs
@@ -34,31 +34,35 @@ pub enum BladeLoopType {
     While,
 }
 
-/// Parse variables from `@foreach` / `@forelse` directive arguments.
-/// Handles: `@foreach($items as $item)`, `@foreach($items as $key => $value)`,
-/// `@foreach($category->items as $item)`, and iterables containing their own
-/// parens — `@foreach($users->where('active', true) as $user)`.
+/// Parse the bound variables from `@foreach` / `@forelse` directive arguments —
+/// every name the loop introduces, in source order.
+///
+/// A foreach target (right of the last ` as `) is a PHP *lvalue*: it has no
+/// method calls or expressions, so every `$ident` token in it IS a bound
+/// variable. Extracting them all — rather than matching one fixed shape — covers
+/// every binding form with one rule:
+/// - plain `$item` → `[item]`
+/// - key/value `$key => $value` → `[key, value]`
+/// - by-reference `&$item` → `[item]` (the `&` carries no name)
+/// - list destructuring `[$a, $b]` / `list($a, $b)` → `[a, b]`
+/// - key + destructured value `$k => [$a, $b]` → `[k, a, b]`
+///
+/// A binding the parser can't see any `$ident` in (a truncated/garbled header)
+/// yields an empty list — the caller treats such a foreach/forelse as an
+/// *opaque* loop and refuses the rename rather than guessing its scope.
 pub fn parse_foreach_variables(arguments: &str) -> Vec<(String, String)> {
     lazy_static! {
-        // Match only the binding (right of the LAST ` as `), so a parenthesized
-        // iterable in the arg list can't truncate the capture.
-        static ref BINDING_RE: Regex =
-            Regex::new(r#"^\s*(?:\$(\w+)\s*=>\s*)?\$(\w+)\s*$"#).unwrap();
+        static ref BOUND_VAR_RE: Regex = Regex::new(r#"\$(\w+)"#).unwrap();
     }
 
-    let mut vars = Vec::new();
     let Some(binding) = foreach_binding(arguments) else {
-        return vars;
+        return Vec::new();
     };
-    if let Some(caps) = BINDING_RE.captures(binding) {
-        if let Some(key_match) = caps.get(1) {
-            vars.push((key_match.as_str().to_string(), "mixed".to_string()));
-        }
-        if let Some(value_match) = caps.get(2) {
-            vars.push((value_match.as_str().to_string(), "mixed".to_string()));
-        }
-    }
-    vars
+    BOUND_VAR_RE
+        .captures_iter(binding)
+        .filter_map(|caps| caps.get(1))
+        .map(|m| (m.as_str().to_string(), "mixed".to_string()))
+        .collect()
 }
 
 /// Parse the iterable expression from `@foreach` / `@forelse` arguments.
@@ -184,12 +188,18 @@ fn matching_paren(s: &str, open: usize) -> Option<usize> {
     None
 }
 
+lazy_static! {
+    /// A loop directive head — `@foreach`/`@forelse`/`@for`/`@while` up to and
+    /// including its opening `(`. Shared by block parsing and broken-header
+    /// detection.
+    static ref LOOP_HEAD_RE: Regex =
+        Regex::new(r#"@(foreach|forelse|for|while)\s*\("#).unwrap();
+}
+
 /// Find all loop blocks in Blade content and their boundaries.
 /// Returns a list of loop blocks with start/end lines and extracted variables.
 pub fn find_loop_blocks(content: &str) -> Vec<BladeLoopBlock> {
     lazy_static! {
-        static ref LOOP_HEAD_RE: Regex =
-            Regex::new(r#"@(foreach|forelse|for|while)\s*\("#).unwrap();
         static ref LOOP_END_RE: Regex =
             Regex::new(r#"@(endforeach|endforelse|endfor|endwhile)"#).unwrap();
     }
@@ -268,6 +278,29 @@ pub fn find_loop_blocks(content: &str) -> Vec<BladeLoopBlock> {
     }
 
     blocks
+}
+
+/// 0-based line of every loop directive head whose parenthesised argument list
+/// never balances — a syntactically broken header (typically a missing `)`).
+/// [`find_loop_blocks`] silently drops such a head (it can't form a block), so
+/// the scope structure below it is unreliable. The scope-aware rename uses this
+/// to fail closed — treating everything from a broken header onward as
+/// unresolved — rather than renaming file-wide. A header that merely *wraps*
+/// across lines still balances (via [`balanced_directive_arguments`]) and is
+/// never flagged; only genuinely unclosed parens are.
+pub fn unbalanced_loop_head_lines(content: &str) -> Vec<usize> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut out = Vec::new();
+    for line_idx in 0..lines.len() {
+        for caps in LOOP_HEAD_RE.captures_iter(lines[line_idx]) {
+            let open = caps.get(0).unwrap().end() - 1;
+            if balanced_directive_arguments(&lines, line_idx, open).is_none() {
+                out.push(line_idx);
+                break;
+            }
+        }
+    }
+    out
 }
 
 /// Get all loop blocks that enclose the given cursor position.

--- a/laravel-lsp/src/blade_loops.rs
+++ b/laravel-lsp/src/blade_loops.rs
@@ -106,35 +106,45 @@ pub fn parse_for_variables(arguments: &str) -> Vec<(String, String)> {
     vars
 }
 
-/// Find every loop directive on a single line, returning
-/// `(directive_keyword, full_argument_substring_including_parens)` for each.
+/// The balanced `(…)` argument list of a loop directive whose opening `(` is at
+/// byte `open` on line `start_line`, joining continuation lines when the header
+/// wraps across physical lines. Returns the argument substring **including** the
+/// outer parens (interior runs of whitespace between joined lines collapsed to a
+/// single space), or `None` if the parens never balance before end of file.
 ///
-/// The argument list is captured by *balancing* parentheses rather than a
-/// `\([^)]*\)` regex, which stops at the first `)`. Without balancing, an
-/// iterable containing a call — `@foreach($users->where('active', true) as
-/// $user)` — truncates to `($users->where('active', true)`, the ` as $user`
-/// tail is lost, and the loop's variable goes unrecognized. That made the loop
-/// scope invisible and the rename clobber the whole file (issue #55). Parens
-/// inside single/double-quoted strings are ignored so a string argument can't
-/// throw off the depth count.
-fn loop_directives_on_line(line: &str) -> Vec<(&str, &str)> {
-    lazy_static! {
-        static ref LOOP_HEAD_RE: Regex =
-            Regex::new(r#"@(foreach|forelse|for|while)\s*\("#).unwrap();
+/// Two reasons the parens must be balanced rather than regex-captured:
+/// - An iterable containing a call — `@foreach($users->where('active', true) as
+///   $user)` — would truncate at the first `)` under a `\([^)]*\)` regex, losing
+///   the ` as $user` tail.
+/// - A long header is routinely broken across lines:
+///   `@foreach($users->where('active', true)` ⏎ `    as $user)`. A per-line scan
+///   gives up at the first line end.
+///
+/// In both cases the binding goes unrecognized, the loop scope turns invisible,
+/// and a rename inside it silently clobbers the whole file — the file-scope
+/// fallback admits every occurrence (issue #55). Parens inside single/double-
+/// quoted strings are ignored so a string argument can't throw off the depth
+/// count. Reads forward only as far as needed for the depth to return to zero.
+fn balanced_directive_arguments(lines: &[&str], start_line: usize, open: usize) -> Option<String> {
+    // Fast path: balanced on the opening line — the overwhelmingly common case.
+    // Returns the exact source slice, byte-for-byte as the old per-line scan did.
+    if let Some(close) = matching_paren(lines[start_line], open) {
+        return Some(lines[start_line][open..=close].to_string());
     }
 
-    let mut out = Vec::new();
-    for caps in LOOP_HEAD_RE.captures_iter(line) {
-        let Some(directive) = caps.get(1) else {
-            continue;
-        };
-        // The opening paren is the final byte of the whole match.
-        let open = caps.get(0).unwrap().end() - 1;
-        if let Some(close) = matching_paren(line, open) {
-            out.push((directive.as_str(), &line[open..=close]));
+    // Slow path: the header wraps. Accumulate continuation lines (joined by a
+    // single space, so a binding split as `… as` ⏎ `$user` still parses) until
+    // the parens balance.
+    let mut buf = lines[start_line][open..].to_string();
+    for line in &lines[start_line + 1..] {
+        buf.push(' ');
+        buf.push_str(line.trim_start());
+        if let Some(close) = matching_paren(&buf, 0) {
+            buf.truncate(close + 1);
+            return Some(buf);
         }
     }
-    out
+    None
 }
 
 /// Given the byte index of an opening `(` in `s`, return the byte index of its
@@ -178,28 +188,41 @@ fn matching_paren(s: &str, open: usize) -> Option<usize> {
 /// Returns a list of loop blocks with start/end lines and extracted variables.
 pub fn find_loop_blocks(content: &str) -> Vec<BladeLoopBlock> {
     lazy_static! {
+        static ref LOOP_HEAD_RE: Regex =
+            Regex::new(r#"@(foreach|forelse|for|while)\s*\("#).unwrap();
         static ref LOOP_END_RE: Regex =
             Regex::new(r#"@(endforeach|endforelse|endfor|endwhile)"#).unwrap();
     }
 
+    let lines: Vec<&str> = content.lines().collect();
     let mut blocks = Vec::new();
     let mut open_loops: Vec<(BladeLoopType, Vec<(String, String)>, Option<String>, usize)> =
         Vec::new();
 
-    for (line_idx, line) in content.lines().enumerate() {
-        for (directive, arguments) in loop_directives_on_line(line) {
-            let (loop_type, variables, iterable) = match directive {
+    for line_idx in 0..lines.len() {
+        let line = lines[line_idx];
+        for caps in LOOP_HEAD_RE.captures_iter(line) {
+            let Some(directive) = caps.get(1) else {
+                continue;
+            };
+            // The opening paren is the final byte of the whole match; the
+            // argument list may continue onto following lines.
+            let open = caps.get(0).unwrap().end() - 1;
+            let Some(arguments) = balanced_directive_arguments(&lines, line_idx, open) else {
+                continue;
+            };
+            let (loop_type, variables, iterable) = match directive.as_str() {
                 "foreach" => (
                     BladeLoopType::Foreach,
-                    parse_foreach_variables(arguments),
-                    parse_foreach_iterable(arguments),
+                    parse_foreach_variables(&arguments),
+                    parse_foreach_iterable(&arguments),
                 ),
                 "forelse" => (
                     BladeLoopType::Forelse,
-                    parse_foreach_variables(arguments),
-                    parse_foreach_iterable(arguments),
+                    parse_foreach_variables(&arguments),
+                    parse_foreach_iterable(&arguments),
                 ),
-                "for" => (BladeLoopType::For, parse_for_variables(arguments), None),
+                "for" => (BladeLoopType::For, parse_for_variables(&arguments), None),
                 "while" => (BladeLoopType::While, Vec::new(), None),
                 _ => continue,
             };

--- a/laravel-lsp/src/blade_var_rename.rs
+++ b/laravel-lsp/src/blade_var_rename.rs
@@ -1,0 +1,549 @@
+//! Scope-aware Blade variable rename, plus controller→view binding rename.
+//!
+//! Two linked capabilities sit on top of the existing rename engine:
+//!
+//! 1. **Scope-aware rename within a template.** Renaming `$foo` inside a
+//!    `.blade.php` file rewrites only the occurrences in `$foo`'s *actual*
+//!    scope. A variable introduced by `@foreach ($items as $foo)` (or
+//!    `@forelse` / `@for`) is treated as block-scoped: renaming it touches
+//!    only occurrences between the loop's open and close directives, and
+//!    never an unrelated `$foo` elsewhere in the file. A variable that is
+//!    *not* loop-introduced (a controller-passed view variable, an inline
+//!    `@php $foo = …; @endphp`) is file-scoped — but a renamed file-scoped
+//!    `$foo` still skips any nested loop block that *re-binds* `$foo`, since
+//!    that inner `$foo` is a different variable (the "nested scope conflict"
+//!    rule).
+//!
+//! 2. **Cross-file rename from controller into view.** Renaming a view-data
+//!    binding key — `view('users.profile', ['name' => $name])` or
+//!    `compact('name')` — rewrites the binding key *and* the in-view `$name`
+//!    usages in lockstep. For `compact('name')` the controller's own local
+//!    `$name` (within the enclosing function) is renamed too, because compact
+//!    binds the view key *by the local's name* — leaving it behind would
+//!    produce a `compact('newname')` with no matching `$newname` local.
+//!
+//! Positions are **0-based** throughout, matching the rest of the stack
+//! (tree-sitter `Point`, LSP `Position`, every match struct). A [`VarSpan`]
+//! covers the identifier *name only* — the leading `$` (for variables) or the
+//! surrounding quotes (for binding-key strings) are deliberately excluded, so
+//! a `TextEdit` over the span swaps just the name and leaves the sigil intact.
+//!
+//! The Blade side is line/regex based (consistent with [`crate::blade_loops`]
+//! and [`crate::blade_php_block`]); the controller side is tree-sitter based
+//! (consistent with [`crate::view_var_index`]). Both sides are pure functions
+//! over source text so the wiring in `main.rs` owns all path resolution and
+//! I/O, and every rule here is unit-testable without the LSP harness.
+
+use tree_sitter::Node;
+
+use crate::blade_loops::find_loop_blocks;
+use crate::parser::parse_php;
+
+/// A 0-based span of an identifier name to rewrite. `start_col`..`end_col`
+/// covers the name only — for a `$foo` variable it starts *after* the `$`;
+/// for a `'key'` binding string it starts *inside* the opening quote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VarSpan {
+    pub line: u32,
+    pub start_col: u32,
+    pub end_col: u32,
+}
+
+impl VarSpan {
+    fn new(line: u32, start_col: u32, end_col: u32) -> Self {
+        Self {
+            line,
+            start_col,
+            end_col,
+        }
+    }
+}
+
+/// Strip a leading `$` a user may have typed into the rename box (Zed/editors
+/// pre-fill the name without the sigil, but a pasted `$bar` should still work)
+/// and trim surrounding whitespace. The bare identifier is what gets written
+/// at a variable span (the `$` already lives in the source) and inside a
+/// binding-key string.
+pub fn normalize_new_var_name(new_name: &str) -> String {
+    new_name.trim().trim_start_matches('$').to_string()
+}
+
+/// Validate that `name` is a legal PHP variable / array-key identifier:
+/// a letter or `_` followed by letters, digits, or `_`. Rename should reject
+/// anything else rather than emit edits that produce invalid source.
+pub fn is_valid_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+// ── Blade side: scope-aware variable spans ────────────────────────────────
+
+/// Every `$name` variable occurrence in a Blade template, as name-only spans,
+/// excluding occurrences inside Blade comments (`{{-- … --}}`) and
+/// `@verbatim … @endverbatim` regions. Property accesses (`$x->name`) are not
+/// matched — only the variable token itself, because `$name` and `$x->name`
+/// are different identifiers.
+pub fn variable_spans(source: &str, name: &str) -> Vec<VarSpan> {
+    if !is_valid_identifier(name) {
+        return Vec::new();
+    }
+    let masked = mask_non_code(source);
+    let pattern = match regex::Regex::new(&format!(r"\${}\b", regex::escape(name))) {
+        Ok(re) => re,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut spans = Vec::new();
+    for (line_idx, line) in masked.lines().enumerate() {
+        for m in pattern.find_iter(line) {
+            // `m` covers `$name`; the rewritable span is the name only,
+            // so advance past the leading `$`.
+            let start = (m.start() + 1) as u32;
+            let end = m.end() as u32;
+            spans.push(VarSpan::new(line_idx as u32, start, end));
+        }
+    }
+    spans
+}
+
+/// Replace the bytes of Blade comments and `@verbatim` regions with spaces,
+/// preserving newlines and overall length so that byte offsets — and hence
+/// line/column positions — are unchanged. Variable scanning runs over the
+/// masked copy so a `$foo` inside `{{-- $foo --}}` is never rewritten.
+fn mask_non_code(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut out: Vec<u8> = bytes.to_vec();
+
+    // Blade comments: `{{-- … --}}` (may span lines, non-nesting).
+    mask_delimited(source, &mut out, "{{--", "--}}");
+    // `@verbatim … @endverbatim`: Blade emits the body literally, so any
+    // `$foo` inside is template text, not a live variable.
+    mask_delimited(source, &mut out, "@verbatim", "@endverbatim");
+
+    // `out` only ever had non-newline bytes replaced with spaces, so it
+    // remains valid UTF-8 (we never split a multi-byte char: the delimiters
+    // are ASCII and we blank ASCII-or-continuation bytes uniformly to b' '
+    // only between ASCII delimiters — see the guard in `mask_delimited`).
+    String::from_utf8(out).unwrap_or_else(|_| source.to_string())
+}
+
+/// Blank (replace with spaces, keeping `\n`) every region of `source` from an
+/// `open` delimiter to the next `close` delimiter, inclusive. Operates on the
+/// shared `out` buffer in place.
+fn mask_delimited(source: &str, out: &mut [u8], open: &str, close: &str) {
+    let mut search_from = 0;
+    while let Some(rel) = source[search_from..].find(open) {
+        let start = search_from + rel;
+        let after_open = start + open.len();
+        let end = match source[after_open..].find(close) {
+            Some(rel_end) => after_open + rel_end + close.len(),
+            None => source.len(), // unclosed: mask to end of file
+        };
+        for b in out.iter_mut().take(end).skip(start) {
+            if *b != b'\n' {
+                *b = b' ';
+            }
+        }
+        search_from = end;
+    }
+}
+
+/// The set of variable spans a rename should rewrite when the user invokes
+/// rename on the `$name` occurrence at `cursor_line` in a Blade template.
+///
+/// Scope resolution:
+/// - If `cursor_line` falls inside the innermost `@foreach`/`@forelse`/`@for`
+///   block that *introduces* `name`, the rename is scoped to that block's
+///   `[start_line, end_line]` (inclusive of both directive lines).
+/// - Otherwise the rename is file-scoped.
+///
+/// In both cases, spans that fall inside a more-deeply-nested loop block that
+/// *re-binds* `name` are excluded — that inner `$name` is a distinct variable
+/// (nested scope conflict). The returned spans always include the cursor's own
+/// occurrence and are sorted by position.
+pub fn in_scope_spans(source: &str, name: &str, cursor_line: u32) -> Vec<VarSpan> {
+    let all = variable_spans(source, name);
+    if all.is_empty() {
+        return all;
+    }
+
+    let binding_blocks = loop_binding_ranges(source, name);
+
+    // The cursor's binding scope: the innermost (largest start_line) binding
+    // block that contains the cursor line. `None` ⇒ file scope.
+    let cursor_scope: Option<(u32, u32)> = binding_blocks
+        .iter()
+        .filter(|(start, end)| cursor_line >= *start && cursor_line <= *end)
+        .max_by_key(|(start, _)| *start)
+        .copied();
+
+    all.into_iter()
+        .filter(|span| {
+            match cursor_scope {
+                // Loop-scoped: keep spans inside the binding block, but drop
+                // any that sit in a strictly-nested block that re-binds `name`.
+                Some((start, end)) => {
+                    if span.line < start || span.line > end {
+                        return false;
+                    }
+                    !in_nested_shadow(span.line, (start, end), &binding_blocks)
+                }
+                // File-scoped: keep every span EXCEPT those that belong to a
+                // loop block that binds `name` (a separate scope).
+                None => !binding_blocks
+                    .iter()
+                    .any(|(start, end)| span.line >= *start && span.line <= *end),
+            }
+        })
+        .collect()
+}
+
+/// File-scoped variable spans: every `$name` occurrence EXCEPT those inside a
+/// loop block that re-binds `name`. This is the set a controller→view rename
+/// rewrites in the template — a controller-passed variable is file-scoped, but
+/// must never clobber a loop's same-named iteration variable (a distinct
+/// scope). Equivalent to [`in_scope_spans`] for a cursor that sits outside
+/// every binding block.
+pub fn file_scope_spans(source: &str, name: &str) -> Vec<VarSpan> {
+    let all = variable_spans(source, name);
+    if all.is_empty() {
+        return all;
+    }
+    let binding_blocks = loop_binding_ranges(source, name);
+    all.into_iter()
+        .filter(|span| {
+            !binding_blocks
+                .iter()
+                .any(|(start, end)| span.line >= *start && span.line <= *end)
+        })
+        .collect()
+}
+
+/// Inclusive `[start_line, end_line]` ranges of every loop block that binds a
+/// variable named `name`. An unclosed loop extends to `u32::MAX`.
+fn loop_binding_ranges(source: &str, name: &str) -> Vec<(u32, u32)> {
+    find_loop_blocks(source)
+        .iter()
+        .filter(|b| b.variables.iter().any(|(v, _)| v == name))
+        .map(|b| {
+            let start = b.start_line as u32;
+            let end = b.end_line.map(|e| e as u32).unwrap_or(u32::MAX);
+            (start, end)
+        })
+        .collect()
+}
+
+/// True if `line` falls inside a binding block that is strictly nested within
+/// `outer` (i.e. a different block whose range is contained in `outer`). Used
+/// to carve nested shadows out of a loop-scoped rename.
+fn in_nested_shadow(line: u32, outer: (u32, u32), binding_blocks: &[(u32, u32)]) -> bool {
+    binding_blocks.iter().any(|&(start, end)| {
+        let is_outer = start == outer.0 && end == outer.1;
+        let nested_within_outer = start >= outer.0 && end <= outer.1;
+        !is_outer && nested_within_outer && line >= start && line <= end
+    })
+}
+
+// ── Controller side: view-data binding key under the cursor ───────────────
+
+/// How a view variable was bound at the controller render site. Determines the
+/// extra controller-local edits a key rename needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingForm {
+    /// `view('v', ['key' => $expr])` or `->with(['key' => $expr])`. The value
+    /// expression is independent of the key, so only the key string moves.
+    ArrayKey,
+    /// `compact('key')`. The key *is* the controller-local variable name, so
+    /// the enclosing-function local `$key` is renamed alongside the string.
+    Compact,
+}
+
+/// A view-data binding key located under the cursor in a controller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ViewBinding {
+    /// The rendered view name (`users.profile`), for resolving the template.
+    pub view_name: String,
+    /// The current binding key / view-variable name (`name`).
+    pub key: String,
+    /// Span of the key text inside its quotes — the rewrite target.
+    pub key_span: VarSpan,
+    pub form: BindingForm,
+}
+
+/// If the cursor sits on the **key** of a view-data binding in a PHP
+/// controller, return the binding. Recognized shapes (cursor on the key):
+/// - `view('users.profile', ['name' => $expr])`
+/// - `view('users.profile', compact('name'))`
+/// - `view('users.profile')->with(['name' => $expr])`
+/// - `view('users.profile')->with('name', $expr)`
+///
+/// Returns `None` when the cursor is anywhere else (the view name, a value
+/// expression, an unrelated string), or when the view name can't be resolved
+/// to a single string literal.
+pub fn view_binding_key_at(php_source: &str, line: u32, col: u32) -> Option<ViewBinding> {
+    let tree = parse_php(php_source).ok()?;
+    let bytes = php_source.as_bytes();
+    let root = tree.root_node();
+
+    // Collect every `view(...)` call with a resolvable view name, then probe
+    // its data argument(s) for a key string under the cursor.
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "function_call_expression" {
+            if let Some(binding) = binding_in_view_call(node, bytes, line, col) {
+                return Some(binding);
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+    None
+}
+
+/// Probe a single `view(...)` call expression (and any chained `->with(...)`)
+/// for a binding key under the cursor.
+fn binding_in_view_call(call: Node, bytes: &[u8], line: u32, col: u32) -> Option<ViewBinding> {
+    if call_function_name(call, bytes)? != "view" {
+        return None;
+    }
+    let args = call.child_by_field_name("arguments")?;
+    let arg_nodes = positional_args(args);
+
+    // First argument is the view name (a single string literal).
+    let view_name = string_literal_text(*arg_nodes.first()?, bytes)?;
+
+    // Second argument carries the data: an array literal or `compact(...)`.
+    if let Some(second) = arg_nodes.get(1) {
+        if let Some(binding) = binding_in_data_arg(*second, bytes, &view_name, line, col) {
+            return Some(binding);
+        }
+    }
+    None
+}
+
+/// Inspect a `view()` data argument — an array literal or a `compact(...)`
+/// call — for a key string under the cursor.
+fn binding_in_data_arg(
+    arg: Node,
+    bytes: &[u8],
+    view_name: &str,
+    line: u32,
+    col: u32,
+) -> Option<ViewBinding> {
+    match arg.kind() {
+        "array_creation_expression" => {
+            array_key_at(arg, bytes, view_name, line, col, BindingForm::ArrayKey)
+        }
+        "function_call_expression" if call_function_name(arg, bytes) == Some("compact") => {
+            compact_key_at(arg, bytes, view_name, line, col)
+        }
+        _ => None,
+    }
+}
+
+/// Find an `'key' => …` array element whose key string contains the cursor.
+fn array_key_at(
+    array: Node,
+    bytes: &[u8],
+    view_name: &str,
+    line: u32,
+    col: u32,
+    form: BindingForm,
+) -> Option<ViewBinding> {
+    let mut cursor = array.walk();
+    for element in array.children(&mut cursor) {
+        if element.kind() != "array_element_initializer" {
+            continue;
+        }
+        // `array_element_initializer` for `'k' => v` has the key as its first
+        // named child (the `=>` makes it a two-child initializer).
+        let mut ec = element.walk();
+        let named: Vec<Node> = element.children(&mut ec).filter(|n| n.is_named()).collect();
+        if named.len() < 2 {
+            continue; // value-only element (no key) — not a binding key.
+        }
+        let key_node = named[0];
+        if let Some(span) = string_content_span_at(key_node, bytes, line, col) {
+            let key = string_literal_text(key_node, bytes)?;
+            return Some(ViewBinding {
+                view_name: view_name.to_string(),
+                key,
+                key_span: span,
+                form,
+            });
+        }
+    }
+    None
+}
+
+/// Find a `compact('key', …)` string argument containing the cursor.
+fn compact_key_at(
+    call: Node,
+    bytes: &[u8],
+    view_name: &str,
+    line: u32,
+    col: u32,
+) -> Option<ViewBinding> {
+    let args = call.child_by_field_name("arguments")?;
+    for arg in positional_args(args) {
+        if let Some(span) = string_content_span_at(arg, bytes, line, col) {
+            let key = string_literal_text(arg, bytes)?;
+            return Some(ViewBinding {
+                view_name: view_name.to_string(),
+                key,
+                key_span: span,
+                form: BindingForm::Compact,
+            });
+        }
+    }
+    None
+}
+
+/// Unwrap a call's `arguments` node into the positional expression nodes,
+/// peeling the grammar's `argument` wrapper where present (mirrors the helper
+/// in [`crate::view_var_index`]).
+fn positional_args(arguments: Node) -> Vec<Node> {
+    let mut out = Vec::new();
+    let mut cursor = arguments.walk();
+    for arg in arguments.named_children(&mut cursor) {
+        if arg.kind() == "argument" {
+            let mut ac = arg.walk();
+            if let Some(expr) = arg.named_children(&mut ac).last() {
+                out.push(expr);
+            }
+        } else {
+            out.push(arg);
+        }
+    }
+    out
+}
+
+/// Controller-local `$name` spans within the function/method enclosing the
+/// byte offset of `anchor` — used for the `compact('name')` case, where the
+/// view key is bound by the local's name and must be renamed alongside it.
+/// Returns name-only spans (after the `$`).
+pub fn enclosing_function_local_spans(
+    php_source: &str,
+    name: &str,
+    anchor: VarSpan,
+) -> Vec<VarSpan> {
+    let tree = match parse_php(php_source) {
+        Ok(t) => t,
+        Err(_) => return Vec::new(),
+    };
+    let bytes = php_source.as_bytes();
+    let root = tree.root_node();
+
+    // Find the innermost function-like node containing the anchor line.
+    let mut best: Option<Node> = None;
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if matches!(
+            node.kind(),
+            "function_definition"
+                | "method_declaration"
+                | "anonymous_function_creation_expression"
+                | "arrow_function"
+        ) {
+            let s = node.start_position().row as u32;
+            let e = node.end_position().row as u32;
+            if anchor.line >= s && anchor.line <= e {
+                // Prefer the innermost (latest, smallest) enclosing scope.
+                best = Some(match best {
+                    Some(prev) if prev.start_position().row >= node.start_position().row => prev,
+                    _ => node,
+                });
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+
+    let scope = best.unwrap_or(root);
+    let mut spans = Vec::new();
+    collect_variable_name_spans(scope, bytes, name, &mut spans);
+    spans.sort();
+    spans
+}
+
+/// Walk `node`, pushing a name-only [`VarSpan`] for every `variable_name`
+/// whose identifier equals `name` (`$name`).
+fn collect_variable_name_spans(node: Node, bytes: &[u8], name: &str, out: &mut Vec<VarSpan>) {
+    if node.kind() == "variable_name" {
+        if let Ok(text) = node.utf8_text(bytes) {
+            if text == format!("${name}") {
+                let start = node.start_position();
+                let end = node.end_position();
+                // Skip the leading `$` so the span covers the name only.
+                out.push(VarSpan::new(
+                    start.row as u32,
+                    start.column as u32 + 1,
+                    end.column as u32,
+                ));
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_variable_name_spans(child, bytes, name, out);
+    }
+}
+
+// ── tree-sitter helpers ───────────────────────────────────────────────────
+
+/// The bare callee name of a `function_call_expression` (`view`, `compact`),
+/// or `None` for method calls / dynamic callees.
+fn call_function_name<'a>(call: Node<'a>, bytes: &'a [u8]) -> Option<&'a str> {
+    let func = call.child_by_field_name("function")?;
+    if func.kind() == "name" {
+        func.utf8_text(bytes).ok()
+    } else {
+        None
+    }
+}
+
+/// The text content of a PHP string-literal node (`'users.profile'`), with the
+/// surrounding quotes stripped. `None` for interpolated / non-string nodes.
+fn string_literal_text(node: Node, bytes: &[u8]) -> Option<String> {
+    let raw = node.utf8_text(bytes).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.len() >= 2
+        && (trimmed.starts_with('\'') || trimmed.starts_with('"'))
+        && (trimmed.ends_with('\'') || trimmed.ends_with('"'))
+    {
+        Some(trimmed[1..trimmed.len() - 1].to_string())
+    } else {
+        None
+    }
+}
+
+/// If `node` is a single-line string literal whose *content* (inside the
+/// quotes) contains `(line, col)`, return the content span. Used to detect the
+/// cursor landing on a binding key, and to target the rewrite at the key text
+/// without disturbing the quotes.
+fn string_content_span_at(node: Node, bytes: &[u8], line: u32, col: u32) -> Option<VarSpan> {
+    string_literal_text(node, bytes)?; // ensure it's a quoted string
+    let start = node.start_position();
+    let end = node.end_position();
+    if start.row != end.row {
+        return None; // multi-line strings can't be a simple binding key
+    }
+    let content_start = start.column as u32 + 1; // inside opening quote
+    let content_end = end.column as u32 - 1; // before closing quote
+    if line == start.row as u32 && col >= content_start && col <= content_end {
+        Some(VarSpan::new(line, content_start, content_end))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/blade_var_rename.rs
+++ b/laravel-lsp/src/blade_var_rename.rs
@@ -152,6 +152,75 @@ fn mask_delimited(source: &str, out: &mut [u8], open: &str, close: &str) {
     }
 }
 
+/// True if `name` surfaces as a Blade *template* variable — at least one
+/// `$name` occurrence in template markup (an echo `{{ $name }}`, a directive, a
+/// loop header), i.e. OUTSIDE every `@php … @endphp` block, `@verbatim` region,
+/// and `{{-- --}}` comment.
+///
+/// This is the `prepare_rename` admissibility gate (issue #55 AC: rename rejects
+/// variables outside a recognized binding context). A `$name` whose only
+/// occurrences live inside `@php` blocks — a PHP-block / function-local temp —
+/// or that appears nowhere is NOT a renameable Blade variable and returns
+/// `false`. Loop variables surface in their headers/bodies, `@php`-assigned
+/// variables that are actually used surface at their echo sites, and
+/// controller-passed variables surface at their usages, so all legitimately
+/// renameable variables pass.
+pub fn is_template_variable(source: &str, name: &str) -> bool {
+    if !is_valid_identifier(name) {
+        return false;
+    }
+    let pattern = match regex::Regex::new(&format!(r"\${}\b", regex::escape(name))) {
+        Ok(re) => re,
+        Err(_) => return false,
+    };
+    mask_non_template(source)
+        .lines()
+        .any(|line| pattern.is_match(line))
+}
+
+/// Blank everything that is NOT live template markup: comments, `@verbatim`
+/// regions, and closed `@php … @endphp` blocks. Used by [`is_template_variable`]
+/// to tell a real Blade variable (surfaces in markup) from a PHP-block-only
+/// local. Length/newlines are preserved, like [`mask_non_code`].
+fn mask_non_template(source: &str) -> String {
+    // Stage 1: blank comments + verbatim (these genuinely extend to EOF when
+    // unclosed, matching `mask_non_code`).
+    let stage1 = {
+        let mut out: Vec<u8> = source.as_bytes().to_vec();
+        mask_delimited(source, &mut out, "{{--", "--}}");
+        mask_delimited(source, &mut out, "@verbatim", "@endverbatim");
+        String::from_utf8(out).unwrap_or_else(|_| source.to_string())
+    };
+    // Stage 2: blank closed `@php … @endphp` blocks, searching the
+    // comment-masked text so a `@php` token inside a comment can't anchor a
+    // spurious block.
+    let mut out: Vec<u8> = stage1.as_bytes().to_vec();
+    mask_php_blocks(&stage1, &mut out);
+    String::from_utf8(out).unwrap_or(stage1)
+}
+
+/// Blank each *closed* `@php … @endphp` block (replacing non-newline bytes with
+/// spaces). An unclosed `@php` is the inline `@php(expr)` directive form, not a
+/// block — leave it as markup rather than masking the rest of the file, which
+/// would wrongly reject every later variable as out-of-context.
+fn mask_php_blocks(source: &str, out: &mut [u8]) {
+    let mut search_from = 0;
+    while let Some(rel) = source[search_from..].find("@php") {
+        let start = search_from + rel;
+        let after_open = start + "@php".len();
+        let Some(rel_end) = source[after_open..].find("@endphp") else {
+            break; // unclosed `@php` (inline `@php(...)`) — not a block.
+        };
+        let end = after_open + rel_end + "@endphp".len();
+        for b in out.iter_mut().take(end).skip(start) {
+            if *b != b'\n' {
+                *b = b' ';
+            }
+        }
+        search_from = end;
+    }
+}
+
 /// The set of variable spans a rename should rewrite when the user invokes
 /// rename on the `$name` occurrence at `cursor_line` in a Blade template.
 ///
@@ -474,8 +543,63 @@ pub fn enclosing_function_local_spans(
     spans
 }
 
+/// Every rewrite span a controller→view binding-key rename produces, split by
+/// file. Pure data — the caller (`main.rs`) owns view-file location, name
+/// validation, and turning spans into LSP `TextEdit`s.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BindingRenameSpans {
+    /// Spans inside the controller: the binding key string, plus (for
+    /// `compact`) the enclosing-function local `$key`. Sorted by position.
+    pub controller: Vec<VarSpan>,
+    /// File-scoped `$key` spans inside the resolved view template.
+    pub view: Vec<VarSpan>,
+}
+
+/// Cross-file orchestration core: given a located [`ViewBinding`], the
+/// controller source, and the resolved view source, compute every rewrite span
+/// across BOTH files. This is the I/O-free heart of `view_binding_rename_edit`,
+/// unit-tested independently of LSP file location and config.
+///
+/// - The controller always gets the key-string span. For [`BindingForm::Compact`]
+///   it also gets the enclosing-function local `$key` spans (compact binds the
+///   view variable BY the local's name, so the local must move too).
+/// - The view gets the file-scoped `$key` usages
+///   ([`file_scope_spans`] — minus any loop block that re-binds `key`, a
+///   separate scope). Pass `view_source = None` when the view can't be located;
+///   only the controller spans are then returned.
+///
+/// Because the view spans are restricted to `binding.key`, a different binding
+/// key bound to the same view from another controller (e.g. `$other`) is never
+/// touched — its spans don't intersect this rename's.
+pub fn binding_rename_spans(
+    binding: &ViewBinding,
+    controller_source: &str,
+    view_source: Option<&str>,
+) -> BindingRenameSpans {
+    let mut controller = vec![binding.key_span];
+    if binding.form == BindingForm::Compact {
+        controller.extend(enclosing_function_local_spans(
+            controller_source,
+            &binding.key,
+            binding.key_span,
+        ));
+    }
+    controller.sort();
+
+    let view = view_source
+        .map(|src| file_scope_spans(src, &binding.key))
+        .unwrap_or_default();
+
+    BindingRenameSpans { controller, view }
+}
+
 /// Walk `node`, pushing a name-only [`VarSpan`] for every `variable_name`
-/// whose identifier equals `name` (`$name`).
+/// whose identifier equals `name` (`$name`) — but NOT descending into a nested
+/// closure that captures `name` in a separate scope. A plain
+/// `function () { … }` doesn't see the enclosing `$name` (PHP closures capture
+/// nothing without a `use` clause), so its body `$name` is a *different*
+/// variable and must be left untouched; an arrow function or a `use ($name)`
+/// closure shares the outer variable, so we keep descending.
 fn collect_variable_name_spans(node: Node, bytes: &[u8], name: &str, out: &mut Vec<VarSpan>) {
     if node.kind() == "variable_name" {
         if let Ok(text) = node.utf8_text(bytes) {
@@ -493,8 +617,47 @@ fn collect_variable_name_spans(node: Node, bytes: &[u8], name: &str, out: &mut V
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
+        if is_isolated_closure(child, bytes, name) {
+            continue;
+        }
         collect_variable_name_spans(child, bytes, name, out);
     }
+}
+
+/// True if `node` is an anonymous function that does NOT see the enclosing
+/// `$name` — a `function () { … }` (or its `_creation_expression` form) with no
+/// `use ($name)` clause. Such a closure is an independent scope, so a rename of
+/// the enclosing-function `$name` must not descend into it (issue #55: renaming
+/// a `compact()` binding once clobbered an unrelated closure variable). Arrow
+/// functions auto-capture, and `use ($name)` closures explicitly capture, so
+/// both return `false` and the caller keeps descending. Mirrors the capture
+/// rule in [`crate::query_chain::flow`].
+fn is_isolated_closure(node: Node, bytes: &[u8], name: &str) -> bool {
+    if !matches!(
+        node.kind(),
+        "anonymous_function" | "anonymous_function_creation_expression"
+    ) {
+        return false;
+    }
+    // A `use (…)` clause that lists `$name` (by value or `&`-reference) binds
+    // the body `$name` to the outer variable's name, so the closure is NOT
+    // isolated — descend so the capture and its uses rename together.
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "anonymous_function_use_clause" {
+            let mut inner = child.walk();
+            for v in child.children(&mut inner) {
+                if v.kind() == "variable_name" {
+                    if let Ok(t) = v.utf8_text(bytes) {
+                        if t.trim_start_matches('$') == name {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    true
 }
 
 // ── tree-sitter helpers ───────────────────────────────────────────────────
@@ -515,10 +678,11 @@ fn call_function_name<'a>(call: Node<'a>, bytes: &'a [u8]) -> Option<&'a str> {
 fn string_literal_text(node: Node, bytes: &[u8]) -> Option<String> {
     let raw = node.utf8_text(bytes).ok()?;
     let trimmed = raw.trim();
-    if trimmed.len() >= 2
-        && (trimmed.starts_with('\'') || trimmed.starts_with('"'))
-        && (trimmed.ends_with('\'') || trimmed.ends_with('"'))
-    {
+    // Require the SAME quote on both ends (`'foo'` / `"foo"`), not just any
+    // quote on each end — otherwise a mismatched `"foo'` would slip through.
+    let open = trimmed.chars().next()?;
+    let close = trimmed.chars().next_back()?;
+    if trimmed.len() >= 2 && (open == '\'' || open == '"') && open == close {
         Some(trimmed[1..trimmed.len() - 1].to_string())
     } else {
         None
@@ -537,8 +701,11 @@ fn string_content_span_at(node: Node, bytes: &[u8], line: u32, col: u32) -> Opti
         return None; // multi-line strings can't be a simple binding key
     }
     let content_start = start.column as u32 + 1; // inside opening quote
-    let content_end = end.column as u32 - 1; // before closing quote
-    if line == start.row as u32 && col >= content_start && col <= content_end {
+    let content_end = end.column as u32 - 1; // before (== position of) closing quote
+                                             // `content_end` is the closing quote's column; the key text occupies
+                                             // `content_start..content_end`, so accept the cursor only strictly before
+                                             // the closing quote (landing ON the quote isn't on the key).
+    if line == start.row as u32 && col >= content_start && col < content_end {
         Some(VarSpan::new(line, content_start, content_end))
     } else {
         None

--- a/laravel-lsp/src/blade_var_rename.rs
+++ b/laravel-lsp/src/blade_var_rename.rs
@@ -208,6 +208,17 @@ fn mask_php_blocks(source: &str, out: &mut [u8]) {
     while let Some(rel) = source[search_from..].find("@php") {
         let start = search_from + rel;
         let after_open = start + "@php".len();
+        // Require a word boundary after `@php` so a longer directive like
+        // `@phpunit` / `@phpdoc` can't anchor a spurious block. A real `@php`
+        // directive is followed by `(` (inline form), whitespace, or EOF.
+        if source[after_open..]
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphanumeric() || c == '_')
+        {
+            search_from = after_open;
+            continue;
+        }
         let Some(rel_end) = source[after_open..].find("@endphp") else {
             break; // unclosed `@php` (inline `@php(...)`) — not a block.
         };
@@ -347,8 +358,9 @@ pub struct ViewBinding {
 /// controller, return the binding. Recognized shapes (cursor on the key):
 /// - `view('users.profile', ['name' => $expr])`
 /// - `view('users.profile', compact('name'))`
-/// - `view('users.profile')->with(['name' => $expr])`
-/// - `view('users.profile')->with('name', $expr)`
+///
+/// The `->with(['name' => …])` / `->with('name', …)` chained forms are not yet
+/// routed (out of scope for #55) and return `None`.
 ///
 /// Returns `None` when the cursor is anywhere else (the view name, a value
 /// expression, an unrelated string), or when the view name can't be resolved
@@ -517,6 +529,12 @@ pub fn enclosing_function_local_spans(
             node.kind(),
             "function_definition"
                 | "method_declaration"
+                // tree-sitter-php 0.24 names the closure node `anonymous_function`;
+                // the `_creation_expression` alias is the older grammar's name. Match
+                // both (repo convention, e.g. `route_chain.rs`, `query_chain/flow.rs`)
+                // so a `compact()` inside a route closure elects the closure as its
+                // scope instead of falling back to the whole file.
+                | "anonymous_function"
                 | "anonymous_function_creation_expression"
                 | "arrow_function"
         ) {

--- a/laravel-lsp/src/blade_var_rename.rs
+++ b/laravel-lsp/src/blade_var_rename.rs
@@ -36,7 +36,9 @@
 
 use tree_sitter::Node;
 
-use crate::blade_loops::find_loop_blocks;
+use crate::blade_loops::{
+    find_loop_blocks, unbalanced_loop_head_lines, BladeLoopBlock, BladeLoopType,
+};
 use crate::parser::parse_php;
 
 /// A 0-based span of an identifier name to rewrite. `start_col`..`end_col`
@@ -169,6 +171,14 @@ pub fn is_template_variable(source: &str, name: &str) -> bool {
     if !is_valid_identifier(name) {
         return false;
     }
+    // `$loop` is Blade's reserved loop-status variable, injected inside every
+    // `@foreach`/`@forelse`/`@for`/`@while` body — it never appears in a header,
+    // so it has no resolvable binding scope and a rename would clobber every
+    // `$loop` across unrelated loops. Renaming it is also semantically always
+    // wrong (the name is framework-defined). Refuse at the prepare gate.
+    if name == "loop" {
+        return false;
+    }
     let pattern = match regex::Regex::new(&format!(r"\${}\b", regex::escape(name))) {
         Ok(re) => re,
         Err(_) => return false,
@@ -251,7 +261,24 @@ pub fn in_scope_spans(source: &str, name: &str, cursor_line: u32) -> Vec<VarSpan
         return all;
     }
 
-    let binding_blocks = loop_binding_ranges(source, name);
+    // Fail-closed: a rename whose cursor sits in an *unresolved* loop region —
+    // an opaque loop (binding unparseable) or below a broken (unbalanced-paren)
+    // loop header — is refused rather than risk a file-wide clobber. Safe over
+    // complete, mirroring the `global`/`compact` refusals in the PHP engine.
+    let unresolved = unresolved_loop_ranges(source);
+    if range_contains_line(&unresolved, cursor_line) {
+        return Vec::new();
+    }
+
+    // Loop blocks are resolved over the comment/`@verbatim`-masked copy, exactly
+    // like `variable_spans`. Without this, a `@foreach` inside a `{{-- --}}`
+    // comment is a phantom binding block, and a paren inside such a comment
+    // desyncs the header parse — both collapse the scope and clobber the file.
+    let binding_blocks: Vec<(u32, u32)> = find_loop_blocks(&mask_non_code(source))
+        .iter()
+        .filter(|b| b.variables.iter().any(|(v, _)| v == name))
+        .map(block_range)
+        .collect();
 
     // The cursor's binding scope: the innermost (largest start_line) binding
     // block that contains the cursor line. `None` ⇒ file scope.
@@ -272,49 +299,97 @@ pub fn in_scope_spans(source: &str, name: &str, cursor_line: u32) -> Vec<VarSpan
                     }
                     !in_nested_shadow(span.line, (start, end), &binding_blocks)
                 }
-                // File-scoped: keep every span EXCEPT those that belong to a
-                // loop block that binds `name` (a separate scope).
-                None => !binding_blocks
-                    .iter()
-                    .any(|(start, end)| span.line >= *start && span.line <= *end),
+                // File-scoped: keep every span EXCEPT those inside a loop that
+                // re-binds `name` (a distinct scope) or inside an unresolved
+                // loop region (whose scope is unknown — never clobber into it).
+                None => {
+                    !range_contains_line(&binding_blocks, span.line)
+                        && !range_contains_line(&unresolved, span.line)
+                }
             }
         })
         .collect()
 }
 
 /// File-scoped variable spans: every `$name` occurrence EXCEPT those inside a
-/// loop block that re-binds `name`. This is the set a controller→view rename
-/// rewrites in the template — a controller-passed variable is file-scoped, but
-/// must never clobber a loop's same-named iteration variable (a distinct
-/// scope). Equivalent to [`in_scope_spans`] for a cursor that sits outside
-/// every binding block.
+/// loop block that re-binds `name` (a distinct scope) or an unresolved loop
+/// region (an opaque loop or a broken header — never clobber into one). This is
+/// the set a controller→view rename rewrites in the template — a
+/// controller-passed variable is file-scoped, but must never clobber a loop's
+/// same-named iteration variable. Equivalent to [`in_scope_spans`] for a cursor
+/// that sits outside every binding block.
 pub fn file_scope_spans(source: &str, name: &str) -> Vec<VarSpan> {
     let all = variable_spans(source, name);
     if all.is_empty() {
         return all;
     }
-    let binding_blocks = loop_binding_ranges(source, name);
+    let mut exclude: Vec<(u32, u32)> = find_loop_blocks(&mask_non_code(source))
+        .iter()
+        .filter(|b| b.variables.iter().any(|(v, _)| v == name))
+        .map(block_range)
+        .collect();
+    exclude.extend(unresolved_loop_ranges(source));
     all.into_iter()
-        .filter(|span| {
-            !binding_blocks
-                .iter()
-                .any(|(start, end)| span.line >= *start && span.line <= *end)
-        })
+        .filter(|span| !range_contains_line(&exclude, span.line))
         .collect()
 }
 
-/// Inclusive `[start_line, end_line]` ranges of every loop block that binds a
-/// variable named `name`. An unclosed loop extends to `u32::MAX`.
-fn loop_binding_ranges(source: &str, name: &str) -> Vec<(u32, u32)> {
-    find_loop_blocks(source)
+/// Inclusive `[start_line, end_line]` range of a loop block. An unclosed loop
+/// extends to `u32::MAX`.
+fn block_range(b: &BladeLoopBlock) -> (u32, u32) {
+    let start = b.start_line as u32;
+    let end = b.end_line.map(|e| e as u32).unwrap_or(u32::MAX);
+    (start, end)
+}
+
+/// A `@foreach`/`@forelse` whose binding yielded no variable — a header the
+/// parser couldn't resolve (a garbled or commented binding, an unsupported
+/// destructuring shape). Such a loop's scope is unknown, so a rename touching it
+/// must fail closed. `@for`/`@while` legitimately bind nothing (`@for(;;)`,
+/// `@while($cond)`), so they are never opaque.
+fn is_opaque_loop(b: &BladeLoopBlock) -> bool {
+    matches!(b.loop_type, BladeLoopType::Foreach | BladeLoopType::Forelse) && b.variables.is_empty()
+}
+
+/// Whether `line` falls within any of the inclusive `[start, end]` ranges.
+fn range_contains_line(ranges: &[(u32, u32)], line: u32) -> bool {
+    ranges
         .iter()
-        .filter(|b| b.variables.iter().any(|(v, _)| v == name))
-        .map(|b| {
-            let start = b.start_line as u32;
-            let end = b.end_line.map(|e| e as u32).unwrap_or(u32::MAX);
-            (start, end)
-        })
-        .collect()
+        .any(|(start, end)| line >= *start && line <= *end)
+}
+
+/// Inclusive line ranges where loop scope is *unresolved*, so a rename must fail
+/// closed rather than guess. Two sources:
+/// - **Opaque loops** — a `@foreach`/`@forelse` whose binding the parser
+///   couldn't resolve into any `$ident` (a garbled or commented binding, an
+///   unsupported destructuring shape). Range = the block.
+/// - **Broken headers** — a loop directive whose parentheses never balance
+///   (e.g. a missing `)`). [`find_loop_blocks`] can't form a block and the
+///   scope structure below it is unreliable, so the range runs to EOF.
+///
+/// Computed over the comment/`@verbatim`-masked copy, so a paren or `@foreach`
+/// inside a comment never counts. A rename whose cursor sits in one of these is
+/// refused; a file-scoped rename never rewrites occurrences inside one.
+fn unresolved_loop_ranges(source: &str) -> Vec<(u32, u32)> {
+    let masked = mask_non_code(source);
+    let mut ranges: Vec<(u32, u32)> = find_loop_blocks(&masked)
+        .iter()
+        .filter(|b| is_opaque_loop(b))
+        .map(block_range)
+        .collect();
+    for line in unbalanced_loop_head_lines(&masked) {
+        ranges.push((line as u32, u32::MAX));
+    }
+    ranges
+}
+
+/// Whether `cursor_line` sits in an unresolved loop region — an opaque loop or
+/// below a broken loop header (see [`unresolved_loop_ranges`]). A rename there
+/// would risk a file-wide clobber, so it is refused. Backs the `prepare_rename`
+/// gate so F2 is never offered there; [`in_scope_spans`] enforces the same
+/// refusal on the edit path.
+pub fn cursor_in_unresolved_loop(source: &str, cursor_line: u32) -> bool {
+    range_contains_line(&unresolved_loop_ranges(source), cursor_line)
 }
 
 /// True if `line` falls inside a binding block that is strictly nested within

--- a/laravel-lsp/src/blade_var_rename/tests.rs
+++ b/laravel-lsp/src/blade_var_rename/tests.rs
@@ -1,0 +1,340 @@
+//! Unit tests for scope-aware Blade variable rename and controller→view
+//! binding rename. Each AC case from issue #55 has at least one test:
+//! `@foreach` / `@forelse` / `@for` / `@php` scoping, the
+//! `view(..., ['key' => …])` and `compact('key')` patterns, nested scope
+//! conflicts, and the multi-controller cross-contamination guard.
+
+use super::*;
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_strips_sigil_and_whitespace() {
+    assert_eq!(normalize_new_var_name("  $bar "), "bar");
+    assert_eq!(normalize_new_var_name("bar"), "bar");
+    assert_eq!(normalize_new_var_name("$user"), "user");
+}
+
+#[test]
+fn identifier_validation() {
+    assert!(is_valid_identifier("foo"));
+    assert!(is_valid_identifier("_foo1"));
+    assert!(!is_valid_identifier("1foo"));
+    assert!(!is_valid_identifier("foo-bar"));
+    assert!(!is_valid_identifier(""));
+    assert!(!is_valid_identifier("foo bar"));
+}
+
+// ── variable_spans ──────────────────────────────────────────────────────────
+
+#[test]
+fn finds_variable_occurrences_excluding_property_access() {
+    let src = "{{ $user }} and {{ $user->name }} but not $username";
+    let spans = variable_spans(src, "user");
+    // Two `$user` occurrences; `$user->name` matches the variable, `$username`
+    // does not (word boundary).
+    assert_eq!(spans.len(), 2);
+    // First `$user`: `$` at col 3, name `user` at cols 4..8.
+    assert_eq!(spans[0], VarSpan::new(0, 4, 8));
+    // Second `$user` in `$user->name`: `$` at col 19, name at 20..24.
+    assert_eq!(spans[1], VarSpan::new(0, 20, 24));
+}
+
+#[test]
+fn variable_spans_skip_blade_comments() {
+    let src = "{{ $foo }}\n{{-- $foo is hidden --}}\n{{ $foo }}";
+    let spans = variable_spans(src, "foo");
+    assert_eq!(spans.len(), 2, "the commented $foo must be ignored");
+    assert_eq!(spans[0].line, 0);
+    assert_eq!(spans[1].line, 2);
+}
+
+#[test]
+fn variable_spans_skip_verbatim() {
+    let src = "{{ $foo }}\n@verbatim\n{{ $foo }}\n@endverbatim\n{{ $foo }}";
+    let spans = variable_spans(src, "foo");
+    assert_eq!(spans.len(), 2);
+    assert_eq!(spans[0].line, 0);
+    assert_eq!(spans[1].line, 4);
+}
+
+// ── in_scope_spans: @foreach ────────────────────────────────────────────────
+
+#[test]
+fn foreach_scopes_rename_to_the_loop_block() {
+    let src = "\
+{{ $item }}
+@foreach ($items as $item)
+    {{ $item->name }}
+@endforeach
+{{ $item }}";
+    // Cursor inside the loop body (line 2) — rename only the in-loop `$item`s.
+    let spans = in_scope_spans(src, "item", 2);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(lines, vec![1, 2], "loop directive + body, not lines 0 or 4");
+}
+
+#[test]
+fn foreach_binding_line_is_in_scope() {
+    let src = "\
+@foreach ($items as $item)
+    {{ $item }}
+@endforeach";
+    // Cursor on the `@foreach` binding line itself.
+    let spans = in_scope_spans(src, "item", 0);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(lines, vec![0, 1]);
+}
+
+#[test]
+fn file_scoped_variable_skips_loop_rebinding_same_name() {
+    // `$item` at file level (line 0) and a loop that re-binds `$item`.
+    let src = "\
+{{ $item }}
+@foreach ($items as $item)
+    {{ $item }}
+@endforeach
+{{ $item }}";
+    // Cursor on the file-level `$item` (line 0) — must NOT touch the loop's
+    // shadowing `$item` (lines 1–2), only the file-level ones (lines 0, 4).
+    let spans = in_scope_spans(src, "item", 0);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(lines, vec![0, 4]);
+}
+
+// ── in_scope_spans: @forelse ────────────────────────────────────────────────
+
+#[test]
+fn forelse_scopes_rename() {
+    let src = "\
+@forelse ($users as $user)
+    {{ $user->email }}
+@empty
+    none
+@endforelse
+{{ $user }}";
+    let spans = in_scope_spans(src, "user", 1);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    // Body inside forelse, not the trailing line-5 `$user`.
+    assert_eq!(lines, vec![0, 1]);
+}
+
+// ── in_scope_spans: @for ────────────────────────────────────────────────────
+
+#[test]
+fn for_loop_scopes_rename() {
+    let src = "\
+@for ($i = 0; $i < 3; $i++)
+    {{ $i }}
+@endfor
+{{ $i }}";
+    let spans = in_scope_spans(src, "i", 1);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    // Lines 0 (three `$i` occurrences) and 1 are in-loop; line 3 is out.
+    assert!(lines.iter().all(|&l| l == 0 || l == 1));
+    assert!(!lines.contains(&3));
+}
+
+// ── in_scope_spans: @php block (file-scoped) ────────────────────────────────
+
+#[test]
+fn php_block_variable_is_file_scoped() {
+    let src = "\
+@php $total = 0; @endphp
+{{ $total }}
+@foreach ($rows as $row)
+    {{ $total }}
+@endforeach";
+    // `$total` is not loop-introduced, so it is file-scoped: every occurrence
+    // renames, including the one inside the loop (the loop doesn't re-bind it).
+    let spans = in_scope_spans(src, "total", 0);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(lines, vec![0, 1, 3]);
+}
+
+// ── in_scope_spans: nested scope conflict ───────────────────────────────────
+
+#[test]
+fn nested_loops_rebinding_same_name_do_not_cross_contaminate() {
+    let src = "\
+@foreach ($outer as $item)
+    {{ $item }}
+    @foreach ($inner as $item)
+        {{ $item }}
+    @endforeach
+    {{ $item }}
+@endforeach";
+    // Cursor in the OUTER loop body (line 1). The inner loop (lines 2–4)
+    // re-binds `$item`, so its occurrences (lines 2, 3) are excluded; the
+    // outer `$item`s (lines 0, 1, 5) rename.
+    let outer = in_scope_spans(src, "item", 1);
+    let outer_lines: Vec<u32> = outer.iter().map(|s| s.line).collect();
+    assert_eq!(outer_lines, vec![0, 1, 5]);
+
+    // Cursor in the INNER loop body (line 3) — only the inner `$item`s
+    // (lines 2, 3) rename.
+    let inner = in_scope_spans(src, "item", 3);
+    let inner_lines: Vec<u32> = inner.iter().map(|s| s.line).collect();
+    assert_eq!(inner_lines, vec![2, 3]);
+}
+
+#[test]
+fn file_scope_spans_exclude_loop_rebinding() {
+    // The controller→view path renames a file-scoped `$user`, but a loop that
+    // re-binds `$user` is a separate scope and must be left alone.
+    let src = "\
+{{ $user->name }}
+@foreach ($admins as $user)
+    {{ $user }}
+@endforeach
+{{ $user->email }}";
+    let spans = file_scope_spans(src, "user");
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(lines, vec![0, 4], "loop-rebound $user (lines 1–2) excluded");
+}
+
+// ── view_binding_key_at: array key ──────────────────────────────────────────
+
+const ARRAY_CONTROLLER: &str = "\
+<?php
+class UserController
+{
+    public function show()
+    {
+        return view('users.profile', ['name' => $user->name]);
+    }
+}";
+
+#[test]
+fn array_key_binding_detected_under_cursor() {
+    // Line 5, the `name` key sits inside the quotes after `['`.
+    // `        return view('users.profile', ['name' => ...`
+    // Find the column of `name` inside `['name'`.
+    let line = ARRAY_CONTROLLER.lines().nth(5).unwrap();
+    let key_quote = line.find("'name'").unwrap();
+    let cursor = (key_quote + 2) as u32; // somewhere inside `name`
+
+    let binding = view_binding_key_at(ARRAY_CONTROLLER, 5, cursor).expect("key under cursor");
+    assert_eq!(binding.view_name, "users.profile");
+    assert_eq!(binding.key, "name");
+    assert_eq!(binding.form, BindingForm::ArrayKey);
+    // Span covers `name` (4 chars) inside the quotes.
+    assert_eq!(binding.key_span.line, 5);
+    assert_eq!(
+        binding.key_span.end_col - binding.key_span.start_col,
+        4,
+        "span covers the 4-char key name only"
+    );
+}
+
+#[test]
+fn cursor_on_value_expression_is_not_a_binding_key() {
+    let line = ARRAY_CONTROLLER.lines().nth(5).unwrap();
+    let value = line.find("$user").unwrap();
+    let binding = view_binding_key_at(ARRAY_CONTROLLER, 5, (value + 1) as u32);
+    assert!(binding.is_none(), "value side must not classify as a key");
+}
+
+#[test]
+fn cursor_on_view_name_is_not_a_binding_key() {
+    let line = ARRAY_CONTROLLER.lines().nth(5).unwrap();
+    let view = line.find("users.profile").unwrap();
+    let binding = view_binding_key_at(ARRAY_CONTROLLER, 5, (view + 1) as u32);
+    assert!(binding.is_none(), "view name is not a data-binding key");
+}
+
+#[test]
+fn multiple_controllers_different_keys_do_not_cross_contaminate() {
+    // Same view rendered from two controllers under different key names.
+    // A controller-initiated rename of one key only rewrites that key's
+    // in-view usages; the other key's `$other` is a different identifier and
+    // is left untouched (AC: no cross-contamination across key names).
+    let view = "\
+{{ $name }}
+{{ $other }}
+{{ $name->email }}";
+    let name_spans = file_scope_spans(view, "name");
+    let other_spans = file_scope_spans(view, "other");
+    let name_lines: Vec<u32> = name_spans.iter().map(|s| s.line).collect();
+    let other_lines: Vec<u32> = other_spans.iter().map(|s| s.line).collect();
+    assert_eq!(name_lines, vec![0, 2], "only $name usages move");
+    assert_eq!(other_lines, vec![1], "the other key's usages are untouched");
+    // The two rename sets are disjoint — no span is shared.
+    assert!(name_spans.iter().all(|s| !other_spans.contains(s)));
+}
+
+// ── view_binding_key_at: compact ────────────────────────────────────────────
+
+const COMPACT_CONTROLLER: &str = "\
+<?php
+class UserController
+{
+    public function show()
+    {
+        $name = $user->name;
+        return view('users.profile', compact('name'));
+    }
+}";
+
+#[test]
+fn compact_key_binding_detected_under_cursor() {
+    let line = COMPACT_CONTROLLER.lines().nth(6).unwrap();
+    let key_quote = line.find("'name'").unwrap();
+    let cursor = (key_quote + 2) as u32;
+
+    let binding = view_binding_key_at(COMPACT_CONTROLLER, 6, cursor).expect("compact key");
+    assert_eq!(binding.view_name, "users.profile");
+    assert_eq!(binding.key, "name");
+    assert_eq!(binding.form, BindingForm::Compact);
+}
+
+#[test]
+fn compact_renames_enclosing_function_local() {
+    // The `compact('name')` case must also rename the controller-local `$name`
+    // within the enclosing method so the code stays valid.
+    let anchor = VarSpan::new(6, 0, 0); // anchor on the `view(...)` line
+    let spans = enclosing_function_local_spans(COMPACT_CONTROLLER, "name", anchor);
+    // `$name` appears once as the assignment target on line 5.
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(lines, vec![5]);
+}
+
+#[test]
+fn enclosing_local_scope_does_not_leak_across_methods() {
+    let src = "\
+<?php
+class C
+{
+    public function a()
+    {
+        $name = 1;
+    }
+    public function b()
+    {
+        $name = 2;
+        return view('v', compact('name'));
+    }
+}";
+    // Anchor in method b (line 10). Only b's `$name` (line 9) should be found,
+    // not a()'s `$name` (line 5).
+    let anchor = VarSpan::new(10, 0, 0);
+    let spans = enclosing_function_local_spans(src, "name", anchor);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(lines, vec![9]);
+}
+
+// ── view_binding_key_at: ->with chains ──────────────────────────────────────
+
+#[test]
+fn with_array_chain_binding_detected() {
+    let src = "\
+<?php
+return view('dash')->with(['count' => 3]);";
+    let line = src.lines().nth(1).unwrap();
+    let key_quote = line.find("'count'").unwrap();
+    let binding = view_binding_key_at(src, 1, (key_quote + 2) as u32);
+    // ->with chains aren't a direct view() data arg; documented as not yet
+    // routed through the key classifier. Assert current behavior so a future
+    // expansion updates the test deliberately.
+    assert!(binding.is_none());
+}

--- a/laravel-lsp/src/blade_var_rename/tests.rs
+++ b/laravel-lsp/src/blade_var_rename/tests.rs
@@ -189,6 +189,166 @@ fn file_scoped_var_skips_multiline_loop_directive() {
     );
 }
 
+#[test]
+fn foreach_destructuring_binding_scopes_to_the_loop() {
+    // Array destructuring binds `$a` inside the loop; renaming it stays
+    // loop-scoped and never touches the file-level `$a` on lines 0 and 4.
+    let src = "\
+{{ $a }}
+@foreach ($pairs as [$a, $b])
+    {{ $a }}: {{ $b }}
+@endforeach
+{{ $a }}";
+    let spans = in_scope_spans(src, "a", 2);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(
+        lines,
+        vec![1, 2],
+        "destructured binding + body, not file 0/4"
+    );
+}
+
+#[test]
+fn foreach_by_reference_binding_scopes_to_the_loop() {
+    // By-reference binding `&$item` is recovered; rename stays loop-scoped.
+    let src = "\
+{{ $item }}
+@foreach ($items as &$item)
+    {{ $item }}
+@endforeach
+{{ $item }}";
+    let spans = in_scope_spans(src, "item", 2);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(lines, vec![1, 2]);
+}
+
+#[test]
+fn commented_out_loop_does_not_create_a_phantom_binding_block() {
+    // A `@foreach` inside a `{{-- --}}` comment must not register as a binding
+    // block. Loop detection runs over the masked copy (like variable_spans), so
+    // the commented loop is invisible and a file-scoped rename of `$item`
+    // touches the file-level occurrences only — the real loop (lines 2–4) is
+    // excluded as a re-binding scope, the commented one contributes nothing.
+    let src = "\
+{{-- @foreach ($x as $item) --}}
+{{ $item }}
+@foreach ($real as $item)
+    {{ $item }}
+@endforeach
+{{ $item }}";
+    let spans = in_scope_spans(src, "item", 1);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(
+        lines,
+        vec![1, 5],
+        "file-level only; no phantom block from the comment"
+    );
+}
+
+#[test]
+fn opaque_loop_refuses_rename_rather_than_clobbering() {
+    // A PHP block comment inside the header desyncs the paren scan, so the
+    // binding can't be resolved — an opaque loop. A rename whose cursor sits
+    // inside it is refused (no spans) rather than falling through to the
+    // file-scope arm and clobbering every `$user`. `cursor_in_unresolved_loop`
+    // gates prepare_rename identically.
+    let src = "\
+{{ $user }}
+@foreach ($users /* :) */ as $user)
+    {{ $user }}
+@endforeach
+{{ $user }}";
+    assert!(
+        cursor_in_unresolved_loop(src, 2),
+        "cursor is inside the opaque loop"
+    );
+    assert!(
+        in_scope_spans(src, "user", 2).is_empty(),
+        "rename refused inside an opaque loop"
+    );
+}
+
+#[test]
+fn broken_loop_header_refuses_rename_rather_than_clobbering() {
+    // A loop header whose parens never close is broken Blade that forms no
+    // block at all — so the opaque-loop backstop alone wouldn't catch it. The
+    // scope below it is unreliable, so a rename there is refused (cursor inside
+    // the unresolved region) rather than clobbering every `$user` file-wide.
+    let src = "\
+{{ $user }}
+@foreach ($users as $user
+    {{ $user->name }}
+@endforeach
+{{ $user }}";
+    assert!(
+        cursor_in_unresolved_loop(src, 2),
+        "cursor is below a broken loop header"
+    );
+    assert!(
+        in_scope_spans(src, "user", 2).is_empty(),
+        "rename refused below a broken header"
+    );
+}
+
+#[test]
+fn blade_comment_inside_a_multiline_header_still_scopes() {
+    // A `{{-- --}}` comment inside a wrapped header is masked before loop
+    // detection, so the binding is recovered and the rename stays loop-scoped
+    // (rewritten correctly, NOT refused and NOT clobbered). Before masking, the
+    // `)` inside the comment desynced the paren scan and clobbered the file.
+    let src = "\
+{{ $user }}
+@foreach ($users
+    {{-- pick the active ones :) --}}
+    as $user)
+    {{ $user->name }}
+@endforeach
+{{ $user }}";
+    let spans = in_scope_spans(src, "user", 4);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(
+        lines,
+        vec![3, 4],
+        "binding line + body, comment masked away"
+    );
+}
+
+#[test]
+fn file_scoped_rename_skips_an_opaque_loop() {
+    // A file-scoped rename (cursor outside any loop) must not clobber INTO an
+    // opaque loop whose scope is unknown — those occurrences are left alone.
+    let src = "\
+{{ $user }}
+@foreach ($users /* :) */ as $user)
+    {{ $user }}
+@endforeach
+{{ $user }}";
+    let spans = in_scope_spans(src, "user", 0);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(
+        lines,
+        vec![0, 4],
+        "file-level occurrences only, opaque loop skipped"
+    );
+}
+
+#[test]
+fn loop_magic_variable_is_not_renameable() {
+    // `$loop` is Blade-injected, never in a header, and renaming it would
+    // clobber across unrelated loops — refused at the prepare gate.
+    let src = "\
+@foreach ($users as $user)
+    {{ $loop->index }}
+@endforeach
+@foreach ($posts as $post)
+    {{ $loop->index }}
+@endforeach";
+    assert!(
+        !is_template_variable(src, "loop"),
+        "$loop is reserved and not renameable"
+    );
+}
+
 // ── in_scope_spans: @forelse ────────────────────────────────────────────────
 
 #[test]

--- a/laravel-lsp/src/blade_var_rename/tests.rs
+++ b/laravel-lsp/src/blade_var_rename/tests.rs
@@ -144,6 +144,51 @@ fn file_scoped_var_skips_loop_with_method_call_iterable() {
     );
 }
 
+#[test]
+fn foreach_with_multiline_directive_still_scopes_to_the_loop() {
+    // issue #55 regression: a `@foreach` whose argument list wraps across
+    // physical lines must still register as a loop block. Before the multi-line
+    // paren-balancing fix, `matching_paren` gave up at the first line end, the
+    // loop's `$user` binding was lost, `loop_binding_ranges` came back empty,
+    // and the file-scope arm admitted EVERY `$user` — clobbering the file-level
+    // occurrences on lines 0 and 5.
+    let src = "\
+{{ $user }}
+@foreach ($users->where('active', true)
+    as $user)
+    {{ $user->name }}
+@endforeach
+{{ $user }}";
+    // Cursor inside the loop body (line 3) — only the in-loop `$user`s.
+    let spans = in_scope_spans(src, "user", 3);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(
+        lines,
+        vec![2, 3],
+        "binding line + body only, never the file-level lines 0/5"
+    );
+}
+
+#[test]
+fn file_scoped_var_skips_multiline_loop_directive() {
+    // The mirror case: a file-level `$user` must not bleed into a loop that
+    // re-binds `$user` via a multi-line directive header.
+    let src = "\
+{{ $user }}
+@foreach ($users->where('active', true)
+    as $user)
+    {{ $user }}
+@endforeach
+{{ $user }}";
+    let spans = in_scope_spans(src, "user", 0);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(
+        lines,
+        vec![0, 5],
+        "file-level occurrences only, multi-line loop excluded"
+    );
+}
+
 // ── in_scope_spans: @forelse ────────────────────────────────────────────────
 
 #[test]

--- a/laravel-lsp/src/blade_var_rename/tests.rs
+++ b/laravel-lsp/src/blade_var_rename/tests.rs
@@ -465,6 +465,38 @@ class C
     assert_eq!(lines, vec![5, 6, 6]);
 }
 
+#[test]
+fn compact_inside_route_closure_does_not_leak_to_sibling_closure() {
+    // The Laravel route-closure pattern: `compact('name')` sits INSIDE a
+    // closure, so the closure itself must be elected as the rename scope. A
+    // sibling closure's unrelated `$name` must stay untouched. Regression for
+    // the round-2 fix: `enclosing_function_local_spans` previously matched only
+    // the legacy `anonymous_function_creation_expression` node kind (which never
+    // exists in tree-sitter-php 0.24), so the real `anonymous_function` closure
+    // was never elected and scope fell back to the whole file.
+    let src = "\
+<?php
+
+Route::get('/a', function () use ($name) {
+    return view('users.index', compact('name'));
+});
+
+Route::get('/b', function () use ($name) {
+    return response($name);
+});";
+    // Anchor on the `view(...)` line inside the `/a` closure (line 3).
+    let anchor = VarSpan::new(3, 0, 0);
+    let spans = enclosing_function_local_spans(src, "name", anchor);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    // Only the `/a` closure's `use ($name)` capture on line 2 — NOT the sibling
+    // `/b` closure's `$name` on lines 6 and 7.
+    assert_eq!(
+        lines,
+        vec![2],
+        "rename must stay inside the enclosing closure, not leak file-wide"
+    );
+}
+
 // ── is_template_variable: prepare_rename admissibility gate (AC #5) ─────────
 
 #[test]
@@ -506,6 +538,16 @@ fn inline_php_directive_does_not_mask_rest_of_file() {
     // The inline `@php(expr)` form has no `@endphp`; masking must not blank the
     // rest of the file, which would wrongly reject every later variable.
     let src = "@php($total = 1)\n{{ $total }}";
+    assert!(is_template_variable(src, "total"));
+}
+
+#[test]
+fn php_word_prefix_does_not_anchor_a_mask_block() {
+    // `@phpdoc` shares the `@php` prefix but is NOT a `@php` block opener. The
+    // bare-substring match used to anchor a spurious mask region here, swallowing
+    // the real `{{ $total }}` markup that follows and wrongly rejecting the
+    // rename. The genuine `@php … @endphp` block later must still mask only itself.
+    let src = "@phpdoc note\n{{ $total }}\n@php $x = 1; @endphp";
     assert!(is_template_variable(src, "total"));
 }
 

--- a/laravel-lsp/src/blade_var_rename/tests.rs
+++ b/laravel-lsp/src/blade_var_rename/tests.rs
@@ -130,9 +130,9 @@ fn for_loop_scopes_rename() {
 {{ $i }}";
     let spans = in_scope_spans(src, "i", 1);
     let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
-    // Lines 0 (three `$i` occurrences) and 1 are in-loop; line 3 is out.
-    assert!(lines.iter().all(|&l| l == 0 || l == 1));
-    assert!(!lines.contains(&3));
+    // The three `$i` in the header (init / condition / step) plus the body
+    // `$i` on line 1 — and NOT the out-of-loop `$i` on line 3.
+    assert_eq!(lines, vec![0, 0, 0, 1]);
 }
 
 // ── in_scope_spans: @php block (file-scoped) ────────────────────────────────
@@ -245,22 +245,110 @@ fn cursor_on_view_name_is_not_a_binding_key() {
 
 #[test]
 fn multiple_controllers_different_keys_do_not_cross_contaminate() {
-    // Same view rendered from two controllers under different key names.
-    // A controller-initiated rename of one key only rewrites that key's
-    // in-view usages; the other key's `$other` is a different identifier and
-    // is left untouched (AC: no cross-contamination across key names).
+    // The SAME view is rendered from two controllers under different key names.
+    // Each binding rename is driven end-to-end through `binding_rename_spans`
+    // (cursor → binding → cross-file spans). A rename initiated from one
+    // controller rewrites only that key's in-view usages; the other
+    // controller's key is a different identifier and is never touched (AC #6:
+    // no cross-contamination across key names).
     let view = "\
 {{ $name }}
 {{ $other }}
 {{ $name->email }}";
-    let name_spans = file_scope_spans(view, "name");
-    let other_spans = file_scope_spans(view, "other");
-    let name_lines: Vec<u32> = name_spans.iter().map(|s| s.line).collect();
-    let other_lines: Vec<u32> = other_spans.iter().map(|s| s.line).collect();
-    assert_eq!(name_lines, vec![0, 2], "only $name usages move");
-    assert_eq!(other_lines, vec![1], "the other key's usages are untouched");
-    // The two rename sets are disjoint — no span is shared.
-    assert!(name_spans.iter().all(|s| !other_spans.contains(s)));
+
+    let ctrl_a = "<?php\nreturn view('shared', ['name' => $u->name]);";
+    let ctrl_b = "<?php\nreturn view('shared', ['other' => $u->other]);";
+
+    let a_line = ctrl_a.lines().nth(1).unwrap();
+    let a_cursor = (a_line.find("'name'").unwrap() + 2) as u32;
+    let binding_a = view_binding_key_at(ctrl_a, 1, a_cursor).expect("name key under cursor");
+    let spans_a = binding_rename_spans(&binding_a, ctrl_a, Some(view));
+    assert_eq!(
+        spans_a.view.iter().map(|s| s.line).collect::<Vec<_>>(),
+        vec![0, 2],
+        "controller A's rename moves only the in-view $name usages"
+    );
+
+    let b_line = ctrl_b.lines().nth(1).unwrap();
+    let b_cursor = (b_line.find("'other'").unwrap() + 2) as u32;
+    let binding_b = view_binding_key_at(ctrl_b, 1, b_cursor).expect("other key under cursor");
+    let spans_b = binding_rename_spans(&binding_b, ctrl_b, Some(view));
+    assert_eq!(
+        spans_b.view.iter().map(|s| s.line).collect::<Vec<_>>(),
+        vec![1],
+        "controller B's rename moves only the in-view $other usage"
+    );
+
+    // The two renames' in-view edit sets are disjoint — no shared span.
+    assert!(spans_a.view.iter().all(|s| !spans_b.view.contains(s)));
+}
+
+// ── binding_rename_spans: cross-file orchestration (AC #6) ──────────────────
+
+#[test]
+fn binding_rename_spans_cover_compact_controller_and_view() {
+    // The full cross-file pipeline for `compact('name')`: the controller gets
+    // the local `$name` AND the compact key; the resolved view gets the
+    // in-view `$name` usages, with an unrelated `$other` left alone.
+    let view = "\
+{{ $name }}
+{{ $other }}
+{{ $name->email }}";
+    let line = COMPACT_CONTROLLER.lines().nth(6).unwrap();
+    let cursor = (line.find("'name'").unwrap() + 2) as u32;
+    let binding = view_binding_key_at(COMPACT_CONTROLLER, 6, cursor).expect("compact key");
+
+    let spans = binding_rename_spans(&binding, COMPACT_CONTROLLER, Some(view));
+    // Controller: the enclosing-function local `$name` (line 5) and the compact
+    // key string (line 6), sorted by position.
+    assert_eq!(
+        spans.controller.iter().map(|s| s.line).collect::<Vec<_>>(),
+        vec![5, 6]
+    );
+    // View: `$name` on lines 0 and 2 — `$other` (line 1) is untouched.
+    assert_eq!(
+        spans.view.iter().map(|s| s.line).collect::<Vec<_>>(),
+        vec![0, 2],
+        "only $name usages move; $other is left alone"
+    );
+}
+
+#[test]
+fn binding_rename_spans_array_key_leaves_controller_value_untouched() {
+    // The `['name' => $user->name]` form: only the key string moves in the
+    // controller (the value `$user->name` is independent of the key), plus the
+    // in-view usages.
+    let view = "{{ $name }}\n{{ $name }}";
+    let line = ARRAY_CONTROLLER.lines().nth(5).unwrap();
+    let cursor = (line.find("'name'").unwrap() + 2) as u32;
+    let binding = view_binding_key_at(ARRAY_CONTROLLER, 5, cursor).expect("array key");
+
+    let spans = binding_rename_spans(&binding, ARRAY_CONTROLLER, Some(view));
+    assert_eq!(
+        spans.controller.iter().map(|s| s.line).collect::<Vec<_>>(),
+        vec![5],
+        "only the key string moves — no compact local for the array form"
+    );
+    assert_eq!(
+        spans.view.iter().map(|s| s.line).collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+}
+
+#[test]
+fn binding_rename_spans_without_resolved_view_only_touch_controller() {
+    // When the view can't be located/read, only the controller-side spans are
+    // produced (no panic, no view edits).
+    let line = COMPACT_CONTROLLER.lines().nth(6).unwrap();
+    let cursor = (line.find("'name'").unwrap() + 2) as u32;
+    let binding = view_binding_key_at(COMPACT_CONTROLLER, 6, cursor).unwrap();
+
+    let spans = binding_rename_spans(&binding, COMPACT_CONTROLLER, None);
+    assert_eq!(
+        spans.controller.iter().map(|s| s.line).collect::<Vec<_>>(),
+        vec![5, 6]
+    );
+    assert!(spans.view.is_empty());
 }
 
 // ── view_binding_key_at: compact ────────────────────────────────────────────
@@ -321,6 +409,104 @@ class C
     let spans = enclosing_function_local_spans(src, "name", anchor);
     let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
     assert_eq!(lines, vec![9]);
+}
+
+#[test]
+fn compact_local_skips_non_capturing_closure() {
+    // A plain `function () { … }` does NOT capture the outer `$name` (PHP
+    // closures capture nothing without a `use` clause), so renaming the
+    // `compact('name')` local must leave the closure's own `$name` untouched.
+    // Regression for the issue #55 correctness fix.
+    let src = "\
+<?php
+class C
+{
+    public function show()
+    {
+        $name = 'Alice';
+        $fn = function () { $name = 'inner'; };
+        return view('v', compact('name'));
+    }
+}";
+    // Anchor on the `view(...)` line (line 7).
+    let anchor = VarSpan::new(7, 0, 0);
+    let spans = enclosing_function_local_spans(src, "name", anchor);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    // Only the outer `$name` on line 5 — NOT the closure body's `$name` (line 6).
+    assert_eq!(
+        lines,
+        vec![5],
+        "the independent closure variable must be left alone"
+    );
+}
+
+#[test]
+fn compact_local_descends_into_use_capturing_closure() {
+    // A closure that captures `$name` via `use ($name)` binds its body `$name`
+    // to the outer variable's name, so the rename MUST descend — both the
+    // `use` capture and the body usage move with the outer local, or the
+    // closure would reference a renamed-away variable.
+    let src = "\
+<?php
+class C
+{
+    public function show()
+    {
+        $name = 'Alice';
+        $fn = function () use ($name) { return strtoupper($name); };
+        return view('v', compact('name'));
+    }
+}";
+    let anchor = VarSpan::new(7, 0, 0);
+    let spans = enclosing_function_local_spans(src, "name", anchor);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    // Line 5 (outer local) plus line 6 twice: the `use ($name)` capture and the
+    // body `$name`.
+    assert_eq!(lines, vec![5, 6, 6]);
+}
+
+// ── is_template_variable: prepare_rename admissibility gate (AC #5) ─────────
+
+#[test]
+fn template_variable_recognized_when_used_in_markup() {
+    // A controller-passed / echoed variable surfaces in markup — renameable.
+    assert!(is_template_variable("{{ $user->name }}", "user"));
+    // A loop variable surfaces in its header — renameable.
+    assert!(is_template_variable(
+        "@foreach ($items as $row)\n    {{ $row }}\n@endforeach",
+        "row"
+    ));
+    // A `@php`-assigned variable that is then echoed surfaces in markup.
+    assert!(is_template_variable(
+        "@php $total = 0; @endphp\n{{ $total }}",
+        "total"
+    ));
+}
+
+#[test]
+fn out_of_context_variable_is_not_a_template_variable() {
+    // Undefined `$ghost`: appears nowhere → not renameable (AC #5).
+    assert!(!is_template_variable("{{ $user }}", "ghost"));
+
+    // A PHP-block / function-local confined to `@php … @endphp`, never echoed,
+    // is not a Blade template variable — rename must reject it.
+    let src = "\
+@php
+    $helper = function () {
+        $local = 5;
+        return $local;
+    };
+@endphp
+{{ $user }}";
+    assert!(!is_template_variable(src, "local"));
+}
+
+#[test]
+fn inline_php_directive_does_not_mask_rest_of_file() {
+    // The inline `@php(expr)` form has no `@endphp`; masking must not blank the
+    // rest of the file, which would wrongly reject every later variable.
+    let src = "@php($total = 1)\n{{ $total }}";
+    assert!(is_template_variable(src, "total"));
 }
 
 // ── view_binding_key_at: ->with chains ──────────────────────────────────────

--- a/laravel-lsp/src/blade_var_rename/tests.rs
+++ b/laravel-lsp/src/blade_var_rename/tests.rs
@@ -102,6 +102,48 @@ fn file_scoped_variable_skips_loop_rebinding_same_name() {
     assert_eq!(lines, vec![0, 4]);
 }
 
+#[test]
+fn foreach_with_method_call_iterable_still_scopes_to_the_loop() {
+    // issue #55 regression: a parenthesized iterable (`->where(...)`) must not
+    // defeat loop-scope detection. Before the paren-balancing fix the loop's
+    // `$user` binding was lost, `loop_binding_ranges` returned empty, and the
+    // file-scope arm admitted EVERY `$user` — clobbering the out-of-loop one.
+    let src = "\
+{{ $user }}
+@foreach ($users->where('active', true) as $user)
+    {{ $user->name }}
+@endforeach
+{{ $user }}";
+    // Cursor inside the loop body (line 2) — rename only the in-loop `$user`s,
+    // never the file-level ones on lines 0 and 4.
+    let spans = in_scope_spans(src, "user", 2);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(
+        lines,
+        vec![1, 2],
+        "loop directive + body only, not lines 0/4"
+    );
+}
+
+#[test]
+fn file_scoped_var_skips_loop_with_method_call_iterable() {
+    // The mirror case: a file-level `$user` must not bleed into a loop that
+    // re-binds `$user` via a parenthesized iterable.
+    let src = "\
+{{ $user }}
+@foreach ($users->where('active', true) as $user)
+    {{ $user }}
+@endforeach
+{{ $user }}";
+    let spans = in_scope_spans(src, "user", 0);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(
+        lines,
+        vec![0, 4],
+        "file-level occurrences only, loop excluded"
+    );
+}
+
 // ── in_scope_spans: @forelse ────────────────────────────────────────────────
 
 #[test]

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -15,6 +15,7 @@ pub mod blade_embedded_php;
 pub mod blade_loops;
 pub mod blade_php_block;
 pub mod blade_props;
+pub mod blade_var_rename;
 pub mod cache_manager;
 pub mod class_locator;
 pub mod class_rename;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18608,6 +18608,225 @@ impl LaravelLanguageServer {
         }
         false
     }
+    /// Read a document's current text — the open editor buffer if the client
+    /// has it open, else the on-disk copy. Mirrors the read pattern used by
+    /// the goto/hover handlers (issue #55 rename helpers).
+    async fn rename_document_text(&self, uri: &Url, path: &str) -> Option<String> {
+        match self.documents.read().await.get(uri).cloned() {
+            Some((content, _version)) => Some(content),
+            None => std::fs::read_to_string(path).ok(),
+        }
+    }
+
+    /// issue #55 — prepare_rename for a Blade `$variable`. Returns the
+    /// name-only range (after the `$`) when the cursor sits on a plain
+    /// variable token in a `.blade.php` file. `None` for property accesses
+    /// (`$x->prop`) or when the cursor isn't on a variable, so the caller
+    /// falls through to the other classifiers.
+    async fn prepare_blade_var_rename(&self, uri: &Url, position: Position) -> Option<Range> {
+        let path = uri.to_file_path().ok()?;
+        let path_str = path.to_str()?;
+        let content = self.rename_document_text(uri, path_str).await?;
+        let line_text = content.lines().nth(position.line as usize)?;
+        let (var_name, property) = extract_blade_variable_at_cursor(line_text, position.character)?;
+        if property.is_some() || var_name.is_empty() {
+            return None;
+        }
+        let span = laravel_lsp::blade_var_rename::variable_spans(line_text, &var_name)
+            .into_iter()
+            .find(|s| {
+                position.character >= s.start_col.saturating_sub(1)
+                    && position.character <= s.end_col
+            })?;
+        Some(Range {
+            start: Position {
+                line: position.line,
+                character: span.start_col,
+            },
+            end: Position {
+                line: position.line,
+                character: span.end_col,
+            },
+        })
+    }
+
+    /// issue #55 — prepare_rename for a controller view-data binding key
+    /// (`view('v', ['name' => …])` / `compact('name')`). Returns the key-text
+    /// range so the editor highlights just the key.
+    async fn prepare_view_binding_rename(&self, uri: &Url, position: Position) -> Option<Range> {
+        let path = uri.to_file_path().ok()?;
+        let path_str = path.to_str()?;
+        let content = self.rename_document_text(uri, path_str).await?;
+        let binding = laravel_lsp::blade_var_rename::view_binding_key_at(
+            &content,
+            position.line,
+            position.character,
+        )?;
+        Some(Range {
+            start: Position {
+                line: binding.key_span.line,
+                character: binding.key_span.start_col,
+            },
+            end: Position {
+                line: binding.key_span.line,
+                character: binding.key_span.end_col,
+            },
+        })
+    }
+
+    /// issue #55 — build the `WorkspaceEdit` for a scope-aware Blade variable
+    /// rename. Rewrites only the in-scope `$var` occurrences within the
+    /// template (loop-block scoped when the variable is loop-introduced, else
+    /// file-scoped minus any nested loop that re-binds the same name).
+    async fn blade_var_rename_edit(
+        &self,
+        uri: &Url,
+        position: Position,
+        new_name: &str,
+    ) -> jsonrpc::Result<Option<WorkspaceEdit>> {
+        let path = match uri.to_file_path() {
+            Ok(p) => p,
+            Err(_) => return Ok(None),
+        };
+        let Some(path_str) = path.to_str() else {
+            return Ok(None);
+        };
+        let Some(content) = self.rename_document_text(uri, path_str).await else {
+            return Ok(None);
+        };
+        let Some(line_text) = content.lines().nth(position.line as usize) else {
+            return Ok(None);
+        };
+        let Some((var_name, property)) =
+            extract_blade_variable_at_cursor(line_text, position.character)
+        else {
+            return Ok(None);
+        };
+        if property.is_some() || var_name.is_empty() {
+            return Ok(None);
+        }
+
+        let new_bare = laravel_lsp::blade_var_rename::normalize_new_var_name(new_name);
+        if !laravel_lsp::blade_var_rename::is_valid_identifier(&new_bare) {
+            return Err(laravel_lsp::rename::rename_error(
+                "invalid variable name: must be a letter or underscore followed by \
+                 letters, digits, or underscores.",
+            ));
+        }
+
+        let spans =
+            laravel_lsp::blade_var_rename::in_scope_spans(&content, &var_name, position.line);
+        let targets: Vec<laravel_lsp::rename::EditTarget> = spans
+            .into_iter()
+            .map(|s| laravel_lsp::rename::EditTarget {
+                file_path: path.clone(),
+                line: s.line,
+                start_column: s.start_col,
+                end_column: s.end_col,
+                new_text: new_bare.clone(),
+            })
+            .collect();
+        Ok(laravel_lsp::rename::build_rename_edit(&targets))
+    }
+
+    /// issue #55 — build the `WorkspaceEdit` for a controller→view binding-key
+    /// rename. Rewrites the controller key string, the in-view file-scoped
+    /// `$key` usages, and (for `compact('key')`) the enclosing-function local
+    /// `$key` so the controller stays valid.
+    async fn view_binding_rename_edit(
+        &self,
+        uri: &Url,
+        position: Position,
+        new_name: &str,
+    ) -> jsonrpc::Result<Option<WorkspaceEdit>> {
+        use laravel_lsp::blade_var_rename::{self, BindingForm};
+
+        let path = match uri.to_file_path() {
+            Ok(p) => p,
+            Err(_) => return Ok(None),
+        };
+        let Some(path_str) = path.to_str() else {
+            return Ok(None);
+        };
+        let Some(content) = self.rename_document_text(uri, path_str).await else {
+            return Ok(None);
+        };
+        let Some(binding) =
+            blade_var_rename::view_binding_key_at(&content, position.line, position.character)
+        else {
+            return Ok(None);
+        };
+
+        let new_bare = blade_var_rename::normalize_new_var_name(new_name);
+        if !blade_var_rename::is_valid_identifier(&new_bare) {
+            return Err(laravel_lsp::rename::rename_error(
+                "invalid binding key: must be a letter or underscore followed by \
+                 letters, digits, or underscores.",
+            ));
+        }
+        if new_bare == binding.key {
+            return Err(laravel_lsp::rename::rename_error(
+                "new binding name must differ from the current name.",
+            ));
+        }
+
+        let mut targets: Vec<laravel_lsp::rename::EditTarget> = Vec::new();
+
+        // 1. The controller key string (array key or compact arg).
+        targets.push(laravel_lsp::rename::EditTarget {
+            file_path: path.clone(),
+            line: binding.key_span.line,
+            start_column: binding.key_span.start_col,
+            end_column: binding.key_span.end_col,
+            new_text: new_bare.clone(),
+        });
+
+        // 2. compact: the enclosing-function local `$key` moves with the key,
+        //    because compact binds the view variable BY the local's name.
+        if binding.form == BindingForm::Compact {
+            for s in blade_var_rename::enclosing_function_local_spans(
+                &content,
+                &binding.key,
+                binding.key_span,
+            ) {
+                targets.push(laravel_lsp::rename::EditTarget {
+                    file_path: path.clone(),
+                    line: s.line,
+                    start_column: s.start_col,
+                    end_column: s.end_col,
+                    new_text: new_bare.clone(),
+                });
+            }
+        }
+
+        // 3. In-view `$key` usages (file-scoped, minus loop re-binds).
+        if let Some(config) = self.get_cached_config().await {
+            if let Some(view_path) =
+                laravel_lsp::view_declaration_locator::locate_view_file(&binding.view_name, &config)
+            {
+                if let Some(view_str) = view_path.to_str() {
+                    if let Ok(view_uri) = Url::from_file_path(&view_path) {
+                        if let Some(view_content) =
+                            self.rename_document_text(&view_uri, view_str).await
+                        {
+                            for s in blade_var_rename::file_scope_spans(&view_content, &binding.key)
+                            {
+                                targets.push(laravel_lsp::rename::EditTarget {
+                                    file_path: view_path.clone(),
+                                    line: s.line,
+                                    start_column: s.start_col,
+                                    end_column: s.end_col,
+                                    new_text: new_bare.clone(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(laravel_lsp::rename::build_rename_edit(&targets))
+    }
 }
 #[tower_lsp::async_trait]
 impl LanguageServer for LaravelLanguageServer {
@@ -20071,6 +20290,19 @@ impl LanguageServer for LaravelLanguageServer {
             }
         }
 
+        // issue #55 — Blade variable (`$foo` in a .blade.php template). Checked
+        // before the literal-symbol classifier, which never tags a variable.
+        if path_str.ends_with(".blade.php") {
+            if let Some(range) = self.prepare_blade_var_rename(uri, position).await {
+                return Ok(Some(PrepareRenameResponse::Range(range)));
+            }
+        } else if let Some(range) = self.prepare_view_binding_rename(uri, position).await {
+            // issue #55 — controller view-data binding key. Only in plain
+            // `.php` files; the `else` keeps a Blade `view(...)` from
+            // shadowing the variable path above.
+            return Ok(Some(PrepareRenameResponse::Range(range)));
+        }
+
         let root_path = self.root_path.read().await.clone();
         let symbol = match classify_with_decl_fallback(
             self,
@@ -20178,6 +20410,29 @@ impl LanguageServer for LaravelLanguageServer {
             .await
         {
             return Ok(Some(edit));
+        }
+
+        // issue #55 — scope-aware Blade variable rename (`$foo` in a template)
+        // and controller→view binding-key rename. Both run before the
+        // literal-symbol classifier: a variable / binding key is never tagged
+        // as a Laravel string-keyed pattern, so this can't shadow route /
+        // config / view renames (a cursor on the view NAME returns `None` from
+        // `view_binding_key_at` and falls through).
+        if path_str.ends_with(".blade.php") {
+            match self.blade_var_rename_edit(uri, position, &new_name).await {
+                Ok(Some(edit)) => return Ok(Some(edit)),
+                Ok(None) => {}
+                Err(e) => return Err(e),
+            }
+        } else {
+            match self
+                .view_binding_rename_edit(uri, position, &new_name)
+                .await
+            {
+                Ok(Some(edit)) => return Ok(Some(edit)),
+                Ok(None) => {}
+                Err(e) => return Err(e),
+            }
         }
 
         let root_path = self.root_path.read().await.clone();

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18632,6 +18632,14 @@ impl LaravelLanguageServer {
         if property.is_some() || var_name.is_empty() {
             return None;
         }
+        // issue #55 AC: reject rename for variables outside a recognized
+        // binding context. A `$var` that never surfaces in template markup —
+        // an undefined `$ghost`, or a PHP-block / function-local confined to
+        // `@php … @endphp` — is not a renameable Blade variable, so return
+        // `None` and let the cursor fall through to the other classifiers.
+        if !laravel_lsp::blade_var_rename::is_template_variable(&content, &var_name) {
+            return None;
+        }
         let span = laravel_lsp::blade_var_rename::variable_spans(line_text, &var_name)
             .into_iter()
             .find(|s| {
@@ -18739,7 +18747,7 @@ impl LaravelLanguageServer {
         position: Position,
         new_name: &str,
     ) -> jsonrpc::Result<Option<WorkspaceEdit>> {
-        use laravel_lsp::blade_var_rename::{self, BindingForm};
+        use laravel_lsp::blade_var_rename;
 
         let path = match uri.to_file_path() {
             Ok(p) => p,
@@ -18770,58 +18778,62 @@ impl LaravelLanguageServer {
             ));
         }
 
+        // Resolve the view template — but only after validating the view NAME.
+        // `binding.view_name` comes from the `view('…')` source, so a hostile
+        // workspace could write `view('/tmp/evil', compact('k'))`; without
+        // validation `resolve_view_path` would `join` an absolute / `..`
+        // segment and read an out-of-project file, leaking its absolute path
+        // into the WorkspaceEdit (issue #55 security review). `validate_view_name`
+        // rejects slashes, `..`, and extensions; we additionally require the
+        // resolved path to live under the project root. A view that fails either
+        // check is skipped — the controller-side rename (key + compact local)
+        // still applies.
+        let view_path: Option<std::path::PathBuf> = match self.get_cached_config().await {
+            Some(config)
+                if laravel_lsp::view_declaration_locator::validate_view_name(
+                    &binding.view_name,
+                )
+                .is_ok() =>
+            {
+                laravel_lsp::view_declaration_locator::locate_view_file(&binding.view_name, &config)
+                    .filter(|p| p.starts_with(&config.root))
+            }
+            _ => None,
+        };
+        let view_source: Option<String> = match view_path.as_ref() {
+            Some(p) => match (p.to_str(), Url::from_file_path(p)) {
+                (Some(s), Ok(view_uri)) => self.rename_document_text(&view_uri, s).await,
+                _ => None,
+            },
+            None => None,
+        };
+
+        // Compute every rewrite span across the controller and the resolved view
+        // via the unit-tested cross-file core (issue #55 AC #6). The controller
+        // gets the key string plus — for `compact` — the enclosing-function
+        // local `$key`; the view gets the file-scoped `$key` usages.
+        let spans =
+            blade_var_rename::binding_rename_spans(&binding, &content, view_source.as_deref());
+
         let mut targets: Vec<laravel_lsp::rename::EditTarget> = Vec::new();
-
-        // 1. The controller key string (array key or compact arg).
-        targets.push(laravel_lsp::rename::EditTarget {
-            file_path: path.clone(),
-            line: binding.key_span.line,
-            start_column: binding.key_span.start_col,
-            end_column: binding.key_span.end_col,
-            new_text: new_bare.clone(),
-        });
-
-        // 2. compact: the enclosing-function local `$key` moves with the key,
-        //    because compact binds the view variable BY the local's name.
-        if binding.form == BindingForm::Compact {
-            for s in blade_var_rename::enclosing_function_local_spans(
-                &content,
-                &binding.key,
-                binding.key_span,
-            ) {
+        for s in spans.controller {
+            targets.push(laravel_lsp::rename::EditTarget {
+                file_path: path.clone(),
+                line: s.line,
+                start_column: s.start_col,
+                end_column: s.end_col,
+                new_text: new_bare.clone(),
+            });
+        }
+        if let Some(view_path) = view_path.as_ref() {
+            for s in spans.view {
                 targets.push(laravel_lsp::rename::EditTarget {
-                    file_path: path.clone(),
+                    file_path: view_path.clone(),
                     line: s.line,
                     start_column: s.start_col,
                     end_column: s.end_col,
                     new_text: new_bare.clone(),
                 });
-            }
-        }
-
-        // 3. In-view `$key` usages (file-scoped, minus loop re-binds).
-        if let Some(config) = self.get_cached_config().await {
-            if let Some(view_path) =
-                laravel_lsp::view_declaration_locator::locate_view_file(&binding.view_name, &config)
-            {
-                if let Some(view_str) = view_path.to_str() {
-                    if let Ok(view_uri) = Url::from_file_path(&view_path) {
-                        if let Some(view_content) =
-                            self.rename_document_text(&view_uri, view_str).await
-                        {
-                            for s in blade_var_rename::file_scope_spans(&view_content, &binding.key)
-                            {
-                                targets.push(laravel_lsp::rename::EditTarget {
-                                    file_path: view_path.clone(),
-                                    line: s.line,
-                                    start_column: s.start_col,
-                                    end_column: s.end_col,
-                                    new_text: new_bare.clone(),
-                                });
-                            }
-                        }
-                    }
-                }
             }
         }
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18366,6 +18366,20 @@ fn zero_anchor() -> Range {
     }
 }
 
+/// True if `path` resolves to a location inside `root`. Both sides are
+/// canonicalized first — `locate_view_file` builds the path by joining and
+/// `Path::starts_with` is purely textual, so a symlink under the project could
+/// otherwise resolve outside the root and leak an absolute, out-of-project path
+/// into a `WorkspaceEdit` (issue #55 cross-file binding rename). When either
+/// side can't be canonicalized (e.g. the file vanished mid-edit) we fall back
+/// to the textual prefix check rather than admitting an unverified path.
+fn path_within_root(path: &std::path::Path, root: &std::path::Path) -> bool {
+    match (path.canonicalize(), root.canonicalize()) {
+        (Ok(real_path), Ok(real_root)) => real_path.starts_with(&real_root),
+        _ => path.starts_with(root),
+    }
+}
+
 impl LaravelLanguageServer {
     /// Collect every code-lens item for a file — each a `(range, symbols)` pair.
     /// Position lenses (magic members, routes, env, config, translation) carry
@@ -18796,7 +18810,7 @@ impl LaravelLanguageServer {
                 .is_ok() =>
             {
                 laravel_lsp::view_declaration_locator::locate_view_file(&binding.view_name, &config)
-                    .filter(|p| p.starts_with(&config.root))
+                    .filter(|p| path_within_root(p, &config.root))
             }
             _ => None,
         };

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18654,6 +18654,14 @@ impl LaravelLanguageServer {
         if !laravel_lsp::blade_var_rename::is_template_variable(&content, &var_name) {
             return None;
         }
+        // Refuse when the cursor sits in an unresolved loop region — an opaque
+        // loop (a `@foreach`/`@forelse` whose binding the parser couldn't
+        // resolve) or below a broken (unbalanced-paren) loop header. The scope
+        // there is unknown, so a scope-local rename would risk a file-wide
+        // clobber. Fail closed: don't offer F2.
+        if laravel_lsp::blade_var_rename::cursor_in_unresolved_loop(&content, position.line) {
+            return None;
+        }
         let span = laravel_lsp::blade_var_rename::variable_spans(line_text, &var_name)
             .into_iter()
             .find(|s| {

--- a/laravel-lsp/src/tests/loop_variable_resolution.rs
+++ b/laravel-lsp/src/tests/loop_variable_resolution.rs
@@ -1,6 +1,6 @@
 use laravel_lsp::blade_loops::{
     find_loop_blocks, get_enclosing_loops, parse_for_variables, parse_foreach_iterable,
-    parse_foreach_variables, BladeLoopType,
+    parse_foreach_variables, unbalanced_loop_head_lines, BladeLoopType,
 };
 
 #[test]
@@ -25,6 +25,87 @@ fn test_parse_foreach_key_value() {
 fn test_parse_foreach_with_spaces() {
     let vars = parse_foreach_variables("( $users as $user )");
     assert_eq!(vars, vec![("user".to_string(), "mixed".to_string())]);
+}
+
+#[test]
+fn test_parse_foreach_list_destructuring() {
+    // Short-syntax array destructuring binds every name inside `[...]`.
+    let vars = parse_foreach_variables("($pairs as [$a, $b])");
+    assert_eq!(
+        vars,
+        vec![
+            ("a".to_string(), "mixed".to_string()),
+            ("b".to_string(), "mixed".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_parse_foreach_list_function_destructuring() {
+    // Long-syntax `list(...)` destructuring is equivalent.
+    let vars = parse_foreach_variables("($pairs as list($a, $b))");
+    assert_eq!(
+        vars,
+        vec![
+            ("a".to_string(), "mixed".to_string()),
+            ("b".to_string(), "mixed".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_parse_foreach_by_reference() {
+    // The `&` is not a name; only `$item` is bound.
+    let vars = parse_foreach_variables("($items as &$item)");
+    assert_eq!(vars, vec![("item".to_string(), "mixed".to_string())]);
+}
+
+#[test]
+fn test_parse_foreach_key_with_destructured_value() {
+    // `$k => [$a, $b]` binds the key and both destructured names, in order.
+    let vars = parse_foreach_variables("($rows as $k => [$a, $b])");
+    assert_eq!(
+        vars,
+        vec![
+            ("k".to_string(), "mixed".to_string()),
+            ("a".to_string(), "mixed".to_string()),
+            ("b".to_string(), "mixed".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_parse_foreach_no_binding_is_empty() {
+    // A header with no ` as ` binding yields no variables — the caller treats
+    // such a foreach as an opaque loop and refuses the rename.
+    assert!(parse_foreach_variables("($items)").is_empty());
+}
+
+#[test]
+fn test_unbalanced_loop_head_flags_broken_header() {
+    // A header with an unclosed paren never balances — flag its line so the
+    // rename can fail closed instead of clobbering file-wide.
+    let content = "\
+<p>ok</p>
+@foreach ($users as $user
+    {{ $user }}
+@endforeach";
+    assert_eq!(unbalanced_loop_head_lines(content), vec![1]);
+}
+
+#[test]
+fn test_unbalanced_loop_head_empty_for_valid_headers() {
+    // Both a single-line and a legitimately-wrapped header balance — neither is
+    // flagged as broken.
+    let content = "\
+@foreach ($users as $user)
+    {{ $user }}
+@endforeach
+@foreach ($posts
+    as $post)
+    {{ $post }}
+@endforeach";
+    assert!(unbalanced_loop_head_lines(content).is_empty());
 }
 
 #[test]

--- a/laravel-lsp/src/tests/loop_variable_resolution.rs
+++ b/laravel-lsp/src/tests/loop_variable_resolution.rs
@@ -245,3 +245,74 @@ fn test_find_loop_blocks_captures_iterable() {
     assert_eq!(blocks.len(), 1);
     assert_eq!(blocks[0].iterable, Some("$this->audits".to_string()));
 }
+
+// ── parenthesized iterables (issue #55 regression) ───────────────────────────
+// A method-call iterable contains its own `)`; the loop arg list must be
+// captured by balancing parens, not a `[^)]` run that truncates at the first
+// `)`. A truncated capture dropped the ` as $var` tail, leaving the loop with
+// no variables — which made the loop scope invisible and let a rename clobber
+// every `$var` in the file.
+
+#[test]
+fn test_parse_foreach_variables_method_call_iterable() {
+    let vars = parse_foreach_variables("($users->where('active', true) as $user)");
+    assert_eq!(vars, vec![("user".to_string(), "mixed".to_string())]);
+}
+
+#[test]
+fn test_parse_foreach_variables_method_call_iterable_key_value() {
+    let vars = parse_foreach_variables("($items->take(5) as $key => $value)");
+    assert_eq!(
+        vars,
+        vec![
+            ("key".to_string(), "mixed".to_string()),
+            ("value".to_string(), "mixed".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn test_parse_foreach_iterable_method_call() {
+    assert_eq!(
+        parse_foreach_iterable("($users->where('active', true) as $user)"),
+        Some("$users->where('active', true)".to_string())
+    );
+}
+
+#[test]
+fn test_find_loop_blocks_method_call_iterable_keeps_variable() {
+    let content = r#"
+@foreach($users->where('active', true) as $user)
+    {{ $user->name }}
+@endforeach
+"#;
+    let blocks = find_loop_blocks(content);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(
+        blocks[0].variables,
+        vec![("user".to_string(), "mixed".to_string())],
+        "the loop variable must survive a parenthesized iterable"
+    );
+    assert_eq!(
+        blocks[0].iterable,
+        Some("$users->where('active', true)".to_string())
+    );
+    assert_eq!(blocks[0].start_line, 1);
+    assert_eq!(blocks[0].end_line, Some(3));
+}
+
+#[test]
+fn test_find_loop_blocks_nested_parens_in_iterable() {
+    // Iterable with nested parens — `Model::query()->whereIn('id', f(1, 2))`.
+    let content = r#"
+@foreach(Model::query()->whereIn('id', collect([1, 2])) as $row)
+    {{ $row }}
+@endforeach
+"#;
+    let blocks = find_loop_blocks(content);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(
+        blocks[0].variables,
+        vec![("row".to_string(), "mixed".to_string())]
+    );
+}

--- a/laravel-lsp/src/tests/loop_variable_resolution.rs
+++ b/laravel-lsp/src/tests/loop_variable_resolution.rs
@@ -121,6 +121,79 @@ fn test_find_loop_blocks_forelse() {
 }
 
 #[test]
+fn test_find_loop_blocks_multiline_foreach() {
+    // A `@foreach` whose argument list wraps across physical lines must still
+    // register as a loop block. A per-line paren scan loses the ` as $user`
+    // tail, the binding goes unrecognized, and the loop becomes invisible to
+    // scope-aware rename — a silent file-wide clobber.
+    let content = "\
+@foreach($users->where('active', true)
+    as $user)
+    {{ $user->name }}
+@endforeach
+";
+    let blocks = find_loop_blocks(content);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].loop_type, BladeLoopType::Foreach);
+    assert_eq!(
+        blocks[0].variables,
+        vec![("user".to_string(), "mixed".to_string())]
+    );
+    assert_eq!(
+        blocks[0].iterable.as_deref(),
+        Some("$users->where('active', true)")
+    );
+    assert_eq!(blocks[0].start_line, 0);
+    assert_eq!(blocks[0].end_line, Some(3));
+}
+
+#[test]
+fn test_find_loop_blocks_multiline_foreach_key_value() {
+    // The directive keyword, the iterable, and the `$key => $value` binding can
+    // each land on their own line. The binding must still be recovered.
+    let content = "\
+@foreach(
+    $items as $key => $value
+)
+    {{ $key }}: {{ $value }}
+@endforeach
+";
+    let blocks = find_loop_blocks(content);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(
+        blocks[0].variables,
+        vec![
+            ("key".to_string(), "mixed".to_string()),
+            ("value".to_string(), "mixed".to_string()),
+        ]
+    );
+    assert_eq!(blocks[0].start_line, 0);
+    assert_eq!(blocks[0].end_line, Some(4));
+}
+
+#[test]
+fn test_find_loop_blocks_multiline_forelse() {
+    // The same wrap on `@forelse` — the other binding-introducing loop.
+    let content = "\
+@forelse($posts->published()
+    as $post)
+    {{ $post->title }}
+@empty
+    none
+@endforelse
+";
+    let blocks = find_loop_blocks(content);
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].loop_type, BladeLoopType::Forelse);
+    assert_eq!(
+        blocks[0].variables,
+        vec![("post".to_string(), "mixed".to_string())]
+    );
+    assert_eq!(blocks[0].start_line, 0);
+    assert_eq!(blocks[0].end_line, Some(5));
+}
+
+#[test]
 fn test_get_enclosing_loops_inside() {
     let content = r#"
 @foreach($users as $user)

--- a/laravel-lsp/src/view_declaration_locator.rs
+++ b/laravel-lsp/src/view_declaration_locator.rs
@@ -56,6 +56,13 @@ impl ViewNameError {
 /// Validate a user-typed new view name. Returns `Ok(())` only when the name
 /// is a well-formed dotted segment list — what Laravel's `view()` helper
 /// actually resolves at runtime.
+///
+/// **Limitation:** namespaced views (`package::view`) are not supported — the
+/// `:` namespace separator trips the [`ViewNameError::InvalidCharacter`] check.
+/// This is intentional for now: rename only handles application views, and the
+/// cross-file binding rename (issue #55) skips a namespaced source `view(...)`
+/// rather than mis-resolving it. Supporting `package::view` would mean parsing
+/// the namespace segment against the registered view hints — a separate change.
 pub fn validate_view_name(name: &str) -> Result<(), ViewNameError> {
     let trimmed = name.trim();
     if trimmed.is_empty() {


### PR DESCRIPTION
## Summary
Implements #55 — scope-aware **Blade template variable rename**, plus **controller→view binding rename**, layered onto the existing rename engine.

## Changes
- **New module `laravel-lsp/src/blade_var_rename.rs`** (pure, fully unit-tested):
  - `in_scope_spans` / `file_scope_spans` — scope-aware variable occurrence resolution. Loop-introduced (`@foreach`/`@forelse`/`@for`) variables are block-scoped; file-level variables (controller-passed, `@php`-assigned) are file-scoped but skip any nested loop that re-binds the same name (nested-scope-conflict rule). Blade comments (`{{-- --}}`) and `@verbatim` regions are masked out.
  - `view_binding_key_at` — detects a view-data binding key under the cursor in a controller: `view('v', ['key' => …])` and `compact('key')`.
  - `enclosing_function_local_spans` — for `compact`, renames the enclosing method's local `$key` so the controller stays valid.
- **Wired into `main.rs`** `prepare_rename` / `rename` handlers, ahead of the literal-symbol classifier (a variable / binding key is never a string-keyed Laravel pattern, so it can't shadow route/config/view renames; cursor on the view *name* falls through correctly).
- **Docs**: `docs/rename.md` gains Blade-variable + controller→view sections; README moves the feature from *Planned* to shipped.

## Acceptance Criteria
- [x] Renaming a Blade variable updates only in-scope occurrences within the template (respecting `@foreach`, `@php`, `@forelse`, `@for` block boundaries).
- [x] Nested scope conflicts respected — same name in nested scopes renames only the target occurrence's scope.
- [x] Cross-file rename: `view('x', ['key' => $value])` / `compact('key')` updates the controller key and the in-view `$key` usages (and the compact local).
- [x] A view rendered from multiple controllers with different key names — scope respected, no cross-contamination.
- [x] `prepare_rename` rejects rename outside recognized contexts (non-variable / non-binding-key cursors return nothing and fall through; invalid new names are rejected with a toast).
- [x] Test coverage: `@foreach` / `@php` / `@forelse` / `@for` scoping, `view(..., ['key' => …])`, `compact('key')`, nested scope conflicts.
- [x] All existing rename tests continue to pass (no regression).

## Test Plan
- [x] 21 new unit tests in `src/blade_var_rename/tests.rs` cover every AC case — all pass.
- [x] Full suite green: 1622 lib + 79/80 integration (the 1 skip is the composer-vendor route fixture CI provisions); `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- [ ] Manual: F2 on a `$var` in a `.blade.php` and on a `view()` binding key in a controller.

Fixes #55