### PR TITLE
docs: 📝 Document language-server config and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,24 @@ Clone the repo, run `cargo build --release` in `laravel-lsp/`, then use "zed: in
 
 The extension works out of the box with zero configuration. It automatically discovers your Laravel project structure, including view paths, component namespaces, route files, and service providers.
 
-Everything below is optional.
+Everything below is optional — **with one exception**: if you've customized which language servers run for PHP or Blade, see [🔌 Coexisting with your PHP / Blade language servers](#-coexisting-with-your-php--blade-language-servers) first, or the extension won't activate in those files.
+
+### 🔌 Coexisting with your PHP / Blade language servers
+
+This extension registers a language server called `laravel-lsp` for **PHP**, **Blade**, **XML**, and `.env` (Shell Script) files. By default Zed runs it automatically alongside your other servers — no setup needed.
+
+**If you've customized `language_servers` for PHP or Blade** (common when pinning a specific PHP LSP), you must add `laravel-lsp` to those lists, or it won't attach and none of the Blade/PHP features appear. An explicit list *replaces* Zed's defaults — keep the `"..."` token to preserve them:
+
+```json
+{
+  "languages": {
+    "PHP":   { "language_servers": ["laravel-lsp", "..."] },
+    "Blade": { "language_servers": ["laravel-lsp", "..."] }
+  }
+}
+```
+
+> 💡 **Symptom:** features work in `.env` files (you see code-lens counts) but do nothing in `.php` / `.blade.php`. That's this setting — `.env` is treated as Shell Script, which you likely didn't override.
 
 ### 🎛️ Extension settings
 
@@ -225,6 +242,41 @@ If you use Intelephense as your PHP language server, goto-definition on a class 
 ```
 
 After saving, restart Intelephense (`Cmd+Shift+P → lsp: restart`). For the licence-key shape, the `_ide_helper*.php` / `.phpstorm.meta.php` trade-offs, the cache caveat, and per-project `.intelephense.json`, see the **[full Intelephense tuning guide](docs/tuning-intelephense.md)**.
+
+## 🩺 Troubleshooting
+
+**The extension installed but nothing happens — no features, no Laravel entry in the language-server list.** Work through these in order; each is a real cause we've seen.
+
+### 1. Is your Zed new enough?
+
+The extension is built against `zed_extension_api 0.7.0`, which requires **Zed 0.205 or newer**. Older versions silently refuse to load it — the extension appears installed but never activates, and the log stays quiet. Check `Zed → About Zed` (or `zed --version`) and update if you're behind.
+
+### 2. Does Zed recognize the file as PHP / Blade?
+
+The language server only attaches to files Zed has classified as **PHP**, **Blade**, **XML**, or `.env` (Shell Script). Open a `.php` file and check the **bottom-right status bar**:
+
+- Says **"PHP"** → good, the language is registered.
+- Says **"Plain Text"** → install the official [**PHP**](https://github.com/zed-extensions/php) extension (and [**Laravel Blade**](https://github.com/bajrangCoder/zed-laravel-blade) for `.blade.php`). Without a language registered, no language server — ours included — can attach.
+
+### 3. Did you override `language_servers` for PHP or Blade?
+
+If features work in `.env` files but not in `.php` / `.blade.php`, you've almost certainly set an explicit `language_servers` list that omits `laravel-lsp`. See [🔌 Coexisting with your PHP / Blade language servers](#-coexisting-with-your-php--blade-language-servers) for the fix.
+
+### 4. Check the language-server log
+
+The running servers show under the **lightning-bolt icon** in the status bar. For the full log: `Cmd+Shift+P → "open language server logs"` and look for **Laravel**. If it's missing entirely, the server never started (revisit steps 1–3). If it's present but erroring, the log will say why — please [open an issue](https://github.com/mike-bronner/zed-laravel/issues) with that output.
+
+### 5. Manual binary fallback
+
+The extension downloads its server binary from GitHub releases on first use. If that download is blocked (proxy, firewall, offline), drop the binary on your `PATH` instead — Zed will find it there. Grab the archive for your platform from the [latest release](https://github.com/mike-bronner/zed-laravel/releases/latest), then (macOS x86_64 shown):
+
+```bash
+tar -xzf ~/Downloads/laravel-lsp-macos-x64.tar.gz
+mkdir -p ~/.local/bin && mv laravel-lsp-macos-x64 ~/.local/bin/laravel-lsp
+chmod +x ~/.local/bin/laravel-lsp
+xattr -d com.apple.quarantine ~/.local/bin/laravel-lsp 2>/dev/null
+# ensure ~/.local/bin is on your PATH, then fully restart Zed
+```
 
 ## 🚧 Planned Features
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "laravel"
 name = "Laravel"
-description = "Laravel development support for Zed with go-to-definition for Blade, Livewire, and Flux components. Install the separate Blade extension for syntax highlighting."
+description = "Laravel support for Zed — go-to-definition, hover & find-references for Blade, Livewire, Flux, views, routes, and config. 📖 See the README for setup & configuration; custom PHP/Blade language servers need a one-line settings tweak."
 version = "0.4.1"
 schema_version = 1
 authors = ["Mike Bronner <mike.bronner@icloud.com>"]


### PR DESCRIPTION
## What & why

[#90](https://github.com/mike-bronner/zed-laravel/issues/90) surfaced a config trap with no signpost: when a user overrides `language_servers` for **PHP** or **Blade** (to pin their own PHP LSP), an explicit list *replaces* Zed's defaults and silently drops `laravel-lsp` — so no Blade/PHP features activate. `.env` kept working because Shell Script wasn't overridden, which is exactly the symptom the reporter described.

The artifacts were all fine (the "Intel binary" theory was a red herring — correct x86_64 Mach-O, present on every release, marketplace version matches). The real gap was **documentation**.

## Changes

- **README — new Configuration subsection** "🔌 Coexisting with your PHP / Blade language servers": the `"..."`-token fix plus the *works-in-.env, silent-in-.php/.blade.php* symptom callout for searchability.
- **README — new 🩺 Troubleshooting section** covering the three gotchas this issue raised:
  1. Stale Zed (`zed_extension_api 0.7.0` needs Zed ≥ 0.205)
  2. File shown as "Plain Text" (no PHP/Blade language registered)
  3. The `language_servers` override
  4. Reading the language-server log
  5. Manual binary fallback (PATH) for blocked downloads
- **`extension.toml` description** reworded to nudge users toward the README for setup/config (Zed already surfaces a repo button, so no raw URL).

Docs-only — no Rust touched.

Fixes #90
