### PR TITLE
feat: Flux component support (goto-definition + hover + completion)

### DIFF
--- a/laravel-lsp/queries/blade.scm
+++ b/laravel-lsp/queries/blade.scm
@@ -59,6 +59,30 @@
   (#match? @tag_name "^livewire:"))
 
 ; ============================================================================
+; Pattern 2b: <flux:component> Flux component tags
+; ============================================================================
+; Matches: <flux:button>
+;          <flux:icon.arrow-right>
+;
+; Flux's single-colon tag syntax is sugar for the `flux` anonymous-component
+; namespace; captured here so it resolves like a Blade component.
+
+(element
+  (start_tag
+    (tag_name) @tag_name)
+  (#match? @tag_name "^flux:"))
+
+; Match closing Flux tags like </flux:button>
+(element
+  (end_tag
+    (tag_name) @tag_name)
+  (#match? @tag_name "^flux:"))
+
+(self_closing_tag
+  (tag_name) @tag_name
+  (#match? @tag_name "^flux:"))
+
+; ============================================================================
 ; Pattern 3: Blade Directives (all types)
 ; ============================================================================
 ; Matches: @extends('layout')

--- a/laravel-lsp/src/blade_props.rs
+++ b/laravel-lsp/src/blade_props.rs
@@ -86,5 +86,155 @@ pub fn extract_props_directive_from_source(content: &str) -> Option<String> {
     None
 }
 
+/// Parse the prop *names* declared by a `@props([...])` directive in Blade
+/// source, in declaration order. Both shorthand entries (`'foo'`) and keyed
+/// entries (`'foo' => default`) yield the bare name `foo` (no leading `$`).
+///
+/// Flux/Blade component attribute completion uses this to offer a resolved
+/// component's declared props as attributes. Returns an empty `Vec` when the
+/// source has no `@props(...)` directive.
+///
+/// Robust to nested arrays in defaults — `'opts' => ['a', 'b']` yields just
+/// `opts`, because only the *first* string literal of each top-level entry
+/// (the key, or the bare name) is taken.
+pub fn extract_prop_names(content: &str) -> Vec<String> {
+    let directive = match extract_props_directive_from_source(content) {
+        Some(d) => d,
+        None => return Vec::new(),
+    };
+    let bytes = directive.as_bytes();
+    // Narrow to the array body between the outermost `[` and its match `]`.
+    let open = match directive.find('[') {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    let body = match matching_bracket(bytes, open) {
+        Some(close) => &directive[open + 1..close],
+        None => return Vec::new(),
+    };
+
+    split_top_level_commas(body)
+        .into_iter()
+        .filter_map(first_string_literal)
+        .filter(|name| is_php_identifier(name))
+        .collect()
+}
+
+/// Index of the `]` matching the `[` at `open`, tracking string literals so
+/// brackets inside strings don't throw off the balance. `None` if unbalanced.
+fn matching_bracket(bytes: &[u8], open: usize) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut i = open;
+    let mut in_string: Option<u8> = None;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(q) = in_string {
+            if b == b'\\' && i + 1 < bytes.len() {
+                i += 2;
+                continue;
+            }
+            if b == q {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' | b'"' => in_string = Some(b),
+            b'[' => depth += 1,
+            b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Split an array body on top-level commas, ignoring commas nested inside
+/// `[]` / `()` or inside string literals.
+fn split_top_level_commas(body: &str) -> Vec<&str> {
+    let bytes = body.as_bytes();
+    let mut parts = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0i32;
+    let mut in_string: Option<u8> = None;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(q) = in_string {
+            if b == b'\\' && i + 1 < bytes.len() {
+                i += 2;
+                continue;
+            }
+            if b == q {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' | b'"' => in_string = Some(b),
+            b'[' | b'(' => depth += 1,
+            b']' | b')' => depth -= 1,
+            b',' if depth == 0 => {
+                parts.push(&body[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    parts.push(&body[start..]);
+    parts
+}
+
+/// Content of the first single- or double-quoted string literal in `entry`,
+/// or `None` when there isn't one. Used to pull the prop name (the key, or the
+/// bare value) from a `@props` array entry.
+fn first_string_literal(entry: &str) -> Option<String> {
+    let bytes = entry.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'\'' || b == b'"' {
+            let quote = b;
+            let mut j = i + 1;
+            let mut s = String::new();
+            while j < bytes.len() {
+                let c = bytes[j];
+                if c == b'\\' && j + 1 < bytes.len() {
+                    s.push(bytes[j + 1] as char);
+                    j += 2;
+                    continue;
+                }
+                if c == quote {
+                    return Some(s);
+                }
+                s.push(c as char);
+                j += 1;
+            }
+            return None; // unterminated literal
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Whether `s` is a valid PHP identifier (the shape a prop name must have to
+/// be offered as an attribute). Rejects array spreads, expressions, etc.
+fn is_php_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c == '_' || c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
 #[cfg(test)]
 mod tests;

--- a/laravel-lsp/src/blade_props/tests.rs
+++ b/laravel-lsp/src/blade_props/tests.rs
@@ -72,3 +72,48 @@ fn returns_none_for_nonexistent_file() {
     let nonexistent = std::path::PathBuf::from("/nonexistent/view.blade.php");
     assert_eq!(extract_props_directive(&nonexistent), None);
 }
+
+// ─── prop name extraction (issue #60: Flux attribute completion) ─────────
+
+#[test]
+fn prop_names_from_keyed_entries() {
+    let src = "@props(['user' => null, 'showAvatar' => true])\n<div></div>\n";
+    assert_eq!(extract_prop_names(src), vec!["user", "showAvatar"]);
+}
+
+#[test]
+fn prop_names_from_shorthand_entries() {
+    // Bare string entries (no default) are still prop names.
+    let src = "@props(['variant', 'size'])\n";
+    assert_eq!(extract_prop_names(src), vec!["variant", "size"]);
+}
+
+#[test]
+fn prop_names_mix_shorthand_and_keyed() {
+    let src = "@props([\n    'variant',\n    'size' => 'base',\n    'icon' => null,\n])\n";
+    assert_eq!(extract_prop_names(src), vec!["variant", "size", "icon"]);
+}
+
+#[test]
+fn prop_names_ignore_nested_array_defaults() {
+    // Only the first string of each top-level entry is the name — strings
+    // inside a nested-array default must not be mistaken for props.
+    let src = "@props(['opts' => ['a', 'b'], 'label' => 'Hi'])\n";
+    assert_eq!(extract_prop_names(src), vec!["opts", "label"]);
+}
+
+#[test]
+fn prop_names_ignore_commas_inside_string_defaults() {
+    let src = "@props(['note' => 'a, b, c', 'count' => 0])\n";
+    assert_eq!(extract_prop_names(src), vec!["note", "count"]);
+}
+
+#[test]
+fn prop_names_empty_without_directive() {
+    assert!(extract_prop_names("<div>no props</div>\n").is_empty());
+}
+
+#[test]
+fn prop_names_empty_for_empty_props() {
+    assert!(extract_prop_names("@props([])\n").is_empty());
+}

--- a/laravel-lsp/src/cache_manager.rs
+++ b/laravel-lsp/src/cache_manager.rs
@@ -143,7 +143,6 @@ impl ScanResult {
 /// Results from scanning node_modules
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NodeModulesScan {
-    pub flux_components: Vec<String>,
     pub livewire_volt_components: Vec<String>,
 }
 

--- a/laravel-lsp/src/component_completion.rs
+++ b/laravel-lsp/src/component_completion.rs
@@ -152,6 +152,23 @@ fn scan_dir(
     out
 }
 
+/// Collect Flux component tag bodies for `<flux:...>` autocomplete. Scans the
+/// app-published `resources/views/flux/` plus the Flux and Flux Pro package
+/// sources under `vendor/`, returning bare dotted names (`button`,
+/// `icon.arrow-right`) deduped and sorted.
+pub fn collect_flux_components(root: &Path) -> Vec<ComponentCandidate> {
+    let dirs = [
+        root.join("resources/views/flux"),
+        root.join("vendor/livewire/flux/stubs/resources/views/flux"),
+        root.join("vendor/livewire/flux-pro/stubs/resources/views/flux"),
+    ];
+    let mut out = Vec::new();
+    for dir in &dirs {
+        out.extend(scan_anonymous_dir(dir, "", root));
+    }
+    dedup_and_sort(out)
+}
+
 /// Dedup candidates by tag name and sort by name. When two candidates share a
 /// name, a `Class` beats an `AnonymousView` (Laravel resolves the class first);
 /// otherwise the first occurrence wins.

--- a/laravel-lsp/src/component_completion/tests.rs
+++ b/laravel-lsp/src/component_completion/tests.rs
@@ -96,6 +96,40 @@ fn scan_class_dir_emits_kebab_class_components_and_skips_blade() {
     assert!(got.iter().all(|c| c.kind == CandidateKind::Class));
 }
 
+// ─── flux scan (issue #60) ──────────────────────────────────────────────
+
+#[test]
+fn collect_flux_components_scans_published_and_vendor_sources() {
+    let (_dir, root) = dir_with_files(&[
+        ("resources/views/flux/button.blade.php", "x"),
+        ("resources/views/flux/icon/arrow-right.blade.php", "x"),
+        (
+            "vendor/livewire/flux/stubs/resources/views/flux/badge.blade.php",
+            "x",
+        ),
+        (
+            "vendor/livewire/flux-pro/stubs/resources/views/flux/chart.blade.php",
+            "x",
+        ),
+        // A non-blade file in the flux dir must be ignored.
+        ("resources/views/flux/notes.md", "x"),
+    ]);
+
+    let got = collect_flux_components(&root);
+
+    assert_eq!(
+        names(&got),
+        vec!["badge", "button", "chart", "icon.arrow-right"],
+        "should offer bare dotted Flux names from all sources, sorted",
+    );
+}
+
+#[test]
+fn collect_flux_components_empty_without_flux_dirs() {
+    let (_dir, root) = dir_with_files(&[("resources/views/components/button.blade.php", "x")]);
+    assert!(collect_flux_components(&root).is_empty());
+}
+
 // ─── dedup ──────────────────────────────────────────────────────────────
 
 #[test]

--- a/laravel-lsp/src/component_completion/tests.rs
+++ b/laravel-lsp/src/component_completion/tests.rs
@@ -130,6 +130,34 @@ fn collect_flux_components_empty_without_flux_dirs() {
     assert!(collect_flux_components(&root).is_empty());
 }
 
+#[test]
+fn collect_flux_components_ignores_node_modules_tree() {
+    // AC #4: the corrected stub discovers Flux via Composer (`vendor/`), never
+    // `node_modules`. A flux-shaped blade sitting under a node_modules tree
+    // must NOT be picked up — only the real Composer source counts.
+    let (_dir, root) = dir_with_files(&[
+        // Decoy: flux-named blade under node_modules — must be ignored.
+        (
+            "node_modules/@livewire/flux/stubs/resources/views/flux/decoy.blade.php",
+            "x",
+        ),
+        ("node_modules/flux/views/flux/ghost.blade.php", "x"),
+        // The genuine Composer source — the only thing that should surface.
+        (
+            "vendor/livewire/flux/stubs/resources/views/flux/button.blade.php",
+            "x",
+        ),
+    ]);
+
+    let got = collect_flux_components(&root);
+
+    assert_eq!(
+        names(&got),
+        vec!["button"],
+        "only the Composer vendor source is scanned; node_modules is ignored",
+    );
+}
+
 // ─── dedup ──────────────────────────────────────────────────────────────
 
 #[test]

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -5538,13 +5538,15 @@ impl LaravelLanguageServer {
         );
     }
 
-    /// Rescan node_modules (for Flux, etc.)
+    /// Rescan node_modules (JS-side packages).
+    ///
+    /// Flux is intentionally not scanned here: it ships via Composer under
+    /// `vendor/livewire/flux`, not node_modules. Flux components are discovered
+    /// through the vendor service-provider scan and the conventional-path
+    /// fallback in `LaravelConfigData::resolve_component_path`.
     async fn rescan_node_modules(&self, _root: &Path) {
         info!("🔍 Rescanning node_modules...");
         let start = std::time::Instant::now();
-
-        // TODO: Scan for Flux components in node_modules
-        // For now, just update the mtime
 
         let mut cache_guard = self.cache.write().await;
         if let Some(ref mut cache) = *cache_guard {
@@ -8066,6 +8068,47 @@ impl LaravelLanguageServer {
                     start_col: start_pos as u32,
                     end_col: cursor as u32,
                     quote_char: ' ', // Not applicable for tag syntax
+                });
+            }
+        }
+
+        None
+    }
+
+    /// Check if cursor is inside a Flux component tag like `<flux:button` or
+    /// `<flux:icon.arrow-right`. Returns the partial name typed after `<flux:`
+    /// (for filtering completions), or `None` when the cursor is past the name
+    /// (hit a space, `>`, or `/`).
+    fn get_flux_component_context(line_text: &str, character: u32) -> Option<StringContext> {
+        let cursor = character as usize;
+        if cursor > line_text.len() {
+            return None;
+        }
+
+        let before_cursor = &line_text[..cursor];
+
+        if let Some(pos) = before_cursor.rfind("<flux:") {
+            let start_pos = pos + 6; // After "<flux:"
+            let after_prefix = &before_cursor[start_pos..];
+
+            if after_prefix.contains(' ')
+                || after_prefix.contains('>')
+                || after_prefix.contains('/')
+            {
+                return None;
+            }
+
+            // Flux names are dotted/kebab (`icon.arrow-right`); reject anything
+            // else so attribute text after the name isn't treated as a name.
+            if after_prefix
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_')
+            {
+                return Some(StringContext {
+                    prefix: after_prefix.to_string(),
+                    start_col: start_pos as u32,
+                    end_col: cursor as u32,
+                    quote_char: ' ',
                 });
             }
         }
@@ -16140,6 +16183,14 @@ return [
         // `resolve_component_existing_file` guarantees diagnostics and
         // goto-definition can never disagree about whether a component exists.
         for comp_ref in &patterns.components {
+            // Flux's `<flux:...>` tags resolve through vendor/published paths
+            // that may be absent in a given editing session; goto/hover degrade
+            // gracefully, so skip the hard not-found error for them (Flux
+            // diagnostics are out of scope). `<x-flux::...>` keeps its check.
+            if comp_ref.name.starts_with("flux:") && !comp_ref.name.starts_with("flux::") {
+                continue;
+            }
+
             if self
                 .resolve_component_existing_file(&comp_ref.name)
                 .await
@@ -21736,6 +21787,66 @@ impl LanguageServer for LaravelLanguageServer {
 
                 debug!(
                     "   Returning {} Blade component completion items",
+                    items.len()
+                );
+
+                return if items.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(CompletionResponse::List(CompletionList {
+                        is_incomplete: false,
+                        items,
+                    })))
+                };
+            }
+
+            // Check for Flux component context (<flux:...)
+            if let Some(flux_ctx) = Self::get_flux_component_context(line_text, position.character)
+            {
+                debug!(
+                    "   Flux component context, filter prefix: '{}'",
+                    flux_ctx.prefix
+                );
+
+                let candidates = match self.root_path.read().await.clone() {
+                    Some(root) => laravel_lsp::component_completion::collect_flux_components(&root),
+                    None => Vec::new(),
+                };
+
+                let prefix_lower = flux_ctx.prefix.to_lowercase();
+                let items: Vec<CompletionItem> = candidates
+                    .into_iter()
+                    .filter(|c| c.name.to_lowercase().starts_with(&prefix_lower))
+                    .map(|c| CompletionItem {
+                        label: c.name.clone(),
+                        kind: Some(CompletionItemKind::STRUCT),
+                        detail: Some(c.detail.clone()),
+                        documentation: Some(
+                            CompletionDoc::new()
+                                .header(format!("<flux:{}>", c.name))
+                                .summary("Flux component.")
+                                .section(format!("Source: {}", c.detail))
+                                .into_documentation(),
+                        ),
+                        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                            range: Range {
+                                start: Position {
+                                    line: position.line,
+                                    character: flux_ctx.start_col,
+                                },
+                                end: Position {
+                                    line: position.line,
+                                    character: flux_ctx.end_col,
+                                },
+                            },
+                            new_text: c.name.clone(),
+                        })),
+                        ..Default::default()
+                    })
+                    .collect();
+
+                debug!(
+                    "   Returning {} Flux component completion items",
                     items.len()
                 );
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -8164,10 +8164,16 @@ impl LaravelLanguageServer {
             return None;
         }
 
-        // The partial attribute is the word after the last whitespace.
+        // The partial attribute is the word after the last whitespace. Walk
+        // back over char boundaries: a raw byte index from `rfind` + 1 lands
+        // inside a multi-byte whitespace (e.g. U+00A0 NO-BREAK SPACE) and
+        // panics the slice below. Mirrors the `char_indices().rev()` helpers
+        // used elsewhere in this file.
         let word_start = before_cursor
-            .rfind(char::is_whitespace)
-            .map(|i| i + 1)
+            .char_indices()
+            .rev()
+            .find(|(_, c)| c.is_whitespace())
+            .map(|(i, c)| i + c.len_utf8())
             .unwrap_or(cursor);
         let partial = &before_cursor[word_start..];
         // `=`, `"` or `'` in the partial means we're past the name into a value.

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -8116,6 +8116,81 @@ impl LaravelLanguageServer {
         None
     }
 
+    /// Check if the cursor sits at an *attribute* position inside an open Flux
+    /// tag — i.e. past the component name but before the tag closes, as in
+    /// `<flux:button │>` or `<flux:button variant="primary" si│>`.
+    ///
+    /// Returns the resolvable component name (`flux:button`, dotted names
+    /// preserved) plus a [`StringContext`] for the partial attribute word being
+    /// typed (its prefix filters the offered props; `start_col`/`end_col` mark
+    /// the replacement range). Returns `None` when the cursor is still in the
+    /// component name (that's [`Self::get_flux_component_context`]'s job), when
+    /// the tag has already closed, or when the cursor is inside an attribute
+    /// *value* (a quoted string) — props complete attribute *names* only.
+    fn get_flux_attribute_context(
+        line_text: &str,
+        character: u32,
+    ) -> Option<(String, StringContext)> {
+        let cursor = character as usize;
+        if cursor > line_text.len() {
+            return None;
+        }
+        let before_cursor = &line_text[..cursor];
+
+        let pos = before_cursor.rfind("<flux:")?;
+        let after_tag = &before_cursor[pos + 6..]; // after "<flux:"
+
+        // A `>` between the tag and the cursor means the tag already closed.
+        if after_tag.contains('>') {
+            return None;
+        }
+
+        // The component name runs until the first whitespace. No whitespace yet
+        // means the cursor is still in the name — not an attribute position.
+        let first_ws = after_tag.find(char::is_whitespace)?;
+        let name = &after_tag[..first_ws];
+        if name.is_empty()
+            || !name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_')
+        {
+            return None;
+        }
+
+        // Everything after the name is the attribute region. An odd number of
+        // quotes means the cursor is inside an attribute value — bail.
+        let attrs = &after_tag[first_ws..];
+        if attrs.matches('"').count() % 2 == 1 || attrs.matches('\'').count() % 2 == 1 {
+            return None;
+        }
+
+        // The partial attribute is the word after the last whitespace.
+        let word_start = before_cursor
+            .rfind(char::is_whitespace)
+            .map(|i| i + 1)
+            .unwrap_or(cursor);
+        let partial = &before_cursor[word_start..];
+        // `=`, `"` or `'` in the partial means we're past the name into a value.
+        if partial.contains('=') || partial.contains('"') || partial.contains('\'') {
+            return None;
+        }
+
+        // Drop a leading `:` (bound attribute) from the filter prefix, keeping
+        // the replacement range pointed at the prop name itself.
+        let prefix = partial.trim_start_matches(':');
+        let prefix_offset = partial.len() - prefix.len();
+
+        Some((
+            format!("flux:{}", name),
+            StringContext {
+                prefix: prefix.to_string(),
+                start_col: (word_start + prefix_offset) as u32,
+                end_col: cursor as u32,
+                quote_char: ' ',
+            },
+        ))
+    }
+
     /// Check if cursor is inside a Livewire component tag like `<livewire:...` or `@livewire('...')`
     /// Returns the partial component name typed so far (for filtering completions)
     ///
@@ -17411,6 +17486,12 @@ return [
     /// disk, otherwise `None`. Handles dotted names (`forms.input` →
     /// `Forms/Input.php`) and kebab segments (`alert-box` → `AlertBox.php`).
     async fn resolve_component_class_file(&self, name: &str) -> Option<PathBuf> {
+        // Namespaced tags (`flux:button`, `pkg::widget`) never map to an
+        // `app/View/Components/*.php` class — and a `:` in the derived filename
+        // is invalid on Windows and a wasted stat on POSIX. Bail before probing.
+        if name.contains(':') {
+            return None;
+        }
         let root = self.root_path.read().await.clone()?;
         let class_path = name
             .split('.')
@@ -21849,6 +21930,70 @@ impl LanguageServer for LaravelLanguageServer {
                     "   Returning {} Flux component completion items",
                     items.len()
                 );
+
+                return if items.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(CompletionResponse::List(CompletionList {
+                        is_incomplete: false,
+                        items,
+                    })))
+                };
+            }
+
+            // Flux attribute context (`<flux:button │>`): offer the resolved
+            // component's `@props` as attributes — the props/slots half of the
+            // completion criterion. Resolution reuses the goto/hover path
+            // (`resolve_component_file` → `resolve_component_path`), so the same
+            // published / vendor / Flux Pro fallbacks apply.
+            if let Some((component_name, attr_ctx)) =
+                Self::get_flux_attribute_context(line_text, position.character)
+            {
+                debug!(
+                    "   Flux attribute context for `<{}>`, filter prefix: '{}'",
+                    component_name, attr_ctx.prefix
+                );
+
+                let prop_names = match self.resolve_component_file(&component_name).await {
+                    Some(path) => {
+                        let content = std::fs::read_to_string(&path).unwrap_or_default();
+                        laravel_lsp::blade_props::extract_prop_names(&content)
+                    }
+                    None => Vec::new(),
+                };
+
+                let prefix_lower = attr_ctx.prefix.to_lowercase();
+                let items: Vec<CompletionItem> = prop_names
+                    .into_iter()
+                    .filter(|p| p.to_lowercase().starts_with(&prefix_lower))
+                    .map(|p| CompletionItem {
+                        label: p.clone(),
+                        kind: Some(CompletionItemKind::FIELD),
+                        detail: Some(format!("<{}> prop", component_name)),
+                        documentation: Some(
+                            CompletionDoc::new()
+                                .header(format!("{} (prop)", p))
+                                .summary("Flux component prop.")
+                                .into_documentation(),
+                        ),
+                        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                            range: Range {
+                                start: Position {
+                                    line: position.line,
+                                    character: attr_ctx.start_col,
+                                },
+                                end: Position {
+                                    line: position.line,
+                                    character: attr_ctx.end_col,
+                                },
+                            },
+                            new_text: p.clone(),
+                        })),
+                        ..Default::default()
+                    })
+                    .collect();
+
+                debug!("   Returning {} Flux prop completion items", items.len());
 
                 return if items.is_empty() {
                     Ok(None)

--- a/laravel-lsp/src/queries.rs
+++ b/laravel-lsp/src/queries.rs
@@ -1318,6 +1318,19 @@ pub fn extract_all_blade_patterns<'a>(
                             end_column: end_pos.column,
                         });
                     }
+                } else if let Some(rest) = text.strip_prefix("flux:") {
+                    if !rest.starts_with(':') && !name_is_runtime_constructed(rest) {
+                        result.components.push(ComponentMatch {
+                            component_name: text,
+                            tag_name: text,
+                            byte_start: node.start_byte(),
+                            byte_end: node.end_byte(),
+                            row: start_pos.row,
+                            column: start_pos.column,
+                            end_column: end_pos.column,
+                            resolved_path: None,
+                        });
+                    }
                 }
             }
 

--- a/laravel-lsp/src/queries/tests/blade_pattern_extraction.rs
+++ b/laravel-lsp/src/queries/tests/blade_pattern_extraction.rs
@@ -41,6 +41,40 @@ fn extract_all_blade_patterns_components() {
 }
 
 #[test]
+fn extract_flux_component_tags() {
+    // Issue #60: `<flux:...>` tags are captured as components, keeping the raw
+    // single-colon name (`flux:button`) that the resolver later normalizes.
+    let blade_code = r#"
+    <div>
+        <flux:button variant="primary">Save</flux:button>
+        <flux:icon.arrow-right />
+    </div>
+    "#;
+
+    let tree = parse_blade(blade_code).expect("Should parse Blade");
+    let lang = language_blade();
+    let patterns =
+        extract_all_blade_patterns(&tree, blade_code, &lang).expect("Should extract patterns");
+
+    let names: Vec<&str> = patterns
+        .components
+        .iter()
+        .map(|m| m.component_name)
+        .collect();
+
+    assert!(
+        names.contains(&"flux:button"),
+        "Should capture <flux:button>: {:?}",
+        names,
+    );
+    assert!(
+        names.contains(&"flux:icon.arrow-right"),
+        "Should capture dotted <flux:icon.arrow-right>: {:?}",
+        names,
+    );
+}
+
+#[test]
 fn extract_all_blade_patterns_directives() {
     let blade_code = r#"
 @extends('layouts.app')

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2891,6 +2891,12 @@ impl LaravelConfigData {
     pub fn resolve_component_path(&self, component_name: &str) -> Vec<PathBuf> {
         let mut paths = Vec::new();
 
+        // Flux's `<flux:button>` sugar maps to the `flux` anonymous-component
+        // namespace; rewrite the single-colon prefix to the `::` form so the
+        // namespace resolution below treats it like `<x-flux::button>`.
+        let flux_normalized = normalize_flux_tag_name(component_name);
+        let component_name = flux_normalized.as_deref().unwrap_or(component_name);
+
         // Icon-set check first: <x-heroicon-o-clock> and friends resolve to a
         // concrete SVG file path. The blade-icons Factory registers each icon
         // at runtime via a loop over filesystem manifests, so static AST analysis
@@ -2974,6 +2980,30 @@ impl LaravelConfigData {
                     let base = self.root.join(view_path).join(dir);
                     push_component_file_candidates(&mut paths, base.join(&component_path));
                 }
+            }
+
+            // Flux ships anonymous Blade components under the `flux` prefix.
+            // Beyond any registration discovered from its service provider, fall
+            // back to Flux's conventional locations: the app-published
+            // `resources/views/flux/`, the package source `vendor/livewire/flux`,
+            // and Flux Pro `vendor/livewire/flux-pro`.
+            if ns == "flux" {
+                push_component_file_candidates(
+                    &mut paths,
+                    self.root.join("resources/views/flux").join(&component_path),
+                );
+                push_component_file_candidates(
+                    &mut paths,
+                    self.root
+                        .join("vendor/livewire/flux/stubs/resources/views/flux")
+                        .join(&component_path),
+                );
+                push_component_file_candidates(
+                    &mut paths,
+                    self.root
+                        .join("vendor/livewire/flux-pro/stubs/resources/views/flux")
+                        .join(&component_path),
+                );
             }
 
             // Package component - check package view path first
@@ -3060,6 +3090,18 @@ impl LaravelConfigData {
 
         Some(path)
     }
+}
+
+/// Rewrite a Flux single-colon component tag name (`flux:button`,
+/// `flux:icon.arrow-right`) into the `flux::` namespace form the component
+/// resolver understands. Returns `None` for names that aren't Flux tags or are
+/// already namespaced (`flux::button` arrives pre-normalized).
+pub fn normalize_flux_tag_name(name: &str) -> Option<String> {
+    let rest = name.strip_prefix("flux:")?;
+    if rest.starts_with(':') {
+        return None;
+    }
+    Some(format!("flux::{rest}"))
 }
 
 /// Push the three file shapes Laravel accepts for an anonymous component at

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -3155,9 +3155,15 @@ pub fn component_candidate_paths(
 ) -> Vec<PathBuf> {
     let mut candidates = config.resolve_component_path(name);
 
-    // Conventional class-backed component (non-namespaced names).
-    candidates
-        .push(crate::component_declaration_locator::conventional_class_file_path(name, config));
+    // Conventional class-backed component (non-namespaced names only). A
+    // namespaced tag like `flux:button` or `pkg::badge` would produce an
+    // invalid `app/View/Components/Flux:button.php` candidate — illegal on
+    // Windows and a wasted `stat` on POSIX. Namespaced forms resolve via the
+    // PSR-4 `componentNamespace` block below instead, so skip them here.
+    if !name.contains(':') {
+        candidates
+            .push(crate::component_declaration_locator::conventional_class_file_path(name, config));
+    }
 
     // Explicit class-backed registration: Blade::component('tag', Class::class)
     // in any provider (facade or instance form). Laravel core registers

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -978,6 +978,36 @@ fn flux_component_props_are_offered_for_completion() {
 }
 
 #[test]
+fn flux_tag_skips_invalid_colon_class_candidate() {
+    // A namespaced tag must not emit a conventional class candidate — the
+    // colon-bearing `app/View/Components/Flux:button.php` is an invalid path on
+    // Windows and a guaranteed-miss `stat` on POSIX. (Follow-up from PR #99
+    // round-2 review; `component_candidate_paths` doesn't touch the FS, so an
+    // empty project root is enough.)
+    let (_dir, root) = project_with_files(&[]);
+    let autoload = ComposerAutoload::load(&root);
+    let config = config_with_component_namespaces(&root, &[]);
+
+    let candidates = component_candidate_paths("flux:button", &config, &autoload);
+    assert!(
+        candidates.iter().all(|p| !p
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .contains(':')),
+        "no candidate may carry a `:` in its filename: {:#?}",
+        candidates,
+    );
+    assert!(
+        !candidates
+            .iter()
+            .any(|p| p.starts_with(root.join("app/View/Components"))),
+        "a namespaced Flux tag must not probe the conventional class dir: {:#?}",
+        candidates,
+    );
+}
+
+#[test]
 fn psr4_class_namespace_component_resolves_across_two_namespaces() {
     // Two separate package namespaces registered via componentNamespace, each
     // shipped under a PSR-4 vendor layout that the naive

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -330,6 +330,107 @@ fn anonymous_component_namespace_resolves_relative_to_view_paths() {
     );
 }
 
+// ─── Flux component resolution (issue #60) ─────────────────────────────
+
+fn make_bare_config() -> LaravelConfigData {
+    LaravelConfigData {
+        root: PathBuf::from("/project"),
+        view_paths: vec![PathBuf::from("resources/views")],
+        component_paths: Vec::new(),
+        livewire_path: None,
+        has_livewire: false,
+        view_namespaces: HashMap::new(),
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+        class_component_files: HashMap::new(),
+    }
+}
+
+#[test]
+fn normalize_flux_tag_name_rewrites_single_colon_prefix() {
+    assert_eq!(
+        normalize_flux_tag_name("flux:button").as_deref(),
+        Some("flux::button"),
+    );
+    assert_eq!(
+        normalize_flux_tag_name("flux:icon.arrow-right").as_deref(),
+        Some("flux::icon.arrow-right"),
+    );
+}
+
+#[test]
+fn normalize_flux_tag_name_leaves_non_flux_and_namespaced_alone() {
+    // Already-namespaced `<x-flux::button>` arrives pre-normalized.
+    assert_eq!(normalize_flux_tag_name("flux::button"), None);
+    // Non-Flux names untouched.
+    assert_eq!(normalize_flux_tag_name("button"), None);
+    assert_eq!(normalize_flux_tag_name("livewire:counter"), None);
+}
+
+#[test]
+fn flux_tag_resolves_to_conventional_sources() {
+    // `<flux:button>` resolves with no explicit registration via the
+    // convention fallback: app-published views, the package source, and Flux Pro.
+    let config = make_bare_config();
+    let paths = config.resolve_component_path("flux:button");
+
+    assert!(
+        paths
+            .iter()
+            .any(|p| p == &PathBuf::from("/project/resources/views/flux/button.blade.php")),
+        "published view path missing: {:?}",
+        paths,
+    );
+    assert!(
+        paths.iter().any(|p| p
+            == &PathBuf::from(
+                "/project/vendor/livewire/flux/stubs/resources/views/flux/button.blade.php"
+            )),
+        "package source path missing: {:?}",
+        paths,
+    );
+    assert!(
+        paths.iter().any(|p| p
+            == &PathBuf::from(
+                "/project/vendor/livewire/flux-pro/stubs/resources/views/flux/button.blade.php"
+            )),
+        "Flux Pro path missing: {:?}",
+        paths,
+    );
+}
+
+#[test]
+fn flux_dotted_tag_maps_dots_to_directories() {
+    // `<flux:icon.arrow-right>` → `flux/icon/arrow-right.blade.php`.
+    let config = make_bare_config();
+    let paths = config.resolve_component_path("flux:icon.arrow-right");
+
+    assert!(
+        paths.iter().any(
+            |p| p == &PathBuf::from("/project/resources/views/flux/icon/arrow-right.blade.php")
+        ),
+        "dotted Flux name must map dots to directories: {:?}",
+        paths,
+    );
+}
+
+#[test]
+fn flux_namespace_tag_resolves_same_as_single_colon() {
+    // The `<x-flux::button>` namespace form resolves through the same fallback.
+    let config = make_bare_config();
+    let paths = config.resolve_component_path("flux::button");
+    assert!(
+        paths
+            .iter()
+            .any(|p| p == &PathBuf::from("/project/resources/views/flux/button.blade.php")),
+        "namespace form must resolve via the Flux fallback: {:?}",
+        paths,
+    );
+}
+
 #[test]
 fn unregistered_anonymous_prefix_does_not_borrow_registered_directory() {
     let config = make_config_with_anonymous_path(

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -928,6 +928,55 @@ fn resolves(name: &str, config: &LaravelConfigData, autoload: &ComposerAutoload)
         .any(|p| p.exists())
 }
 
+/// End-to-end for issue #60's completion criterion: a Flux component resolved
+/// from its conventional vendor source must surface its declared `@props` as
+/// offered attributes. Exercises the same chain the completion handler runs —
+/// `resolve_component_path` → first on-disk candidate → `extract_prop_names`.
+#[test]
+fn flux_component_props_are_offered_for_completion() {
+    let (_dir, root) = project_with_files(&[(
+        "vendor/livewire/flux/stubs/resources/views/flux/button.blade.php",
+        "@props([\n    'variant' => 'primary',\n    'size',\n    'icon' => null,\n])\n\
+         <button {{ $attributes }}>{{ $slot }}</button>\n",
+    )]);
+    let config = LaravelConfigData {
+        root: root.clone(),
+        view_paths: vec![PathBuf::from("resources/views")],
+        component_paths: Vec::new(),
+        livewire_path: None,
+        has_livewire: false,
+        view_namespaces: HashMap::new(),
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+        class_component_files: HashMap::new(),
+    };
+
+    // Resolve `<flux:button>` the way goto/hover/completion do, then read the
+    // first candidate that actually exists on disk.
+    let resolved = config
+        .resolve_component_path("flux:button")
+        .into_iter()
+        .find(|p| p.exists())
+        .expect("flux:button should resolve to its vendor blade source");
+
+    let content = std::fs::read_to_string(&resolved).unwrap();
+    let props = crate::blade_props::extract_prop_names(&content);
+
+    assert!(
+        props.contains(&"variant".to_string()),
+        "known prop `variant` must be offered for a resolved Flux component: {:?}",
+        props,
+    );
+    assert_eq!(
+        props,
+        vec!["variant", "size", "icon"],
+        "all declared props offered, in declaration order",
+    );
+}
+
 #[test]
 fn psr4_class_namespace_component_resolves_across_two_namespaces() {
     // Two separate package namespaces registered via componentNamespace, each

--- a/laravel-lsp/src/tests/flux_component_context.rs
+++ b/laravel-lsp/src/tests/flux_component_context.rs
@@ -1,0 +1,136 @@
+//! Flux tag completion-context detection (issue #60).
+//!
+//! Two contexts feed `<flux:…>` completion:
+//! - `get_flux_component_context` — the cursor is in the component *name*
+//!   (`<flux:butt│`), offering component names.
+//! - `get_flux_attribute_context` — the cursor is past the name, at an
+//!   *attribute* position (`<flux:button │>`), offering the component's props.
+
+use crate::LaravelLanguageServer;
+
+// ─── name context ───────────────────────────────────────────────────────
+
+#[test]
+fn name_context_at_bare_prefix() {
+    let line = "<flux:";
+    let ctx = LaravelLanguageServer::get_flux_component_context(line, line.len() as u32)
+        .expect("`<flux:` should be a name context");
+    assert_eq!(ctx.prefix, "");
+    assert_eq!(ctx.start_col, 6, "replacement starts right after `<flux:`");
+}
+
+#[test]
+fn name_context_with_partial_name() {
+    let line = "    <flux:butt";
+    let ctx = LaravelLanguageServer::get_flux_component_context(line, line.len() as u32)
+        .expect("partial Flux name should be a name context");
+    assert_eq!(ctx.prefix, "butt");
+}
+
+#[test]
+fn name_context_allows_dotted_names() {
+    let line = "<flux:icon.arrow-right";
+    let ctx = LaravelLanguageServer::get_flux_component_context(line, line.len() as u32)
+        .expect("dotted Flux name should be a name context");
+    assert_eq!(ctx.prefix, "icon.arrow-right");
+}
+
+#[test]
+fn name_context_ends_at_first_space() {
+    // Once attributes begin, the name context is over.
+    let line = "<flux:button ";
+    assert!(
+        LaravelLanguageServer::get_flux_component_context(line, line.len() as u32).is_none(),
+        "a space (start of attributes) must end the name context",
+    );
+}
+
+#[test]
+fn name_context_none_for_non_flux_tag() {
+    let line = "<x-button";
+    assert!(LaravelLanguageServer::get_flux_component_context(line, line.len() as u32).is_none());
+}
+
+// ─── attribute context ──────────────────────────────────────────────────
+
+#[test]
+fn attribute_context_after_name_space() {
+    let line = "<flux:button ";
+    let (name, ctx) = LaravelLanguageServer::get_flux_attribute_context(line, line.len() as u32)
+        .expect("a space after the name opens the attribute context");
+    assert_eq!(name, "flux:button");
+    assert_eq!(ctx.prefix, "", "no partial typed yet → offer all props");
+    assert_eq!(ctx.start_col, line.len() as u32);
+}
+
+#[test]
+fn attribute_context_with_partial_attribute() {
+    let line = "<flux:button vari";
+    let (name, ctx) = LaravelLanguageServer::get_flux_attribute_context(line, line.len() as u32)
+        .expect("partial attribute should be an attribute context");
+    assert_eq!(name, "flux:button");
+    assert_eq!(ctx.prefix, "vari");
+    assert_eq!(ctx.start_col, "<flux:button ".len() as u32);
+}
+
+#[test]
+fn attribute_context_preserves_dotted_component_name() {
+    let line = "<flux:icon.arrow-right cl";
+    let (name, ctx) = LaravelLanguageServer::get_flux_attribute_context(line, line.len() as u32)
+        .expect("dotted component still resolves in attribute context");
+    assert_eq!(name, "flux:icon.arrow-right");
+    assert_eq!(ctx.prefix, "cl");
+}
+
+#[test]
+fn attribute_context_strips_leading_colon_for_bound_attribute() {
+    // `:variant="..."` is a bound attribute — filter on the name, but replace
+    // only the part after the `:`.
+    let line = "<flux:button :vari";
+    let (_name, ctx) = LaravelLanguageServer::get_flux_attribute_context(line, line.len() as u32)
+        .expect("bound-attribute prefix should still be an attribute context");
+    assert_eq!(ctx.prefix, "vari", "leading `:` dropped from the filter");
+    assert_eq!(
+        ctx.start_col,
+        "<flux:button :".len() as u32,
+        "replacement starts after the `:`",
+    );
+}
+
+#[test]
+fn attribute_context_skips_second_attribute() {
+    let line = "<flux:button variant=\"primary\" si";
+    let (name, ctx) = LaravelLanguageServer::get_flux_attribute_context(line, line.len() as u32)
+        .expect("attribute context after a completed attribute");
+    assert_eq!(name, "flux:button");
+    assert_eq!(ctx.prefix, "si");
+}
+
+#[test]
+fn attribute_context_none_inside_attribute_value() {
+    // Cursor inside the quoted value — props complete attribute *names* only.
+    let line = "<flux:button variant=\"pri";
+    assert!(
+        LaravelLanguageServer::get_flux_attribute_context(line, line.len() as u32).is_none(),
+        "inside an attribute value there is no prop-name completion",
+    );
+}
+
+#[test]
+fn attribute_context_none_while_still_in_name() {
+    // No space yet → still the name context, not attributes.
+    let line = "<flux:butt";
+    assert!(
+        LaravelLanguageServer::get_flux_attribute_context(line, line.len() as u32).is_none(),
+        "the name position must not be treated as an attribute position",
+    );
+}
+
+#[test]
+fn attribute_context_none_after_tag_closed() {
+    let line = "<flux:button variant=\"primary\"> ";
+    assert!(
+        LaravelLanguageServer::get_flux_attribute_context(line, line.len() as u32).is_none(),
+        "a closed tag (`>` before cursor) is not an attribute position",
+    );
+}

--- a/laravel-lsp/src/tests/flux_component_context.rs
+++ b/laravel-lsp/src/tests/flux_component_context.rs
@@ -134,3 +134,15 @@ fn attribute_context_none_after_tag_closed() {
         "a closed tag (`>` before cursor) is not an attribute position",
     );
 }
+
+#[test]
+fn attribute_context_handles_multibyte_whitespace() {
+    // Regression: U+00A0 NO-BREAK SPACE (2 bytes) separating the name from the
+    // attribute. A raw `rfind(is_whitespace) + 1` lands inside the encoding and
+    // panics the byte slice; the boundary-safe walk must keep working.
+    let line = "<flux:button\u{00A0}vari";
+    let (name, ctx) = LaravelLanguageServer::get_flux_attribute_context(line, line.len() as u32)
+        .expect("multi-byte whitespace must not break attribute detection");
+    assert_eq!(name, "flux:button");
+    assert_eq!(ctx.prefix, "vari", "partial after the NBSP, not a panic");
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -6,6 +6,7 @@ mod class_locator_and_properties;
 mod code_lens_opt_in;
 mod diagnostic_severity;
 mod dynamic_where_sparseness;
+mod flux_component_context;
 mod generic_type_parsing;
 mod livewire_component_resolution;
 mod loop_variable_resolution;


### PR DESCRIPTION
## Summary
Implements #60 — brings Flux `<flux:…>` components to parity with how Blade/Livewire components are handled.

Flux's single-colon tag syntax is sugar for the `flux` anonymous-component namespace (Flux's runtime rewrites `<flux:button>` → `<x-flux::button>`). The implementation models it the same way: `<flux:…>` tags are parsed as components and the prefix is normalized to the `flux::` form, so the existing Blade resolution pipeline drives goto-definition and hover for free.

## Changes
- **Parsing** — capture `<flux:component>` tags (incl. dotted names like `<flux:icon.arrow-right>`) in the tree-sitter Blade query (`queries/blade.scm`) and the pattern extractor (`queries.rs`).
- **Resolution** — `resolve_component_path` normalizes `flux:name` → `flux::name` and resolves the `flux` namespace to its conventional sources: the app-published `resources/views/flux/`, the package source `vendor/livewire/flux/stubs/resources/views/flux/`, and Flux Pro `vendor/livewire/flux-pro/…`. This drives **goto-definition** and **hover** (the shared `hover_for_component` path, which also surfaces the `@props` card).
- **Completion (names)** — `<flux:` context detection + component-name enumeration from the same sources.
- **Completion (props)** — at the attribute position (`<flux:button │>`), resolve the backing blade via the same `resolve_component_path`, parse its `@props([...])` with a new bracket/string-aware `extract_prop_names`, and offer the props as attributes. `get_flux_attribute_context` detects the attribute position and bails inside attribute values or once the tag closes.
- **Diagnostics** — skip the hard "not found" error for `<flux:…>` tags (they resolve through vendor/published paths that may be absent in a given session; goto/hover degrade gracefully). Existing `<x-flux::…>` behaviour is unchanged.
- **Stub cleanup** — remove the dead `flux_components` field from `NodeModulesScan` and correct the misleading `rescan_node_modules` TODO (Flux ships via Composer under `vendor/`, not node_modules).
- **Hardening** — `resolve_component_class_file` now bails when the tag name contains `:`, so it no longer probes the invalid `app/View/Components/Flux:button.php` path.

## Design note: canonical path (open question in the issue)
Resolution does **not** hardcode a single path. It relies on the existing vendor service-provider scan (which already extracts `Blade::anonymousComponentPath`/`anonymousComponentNamespace` registrations) **plus** a convention fallback to Flux's documented locations. The test-project fixture (`resources/views/flux/icon/…`, `resources/views/flux/navlist/…`) confirms the published layout.

## Acceptance Criteria
- [x] Goto-definition resolves `<flux:component>` (incl. dotted names) to its Flux source in `vendor/livewire/flux` or Flux Pro path
- [x] Hover displays a summary card for Flux components (reuses `hover_for_component`, incl. `@props`)
- [x] Completion offers Flux component names **and props** (props at the attribute position). Named **slots** are a distinct syntactic context (`<flux:slot name>`), tracked in #106.
- [x] The stale `node_modules` Flux stub is corrected/removed (pinned by a new node_modules-exclusion test)
- [x] Tests cover goto-definition resolution + dotted-name handling, prop parsing, attribute/name context detection, and an end-to-end "known prop offered for a resolved Flux component"

## Scope note: props vs. slots
Prop completion now fires at the attribute position — props *are* the attributes you type at `<flux:… │>`. Content **slots** are filled via `<flux:slot name="…">` / `<x-slot:…>` tags, a different context; offering slot names as attributes would emit broken markup if accepted, and doing it right needs enclosing-tag resolution. Tracked as a follow-up in **#106** rather than shipped incorrectly. A Flux-specific hover-card test (resolution leg already covered) is tracked in **#107**.

## Test Plan
- [x] `cargo test` — 1644 lib unit tests pass; new tests cover Flux prop parsing (`extract_prop_names`), attribute/name context detection, conventional-path resolution → prop offered, and node_modules exclusion
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features` clean
- [x] Integration tests pass except the vendor-dependent route test (needs `composer install`, which CI runs)

Fixes #60
