### PR TITLE
Folio cursor-file read: add explicit root-containment guard (defense-in-depth)

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4790,11 +4790,18 @@ impl LaravelLanguageServer {
     /// editor buffer or disk asynchronously. So this find-references / rename hot
     /// path never blocks a Tokio worker thread on a synchronous project walk
     /// (the walk happens at most once, inside `spawn_blocking`, when the index is
-    /// built). Containment is structural: the file text is read only after the
-    /// index match succeeds, and the index holds only mounts that stayed under
-    /// the project root, so an out-of-tree page is never read here. Returns
-    /// `None` when the file isn't a named Folio page or the cursor isn't on its
-    /// `name(...)` call.
+    /// built).
+    ///
+    /// Containment is enforced explicitly: after the index name lookup the page
+    /// path is checked against the project root (`self.root_path`, compared
+    /// lexically with `normalize_path` — the same check
+    /// `folio_discovery::resolve_folio_path` applies) and an out-of-tree page
+    /// returns `None` *before* any disk read. The index already holds only
+    /// contained mounts, so this guard is defense in depth: it keeps the disk
+    /// read unreachable for out-of-root paths even if a future discovery path
+    /// ever seeded the index without that structural guarantee. Returns `None`
+    /// when the file isn't a named Folio page, the cursor isn't on its
+    /// `name(...)` call, or the path escapes the project root.
     async fn folio_route_name_for_cursor(
         &self,
         file_path: &Path,
@@ -4804,6 +4811,14 @@ impl LaravelLanguageServer {
             let guard = self.route_index.read().await;
             laravel_lsp::folio_discovery::folio_name_for_file(guard.as_ref()?, file_path)?
         };
+        // Defense-in-depth containment guard: refuse to read a page that sits
+        // outside the project root, even if the index were ever seeded with one.
+        // Checked lexically with `normalize_path` (matching `resolve_folio_path`)
+        // before any disk access, so an out-of-tree path never reaches the read.
+        let root = self.root_path.read().await.clone()?;
+        if !normalize_path(file_path).starts_with(normalize_path(&root)) {
+            return None;
+        }
         let uri = Url::from_file_path(file_path).ok()?;
         let content = self.document_or_disk_content(&uri, file_path).await?;
         laravel_lsp::folio_discovery::cursor_on_page_name(

--- a/laravel-lsp/src/tests/folio_cursor_containment.rs
+++ b/laravel-lsp/src/tests/folio_cursor_containment.rs
@@ -1,0 +1,99 @@
+//! Tests for the explicit root-containment guard in
+//! `LaravelLanguageServer::folio_route_name_for_cursor` (issue #104).
+//!
+//! The guard is defense in depth: the route index already holds only mounts
+//! that stayed under the project root, but the method re-checks containment
+//! against `self.root_path` before reading the cursor file from disk. These
+//! tests drive the private method directly by building the server through
+//! `tower_lsp::LspService` and reaching its inner value with `inner()`.
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::route_discovery::{RouteDefinition, RouteIndex, PRIORITY_APP};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::Position;
+use tower_lsp::LspService;
+
+/// A bare Folio page that declares `name('contact')`. Cursor character 13 sits
+/// inside the `contact` argument string, so `cursor_on_page_name` matches.
+const PAGE_SRC: &str = "<?php name('contact'); ?>";
+const CURSOR: Position = Position {
+    line: 0,
+    character: 13,
+};
+
+/// Build a server instance for testing. `LspService::new` wires up a real
+/// `Client`; `inner()` hands back the `LaravelLanguageServer` so we can call
+/// its private methods directly.
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// Seed the route index with a single Folio page keyed by `name`, pointing at
+/// `file`. With this entry present, `folio_name_for_file` succeeds, so the
+/// containment guard — not a missing index match — decides the outcome.
+async fn seed_folio_page(server: &LaravelLanguageServer, name: &str, file: &Path) {
+    let mut index = RouteIndex::new();
+    index.insert(
+        name.to_string(),
+        RouteDefinition {
+            file: file.to_path_buf(),
+            line: 0,
+            column: 0,
+            end_column: 0,
+            priority: PRIORITY_APP,
+            method: None,
+            uri: Some("/contact".to_string()),
+            action: None,
+        },
+    );
+    *server.route_index.write().await = Some(index);
+}
+
+#[tokio::test]
+async fn out_of_root_page_returns_none_without_disk_read() {
+    // The page lives in a directory that is NOT under the project root, yet it
+    // exists on disk, is indexed, and the cursor sits on its `name(...)` call.
+    // Without the guard the method would read it and resolve `contact`; the
+    // guard must refuse it on containment grounds alone.
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let page = outside.path().join("contact.blade.php");
+    fs::write(&page, PAGE_SRC).unwrap();
+
+    let server = test_server();
+    *server.root_path.write().await = Some(root.path().to_path_buf());
+    seed_folio_page(&server, "contact", &page).await;
+
+    let result = server.folio_route_name_for_cursor(&page, CURSOR).await;
+
+    assert_eq!(
+        result, None,
+        "an out-of-root page must not resolve, even though it exists, is indexed, \
+         and the cursor is on its name() call — the containment guard refuses it"
+    );
+}
+
+#[tokio::test]
+async fn in_tree_page_still_resolves() {
+    // Positive control: a page inside the project root resolves exactly as
+    // before, confirming the guard doesn't regress in-tree behavior.
+    let root = TempDir::new().unwrap();
+    let page = root.path().join("pages").join("contact.blade.php");
+    fs::create_dir_all(page.parent().unwrap()).unwrap();
+    fs::write(&page, PAGE_SRC).unwrap();
+
+    let server = test_server();
+    *server.root_path.write().await = Some(root.path().to_path_buf());
+    seed_folio_page(&server, "contact", &page).await;
+
+    let result = server.folio_route_name_for_cursor(&page, CURSOR).await;
+
+    assert_eq!(
+        result,
+        Some("contact".to_string()),
+        "an in-tree page on its name() call must still resolve to its route name"
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod code_lens_opt_in;
 mod diagnostic_severity;
 mod dynamic_where_sparseness;
 mod flux_component_context;
+mod folio_cursor_containment;
 mod generic_type_parsing;
 mod livewire_component_resolution;
 mod loop_variable_resolution;


### PR DESCRIPTION
## Summary
Implements #104 — adds an explicit root-containment guard to `folio_route_name_for_cursor` so a Folio page outside the project root is never read from disk. Defense in depth: the route index already holds only contained mounts, but the read site now re-checks containment instead of inferring it, closing the gap if a future discovery path ever seeds the index without that structural guarantee.

## Changes
- **`laravel-lsp/src/main.rs`** — after the route-index name lookup and before `Url::from_file_path`/`document_or_disk_content`, `folio_route_name_for_cursor` now reads the root from `self.root_path` and returns `None` unless `normalize_path(file_path)` starts with `normalize_path(root)` — the same lexical check `folio_discovery::resolve_folio_path` uses. Out-of-tree paths never reach the disk read.
- Updated the method's doc comment to describe the explicit containment guard, replacing the prior "containment is structural" wording.
- **`laravel-lsp/src/tests/folio_cursor_containment.rs`** (new) — two `#[tokio::test]` cases driving the private method via `LspService::inner()`.

## Acceptance Criteria
- [x] `folio_route_name_for_cursor` reads the root from `self.root_path` and uses `normalize_path` to check `file_path` starts with root before calling `document_or_disk_content`; returns `None` without touching disk if the check fails.
- [x] The guard is placed after the route-index name lookup but before `Url::from_file_path`/`document_or_disk_content`, so out-of-tree paths never reach the disk read.
- [x] Existing in-tree behavior is unchanged — covered by the `in_tree_page_still_resolves` positive control.
- [x] A unit test asserts that an out-of-root path to `folio_route_name_for_cursor` returns `None` (no disk read). The negative test is discriminating: the out-of-root file **exists**, is indexed, and the cursor sits on its `name()` call, so without the guard it would resolve — proving the guard short-circuits ahead of the read.
- [x] The method's doc comment now states the explicit containment guard.

## Test Plan
- [x] `cargo test --bin laravel-lsp` — 263 passed (2 new).
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [ ] CI green.

Fixes #104