### PR TITLE
Remove unreachable ContainsDoubleDot variant in name validators

### DIFF
--- a/laravel-lsp/src/component_declaration_locator.rs
+++ b/laravel-lsp/src/component_declaration_locator.rs
@@ -30,7 +30,6 @@ use crate::salsa_impl::LaravelConfigData;
 pub enum ComponentNameError {
     Empty,
     ContainsSlash,
-    ContainsDoubleDot,
     EmptySegment,
     HasExtension,
     InvalidCharacter(char),
@@ -42,7 +41,6 @@ impl ComponentNameError {
         match self {
             Self::Empty => "component name cannot be empty".to_string(),
             Self::ContainsSlash => "use dots instead of slashes (e.g., forms.input)".to_string(),
-            Self::ContainsDoubleDot => "component name cannot contain '..'".to_string(),
             Self::EmptySegment => {
                 "component name cannot have empty segments (no leading, trailing, \
                  or double dots)"
@@ -84,9 +82,6 @@ pub fn validate_component_name(name: &str) -> Result<(), ComponentNameError> {
     for segment in trimmed.split('.') {
         if segment.is_empty() {
             return Err(ComponentNameError::EmptySegment);
-        }
-        if segment == ".." {
-            return Err(ComponentNameError::ContainsDoubleDot);
         }
         for c in segment.chars() {
             if !c.is_alphanumeric() && c != '-' && c != '_' {

--- a/laravel-lsp/src/livewire_declaration_locator.rs
+++ b/laravel-lsp/src/livewire_declaration_locator.rs
@@ -21,7 +21,6 @@ use crate::naming;
 pub enum LivewireNameError {
     Empty,
     ContainsSlash,
-    ContainsDoubleDot,
     EmptySegment,
     HasExtension,
     InvalidCharacter(char),
@@ -35,7 +34,6 @@ impl LivewireNameError {
             Self::ContainsSlash => {
                 "use dots instead of slashes (e.g., admin.user-list)".to_string()
             }
-            Self::ContainsDoubleDot => "Livewire component name cannot contain '..'".to_string(),
             Self::EmptySegment => "Livewire component name cannot have empty segments \
                  (no leading, trailing, or double dots)"
                 .to_string(),
@@ -74,9 +72,6 @@ pub fn validate_livewire_name(name: &str) -> Result<(), LivewireNameError> {
     for segment in trimmed.split('.') {
         if segment.is_empty() {
             return Err(LivewireNameError::EmptySegment);
-        }
-        if segment == ".." {
-            return Err(LivewireNameError::ContainsDoubleDot);
         }
         for c in segment.chars() {
             if !c.is_alphanumeric() && c != '-' && c != '_' {

--- a/laravel-lsp/src/view_declaration_locator.rs
+++ b/laravel-lsp/src/view_declaration_locator.rs
@@ -21,7 +21,6 @@ use crate::salsa_impl::LaravelConfigData;
 pub enum ViewNameError {
     Empty,
     ContainsSlash,
-    ContainsDoubleDot,
     EmptySegment,
     HasExtension,
     InvalidCharacter(char),
@@ -35,7 +34,6 @@ impl ViewNameError {
         match self {
             Self::Empty => "view name cannot be empty".to_string(),
             Self::ContainsSlash => "use dots instead of slashes (e.g., users.profile)".to_string(),
-            Self::ContainsDoubleDot => "view name cannot contain '..'".to_string(),
             Self::EmptySegment => "view name cannot have empty segments (no leading, trailing, \
                  or double dots)"
                 .to_string(),
@@ -77,9 +75,6 @@ pub fn validate_view_name(name: &str) -> Result<(), ViewNameError> {
     for segment in trimmed.split('.') {
         if segment.is_empty() {
             return Err(ViewNameError::EmptySegment);
-        }
-        if segment == ".." {
-            return Err(ViewNameError::ContainsDoubleDot);
         }
         for c in segment.chars() {
             if !c.is_alphanumeric() && c != '-' && c != '_' {


### PR DESCRIPTION
## Summary
Removes the unreachable `ContainsDoubleDot` error variant from all three name
validators. Follow-up from Holmes's review of #55 (PR #89).

The `if segment == ".."` guard could never fire: a `".."` name splits on `.`
into empty segments, so `EmptySegment` is returned first — and a single
post-split segment can never itself contain a `.`. The variant, its message
arm, and the guard were therefore dead code in every locator.

## Changes
- `view_declaration_locator.rs` — removed `ContainsDoubleDot` from `ViewNameError`, its `message()` arm, and the dead guard in `validate_view_name`
- `livewire_declaration_locator.rs` — same removal across `LivewireNameError` / `validate_livewire_name`
- `component_declaration_locator.rs` — same removal across `ComponentNameError` / `validate_component_name`
- Net: 15 line deletions, no behavioral change

## Acceptance Criteria
- [x] `ContainsDoubleDot` variant removed from `ViewNameError` enum in `view_declaration_locator.rs`
- [x] `Self::ContainsDoubleDot` match arm removed from `ViewNameError::message()`
- [x] Dead `if segment == ".."` guard removed from `validate_view_name`
- [x] `ContainsDoubleDot` variant removed from `LivewireNameError` enum in `livewire_declaration_locator.rs`
- [x] `Self::ContainsDoubleDot` match arm removed from `LivewireNameError::message()`
- [x] Dead `if segment == ".."` guard removed from `validate_livewire_name`
- [x] `ContainsDoubleDot` variant removed from `ComponentNameError` enum in `component_declaration_locator.rs`
- [x] `Self::ContainsDoubleDot` match arm removed from `ComponentNameError::message()`
- [x] Dead `if segment == ".."` guard removed from `validate_component_name`
- [x] `cargo check` passes with no new warnings or errors
- [x] All existing tests pass — `rejects_double_dot_segment_break` (view) and `rejects_empty_segment` (component/livewire) still assert `EmptySegment` for `..` input, unchanged
- [x] No remaining references to `ContainsDoubleDot` anywhere in the codebase

## Test Plan
- [x] `cargo check` — clean
- [x] `cargo clippy` — no lints
- [x] `cargo fmt` — no diff
- [x] `cargo test` — 1984 unit tests pass (1723 + 261), including all validator tests
- [x] No new tests needed — this removes unreachable code; existing tests already cover the `..` → `EmptySegment` path that supersedes it

> Note: 8 pre-existing integration tests in `tests/integration_tests.rs` fail in CI/local because they require an on-disk Laravel fixture project with a `.env` (`​.env must exist`). Verified identical failures on the untouched base via `git stash` — unrelated to this change.

Fixes #94