### PR TITLE
fix: is_in_routes_dir matches any 'routes' path component, not just project-root routes/

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18097,7 +18097,7 @@ async fn classify_with_decl_fallback(
     // Fallback path: route-name declarations live in `routes/*.php` and
     // aren't tagged by php.scm. Use the mtime-cached decl walker so
     // subsequent invocations don't re-parse the file.
-    if !is_in_routes_dir(file_path) {
+    if !is_in_routes_dir(root, file_path) {
         // A Folio page's `name('...')` helper declares its route name, but the
         // page lives outside `routes/` and the bare helper isn't tagged by
         // php.scm. If the cursor sits on that call, resolve it to the page's
@@ -18180,12 +18180,22 @@ async fn decl_range_at(
     None
 }
 
-/// Heuristic: is this file under a `routes/` subdirectory anywhere in its
-/// path? Used to gate the declaration-fallback walk so we don't pay the
-/// parse cost on every PHP file.
-fn is_in_routes_dir(path: &Path) -> bool {
-    path.components()
-        .any(|c| c.as_os_str() == std::ffi::OsStr::new("routes"))
+/// Is this file a conventional route file — i.e. does it live directly under
+/// the project root's `routes/` directory? Used to gate the declaration-fallback
+/// walk so we don't pay the parse cost on every PHP file.
+///
+/// Only the project-root `routes/` qualifies. A `routes` component nested
+/// deeper — a package's `vendor/.../routes/`, or a Folio mount that happens to
+/// carry a `routes` segment (issue #98) — must NOT be treated as the
+/// conventional routes dir, or find-references from such a file would be routed
+/// into the decl walk and never reach its real resolver. When the project root
+/// is unknown (`None`), default to `false` so the walk never triggers without a
+/// root to anchor against.
+fn is_in_routes_dir(root: Option<&Path>, path: &Path) -> bool {
+    match root {
+        Some(r) => path.starts_with(r.join("routes")),
+        None => false,
+    }
 }
 
 /// Return the column range of the classified pattern under the cursor.

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod loop_variable_resolution;
 mod rename_integration;
 mod route_binding_resolution;
 mod route_diagnostics;
+mod routes_dir_gate;
 mod slot_variable_resolution;
 mod translation_namespace_check;
 mod vite_completion_context;

--- a/laravel-lsp/src/tests/routes_dir_gate.rs
+++ b/laravel-lsp/src/tests/routes_dir_gate.rs
@@ -1,0 +1,41 @@
+//! Unit tests for `is_in_routes_dir` — the gate deciding whether the
+//! declaration-fallback route walk runs for a given file. Only the project
+//! root's own `routes/` directory qualifies; a `routes` component nested
+//! deeper (a package's `vendor/.../routes/`, or a Folio mount) must not be
+//! mistaken for it (issue #98).
+
+use crate::is_in_routes_dir;
+use std::path::Path;
+
+#[test]
+fn matches_project_root_routes_dir() {
+    assert!(is_in_routes_dir(
+        Some(Path::new("/project")),
+        Path::new("/project/routes/web.php")
+    ));
+}
+
+#[test]
+fn rejects_package_routes_below_root() {
+    // A package's own `routes/` under vendor/ is not the project's route dir.
+    assert!(!is_in_routes_dir(
+        Some(Path::new("/project")),
+        Path::new("/project/vendor/somepackage/routes/web.php")
+    ));
+}
+
+#[test]
+fn rejects_folio_style_nested_routes_component() {
+    // A Folio page path with `routes` as a non-root component must not be
+    // treated as the conventional routes dir (issue #98).
+    assert!(!is_in_routes_dir(
+        Some(Path::new("/project")),
+        Path::new("/project/pages/routes/index.php")
+    ));
+}
+
+#[test]
+fn rejects_when_root_unknown() {
+    // No project root to anchor against → never trigger the fallback walk.
+    assert!(!is_in_routes_dir(None, Path::new("/any/routes/file.php")));
+}


### PR DESCRIPTION
## Summary
Implements #98 — `is_in_routes_dir` matched *any* path component named `routes`, so a Folio mount or a package's `vendor/.../routes/` dir was treated as the conventional project routes dir. Find-references from such a file was routed into the route decl-fallback walk instead of its real resolver, and silently returned nothing. This tightens the gate to the **project-root `routes/` only**.

## Changes
- `is_in_routes_dir` now takes `root: Option<&Path>` alongside `path: &Path`.
- With `Some(r)`, returns `true` only when `path.starts_with(r.join("routes"))` — i.e. `routes/` is an immediate child of the project root (component-wise prefix, so `routesXYZ/` won't match either).
- With `None`, returns `false` (safe default — never trigger the decl-fallback walk without a project root to anchor against).
- Threaded `root` through the call site in `classify_with_decl_fallback`.
- Updated the doc comment to reflect the project-root-only semantics.
- Added a `routes_dir_gate` unit-test module covering all four AC cases.

## Acceptance Criteria
- [x] `is_in_routes_dir` signature updated to accept `root: Option<&Path>` alongside the existing `path: &Path`
- [x] When `root` is `Some(r)`, returns `true` only if `path` starts with `r.join("routes")`
- [x] When `root` is `None`, returns `false` (safe default)
- [x] The call site in `classify_with_decl_fallback` is updated to pass `root`
- [x] Unit test: `is_in_routes_dir(Some("/project"), "/project/routes/web.php")` → `true`
- [x] Unit test: `is_in_routes_dir(Some("/project"), "/project/vendor/somepackage/routes/web.php")` → `false`
- [x] Unit test: `is_in_routes_dir(Some("/project"), "/project/pages/routes/index.php")` → `false`
- [x] Unit test: `is_in_routes_dir(None, "/any/routes/file.php")` → `false`

## Test Plan
- [x] All four new `routes_dir_gate` unit tests pass (`cargo test routes_dir_gate`).
- [x] Full unit suite green (1723 + 265 passing); the only `integration_tests` failures locally are pre-existing fixture gaps (gitignored `test-project/.env` and `vendor/`), which CI bootstraps — verified the env/project tests pass once `.env` is in place.
- [x] `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean (matches CI gates).

Fixes #98