### PR TITLE
Folio find-references: add a usages-leg test (route('folio.name') call-sites returned)

### DIFF
--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -817,6 +817,59 @@ fn collect_route_matches() {
 }
 
 #[test]
+fn collect_route_matches_dotted_name_exact() {
+    // Folio-style dotted route names (e.g. `route('users.show')`) must match by
+    // full-string equality, never by prefix. Two entries whose names overlap as
+    // prefixes — "users.show" and the shorter "users" — let us prove neither
+    // bleeds into the other. The `collect_route_matches` fixture above uses
+    // distinct names ("home" / "admin.users"), so a `starts_with`-style
+    // regression in the route arm would slip past it; this test guards that gap.
+    let mut p = ParsedPatternsData::default();
+    p.route_refs.push(Arc::new(RouteReferenceData {
+        name: "users.show".into(),
+        line: 0,
+        column: 6,
+        end_column: 16,
+    }));
+    p.route_refs.push(Arc::new(RouteReferenceData {
+        name: "users".into(),
+        line: 1,
+        column: 6,
+        end_column: 11,
+    }));
+    p.build_position_index();
+
+    // Querying the full dotted name returns only its own entry (line 0); the
+    // shorter "users" prefix must not be swept in.
+    let mut out = Vec::new();
+    collect_matches_for_symbol(
+        &dummy_path(),
+        &p,
+        &SymbolRefData::Route("users.show".into()),
+        &mut out,
+    );
+    assert_eq!(
+        out.len(),
+        1,
+        "dotted name should match exactly its own entry"
+    );
+    assert_eq!(out[0].line, 0);
+
+    // Querying the shorter prefix returns only its own entry (line 1); the
+    // longer "users.show" must not be matched — catching a `starts_with`
+    // regression that the distinct-name fixture above cannot.
+    let mut out = Vec::new();
+    collect_matches_for_symbol(
+        &dummy_path(),
+        &p,
+        &SymbolRefData::Route("users".into()),
+        &mut out,
+    );
+    assert_eq!(out.len(), 1, "prefix must not match the longer dotted name");
+    assert_eq!(out[0].line, 1);
+}
+
+#[test]
 fn collect_config_matches_by_key() {
     let mut p = ParsedPatternsData::default();
     p.config_refs.push(Arc::new(ConfigReferenceData {


### PR DESCRIPTION
## Summary
Implements #102 — a unit test guarding the route arm of find-references against
`starts_with`-style prefix matching on Folio-style dotted route names.

Per Inspector Lestrade's re-triage, the original AC was re-scoped: the end-to-end
usages leg is already guarded by `folio_route_usages_are_returned_by_symbol_index`
(PR #114), and the engine arm is unit-tested by `collect_route_matches`. The one
genuinely uncovered gap is **prefix isolation** — `collect_route_matches` uses
distinct names (`home` / `admin.users`), so a `==` → `starts_with` regression
would slip past it. This test closes that gap. No production-code change required;
the test lives in `salsa_impl/tests.rs` (same module, `use super::*` already in
scope).

## Changes
- Add `collect_route_matches_dotted_name_exact` to `laravel-lsp/src/salsa_impl/tests.rs`:
  - Builds `ParsedPatternsData` with two prefix-overlapping `RouteReferenceData`
    entries — `users.show` at line 0 and `users` at line 1.
  - Query `Route("users.show")` → asserts exactly 1 result at line 0 (no bleed
    into the shorter `users`).
  - Query `Route("users")` → asserts exactly 1 result at line 1 (no bleed into
    `users.show`, catching a `starts_with` regression).

## Acceptance Criteria
- [x] A new test (`collect_route_matches_dotted_name_exact`) in `salsa_impl/tests.rs`
      builds `ParsedPatternsData` with `users.show` (line 0) and `users` (line 1),
      queries `Route("users.show")`, and asserts exactly one result at line 0.
- [x] The same test queries `Route("users")` and asserts exactly one result at
      line 1 — confirming the prefix does not match the longer dotted name.
- [x] No production-code changes; the test calls `collect_matches_for_symbol`
      directly via `use super::*` (private fn already in scope for that module).
- [x] `cargo test -p laravel-lsp` passes green; no existing tests regressed.

## Test Plan
- [x] New test passes: `cargo test -p laravel-lsp collect_route_matches_dotted_name_exact`
- [x] Full unit suite green: 1734 + 268 tests pass
- [x] Integration suite green with CI fixture (`.env` + composer `vendor/`): 80 pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (exit 0)

Fixes #102