### PR TITLE
test: add false-prefix case to is_in_routes_dir gate tests

### DIFF
--- a/laravel-lsp/src/tests/routes_dir_gate.rs
+++ b/laravel-lsp/src/tests/routes_dir_gate.rs
@@ -35,6 +35,18 @@ fn rejects_folio_style_nested_routes_component() {
 }
 
 #[test]
+fn rejects_false_prefix_sibling() {
+    // A sibling directory whose name merely *starts with* `routes` (e.g.
+    // `routesX/`) is not the routes dir. The gate matches path components,
+    // not string prefixes — a future "optimization" to a raw prefix check
+    // would silently reintroduce the bug (issue #98).
+    assert!(!is_in_routes_dir(
+        Some(Path::new("/project")),
+        Path::new("/project/routesX/web.php")
+    ));
+}
+
+#[test]
 fn rejects_when_root_unknown() {
     // No project root to anchor against → never trigger the fallback walk.
     assert!(!is_in_routes_dir(None, Path::new("/any/routes/file.php")));


### PR DESCRIPTION
## Summary
Implements #123 — adds the missing false-prefix regression case Holmes flagged in review of #98 (PR #120). Test-only; no production code changes.

## Changes
- Add `rejects_false_prefix_sibling` to `laravel-lsp/src/tests/routes_dir_gate.rs`, asserting `is_in_routes_dir(Some("/project"), "/project/routesX/web.php") → false`.
- Documents that the gate matches path *components*, not string prefixes — guarding against a future "optimization" to a raw prefix check that would silently reintroduce the #98 bug.

## Acceptance Criteria
- [x] New test function `rejects_false_prefix_sibling` added to `laravel-lsp/src/tests/routes_dir_gate.rs`
- [x] Asserts `is_in_routes_dir(Some(Path::new("/project")), Path::new("/project/routesX/web.php"))` returns `false`
- [x] No production code changes — test-only addition
- [x] `cargo test routes_dir_gate` passes with all five tests green
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` remain clean

## Test Plan
- [x] All existing tests pass (`cargo test routes_dir_gate` → 5 passed)
- [x] New test covers the false-prefix sibling case
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` exits 0

Fixes #123