### PR TITLE
fix: salsa_impl::normalize_path pops RootDir on ParentDir, can turn an absolute path relative

### DIFF
--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -1164,3 +1164,52 @@ fn external_prefixes_for_returns_cached_prefixes() {
         vec![String::new(), "admin.".to_string()]
     );
 }
+
+// ---------------------------------------------------------------------------
+// normalize_path — lexical `.`/`..` resolution (regression cover for #117,
+// where salsa_impl's divergent copy popped `RootDir` and relativized absolute
+// paths; salsa_impl now delegates to this canonical function).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn normalize_path_resolves_interior_parent_dir_and_stays_absolute() {
+    // A `..` after a `Normal` segment pops that segment; the path stays absolute.
+    let result = normalize_path(&PathBuf::from("/app/models/../views"));
+    assert_eq!(result, PathBuf::from("/app/views"));
+    assert!(result.is_absolute(), "absolute input must stay absolute");
+}
+
+#[test]
+fn normalize_path_never_pops_root_dir() {
+    // Regression for #117: a `..` walking past root must NOT pop `RootDir` and
+    // silently turn an absolute path relative. The escaping `..` is preserved
+    // and the result stays rooted (the buggy copy returned a relative `escape`).
+    let result = normalize_path(&PathBuf::from("/app/../../escape"));
+    assert!(
+        result.is_absolute(),
+        "absolute input must stay absolute, got {result:?}"
+    );
+    assert_eq!(result, PathBuf::from("/../escape"));
+}
+
+#[test]
+fn normalize_path_preserves_leading_parent_dir() {
+    // A leading `..` on a relative path can't be resolved lexically, so it's kept.
+    assert_eq!(
+        normalize_path(&PathBuf::from("../sibling/file.php")),
+        PathBuf::from("../sibling/file.php")
+    );
+}
+
+#[test]
+fn normalize_path_unchanged_without_parent_dir() {
+    // No `..` segments: behavior is unchanged (only `CurDir` collapses).
+    assert_eq!(
+        normalize_path(&PathBuf::from("/app/views/home.blade.php")),
+        PathBuf::from("/app/views/home.blade.php")
+    );
+    assert_eq!(
+        normalize_path(&PathBuf::from("/app/./views/./home.php")),
+        PathBuf::from("/app/views/home.php")
+    );
+}

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -24,6 +24,12 @@ use crate::config::kebab_to_pascal_case;
 use crate::middleware_parser::middleware_base_alias;
 use crate::parser::{language_php, parse_php};
 use crate::queries::extract_all_php_patterns;
+// Single source of truth for lexical path normalization. The local copy this
+// replaced popped unconditionally on `..`, so a `..` walking past root would
+// pop the `RootDir` component and silently relativize an absolute path (#117).
+// `route_discovery::normalize_path` pops only a preceding `Normal` segment and
+// preserves root / leading `..`. Every other module already delegates here.
+use crate::route_discovery::normalize_path;
 
 // ============================================================================
 // Database Definition
@@ -2277,21 +2283,6 @@ fn extract_anonymous_component_namespaces(text: &str) -> Vec<(String, String, u3
         }
     }
     out
-}
-
-/// Normalize a path by resolving . and .. components without requiring the path to exist
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut components = Vec::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::ParentDir => {
-                components.pop();
-            }
-            std::path::Component::CurDir => {}
-            c => components.push(c),
-        }
-    }
-    components.iter().collect()
 }
 
 /// The namespace a fluent package-builder derives from a package name when


### PR DESCRIPTION
## Summary
Implements #117. `salsa_impl::normalize_path` carried a private copy that popped unconditionally on a `ParentDir` (`..`) component — a `..` walking past root popped the `RootDir` component and silently turned an absolute path relative, corrupting any downstream containment or resolution check that trusted the result.

## Changes
- **`salsa_impl.rs`**: deleted the divergent private `normalize_path` and delegated to the canonical `crate::route_discovery::normalize_path` via a `use` import — the call sites are unchanged. This is the same function `livewire_resolver`, `folio_discovery`, and `main` already use; it pops only a preceding `Normal` segment and preserves root / leading `..`.
- **`route_discovery/tests.rs`**: added four regression tests for the canonical function.

## Acceptance Criteria
- [x] `salsa_impl::normalize_path` never pops a `RootDir` component — an absolute input stays absolute (now delegates to the safe implementation)
- [x] On `ParentDir`, it pops only a preceding `Normal` segment and preserves a leading `..` (matching `route_discovery::normalize_path` semantics)
- [x] Unit tests cover: absolute path with interior `..`, leading `..` preserved, and `..` that would otherwise escape root
- [x] No behavioral change for inputs without `..` segments
- [x] **Consolidated** — rather than keep a third divergent copy, `salsa_impl` now delegates to the single shared `route_discovery::normalize_path`. The whole codebase (`livewire_resolver`, `folio_discovery`, `main`) already routes through it; `salsa_impl` was the lone holdout. Tests live with the canonical function.
- [x] `cargo test`, `cargo fmt --check`, and `cargo clippy` are clean

## Test Plan
- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets` — clean (no warnings)
- [x] `cargo test` — all 1739 lib + 272 unit tests pass, including the 4 new `normalize_path_*` regression tests
- [x] Integration tests: pass once the gitignored `test-project/.env` + composer vendor fixtures are bootstrapped, exactly as CI does (`cp test-project/.env.example test-project/.env` + `composer update`). The fresh-clone-only failures are fixture absence, not code.

Fixes #117