### PR TITLE
Decode UTF-8 correctly in first_string_literal (blade_props)

### DIFF
--- a/laravel-lsp/src/blade_props.rs
+++ b/laravel-lsp/src/blade_props.rs
@@ -197,32 +197,34 @@ fn split_top_level_commas(body: &str) -> Vec<&str> {
 /// or `None` when there isn't one. Used to pull the prop name (the key, or the
 /// bare value) from a `@props` array entry.
 fn first_string_literal(entry: &str) -> Option<String> {
-    let bytes = entry.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        let b = bytes[i];
-        if b == b'\'' || b == b'"' {
-            let quote = b;
-            let mut j = i + 1;
-            let mut s = String::new();
-            while j < bytes.len() {
-                let c = bytes[j];
-                if c == b'\\' && j + 1 < bytes.len() {
-                    s.push(bytes[j + 1] as char);
-                    j += 2;
-                    continue;
-                }
-                if c == quote {
-                    return Some(s);
-                }
-                s.push(c as char);
-                j += 1;
-            }
-            return None; // unterminated literal
+    // Iterate over `char`s (not raw `u8` bytes) so a multi-byte UTF-8 codepoint
+    // inside the literal (e.g. `é` in `'café'`) stays whole instead of being
+    // split into individual Latin-1 byte casts.
+    let mut chars = entry.chars();
+    // Find the opening quote (single or double); no quote → no literal.
+    let quote = loop {
+        let c = chars.next()?;
+        if c == '\'' || c == '"' {
+            break c;
         }
-        i += 1;
+    };
+    let mut s = String::new();
+    while let Some(c) = chars.next() {
+        match c {
+            // Escape sequence (`\'`, `\"`, `\\`, …): take the next char
+            // verbatim. Stepping by `char` means we never index into the middle
+            // of a multi-byte codepoint. A trailing backslash with no following
+            // char falls through to the unterminated-literal `None` below.
+            '\\' => {
+                if let Some(escaped) = chars.next() {
+                    s.push(escaped);
+                }
+            }
+            _ if c == quote => return Some(s),
+            _ => s.push(c),
+        }
     }
-    None
+    None // unterminated literal
 }
 
 /// Whether `s` is a valid PHP identifier (the shape a prop name must have to

--- a/laravel-lsp/src/blade_props/tests.rs
+++ b/laravel-lsp/src/blade_props/tests.rs
@@ -117,3 +117,31 @@ fn prop_names_empty_without_directive() {
 fn prop_names_empty_for_empty_props() {
     assert!(extract_prop_names("@props([])\n").is_empty());
 }
+
+// ─── string-literal decoding (issue #111: UTF-8 correctness) ─────────────
+
+#[test]
+fn first_string_literal_utf8_multibyte() {
+    // A multi-byte UTF-8 character inside the literal must be decoded whole,
+    // not split into raw Latin-1 byte casts.
+    assert_eq!(first_string_literal("'café'"), Some("café".to_string()));
+    assert_eq!(
+        first_string_literal("\"naïve façade — €\""),
+        Some("naïve façade — €".to_string())
+    );
+}
+
+#[test]
+fn first_string_literal_escapes() {
+    // Escape sequences take the next char verbatim, even when it is multi-byte.
+    assert_eq!(first_string_literal(r"'it\'s'"), Some("it's".to_string()));
+    assert_eq!(first_string_literal(r#""a\"b""#), Some("a\"b".to_string()));
+    assert_eq!(first_string_literal(r"'a\\b'"), Some("a\\b".to_string()));
+    assert_eq!(first_string_literal(r"'caf\é'"), Some("café".to_string()));
+}
+
+#[test]
+fn first_string_literal_none_cases() {
+    assert_eq!(first_string_literal("no quotes here"), None);
+    assert_eq!(first_string_literal("'unterminated"), None);
+}


### PR DESCRIPTION
## Summary
Implements #111 — `first_string_literal` in `laravel-lsp/src/blade_props.rs` cast individual `u8` bytes to `char`, so a byte in 0x80–0xFF became a lone Latin-1 scalar. A multi-byte UTF-8 sequence inside a PHP string literal (e.g. `'café'`) was split into separate corrupted chars. No real-world impact today (prop names are ASCII and `is_php_identifier` filters the garbage out), but the encoding model was unsound.

## Changes
- Rewrote `first_string_literal` to iterate over `char`s (via `str::chars`) instead of raw `u8` bytes, so multi-byte UTF-8 codepoints are decoded whole.
- Escape handling now takes the next `char` verbatim, never indexing into the middle of a multi-byte codepoint.
- Added `blade_props` unit tests for multi-byte decoding, escape sequences, and the no-literal / unterminated cases.

## Acceptance Criteria
- [x] `first_string_literal` iterates over `char`s instead of raw `u8` bytes, so multi-byte UTF-8 sequences are decoded correctly rather than split into Latin-1 scalar casts
- [x] Escape handling correctly skips single escape sequences (`\'`, `\"`, `\\`) without indexing into the middle of a multi-byte codepoint
- [x] A unit test (`first_string_literal_utf8_multibyte`) asserts `'café'` decodes to the Rust `String` `"café"`
- [x] All existing `blade_props` tests continue to pass unchanged
- [x] `cargo test`, `cargo fmt --check`, and `cargo clippy --all-targets --all-features` all pass

## Test Plan
- [x] `cargo test --all-features` — full suite green (1738 + 278 + 80 tests, 0 failures) with CI fixtures (`test-project/.env` + Composer vendor) bootstrapped as in `ci.yml`
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] New regression tests cover multi-byte decoding, escapes, and edge cases

Fixes #111