### PR TITLE
Folio cursor-read guard: harden lexical normalize_path against symlink escape (path_within_root)

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4793,15 +4793,16 @@ impl LaravelLanguageServer {
     /// built).
     ///
     /// Containment is enforced explicitly: after the index name lookup the page
-    /// path is checked against the project root (`self.root_path`, compared
-    /// lexically with `normalize_path` — the same check
-    /// `folio_discovery::resolve_folio_path` applies) and an out-of-tree page
-    /// returns `None` *before* any disk read. The index already holds only
-    /// contained mounts, so this guard is defense in depth: it keeps the disk
-    /// read unreachable for out-of-root paths even if a future discovery path
-    /// ever seeded the index without that structural guarantee. Returns `None`
-    /// when the file isn't a named Folio page, the cursor isn't on its
-    /// `name(...)` call, or the path escapes the project root.
+    /// path is checked against the project root (`self.root_path`) with
+    /// `path_within_root`, which canonicalizes both sides — so a symlink *under*
+    /// the root that resolves outside it is rejected, not just a lexically
+    /// out-of-prefix path — and an out-of-tree page returns `None` *before* any
+    /// disk read. The index already holds only contained mounts, so this guard
+    /// is defense in depth: it keeps the disk read unreachable for out-of-root
+    /// paths even if a future discovery path ever seeded the index without that
+    /// structural guarantee. Returns `None` when the file isn't a named Folio
+    /// page, the cursor isn't on its `name(...)` call, or the path escapes the
+    /// project root.
     async fn folio_route_name_for_cursor(
         &self,
         file_path: &Path,
@@ -4813,10 +4814,12 @@ impl LaravelLanguageServer {
         };
         // Defense-in-depth containment guard: refuse to read a page that sits
         // outside the project root, even if the index were ever seeded with one.
-        // Checked lexically with `normalize_path` (matching `resolve_folio_path`)
-        // before any disk access, so an out-of-tree path never reaches the read.
+        // `path_within_root` canonicalizes both sides before comparing, so a
+        // symlink *under* the root that points outside it is rejected here —
+        // before any disk access — rather than slipping past a purely lexical
+        // prefix check.
         let root = self.root_path.read().await.clone()?;
-        if !normalize_path(file_path).starts_with(normalize_path(&root)) {
+        if !path_within_root(file_path, &root) {
             return None;
         }
         let uri = Url::from_file_path(file_path).ok()?;

--- a/laravel-lsp/src/tests/folio_cursor_containment.rs
+++ b/laravel-lsp/src/tests/folio_cursor_containment.rs
@@ -97,3 +97,45 @@ async fn in_tree_page_still_resolves() {
         "an in-tree page on its name() call must still resolve to its route name"
     );
 }
+
+#[cfg(unix)]
+#[tokio::test]
+async fn under_root_symlink_to_outside_target_returns_none() {
+    // The discriminating case the lexical guard could not catch (issue #116): the
+    // page path lives *under* the project root — a symlink at
+    // `<root>/pages/contact.blade.php` — yet it resolves to a file OUTSIDE the
+    // root. The target exists on disk (through the link), the page is indexed
+    // under its in-root link path, and the cursor sits on its `name(...)` call,
+    // so a missing index entry can't explain a `None` result. A purely lexical
+    // `starts_with` check would *admit* this path (the link itself is under the
+    // root); only canonicalization — `path_within_root` resolving the symlink to
+    // its out-of-tree target — can reject it. That makes the test fail against
+    // the old lexical guard and pass against the canonicalize guard.
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+
+    // Real target file, outside the project root.
+    let target = outside.path().join("contact.blade.php");
+    fs::write(&target, PAGE_SRC).unwrap();
+
+    // Symlink under the root that points at the outside target.
+    let pages = root.path().join("pages");
+    fs::create_dir_all(&pages).unwrap();
+    let link = pages.join("contact.blade.php");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let server = test_server();
+    *server.root_path.write().await = Some(root.path().to_path_buf());
+    // Index under the in-root symlink path so `folio_name_for_file` matches and
+    // the containment guard — not a missing entry — decides the outcome.
+    seed_folio_page(&server, "contact", &link).await;
+
+    let result = server.folio_route_name_for_cursor(&link, CURSOR).await;
+
+    assert_eq!(
+        result, None,
+        "a page reached through an under-root symlink that resolves outside the \
+         project root must not resolve — the canonicalize-based containment guard \
+         refuses it even though the link path is lexically inside the root"
+    );
+}


### PR DESCRIPTION
## Summary
Implements #116 — hardens the Folio cursor-read containment guard against the symlink-escape class (#55) that the lexical check left open.

`folio_route_name_for_cursor` previously gated its pre-read root-containment check with the lexical `normalize_path(file_path).starts_with(normalize_path(&root))`. A symlink *under* the project root pointing outside it passes that purely textual check while resolving to an out-of-tree file. This routes the read site through the existing canonicalize-based `path_within_root` helper, closing the symlink leg and making the doc comment's "defense in depth" claim accurate.

## Changes
- `folio_route_name_for_cursor` (`laravel-lsp/src/main.rs`): the containment guard now calls `path_within_root(file_path, &root)` instead of the lexical `normalize_path` prefix check. No new symlink-resolution logic — reuses the existing `#55` helper as-is.
- Updated the method's doc comment and the inline guard comment to state canonicalize-based containment rather than the lexical-only claim.
- New `#[cfg(unix)] #[tokio::test] under_root_symlink_to_outside_target_returns_none` in `laravel-lsp/src/tests/folio_cursor_containment.rs`: seeds an under-root symlink (`std::os::unix::fs::symlink`) pointing outside the root, indexes the page under its in-root link path, and asserts `folio_route_name_for_cursor` returns `None`. Verified discriminating — it fails against the old lexical guard and passes against `path_within_root`.

## Acceptance Criteria
- [x] `folio_route_name_for_cursor` replaces the `normalize_path(...).starts_with(...)` guard with a call to `path_within_root(file_path, &root)`
- [x] The fix reuses `path_within_root` as-is — no new symlink-resolution logic
- [x] New `#[tokio::test]` seeds an under-root symlink pointing outside the root, asserts `None`, and is discriminating (target exists and is indexed, so only the canonicalize guard can reject it)
- [x] Existing `in_tree_page_still_resolves` and `out_of_root_page_returns_none_without_disk_read` controls remain green
- [x] The method's doc comment now states canonicalize-based containment (`path_within_root`) so the "defense in depth" wording is accurate
- [x] `cargo test`, `cargo fmt --check`, and `cargo clippy` pass clean

## Test Plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets` — clean (no lints)
- [x] Unit tests green: `laravel_lsp` lib (1735) + `main` bin (279), including the 3 `folio_cursor_containment` tests
- [x] Discrimination check: new test fails against the old lexical guard, passes against `path_within_root`
- [x] CI bootstraps the `test-project` fixture (.env + `composer update`) and runs the full suite on `ubuntu-latest` (Unix), where the `#[cfg(unix)]` test runs

Fixes #116