### PR TITLE
test: cover hover_for_helper source-link branch (vendored helpers.php present vs. absent)

### DIFF
--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -35,6 +35,7 @@
 
 use crate::livewire_resolver::extract_blade_variable_at_cursor;
 use crate::salsa_impl::{ParsedPatternsData, PatternAtPosition};
+use std::path::Path;
 
 /// Anything the cursor might be hovering. Pattern variants come straight from
 /// the Salsa position index; the Blade-variable variant is extracted by line
@@ -326,6 +327,54 @@ pub fn helper_identifier_card(name: &str, source_link: Option<&str>) -> Option<S
         source_link,
         ..Default::default()
     }))
+}
+
+/// Resolve the bottom-of-hover source link for a curated helper card, driving
+/// the vendored-vs-docs decision off a real on-disk probe under `root`.
+///
+/// When the framework's `helpers.php` (`card.vendor_path`) is vendored under
+/// `root`, returns a `file://` link into it, labelled with the path relative to
+/// `root`. Otherwise — no root, or the file isn't present — falls back to the
+/// canonical `laravel.com/docs` anchor (`card.docs_url`).
+///
+/// This is the single source of truth for the branch: the binary's
+/// `Backend::hover_for_helper` delegates to it, and the behavior tests drive it
+/// directly with a real `TempDir`, so the test and the production decision can
+/// never diverge.
+pub async fn resolve_helper_source_link(root: Option<&Path>, card: &HelperCard) -> String {
+    use tower_lsp::lsp_types::Url;
+
+    // Probe the workspace for the vendored framework helpers file — a single
+    // existence stat, no vendor scan. `try_exists` treats a probe error
+    // (permission denied, broken symlink) as "absent".
+    let vendored = match root {
+        Some(r) => {
+            let path = r.join(card.vendor_path);
+            tokio::fs::try_exists(&path)
+                .await
+                .unwrap_or(false)
+                .then_some((r, path))
+        }
+        None => None,
+    };
+
+    let Some((root, path)) = vendored else {
+        // No root, or the framework isn't vendored: the curated docs anchor.
+        return source_link("Laravel documentation", card.docs_url, None);
+    };
+
+    // A `file://` link into the vendored helpers.php, labelled relative to the
+    // workspace root — mirrors `Backend::source_link` (the `root` here IS the
+    // workspace root, so the label reduces to `card.vendor_path`). Falls back to
+    // an unlinked monospace path when the URL can't be built (non-absolute path).
+    let display = path
+        .strip_prefix(root)
+        .map(|rel| rel.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| path.to_string_lossy().into_owned());
+    match Url::from_file_path(&path) {
+        Ok(url) => source_link(&display, url.as_str(), None),
+        Err(_) => format!("`{}`", display),
+    }
 }
 
 /// The declaring method names a magic-member usage name could map to, by kind.

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -17644,22 +17644,10 @@ return [
         let Some(card) = hover::helper_card(name) else {
             return String::new();
         };
-        // Prefer a file:// link into the vendored framework source; fall back to
-        // the docs URL when the framework isn't vendored under the workspace.
-        let vendored = match root {
-            Some(r) => {
-                let p = r.join(card.vendor_path);
-                tokio::fs::try_exists(&p)
-                    .await
-                    .unwrap_or(false)
-                    .then_some(p)
-            }
-            None => None,
-        };
-        let link = match vendored {
-            Some(p) => self.source_link(&p, None).await,
-            None => hover::source_link("Laravel documentation", card.docs_url, None),
-        };
+        // The vendored-vs-docs source-link decision lives in `hover` so it can be
+        // tested directly against a real `TempDir` (the `root` passed here IS
+        // `self.root_path`, so the relative-display label matches `source_link`).
+        let link = hover::resolve_helper_source_link(root, card).await;
         hover::helper_identifier_card(name, Some(&link)).unwrap_or_default()
     }
 

--- a/laravel-lsp/src/tests/helper_identifier_hover.rs
+++ b/laravel-lsp/src/tests/helper_identifier_hover.rs
@@ -5,10 +5,13 @@
 //! NAME token, and the resolved pattern + rendered card are asserted. Mirrors
 //! the example call sites in the issue's acceptance criteria.
 
-use laravel_lsp::hover;
+use laravel_lsp::hover::{self, HelperCard};
 use laravel_lsp::pattern_indexer::parse_owned;
 use laravel_lsp::salsa_impl::PatternAtPosition;
+use std::fs;
 use std::path::Path;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::Url;
 
 /// Parse a `.php` snippet the way the warming path does.
 fn parse(src: &str) -> std::sync::Arc<laravel_lsp::salsa_impl::ParsedPatternsData> {
@@ -101,4 +104,105 @@ fn helper_identifier_hover_works_in_blade_embedded_php() {
         .expect("route helper identifier captured in Blade-embedded PHP");
     // The card renders the same regardless of host file type.
     assert!(hover::helper_identifier_card(&route.name, None).is_some());
+}
+
+// ─── source-link branch: vendored helpers.php present vs. absent (#118) ───
+//
+// `Backend::hover_for_helper` (`main.rs`) probes the workspace root for the
+// vendored framework `helpers.php`: present → a `file://` link into that file,
+// absent → the canonical `laravel.com/docs` anchor. The two arms below walk
+// that decision with a `TempDir` — the same backend-free approach
+// `flux_component_hover.rs` uses for the Flux hover chain — so a regression that
+// flipped the branch selection or broke the vendor-path probe is caught.
+
+/// Reproduce `Backend::hover_for_helper`'s source-link decision (`main.rs`)
+/// without standing up an async LSP backend. The vendored-vs-docs branch is
+/// *driven* by the on-disk probe (`vendored.exists()`, mirroring the production
+/// `tokio::fs::try_exists`), so the fixture — vendored file present or absent —
+/// selects the arm exactly as production does; it is never hand-picked.
+fn helper_source_link(root: &Path, card: &HelperCard) -> String {
+    let vendored = root.join(card.vendor_path);
+    if vendored.exists() {
+        // Mirror `Backend::source_link`: a root-relative display label over a
+        // `file://` URL (`relative_display_path` strips the project root,
+        // falling back to the absolute path on mismatch — here the fixture root
+        // IS the workspace root, so the label reduces to `card.vendor_path`).
+        let url = Url::from_file_path(&vendored).expect("absolute path → file URL");
+        let display = vendored
+            .strip_prefix(root)
+            .unwrap_or(&vendored)
+            .to_string_lossy();
+        hover::source_link(&display, url.as_str(), None)
+    } else {
+        // Fallback arm: the curated `laravel.com/docs` anchor for this helper.
+        hover::source_link("Laravel documentation", card.docs_url, None)
+    }
+}
+
+#[test]
+fn vendored_helpers_file_present_yields_a_file_source_link() {
+    let card = hover::helper_card("route").expect("route is curated");
+
+    // A workspace root with the framework vendored: materialize the exact file
+    // `hover_for_helper` probes for.
+    let dir = TempDir::new().unwrap();
+    let vendored = dir.path().join(card.vendor_path);
+    fs::create_dir_all(vendored.parent().unwrap()).unwrap();
+    fs::write(&vendored, "<?php\n// Illuminate\\Foundation helpers\n").unwrap();
+
+    let link = helper_source_link(dir.path(), card);
+    let render = hover::helper_identifier_card("route", Some(&link))
+        .expect("route is curated, so a card renders");
+
+    // The card carries the resolved source link verbatim…
+    assert!(
+        render.contains(&link),
+        "card carries the source link string:\n{render}",
+    );
+    // …a `file://` link resolving into the vendored path…
+    assert!(
+        render.contains("file://"),
+        "vendored framework yields a file:// source link:\n{render}",
+    );
+    assert!(
+        render.contains(card.vendor_path),
+        "the link resolves into the vendored helpers.php path:\n{render}",
+    );
+    // …and the docs-URL fallback is NOT used.
+    assert!(
+        !render.contains("laravel.com/docs"),
+        "the docs fallback must not appear when the framework is vendored:\n{render}",
+    );
+}
+
+#[test]
+fn vendored_helpers_file_absent_falls_back_to_the_docs_url() {
+    let card = hover::helper_card("route").expect("route is curated");
+
+    // An empty workspace root — the framework is not vendored, so the probe
+    // misses and the docs anchor is the source link.
+    let dir = TempDir::new().unwrap();
+    assert!(
+        !dir.path().join(card.vendor_path).exists(),
+        "fixture root must not contain the vendored helpers.php",
+    );
+
+    let link = helper_source_link(dir.path(), card);
+    let render = hover::helper_identifier_card("route", Some(&link))
+        .expect("route is curated, so a card renders");
+
+    // The card carries the docs anchor (with its `#method-route` fragment)…
+    assert!(
+        render.contains(card.docs_url),
+        "absent framework falls back to the docs URL:\n{render}",
+    );
+    assert!(
+        render.contains("#method-route"),
+        "the docs anchor fragment is preserved:\n{render}",
+    );
+    // …and no `file://` link is rendered.
+    assert!(
+        !render.contains("file://"),
+        "no file:// link when the framework isn't vendored:\n{render}",
+    );
 }

--- a/laravel-lsp/src/tests/helper_identifier_hover.rs
+++ b/laravel-lsp/src/tests/helper_identifier_hover.rs
@@ -5,7 +5,7 @@
 //! NAME token, and the resolved pattern + rendered card are asserted. Mirrors
 //! the example call sites in the issue's acceptance criteria.
 
-use laravel_lsp::hover::{self, HelperCard};
+use laravel_lsp::hover;
 use laravel_lsp::pattern_indexer::parse_owned;
 use laravel_lsp::salsa_impl::PatternAtPosition;
 use std::fs;
@@ -108,75 +108,51 @@ fn helper_identifier_hover_works_in_blade_embedded_php() {
 
 // ─── source-link branch: vendored helpers.php present vs. absent (#118) ───
 //
-// `Backend::hover_for_helper` (`main.rs`) probes the workspace root for the
-// vendored framework `helpers.php`: present → a `file://` link into that file,
-// absent → the canonical `laravel.com/docs` anchor. The two arms below walk
-// that decision with a `TempDir` — the same backend-free approach
-// `flux_component_hover.rs` uses for the Flux hover chain — so a regression that
-// flipped the branch selection or broke the vendor-path probe is caught.
+// `Backend::hover_for_helper` (`main.rs`) delegates its vendored-vs-docs
+// source-link decision to `hover::resolve_helper_source_link`, which probes the
+// workspace root for the vendored framework `helpers.php`: present → a `file://`
+// link into that file, absent → the canonical `laravel.com/docs` anchor. The two
+// arms below drive that *production* function directly with a `TempDir` — the
+// same standalone-function + `TempDir` convention as `vendor_translations` and
+// `vendor_member_prover` — and assert on the link it RETURNS, so a regression
+// flipping the branch selection or breaking the vendor-path probe is caught.
 
-/// Reproduce `Backend::hover_for_helper`'s source-link decision (`main.rs`)
-/// without standing up an async LSP backend. The vendored-vs-docs branch is
-/// *driven* by the on-disk probe (`vendored.exists()`, mirroring the production
-/// `tokio::fs::try_exists`), so the fixture — vendored file present or absent —
-/// selects the arm exactly as production does; it is never hand-picked.
-fn helper_source_link(root: &Path, card: &HelperCard) -> String {
-    let vendored = root.join(card.vendor_path);
-    if vendored.exists() {
-        // Mirror `Backend::source_link`: a root-relative display label over a
-        // `file://` URL (`relative_display_path` strips the project root,
-        // falling back to the absolute path on mismatch — here the fixture root
-        // IS the workspace root, so the label reduces to `card.vendor_path`).
-        let url = Url::from_file_path(&vendored).expect("absolute path → file URL");
-        let display = vendored
-            .strip_prefix(root)
-            .unwrap_or(&vendored)
-            .to_string_lossy();
-        hover::source_link(&display, url.as_str(), None)
-    } else {
-        // Fallback arm: the curated `laravel.com/docs` anchor for this helper.
-        hover::source_link("Laravel documentation", card.docs_url, None)
-    }
-}
-
-#[test]
-fn vendored_helpers_file_present_yields_a_file_source_link() {
+#[tokio::test]
+async fn vendored_helpers_file_present_yields_a_file_source_link() {
     let card = hover::helper_card("route").expect("route is curated");
 
     // A workspace root with the framework vendored: materialize the exact file
-    // `hover_for_helper` probes for.
+    // `resolve_helper_source_link` probes for.
     let dir = TempDir::new().unwrap();
     let vendored = dir.path().join(card.vendor_path);
     fs::create_dir_all(vendored.parent().unwrap()).unwrap();
     fs::write(&vendored, "<?php\n// Illuminate\\Foundation helpers\n").unwrap();
 
-    let link = helper_source_link(dir.path(), card);
-    let render = hover::helper_identifier_card("route", Some(&link))
-        .expect("route is curated, so a card renders");
+    // Drive the real production decision off the on-disk probe.
+    let link = hover::resolve_helper_source_link(Some(dir.path()), card).await;
 
-    // The card carries the resolved source link verbatim…
+    // The probe hit → a `file://` link into the vendored helpers.php, labelled
+    // with the root-relative vendored path. The `file://` URL is computed
+    // independently here and must match what production returned (output, not
+    // an echo of an input we built).
+    let expected_url = Url::from_file_path(&vendored).expect("absolute path → file URL");
     assert!(
-        render.contains(&link),
-        "card carries the source link string:\n{render}",
+        link.contains(expected_url.as_str()),
+        "present framework yields a file:// link into the vendored helpers.php:\n{link}",
     );
-    // …a `file://` link resolving into the vendored path…
     assert!(
-        render.contains("file://"),
-        "vendored framework yields a file:// source link:\n{render}",
-    );
-    assert!(
-        render.contains(card.vendor_path),
-        "the link resolves into the vendored helpers.php path:\n{render}",
+        link.contains(card.vendor_path),
+        "the link is labelled with the root-relative vendored path:\n{link}",
     );
     // …and the docs-URL fallback is NOT used.
     assert!(
-        !render.contains("laravel.com/docs"),
-        "the docs fallback must not appear when the framework is vendored:\n{render}",
+        !link.contains("laravel.com/docs"),
+        "the docs fallback must not appear when the framework is vendored:\n{link}",
     );
 }
 
-#[test]
-fn vendored_helpers_file_absent_falls_back_to_the_docs_url() {
+#[tokio::test]
+async fn vendored_helpers_file_absent_falls_back_to_the_docs_url() {
     let card = hover::helper_card("route").expect("route is curated");
 
     // An empty workspace root — the framework is not vendored, so the probe
@@ -187,22 +163,23 @@ fn vendored_helpers_file_absent_falls_back_to_the_docs_url() {
         "fixture root must not contain the vendored helpers.php",
     );
 
-    let link = helper_source_link(dir.path(), card);
-    let render = hover::helper_identifier_card("route", Some(&link))
-        .expect("route is curated, so a card renders");
+    // Drive the real production decision off the on-disk probe.
+    let link = hover::resolve_helper_source_link(Some(dir.path()), card).await;
 
-    // The card carries the docs anchor (with its `#method-route` fragment)…
-    assert!(
-        render.contains(card.docs_url),
-        "absent framework falls back to the docs URL:\n{render}",
+    // The probe missed → exactly the curated docs source link (anchor and all),
+    // and no `file://` link. Asserting equality against the docs link the helper
+    // would build distinguishes the branch's output from the vendored arm.
+    assert_eq!(
+        link,
+        hover::source_link("Laravel documentation", card.docs_url, None),
+        "absent framework falls back to the exact docs source link",
     );
     assert!(
-        render.contains("#method-route"),
-        "the docs anchor fragment is preserved:\n{render}",
+        link.contains(card.docs_url),
+        "the docs URL (with its #method-route anchor) is the link target:\n{link}",
     );
-    // …and no `file://` link is rendered.
     assert!(
-        !render.contains("file://"),
-        "no file:// link when the framework isn't vendored:\n{render}",
+        !link.contains("file://"),
+        "no file:// link when the framework isn't vendored:\n{link}",
     );
 }


### PR DESCRIPTION
## Summary
Implements #118 — adds coverage for `Backend::hover_for_helper`'s source-link branch (the vendored framework `helpers.php` present vs. absent decision; Holmes follow-up from #58 / PR #88). The branch had no test: a regression flipping the selection, or breaking the vendor-path probe, would have shipped green since AC8's named cases don't distinguish the two link forms.

## Changes
- `laravel-lsp/src/hover.rs`: extract the vendored-vs-docs decision into a new `resolve_helper_source_link(root, card)` — a behavior-preserving lift of the on-disk probe (`tokio::fs::try_exists`) + link-building. This is the single source of truth for the branch, so the test and production can't diverge.
- `laravel-lsp/src/main.rs`: `Backend::hover_for_helper` now delegates to `hover::resolve_helper_source_link`. The `root` it passes is `self.root_path`, so the relative-display label is identical to the previous `source_link` path — no behavior change.
- `laravel-lsp/src/tests/helper_identifier_hover.rs`: two tests that drive the **production** function directly with a `TempDir` and assert on the link it RETURNS (the standalone-function + `TempDir` convention from `vendor_translations` and `vendor_member_prover`):
  - `vendored_helpers_file_present_yields_a_file_source_link` — materializes the vendored `helpers.php`; asserts the returned link contains the independently-computed `file://` URL and not the docs fallback.
  - `vendored_helpers_file_absent_falls_back_to_the_docs_url` — empty `TempDir`; asserts the returned link equals the curated docs source link (anchor and all) and carries no `file://`.

### Addressing Holmes's review of the first revision
The original tests re-implemented the branch in the test file and asserted on strings they had built — tautological, catching no regression. The fix extracts the decision into a testable seam (Holmes's preferred path, and the established repo convention) and points the tests at it, asserting branch **output** vs. input. A probe or branch regression now fails these assertions.

## Acceptance Criteria
- [x] A test sets up a `TempDir` with the vendored `helpers.php` present and asserts a helper hover (`route`) yields a `file://` source link resolving into that vendored path
- [x] A complementary test with the vendored file absent asserts the hover falls back to the `https://laravel.com/docs/…` URL (with its anchor)
- [x] Both tests added to `laravel-lsp/src/tests/helper_identifier_hover.rs`, following the `TempDir` convention from `vendor_translations/tests.rs` and `vendor_member_prover/tests.rs`
- [x] `cargo test`, `cargo fmt --check`, and `cargo clippy` pass clean

## Test Plan
- [x] `cargo test --bin laravel-lsp helper_identifier_hover` — 7 passed (5 existing + 2 new)
- [x] `cargo test --lib --bins` — 280 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — exit 0, no diagnostics
- The `integration_tests` target needs the gitignored fixture (`test-project/.env` + composer `vendor/`) which CI provisions; this PR is additive test code + a behavior-preserving refactor and touches none of it.

Fixes #118