### PR TITLE
test: strengthen helper-hover assertions — config content check + table-driven over all 7 helpers

### DIFF
--- a/laravel-lsp/src/tests/helper_identifier_hover.rs
+++ b/laravel-lsp/src/tests/helper_identifier_hover.rs
@@ -49,7 +49,14 @@ fn hovering_config_identifier_resolves_a_helper_card() {
         panic!("expected HelperIdentifier, got {pattern:?}");
     };
     assert_eq!(helper.name, "config");
-    assert!(hover::helper_identifier_card(&helper.name, None).is_some());
+
+    let card = hover::helper_identifier_card(&helper.name, None)
+        .expect("config is curated, so a card renders");
+    assert!(card.contains("**config**"), "card headers the helper name");
+    assert!(
+        card.contains("configuration variable"),
+        "card carries the Laravel-aware synopsis"
+    );
 }
 
 #[test]
@@ -101,4 +108,35 @@ fn helper_identifier_hover_works_in_blade_embedded_php() {
         .expect("route helper identifier captured in Blade-embedded PHP");
     // The card renders the same regardless of host file type.
     assert!(hover::helper_identifier_card(&route.name, None).is_some());
+}
+
+#[test]
+fn every_curated_helper_renders_its_own_card() {
+    // Lock in that each of the seven curated helpers renders ITS OWN card — the
+    // right header AND the right Laravel-aware synopsis — rather than a bare
+    // `is_some()` that would pass even if the wrong (or an empty) card rendered.
+    // Each keyword is distinctive to that one synopsis (and absent from the
+    // `**name**` header), so a swapped or blank card fails the assertion.
+    let cases = [
+        ("route", "named route"),
+        ("view", "evaluated view"),
+        ("config", "configuration variable"),
+        ("auth", "auth guard"),
+        ("app", "container"),
+        ("session", "session store"),
+        ("cache", "cache store"),
+    ];
+
+    for (name, synopsis_keyword) in cases {
+        let card = hover::helper_identifier_card(name, None)
+            .unwrap_or_else(|| panic!("`{name}` is curated, so a card renders"));
+        assert!(
+            card.contains(&format!("**{name}**")),
+            "`{name}` card headers its own name, got: {card}"
+        );
+        assert!(
+            card.contains(synopsis_keyword),
+            "`{name}` card carries its distinctive synopsis keyword `{synopsis_keyword}`, got: {card}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Implements #119 — strengthens the curated helper-identifier hover tests so they assert *rendered card content*, not just that *a* card exists.

## Changes
- **`hovering_config_identifier_resolves_a_helper_card`**: replaced the bare `hover::helper_identifier_card(...).is_some()` with content assertions — `card.contains("**config**")` (header) and `card.contains("configuration variable")` (synopsis) — mirroring the existing `route` test.
- **New `every_curated_helper_renders_its_own_card`**: a table-driven test over all 7 curated helpers (`route`, `view`, `config`, `auth`, `app`, `session`, `cache`). For each it asserts the card is `Some`, contains `**{name}**`, and contains a synopsis keyword **unique to that one helper** — so a swapped or empty card now fails.

### Note on keyword choice
For `session`/`cache` the AC's example keywords ("session"/"cache") also appear in the `**name**` header, which would make the synopsis check redundant with the header check. I used `session store`/`cache store` instead — distinctive across all 7 synopses — which better delivers the AC's stated goal ("lock in that each helper renders its own card"). Within the AC's "e.g." latitude; no production code touched.

## Acceptance Criteria
- [x] `hovering_config_identifier_resolves_a_helper_card` updated: bare `.is_some()` replaced with `card.contains("**config**")` and `card.contains("configuration variable")`
- [x] New table-driven test iterates all 7 curated helpers, asserting card `Some`, `**{name}**`, and a distinctive synopsis keyword each
- [x] Existing tests (`hovering_route_identifier_resolves_a_helper_card`, `hovering_a_non_curated_helper_yields_no_card`, `hovering_the_string_argument_is_not_a_helper_identifier`, `helper_identifier_hover_works_in_blade_embedded_php`) remain green and unmodified
- [x] `cargo test --lib --bins`, `cargo fmt --check`, and `cargo clippy` pass with no new warnings

## Test Plan
- [x] `cargo test --lib --bins` — 2014 tests pass (1735 lib + 279 bin), 0 failures; all 6 helper-hover tests green
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --bins -- -D warnings` — clean (exit 0)

Fixes #119