### PR TITLE
harden: canonicalize paths in is_in_routes_dir to survive symlinked project roots

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18241,10 +18241,25 @@ async fn decl_range_at(
 /// into the decl walk and never reach its real resolver. When the project root
 /// is unknown (`None`), default to `false` so the walk never triggers without a
 /// root to anchor against.
+///
+/// Both `path` and the joined `routes/` dir are canonicalized before the
+/// component-wise prefix check (issue #122), mirroring the sibling helper
+/// `path_within_root`. `root` is stored once (from an earlier `did_open`) while
+/// `path` arrives per-request, so the two can resolve through different symlink
+/// states — e.g. macOS `/tmp` → `/private/tmp`. A raw textual `starts_with`
+/// would then return a false negative and silently skip the decl-fallback walk
+/// for a real conventional route file. When either side can't be canonicalized
+/// (the file doesn't exist yet, a permission error) we fall back to the textual
+/// prefix check rather than guess — no panic, and the same behaviour as before
+/// for in-memory paths that aren't on disk.
 fn is_in_routes_dir(root: Option<&Path>, path: &Path) -> bool {
-    match root {
-        Some(r) => path.starts_with(r.join("routes")),
-        None => false,
+    let Some(r) = root else {
+        return false;
+    };
+    let routes_dir = r.join("routes");
+    match (path.canonicalize(), routes_dir.canonicalize()) {
+        (Ok(real_path), Ok(real_routes)) => real_path.starts_with(&real_routes),
+        _ => path.starts_with(&routes_dir),
     }
 }
 

--- a/laravel-lsp/src/tests/routes_dir_gate.rs
+++ b/laravel-lsp/src/tests/routes_dir_gate.rs
@@ -51,3 +51,57 @@ fn rejects_when_root_unknown() {
     // No project root to anchor against → never trigger the fallback walk.
     assert!(!is_in_routes_dir(None, Path::new("/any/routes/file.php")));
 }
+
+#[cfg(unix)]
+#[test]
+fn matches_through_symlinked_root() {
+    // `root` and `path` can resolve through different symlink states (issue
+    // #122) — e.g. a stored root reached via a symlink vs. a per-request file
+    // addressed by its real path. A raw textual `starts_with` would return a
+    // false negative; canonicalizing both sides makes the gate survive it.
+    use std::os::unix::fs::symlink;
+
+    let tmp = tempfile::tempdir().unwrap();
+    // Real project with a conventional routes/ dir and a route file on disk.
+    let real_root = tmp.path().join("real_project");
+    std::fs::create_dir_all(real_root.join("routes")).unwrap();
+    let route_file = real_root.join("routes").join("web.php");
+    std::fs::write(&route_file, "<?php\n").unwrap();
+
+    // A symlink standing in for the stored project root.
+    let link_root = tmp.path().join("link_project");
+    symlink(&real_root, &link_root).unwrap();
+
+    // Sanity: the raw textual prefix check fails here — `link_project/routes`
+    // is not a textual prefix of `real_project/routes/web.php`. Canonicalizing
+    // both is what makes the gate return true.
+    assert!(!route_file.starts_with(link_root.join("routes")));
+    assert!(is_in_routes_dir(Some(&link_root), &route_file));
+}
+
+#[test]
+fn rejects_real_path_outside_routes_dir() {
+    // Both the file and the routes/ dir exist on disk, so the canonical branch
+    // runs — a path outside routes/ must still return false in canonical form.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("project");
+    std::fs::create_dir_all(root.join("routes")).unwrap();
+    std::fs::create_dir_all(root.join("app")).unwrap();
+    let file = root.join("app").join("Model.php");
+    std::fs::write(&file, "<?php\n").unwrap();
+
+    assert!(!is_in_routes_dir(Some(&root), &file));
+}
+
+#[test]
+fn falls_back_to_textual_when_path_missing() {
+    // A path that doesn't exist can't be canonicalized; the gate must fall back
+    // to the textual component check rather than panic (issue #122). Use a real
+    // tempdir root so only `path` fails canonicalization.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().to_path_buf();
+    let missing = root.join("routes").join("does_not_exist.php");
+
+    // No panic, and the textual prefix still matches the project routes/ dir.
+    assert!(is_in_routes_dir(Some(&root), &missing));
+}

--- a/laravel-lsp/src/tests/routes_dir_gate.rs
+++ b/laravel-lsp/src/tests/routes_dir_gate.rs
@@ -96,12 +96,23 @@ fn rejects_real_path_outside_routes_dir() {
 #[test]
 fn falls_back_to_textual_when_path_missing() {
     // A path that doesn't exist can't be canonicalized; the gate must fall back
-    // to the textual component check rather than panic (issue #122). Use a real
-    // tempdir root so only `path` fails canonicalization.
+    // to the textual component check rather than panic (issue #122). Create a
+    // real `routes/` dir on disk so `routes_dir` canonicalizes but the missing
+    // `path` does not — genuinely driving the `(Err, Ok)` arm. This is the
+    // realistic case the production doc comment calls out: a brand-new route
+    // file still in the editor buffer, not yet saved to disk, sitting inside a
+    // real `routes/` directory.
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path().to_path_buf();
+    std::fs::create_dir_all(root.join("routes")).unwrap();
     let missing = root.join("routes").join("does_not_exist.php");
 
     // No panic, and the textual prefix still matches the project routes/ dir.
     assert!(is_in_routes_dir(Some(&root), &missing));
+
+    // False-negative side: a missing path *outside* routes/ must still return
+    // false through the same textual fallback (routes_dir canonicalizes, the
+    // path does not — again the `(Err, Ok)` arm).
+    let missing_outside = root.join("app").join("does_not_exist.php");
+    assert!(!is_in_routes_dir(Some(&root), &missing_outside));
 }


### PR DESCRIPTION
## Summary
Implements #122 — hardens the route-dir gate `is_in_routes_dir` so it survives symlinked project roots, applying the same try-canonicalize / fall-back-to-textual mitigation the sibling helper `path_within_root` already uses.

The gate compared `path` against `root.join("routes")` with a purely textual `Path::starts_with`. `root` is stored once (an earlier `did_open`) while `path` arrives per-request, so the two can resolve through different symlink states — e.g. macOS `/tmp` → `/private/tmp`. The raw check then returns a false negative and silently skips the declaration-fallback walk for a real route file. Canonicalizing both sides closes that gap.

## Changes
- `is_in_routes_dir` now canonicalizes both `path` and the joined `routes/` dir before the component-wise prefix check; falls back to the existing textual check when either side can't be canonicalized (missing file, permission error) — no panic, identical behaviour for in-memory paths not yet on disk.
- Extended the function doc comment with the issue #122 rationale and the `path_within_root` cross-reference.
- Three new unit tests in `tests/routes_dir_gate.rs`.

## ⚠️ AC reconciliation (stale signature)
The issue's AC was written against `fn is_in_routes_dir(path: &Path) -> bool` with a "check for a `routes` component" body. PR #120 (the #98 fix this follows up) since refactored the function to `fn is_in_routes_dir(root: Option<&Path>, path: &Path) -> bool` doing `path.starts_with(r.join("routes"))`. I implemented the AC's clear *intent* — the `path_within_root` canonicalization mitigation — against the live code, which maps even more naturally onto the current root-vs-path comparison (both sides canonicalized, exactly as `path_within_root` does). The current 2-arg signature is **unchanged**, so AC #2's "no call-site changes in `classify_with_decl_fallback`" intent is honoured.

## Acceptance Criteria
- [x] `is_in_routes_dir` canonicalizes paths before the prefix check, using the same try-canonicalize / fall-back-to-textual pattern as `path_within_root` — applied to **both** `path` and `root/routes` (the live code compares against `root/routes`, not a bare `routes` component)
- [x] Function signature unchanged → no call-site changes in `classify_with_decl_fallback` (kept the live `(root, path)` signature rather than the AC's stale `(path)` one — see reconciliation above)
- [x] When `canonicalize()` fails, falls back to the textual prefix check — no panic, no regression (covered by `falls_back_to_textual_when_path_missing` + the 5 pre-existing tests)
- [x] Unit test: a path whose **canonical** form resolves through a symlink into `routes/` returns `true` (`matches_through_symlinked_root`, via `std::os::unix::fs::symlink` in a tempdir)
- [x] Unit test: a path with no `routes/` component returns `false` (`rejects_real_path_outside_routes_dir` exercises the canonical branch; `rejects_*` cover the textual branch)
- [x] Unit test: a non-existent path (canonicalization fails) falls back gracefully (`falls_back_to_textual_when_path_missing`)

## Test Plan
- [x] `cargo check` clean; `cargo clippy` clean on touched code
- [x] `cargo fmt` applied
- [x] Unit suite green — 1735 (lib) + 281 (bin, incl. all 8 `routes_dir_gate` tests) pass
- [ ] Note: 8 `tests/integration_tests.rs` cases fail in a fresh clone (env/`vendor` fixtures are gitignored — `test-project/.env`, `composer install`). **Verified identical on pristine `main`** — pre-existing and unrelated to this change; CI with full fixture setup is the real gate.

Fixes #122