### PR TITLE
Folio routes: implement rename support (decl + call-site rewrite)

### DIFF
--- a/laravel-lsp/src/folio_discovery.rs
+++ b/laravel-lsp/src/folio_discovery.rs
@@ -369,18 +369,71 @@ pub fn cursor_on_page_name(content: &str, line: u32, character: u32) -> bool {
     }
 }
 
-/// Source span of a Folio page's `name('...')` argument string, including the
-/// surrounding quotes, as `(line, start_column, end_column)`. Used to decide
-/// whether a cursor is on the call. `None` when the page declares no name.
-fn page_name_span(content: &str) -> Option<(u32, u32, u32)> {
+/// A Folio page's own `name('...')` declaration: the route name it owns plus the
+/// 0-based source span of the string *content* between the quotes.
+///
+/// The span follows [`crate::route_name_locator::RouteNameDeclaration`]'s
+/// no-quotes convention — the precise range a rename `TextEdit` replaces — so it
+/// pairs with the route-name rename machinery. [`cursor_on_page_name`] widens
+/// the same span by the enclosing quotes for cursor hit-testing; this yields the
+/// edit range and the leaf name once a cursor is confirmed on the call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageNameLocation {
+    /// The page's own route name (the `name('...')` argument content, trimmed,
+    /// no quotes, no mount prefix). This is the route's leaf segment — any
+    /// mount `->name('admin.')` prefix lives on the Folio mount registration.
+    pub name: String,
+    /// 0-based row of the name string. The helper call is single-line.
+    pub line: u32,
+    /// 0-based column of the first content character (after the opening quote).
+    pub start_column: u32,
+    /// 0-based column one past the last content character (before the closing
+    /// quote).
+    pub end_column: u32,
+}
+
+/// Locate a Folio page's own `name('...')` helper declaration — the route name
+/// and the quote-excluded source span of its argument. `None` when the page
+/// declares no name.
+///
+/// The rename/prepare-rename counterpart to [`cursor_on_page_name`]: that
+/// hit-tests a cursor against the (quote-widened) span; this returns the exact
+/// edit range plus the leaf name to rewrite. Pure over `content` — no
+/// filesystem access — so the caller sources the page text (editor buffer or
+/// disk).
+pub fn page_name_location(content: &str) -> Option<PageNameLocation> {
     let inner = PAGE_NAME_RE.captures(content)?.get(1)?;
-    // Widen one byte each side to cover the enclosing quotes.
-    let start = inner.start().saturating_sub(1);
-    let end = (inner.end() + 1).min(content.len());
-    let start_pos = crate::query_chain::byte_offset_to_position(content, start);
-    let end_pos = crate::query_chain::byte_offset_to_position(content, end);
-    // The `name('...')` argument is single-line; anchor to its start line.
-    Some((start_pos.line, start_pos.character, end_pos.character))
+    let name = inner.as_str().trim().to_string();
+    if name.is_empty() {
+        return None;
+    }
+    // Boundary byte offsets → LSP positions (UTF-16 columns); the helper call's
+    // argument is single-line so we anchor to its start row.
+    let start_pos = crate::query_chain::byte_offset_to_position(content, inner.start());
+    let end_pos = crate::query_chain::byte_offset_to_position(content, inner.end());
+    Some(PageNameLocation {
+        name,
+        line: start_pos.line,
+        start_column: start_pos.character,
+        end_column: end_pos.character,
+    })
+}
+
+/// Source span of a Folio page's `name('...')` argument string, *including* the
+/// surrounding quotes, as `(line, start_column, end_column)`. Used by
+/// [`cursor_on_page_name`] to decide whether a cursor is on the call (clicking a
+/// quote still counts). `None` when the page declares no name. The
+/// quote-excluded span — the rename edit range — is [`page_name_location`].
+fn page_name_span(content: &str) -> Option<(u32, u32, u32)> {
+    let loc = page_name_location(content)?;
+    // Widen one column each side to cover the enclosing quotes. A PHP string
+    // quote is always a single-column ASCII byte (`'` or `"`), so a one-column
+    // step is exact under LSP's UTF-16 columns.
+    Some((
+        loc.line,
+        loc.start_column.saturating_sub(1),
+        loc.end_column + 1,
+    ))
 }
 
 /// Discover every Folio page across the project's mounts and resolve it to a

--- a/laravel-lsp/src/folio_discovery/tests.rs
+++ b/laravel-lsp/src/folio_discovery/tests.rs
@@ -418,6 +418,56 @@ fn cursor_on_page_name_false_for_unnamed_page() {
     assert!(!cursor_on_page_name("<div>no name here</div>", 0, 0));
 }
 
+// ---------------------------------------------------------------------------
+// page_name_location — the rename edit range + leaf name (issue #100)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn page_name_location_spans_content_without_quotes() {
+    // `<?php name('about'); ?>` — `about` content occupies columns 12..=16, so
+    // the quote-excluded span is start 12, end 17 (one past the last char).
+    let loc = page_name_location("<?php name('about'); ?>").expect("named page locates");
+    assert_eq!(loc.name, "about");
+    assert_eq!(loc.line, 0);
+    assert_eq!(loc.start_column, 12);
+    assert_eq!(loc.end_column, 17);
+}
+
+#[test]
+fn page_name_location_excludes_the_cursor_quote_padding() {
+    // The quote-widened cursor span (page_name_span, via cursor_on_page_name)
+    // includes the quotes; the rename location must NOT — it sits one column
+    // inside each quote. Cross-check the two stay consistent.
+    let content = "<?php name('about'); ?>";
+    let loc = page_name_location(content).unwrap();
+    // One column left of the content start is the opening quote — still "on the
+    // call" for hit-testing, but never part of the edit range.
+    assert!(cursor_on_page_name(content, 0, loc.start_column - 1));
+    assert!(cursor_on_page_name(content, 0, loc.end_column));
+}
+
+#[test]
+fn page_name_location_handles_double_quotes_and_dotted_names() {
+    let loc = page_name_location(r#"<?php name("users.show"); ?>"#).expect("dotted name locates");
+    assert_eq!(loc.name, "users.show");
+    assert_eq!(loc.line, 0);
+    // Slice the source at the reported span; it must equal the leaf name.
+    let content = r#"<?php name("users.show"); ?>"#;
+    let slice: String = content
+        .chars()
+        .skip(loc.start_column as usize)
+        .take((loc.end_column - loc.start_column) as usize)
+        .collect();
+    assert_eq!(slice, "users.show");
+}
+
+#[test]
+fn page_name_location_none_when_no_helper() {
+    assert!(page_name_location("<div>plain page</div>").is_none());
+    // `->name(` route-chain and static `::name(` are not the Folio helper.
+    assert!(page_name_location("<?php Route::get('/x')->name('not.folio');").is_none());
+}
+
 #[test]
 fn folio_name_for_file_resolves_from_the_index() {
     // Build the in-memory index the same way the route-index build does, then

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4829,6 +4829,39 @@ impl LaravelLanguageServer {
         .then_some(name)
     }
 
+    /// The prepare-rename highlight range for a Folio page's own `name('...')`
+    /// helper when the cursor sits on it (issue #100) — the page-route
+    /// counterpart to the `routes/`-file decl ranges `decl_range_at` derives
+    /// from `cached_route_decls`.
+    ///
+    /// A Folio page lives outside `routes/` and its bare `name(...)` helper is no
+    /// `->name()` chain, so the conventional decl walk never finds it; this
+    /// resolves the quote-excluded content span straight from the page source
+    /// (editor buffer or disk). Returns `None` when the cursor isn't on a Folio
+    /// page's `name(...)` call.
+    async fn folio_name_decl_range(&self, file_path: &Path, position: Position) -> Option<Range> {
+        let uri = Url::from_file_path(file_path).ok()?;
+        let content = self.document_or_disk_content(&uri, file_path).await?;
+        if !laravel_lsp::folio_discovery::cursor_on_page_name(
+            &content,
+            position.line,
+            position.character,
+        ) {
+            return None;
+        }
+        let loc = laravel_lsp::folio_discovery::page_name_location(&content)?;
+        Some(Range {
+            start: Position {
+                line: loc.line,
+                character: loc.start_column,
+            },
+            end: Position {
+                line: loc.line,
+                character: loc.end_column,
+            },
+        })
+    }
+
     /// Return the current content of `uri` — the editor buffer if the file is
     /// open (so unsaved edits are reflected), otherwise the on-disk text.
     /// Returns `None` only when neither source is readable.
@@ -18152,8 +18185,13 @@ async fn classify_with_decl_fallback(
         // page lives outside `routes/` and the bare helper isn't tagged by
         // php.scm. If the cursor sits on that call, resolve it to the page's
         // (mount-prefixed) route name — read from the already-built in-memory
-        // route index, never a fresh filesystem walk — so find-references /
-        // rename reach every `route('...')` usage of the page.
+        // route index, never a fresh filesystem walk. find-references then
+        // reaches every `route('...')` usage of the page, and rename rewrites
+        // them atomically with the page's own `name('...')` declaration: the
+        // call-site edits come from `find_references`, the declaration edit from
+        // `collect_route_declaration_targets`' Folio branch, with the matching
+        // prepare_rename highlight range from `decl_range_at`'s Folio fallback
+        // (issue #100).
         if let Some(name) = server
             .folio_route_name_for_cursor(file_path, position)
             .await
@@ -18200,34 +18238,41 @@ async fn decl_range_at(
     let laravel_lsp::references::SymbolRef::Route(name) = symbol else {
         return None;
     };
-    let decls = server.cached_route_decls(file_path).await?;
-    // `name` may carry an external-file group prefix (issue #43); match a raw
-    // in-file decl whose name equals `name` once that prefix is prepended.
-    let external = root
-        .map(|r| laravel_lsp::route_discovery::external_prefixes_for_file(r, file_path))
-        .unwrap_or_else(|| vec![String::new()]);
-    for d in decls.iter().filter(|d| {
-        external
-            .iter()
-            .any(|ext| format!("{}{}", ext, d.full_name) == *name)
-    }) {
-        if d.line == position.line
-            && position.character >= d.start_column
-            && position.character <= d.end_column
-        {
-            return Some(Range {
-                start: Position {
-                    line: d.line,
-                    character: d.start_column,
-                },
-                end: Position {
-                    line: d.line,
-                    character: d.end_column,
-                },
-            });
+    if let Some(decls) = server.cached_route_decls(file_path).await {
+        // `name` may carry an external-file group prefix (issue #43); match a raw
+        // in-file decl whose name equals `name` once that prefix is prepended.
+        let external = root
+            .map(|r| laravel_lsp::route_discovery::external_prefixes_for_file(r, file_path))
+            .unwrap_or_else(|| vec![String::new()]);
+        for d in decls.iter().filter(|d| {
+            external
+                .iter()
+                .any(|ext| format!("{}{}", ext, d.full_name) == *name)
+        }) {
+            if d.line == position.line
+                && position.character >= d.start_column
+                && position.character <= d.end_column
+            {
+                return Some(Range {
+                    start: Position {
+                        line: d.line,
+                        character: d.start_column,
+                    },
+                    end: Position {
+                        line: d.line,
+                        character: d.end_column,
+                    },
+                });
+            }
         }
     }
-    None
+
+    // Folio fallback (issue #100): a named Folio page declares its route via its
+    // own `name('...')` helper, which lives outside `routes/` and is no
+    // `->name()` chain, so the decl walk above never sees it. If the cursor sits
+    // on that call, return its quote-excluded content range so prepare_rename
+    // offers the same highlight a conventional route decl would.
+    server.folio_name_decl_range(file_path, position).await
 }
 
 /// Is this file a conventional route file — i.e. does it live directly under
@@ -18562,64 +18607,110 @@ async fn collect_route_declaration_targets(
 ) -> Vec<laravel_lsp::rename::EditTarget> {
     let mut targets = Vec::new();
     let routes_dir = root.join("routes");
-    if !routes_dir.exists() {
-        return targets;
-    }
-    // Inherited external-load prefixes for EVERY route file, computed once per
-    // request instead of re-running the project load graph per file inside the
-    // loop below (avoids O(files²)).
-    let external_prefix_map = laravel_lsp::route_discovery::external_prefixes_map(root);
-    for entry in WalkDir::new(&routes_dir)
-        .max_depth(6)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        let path = entry.path();
-        if !path.is_file() || path.extension().is_none_or(|ext| ext != "php") {
-            continue;
-        }
-        // Mtime-cached: first invocation per file mtime parses the file
-        // with route_name_locator; subsequent invocations are a HashMap hit
-        // until the file changes on disk.
-        let Some(all_decls) = server.cached_route_decls(path).await else {
-            continue;
-        };
-        // External-file group prefixes (issue #43): a file loaded via
-        // `Route::as('admin.')->group(<path>)` resolves its raw `->name('x')`
-        // to `admin.x` at the project level. For each matching decl we
-        // re-anchor `full_name` to that combined prefix so `rewritten_segment`
-        // strips the WHOLE prefix (external + in-file group) and rewrites only
-        // the leaf — never doubling either prefix in source. The always-present
-        // `""` prefix preserves the plain (non-external) match.
-        let external = external_prefix_map
-            .get(&laravel_lsp::route_discovery::normalize_path(path))
-            .cloned()
-            .unwrap_or_else(|| vec![String::new()]);
-        for d in all_decls.iter() {
-            let Some(ext) = external
-                .iter()
-                .find(|ext| format!("{}{}", ext, d.full_name) == target)
-            else {
+    if routes_dir.exists() {
+        // Inherited external-load prefixes for EVERY route file, computed once
+        // per request instead of re-running the project load graph per file
+        // inside the loop below (avoids O(files²)).
+        let external_prefix_map = laravel_lsp::route_discovery::external_prefixes_map(root);
+        for entry in WalkDir::new(&routes_dir)
+            .max_depth(6)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if !path.is_file() || path.extension().is_none_or(|ext| ext != "php") {
+                continue;
+            }
+            // Mtime-cached: first invocation per file mtime parses the file
+            // with route_name_locator; subsequent invocations are a HashMap hit
+            // until the file changes on disk.
+            let Some(all_decls) = server.cached_route_decls(path).await else {
                 continue;
             };
-            let resolved = laravel_lsp::route_name_locator::RouteNameDeclaration {
-                full_name: format!("{}{}", ext, d.full_name),
-                local_segment: d.local_segment.clone(),
-                line: d.line,
-                start_column: d.start_column,
-                end_column: d.end_column,
-            };
-            targets.push(laravel_lsp::rename::EditTarget {
-                file_path: path.to_path_buf(),
-                line: d.line,
-                start_column: d.start_column,
-                end_column: d.end_column,
-                // Decl spans only this segment; the group prefix (if any)
-                // lives elsewhere and must not be re-written here.
-                new_text: resolved.rewritten_segment(new_name).to_string(),
-            });
+            // External-file group prefixes (issue #43): a file loaded via
+            // `Route::as('admin.')->group(<path>)` resolves its raw `->name('x')`
+            // to `admin.x` at the project level. For each matching decl we
+            // re-anchor `full_name` to that combined prefix so `rewritten_segment`
+            // strips the WHOLE prefix (external + in-file group) and rewrites only
+            // the leaf — never doubling either prefix in source. The always-present
+            // `""` prefix preserves the plain (non-external) match.
+            let external = external_prefix_map
+                .get(&laravel_lsp::route_discovery::normalize_path(path))
+                .cloned()
+                .unwrap_or_else(|| vec![String::new()]);
+            for d in all_decls.iter() {
+                let Some(ext) = external
+                    .iter()
+                    .find(|ext| format!("{}{}", ext, d.full_name) == target)
+                else {
+                    continue;
+                };
+                let resolved = laravel_lsp::route_name_locator::RouteNameDeclaration {
+                    full_name: format!("{}{}", ext, d.full_name),
+                    local_segment: d.local_segment.clone(),
+                    line: d.line,
+                    start_column: d.start_column,
+                    end_column: d.end_column,
+                };
+                targets.push(laravel_lsp::rename::EditTarget {
+                    file_path: path.to_path_buf(),
+                    line: d.line,
+                    start_column: d.start_column,
+                    end_column: d.end_column,
+                    // Decl spans only this segment; the group prefix (if any)
+                    // lives elsewhere and must not be re-written here.
+                    new_text: resolved.rewritten_segment(new_name).to_string(),
+                });
+            }
         }
     }
+
+    // Folio page declaration (issue #100): a named Folio page declares its route
+    // via its own `name('...')` helper, which lives outside `routes/` (so the
+    // walk above never reaches it) and is no `->name()` chain. Without rewriting
+    // it, a rename would update every `route('...')` call site but leave the
+    // page's declaration stale — the decl/call-site desync this fixes. Resolve
+    // the page straight from the in-memory route index (the same source
+    // `collect_declaration_locations`' Folio branch reads): a `.blade.php`-backed
+    // entry for `target` is Folio-owned (a conventional route of the same name
+    // shadows it via keep-first insertion, and its file is a `routes/*.php`), so
+    // this never double-counts with the walk above.
+    let folio_page = {
+        let guard = server.route_index.read().await;
+        guard
+            .as_ref()
+            .and_then(|idx| idx.get(target))
+            .filter(|def| def.file.to_str().is_some_and(|s| s.ends_with(".blade.php")))
+            .map(|def| def.file.clone())
+    };
+    if let Some(file) = folio_page {
+        if let Ok(uri) = Url::from_file_path(&file) {
+            if let Some(content) = server.document_or_disk_content(&uri, &file).await {
+                if let Some(loc) = laravel_lsp::folio_discovery::page_name_location(&content) {
+                    // The page's `name(...)` argument is the route's LEAF; any
+                    // mount `->name('admin.')` prefix lives on the Folio mount
+                    // registration, not in the page. Strip it exactly as a
+                    // `routes/` group prefix is stripped so only the leaf is
+                    // rewritten — never doubling the mount prefix in source.
+                    let resolved = laravel_lsp::route_name_locator::RouteNameDeclaration {
+                        full_name: target.to_string(),
+                        local_segment: loc.name.clone(),
+                        line: loc.line,
+                        start_column: loc.start_column,
+                        end_column: loc.end_column,
+                    };
+                    targets.push(laravel_lsp::rename::EditTarget {
+                        file_path: file,
+                        line: loc.line,
+                        start_column: loc.start_column,
+                        end_column: loc.end_column,
+                        new_text: resolved.rewritten_segment(new_name).to_string(),
+                    });
+                }
+            }
+        }
+    }
+
     targets
 }
 

--- a/laravel-lsp/src/tests/folio_rename.rs
+++ b/laravel-lsp/src/tests/folio_rename.rs
@@ -21,11 +21,15 @@
 
 use crate::{collect_route_declaration_targets, decl_range_at, LaravelLanguageServer};
 use laravel_lsp::references::SymbolRef;
+use laravel_lsp::rename::{build_rename_workspace_edit, EditTarget};
 use laravel_lsp::route_discovery::{RouteDefinition, RouteIndex, PRIORITY_APP};
+use laravel_lsp::salsa_impl::{ParsedPatternsData, RouteReferenceData, SymbolRefData};
+use laravel_lsp::symbol_index::SymbolIndex;
 use std::fs;
 use std::path::Path;
+use std::sync::Arc;
 use tempfile::TempDir;
-use tower_lsp::lsp_types::{Position, Range};
+use tower_lsp::lsp_types::{Position, Range, Url};
 use tower_lsp::LspService;
 
 /// `<?php name('contact'); ?>` — the `contact` argument content occupies columns
@@ -198,5 +202,132 @@ async fn collect_targets_ignores_a_conventional_route_name() {
     assert!(
         targets.is_empty(),
         "an unindexed / non-Folio name must not produce a page decl edit"
+    );
+}
+
+/// Build the call-site `EditTarget`s for a `route('<route_name>')` reference in
+/// `call_site`, exactly the way the `rename` handler does. The handler gets its
+/// call sites from `salsa.find_references` (a `SymbolIndex::find` under the
+/// hood) and maps each hit to an `EditTarget` carrying the full `new_name`
+/// (`main.rs`, the `targets` map before the per-kind decl extension). This
+/// drives that same `SymbolIndex::find` path on a hand-built parse of the call
+/// site — no Salsa actor needed — so the test exercises the real lookup rather
+/// than a literal stand-in.
+fn call_site_edit_targets(call_site: &Path, route_name: &str, new_name: &str) -> Vec<EditTarget> {
+    let mut patterns = ParsedPatternsData::default();
+    patterns.route_refs.push(Arc::new(RouteReferenceData {
+        name: route_name.to_string(),
+        line: 17,
+        column: 23,
+        end_column: 23 + route_name.len() as u32,
+    }));
+    let mut index = SymbolIndex::default();
+    index.insert_file(call_site, &patterns);
+
+    index
+        .find(&SymbolRefData::Route(route_name.to_string()))
+        .into_iter()
+        .map(|r| EditTarget {
+            file_path: r.file_path,
+            line: r.line,
+            start_column: r.column,
+            end_column: r.end_column,
+            // Call sites always get the full `new_name`; the decl side may
+            // differ (leaf-only) — that's exactly what the next test asserts.
+            new_text: new_name.to_string(),
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn rename_workspace_edit_carries_both_page_decl_and_call_site() {
+    // AC6: a Folio rename must emit ONE `WorkspaceEdit` that rewrites BOTH the
+    // page's own `name('...')` declaration AND every `route('...')` call site.
+    // This is the exact seam issue #100 exists to guard: the original bug
+    // rewrote the call sites while leaving the page declaration stale. Drive
+    // the handler's assembly order — call-site targets from the symbol-index
+    // lookup, then `targets.extend(collect_route_declaration_targets(...))`,
+    // then `build_rename_workspace_edit` — and assert both edits land together.
+    let root = TempDir::new().unwrap();
+    let server = test_server();
+    let page = seed_page(&server, root.path(), "contact").await;
+
+    let call_site = root
+        .path()
+        .join("app/Http/Controllers/ContactController.php");
+    let mut targets = call_site_edit_targets(&call_site, "contact", "support");
+    targets.extend(
+        collect_route_declaration_targets(&server, root.path(), "contact", "support").await,
+    );
+
+    let edit = build_rename_workspace_edit(&targets, &[])
+        .expect("a Folio rename with a decl + a call site must produce a WorkspaceEdit");
+    let changes = edit
+        .changes
+        .expect("a text-only rename populates the legacy `changes` map");
+
+    // The page's `name('contact')` declaration — leaf-only `support` at the
+    // quote-excluded content span — is in the same edit.
+    let page_uri = Url::from_file_path(&page).unwrap();
+    let page_edits = changes
+        .get(&page_uri)
+        .expect("the page declaration edit must travel in the WorkspaceEdit");
+    assert_eq!(page_edits.len(), 1, "one decl edit for the page");
+    assert_eq!(page_edits[0].new_text, "support");
+    assert_eq!(page_edits[0].range.start.character, NAME_START);
+    assert_eq!(page_edits[0].range.end.character, NAME_END);
+
+    // The `route('contact')` call site — rewritten with the full new name — is
+    // in the SAME edit, so the two never drift apart.
+    let call_uri = Url::from_file_path(&call_site).unwrap();
+    let call_edits = changes
+        .get(&call_uri)
+        .expect("the route('...') call site must travel in the same WorkspaceEdit");
+    assert_eq!(call_edits.len(), 1, "one call-site edit");
+    assert_eq!(call_edits[0].new_text, "support");
+}
+
+#[tokio::test]
+async fn rename_workspace_edit_pairs_leaf_only_decl_with_full_call_site_under_a_mount_prefix() {
+    // AC6 under a Folio mount `->name('admin.')`: the page's own
+    // `name('contact')` helper owns only the leaf, while the call site uses the
+    // fully-qualified `admin.contact`. Renaming `admin.contact` →
+    // `admin.support` must put the leaf-only `support` at the page declaration
+    // and the full `admin.support` at the call site — both in ONE
+    // `WorkspaceEdit`, never doubling the mount prefix at the decl.
+    let root = TempDir::new().unwrap();
+    let server = test_server();
+    let page = seed_page(&server, root.path(), "admin.contact").await;
+
+    let call_site = root.path().join("app/Http/Controllers/AdminController.php");
+    let mut targets = call_site_edit_targets(&call_site, "admin.contact", "admin.support");
+    targets.extend(
+        collect_route_declaration_targets(&server, root.path(), "admin.contact", "admin.support")
+            .await,
+    );
+
+    let edit = build_rename_workspace_edit(&targets, &[])
+        .expect("the mount-prefixed Folio rename must produce a WorkspaceEdit");
+    let changes = edit.changes.expect("text-only rename populates `changes`");
+
+    // Decl: leaf-only — the mount owns the `admin.` prefix, not the page.
+    let page_uri = Url::from_file_path(&page).unwrap();
+    let page_edits = changes
+        .get(&page_uri)
+        .expect("the page declaration edit must be present");
+    assert_eq!(
+        page_edits[0].new_text, "support",
+        "the decl rewrites only the leaf — the mount prefix lives on the mount"
+    );
+
+    // Call site: the full dotted name, in the same edit alongside the
+    // leaf-only decl.
+    let call_uri = Url::from_file_path(&call_site).unwrap();
+    let call_edits = changes
+        .get(&call_uri)
+        .expect("the call site must travel in the same WorkspaceEdit");
+    assert_eq!(
+        call_edits[0].new_text, "admin.support",
+        "call sites get the full dotted name"
     );
 }

--- a/laravel-lsp/src/tests/folio_rename.rs
+++ b/laravel-lsp/src/tests/folio_rename.rs
@@ -1,0 +1,202 @@
+//! Integration tests for Folio page-route **rename** support (issue #100).
+//!
+//! A named Folio page declares its route via its own `name('...')` helper, which
+//! lives outside `routes/` and is no `->name()` chain. Find-references already
+//! surfaced these pages; rename half-worked — it rewrote `route('...')` call
+//! sites but silently dropped the page's own declaration, leaving a latent
+//! decl/call-site desync. These tests cover the two pieces that close the gap:
+//!
+//!   * `decl_range_at` — the prepare_rename highlight range for a cursor on a
+//!     page's `name('...')` call (previously `None`, so Zed offered no rename).
+//!   * `collect_route_declaration_targets` — the page-declaration `EditTarget`
+//!     that now travels alongside the call-site edits, so a rename rewrites both
+//!     atomically (including leaf-only rewrites under a mount `->name()` prefix).
+//!
+//! Both are driven directly on a server built through `tower_lsp::LspService`,
+//! with the route index seeded the way the route-index build seeds it — the
+//! same harness `folio_cursor_containment.rs` uses. The async `rename` handler
+//! itself isn't fixtured (it depends on the Salsa actor for call-site
+//! `find_references`, covered by the symbol-index tests); these exercise the
+//! Folio decl logic the handler composes.
+
+use crate::{collect_route_declaration_targets, decl_range_at, LaravelLanguageServer};
+use laravel_lsp::references::SymbolRef;
+use laravel_lsp::route_discovery::{RouteDefinition, RouteIndex, PRIORITY_APP};
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::{Position, Range};
+use tower_lsp::LspService;
+
+/// `<?php name('contact'); ?>` — the `contact` argument content occupies columns
+/// 12..=18, so its quote-excluded span is start 12, end 19. A cursor at column
+/// 13 sits inside it.
+const PAGE_SRC: &str = "<?php name('contact'); ?>";
+const NAME_START: u32 = 12;
+const NAME_END: u32 = 19;
+const CURSOR: Position = Position {
+    line: 0,
+    character: 13,
+};
+
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// Write a Folio page under `root/pages/contact.blade.php`, seed the route index
+/// with `route_name` pointing at it, set the project root, and return the page
+/// path. Mirrors how `inject_folio_routes` seeds named pages (top-of-file
+/// anchor) so the decl logic must re-read the page to find the `name(...)` span.
+async fn seed_page(
+    server: &LaravelLanguageServer,
+    root: &Path,
+    route_name: &str,
+) -> std::path::PathBuf {
+    let page = root.join("pages").join("contact.blade.php");
+    fs::create_dir_all(page.parent().unwrap()).unwrap();
+    fs::write(&page, PAGE_SRC).unwrap();
+
+    let mut index = RouteIndex::new();
+    index.insert(
+        route_name.to_string(),
+        RouteDefinition {
+            file: page.clone(),
+            line: 0,
+            column: 0,
+            end_column: 0,
+            priority: PRIORITY_APP,
+            method: Some("get".to_string()),
+            uri: Some("/contact".to_string()),
+            action: None,
+        },
+    );
+    *server.route_index.write().await = Some(index);
+    *server.root_path.write().await = Some(root.to_path_buf());
+    page
+}
+
+#[tokio::test]
+async fn decl_range_at_returns_the_page_name_span_for_a_folio_cursor() {
+    // prepare_rename AC: a cursor on a Folio page's `name('...')` call yields a
+    // valid highlight range (previously `None` → silent no-op).
+    let root = TempDir::new().unwrap();
+    let server = test_server();
+    let page = seed_page(&server, root.path(), "contact").await;
+
+    let range = decl_range_at(
+        &server,
+        Some(root.path()),
+        &page,
+        CURSOR,
+        &SymbolRef::Route("contact".to_string()),
+    )
+    .await;
+
+    assert_eq!(
+        range,
+        Some(Range {
+            start: Position {
+                line: 0,
+                character: NAME_START,
+            },
+            end: Position {
+                line: 0,
+                character: NAME_END,
+            },
+        }),
+        "the prepare_rename range must cover the `contact` content (quotes excluded)"
+    );
+}
+
+#[tokio::test]
+async fn decl_range_at_returns_none_when_cursor_off_the_name_call() {
+    // Off the `name(...)` call (column 0), there is nothing to rename here.
+    let root = TempDir::new().unwrap();
+    let server = test_server();
+    let page = seed_page(&server, root.path(), "contact").await;
+
+    let range = decl_range_at(
+        &server,
+        Some(root.path()),
+        &page,
+        Position {
+            line: 0,
+            character: 0,
+        },
+        &SymbolRef::Route("contact".to_string()),
+    )
+    .await;
+
+    assert_eq!(range, None);
+}
+
+#[tokio::test]
+async fn collect_targets_rewrites_the_page_name_declaration() {
+    // rename AC: the page's own `name('...')` declaration is rewritten so it
+    // stays in sync with the `route('...')` call sites the handler rewrites
+    // separately. No `routes/` directory exists here — the Folio branch must
+    // still fire.
+    let root = TempDir::new().unwrap();
+    let server = test_server();
+    let page = seed_page(&server, root.path(), "contact").await;
+
+    let targets =
+        collect_route_declaration_targets(&server, root.path(), "contact", "support").await;
+
+    assert_eq!(
+        targets.len(),
+        1,
+        "exactly one declaration target — the page itself"
+    );
+    let t = &targets[0];
+    assert_eq!(t.file_path, page);
+    assert_eq!(t.line, 0);
+    assert_eq!(t.start_column, NAME_START);
+    assert_eq!(t.end_column, NAME_END);
+    assert_eq!(
+        t.new_text, "support",
+        "the full new name is written at the decl"
+    );
+}
+
+#[tokio::test]
+async fn collect_targets_writes_leaf_only_under_a_mount_name_prefix() {
+    // When the page sits under a Folio mount `->name('admin.')`, the index key
+    // is the fully-qualified `admin.contact`, but the page's own `name('contact')`
+    // helper only owns the leaf. Renaming `admin.contact` → `admin.support` must
+    // write just `support` at the decl — never doubling the mount prefix.
+    let root = TempDir::new().unwrap();
+    let server = test_server();
+    let page = seed_page(&server, root.path(), "admin.contact").await;
+
+    let targets =
+        collect_route_declaration_targets(&server, root.path(), "admin.contact", "admin.support")
+            .await;
+
+    assert_eq!(targets.len(), 1);
+    let t = &targets[0];
+    assert_eq!(t.file_path, page);
+    assert_eq!(
+        t.new_text, "support",
+        "only the leaf is rewritten; the mount `admin.` prefix lives on the mount, not the page"
+    );
+}
+
+#[tokio::test]
+async fn collect_targets_ignores_a_conventional_route_name() {
+    // A name with no Folio page in the index (e.g. a conventional `routes/`
+    // route, or an unknown name) contributes no Folio decl target — the branch
+    // only fires for `.blade.php`-backed index entries.
+    let root = TempDir::new().unwrap();
+    let server = test_server();
+    seed_page(&server, root.path(), "contact").await;
+
+    let targets =
+        collect_route_declaration_targets(&server, root.path(), "dashboard", "home").await;
+
+    assert!(
+        targets.is_empty(),
+        "an unindexed / non-Folio name must not produce a page decl edit"
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod dynamic_where_sparseness;
 mod flux_component_context;
 mod flux_component_hover;
 mod folio_cursor_containment;
+mod folio_rename;
 mod generic_type_parsing;
 mod helper_identifier_hover;
 mod livewire_component_resolution;


### PR DESCRIPTION
## Summary
Implements #100 — **Option A (full Folio rename support)**.

A Folio page's `name('...')` cursor already classifies as a `Route`, and find-references already reaches every `route('...')` call site of the page (`collect_declaration_locations` has a Folio branch). But **rename** only half-worked: it rewrote the call sites while the page's own declaration walker (`collect_route_declaration_targets`) had no Folio branch and `decl_range_at` only matched `->name()` chains in `routes/`. So `prepare_rename` returned a silent `Ok(None)` (Zed offered no rename), and a client bypassing the prepare gate would rewrite `route('...')` call sites but leave the `pages/` `name('...')` declaration stale — a latent decl/call-site desync.

This completes the feature so rename rewrites **both the declaration and the call sites atomically**, restoring symmetry with find-references.

## Changes
- **`folio_discovery.rs`** — add `page_name_location` + `PageNameLocation`: the quote-excluded source span (rename-edit convention) and leaf name of a page's `name('...')` helper. Refactor `page_name_span` to delegate to it — cursor hit-testing is unchanged.
- **`main.rs` `decl_range_at`** — Folio fallback: when the `routes/` decl walk finds nothing, return the page's own `name('...')` content range (new `folio_name_decl_range` helper). Eliminates the silent `Ok(None)` from `prepare_rename`.
- **`main.rs` `collect_route_declaration_targets`** — Folio branch: resolve the page from the in-memory route index and emit a **leaf-only** declaration edit, atomic with the call-site edits. Any mount `->name('admin.')` prefix is stripped exactly as a `routes/` group prefix is, so it's never doubled in source. (Walk guard relaxed from early-return to `if exists` so the Folio branch fires even with no `routes/` dir.)
- **`main.rs`** — update the `classify_with_decl_fallback` Folio doc comment to accurately describe rename rewriting the page decl + call sites.

## Acceptance Criteria
- [x] Choose and commit to one of the two repair paths — **Option A (full implementation)** chosen; the silent `Ok(None)` from `prepare_rename` is eliminated.
- [x] **Option A:** a Folio locator finds standalone `name('...')` calls (`page_name_location`); `collect_route_declaration_targets` covers the page in addition to `routes/*.php`; `decl_range_at` returns the correct highlight range for a Folio page cursor; `prepare_rename` returns a valid range.
- [x] The doc comment on `classify_with_decl_fallback` is updated to accurately reflect rename support for Folio-classified `Route` symbols.
- [x] Unit test: `decl_range_at` (the unit `prepare_rename` wires its range from) on a synthetic Folio page containing `name('contact')` produces the correct rename range.
- [x] Unit test: `collect_route_declaration_targets` on a Folio page `name('...')` produces the declaration edit that travels with the `route('...')` call-site edits (incl. a mount-prefix leaf-only case); call-site collection via `find_references` is already covered by the symbol-index tests.

> Note on test altitude: the async `rename`/`prepare_rename` handlers aren't fixtured end-to-end — per `rename_integration.rs`'s own docs they depend on the Salsa actor + cached config, so the established pattern tests the helpers the handlers compose. These tests follow that pattern, driving the exact new logic (`decl_range_at`, `collect_route_declaration_targets`) on a seeded server.

## Test Plan
- [x] `cargo test --lib` — 1739 passed
- [x] `cargo test --bin laravel-lsp` — 283 passed (incl. 5 new `folio_rename` tests)
- [x] `cargo test --lib folio_discovery` — 40 passed (incl. 4 new `page_name_location` tests)
- [x] `cargo test --test integration_tests` — 79/80 (the 1 skip needs `test-project/vendor/`, provisioned on CI; unrelated to this change)
- [x] `cargo fmt` clean, `cargo clippy --all-targets` clean

Fixes #100