### PR TITLE
test: strengthen helper_identifier_hover_works_in_blade_embedded_php to assert card content

### DIFF
--- a/laravel-lsp/src/tests/helper_identifier_hover.rs
+++ b/laravel-lsp/src/tests/helper_identifier_hover.rs
@@ -109,8 +109,15 @@ fn helper_identifier_hover_works_in_blade_embedded_php() {
         .iter()
         .find(|h| h.name == "route")
         .expect("route helper identifier captured in Blade-embedded PHP");
-    // The card renders the same regardless of host file type.
-    assert!(hover::helper_identifier_card(&route.name, None).is_some());
+    // The card renders the same regardless of host file type — assert its
+    // content, not mere existence, so a wrong or empty card can't pass.
+    let card = hover::helper_identifier_card(&route.name, None)
+        .expect("route is curated, so a card renders in Blade-embedded PHP too");
+    assert!(card.contains("**route**"), "card headers the helper name");
+    assert!(
+        card.contains("named route"),
+        "card carries the Laravel-aware synopsis"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Implements #136 — strengthens `helper_identifier_hover_works_in_blade_embedded_php` so it asserts the rendered card *content* in the Blade-embedded-PHP context, not merely that a card exists. Follow-up from Holmes's review of PR #135 (AC #3 of #119 had pinned this test as unmodifiable, so it could only be touched here).

## Changes
- Replaced the bare `hover::helper_identifier_card(&route.name, None).is_some()` assertion with content assertions: `card.contains("**route**")` (the header) and `card.contains("named route")` (the `route` synopsis keyword).
- The test still drives the Blade-embedded-PHP host path — `parse_owned` on `nav.blade.php` with `route('home')` inside a Blade `{{ }}` echo, finding the helper via `helper_refs` — so it now proves its own claim of host-file-type invariance.
- Matches the content-assertion pattern already used by the sibling curated-helper hover tests.

## Acceptance Criteria
- [x] Replaces the bare `.is_some()` assertion with `card.contains("**route**")` and `card.contains("named route")`
- [x] Continues to exercise the Blade-embedded-PHP host path (the `route()` call inside Blade `{{ }}`), not just a direct `helper_identifier_card` call
- [x] All other tests in the file remain green and unmodified
- [x] `cargo test --lib --bins`, `cargo fmt --check`, and `cargo clippy` pass with no new warnings

## Test Plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --bins` — no warnings
- [x] `cargo test --lib --bins` — 2041 tests pass (1747 + 294), 0 failures; all 8 `helper_identifier_hover` tests green including the strengthened one

Fixes #136