### PR TITLE
Folio mount discovery: matching_paren mis-scans PHP escaped quotes

### DIFF
--- a/laravel-lsp/src/folio_discovery.rs
+++ b/laravel-lsp/src/folio_discovery.rs
@@ -196,14 +196,27 @@ fn parse_folio_mounts(content: &str, root: &Path) -> Vec<FolioMount> {
 
 /// Find the index of the `)` that closes the `(` at byte `open`, balancing
 /// nested parens and skipping over single/double-quoted string contents (so a
-/// `)` inside a path literal never ends the scan early).
+/// `)` inside a path literal never ends the scan early). Backslash escapes
+/// inside a quoted string are honored: a `\` skips the byte that follows it, so
+/// a PHP `\'` or `\"` cannot close the quote state prematurely (which would
+/// otherwise reopen the quote on the trailing delimiter and swallow the real
+/// closing `)`, silently dropping the mount).
 fn matching_paren(bytes: &[u8], open: usize) -> Option<usize> {
     let mut depth = 0usize;
     let mut quote: Option<u8> = None;
+    let mut escaped = false;
     for (i, &b) in bytes.iter().enumerate().skip(open) {
         match quote {
             Some(q) => {
-                if b == q {
+                if escaped {
+                    // Previous byte was a backslash: this byte is escaped (the
+                    // `'` in `\'`, the `"` in `\"`, etc.) and is consumed
+                    // unconditionally, so it can't close the string.
+                    escaped = false;
+                } else if b == b'\\' {
+                    // Start of a PHP escape sequence — skip the next byte.
+                    escaped = true;
+                } else if b == q {
                     quote = None;
                 }
             }
@@ -226,6 +239,16 @@ fn matching_paren(bytes: &[u8], open: usize) -> Option<usize> {
 /// Parse a single- or double-quoted PHP string literal, returning its inner
 /// content. `None` for anything that isn't a bare quoted literal (e.g. a
 /// variable or a concatenation we can't resolve statically).
+///
+/// The inner content is returned **raw** — PHP escape sequences (`\'`, `\\`, …)
+/// are deliberately not unescaped. Decision (issue #103): a correct unescape
+/// would have to be quote-type aware (single quotes recognize only `\'` and
+/// `\\`; double quotes carry a far larger table — `\n`, `\t`, `\$`, `\xNN`, …),
+/// which is out of scope and disproportionate risk for the reported bug. That
+/// bug was an escaped quote causing the mount to be *silently dropped* — a
+/// `matching_paren` scan bug, now fixed. A directory whose name literally
+/// contains a quote is pathological; with the scan fixed it now resolves (with
+/// the backslash retained in the path) instead of disappearing.
 fn parse_literal(expr: &str) -> Option<String> {
     let expr = expr.trim();
     let bytes = expr.as_bytes();

--- a/laravel-lsp/src/folio_discovery/tests.rs
+++ b/laravel-lsp/src/folio_discovery/tests.rs
@@ -188,6 +188,37 @@ fn discover_folio_mounts_falls_back_when_only_mount_escapes() {
 }
 
 #[test]
+fn matching_paren_honors_escaped_quote() {
+    // A PHP-escaped quote inside a single-quoted argument must NOT close the
+    // string early. Without escape tracking the scan closes on the `'` of `\'`,
+    // reopens on the trailing `'`, and then swallows the real closing `)` —
+    // returning `None` (or, with an even number of escapes, the wrong index).
+    // The returned index must point at the true `)` (the final byte here).
+    let src = b"Folio::path('pages\\'special')";
+    let open = src.iter().position(|&b| b == b'(').unwrap();
+    let close = matching_paren(src, open).expect("the true closing paren is found");
+    assert_eq!(close, src.len() - 1);
+    assert_eq!(src[close], b')');
+
+    // Same guarantee for a double-quoted argument with an escaped `\"`.
+    let dq = b"Folio::path(\"pages\\\"special\")";
+    let dq_open = dq.iter().position(|&b| b == b'(').unwrap();
+    let dq_close = matching_paren(dq, dq_open).expect("the true closing paren is found");
+    assert_eq!(dq_close, dq.len() - 1);
+}
+
+#[test]
+fn parse_folio_mounts_keeps_mount_with_escaped_quote_in_path() {
+    // A path containing a PHP-escaped quote (`pages\'special`) must not cause
+    // the mount to be silently dropped: `matching_paren` honors the escape and
+    // delimits the `Folio::path(...)` argument correctly, so exactly one mount
+    // is returned rather than zero.
+    let src = "<?php Folio::path('pages\\'special');";
+    let mounts = parse_folio_mounts(src, Path::new("/app"));
+    assert_eq!(mounts.len(), 1);
+}
+
+#[test]
 fn parse_folio_mounts_with_uri_and_name_prefixes() {
     let src = "<?php Folio::path('resources/views/admin')->uri('/admin')->name('admin.');";
     let mounts = parse_folio_mounts(src, Path::new("/app"));


### PR DESCRIPTION
## Summary
Implements #103 — `matching_paren` in `folio_discovery.rs` did not track PHP backslash escapes inside quoted strings, so a `Folio::path('pages\'special')` argument closed the quote early, reopened it on the trailing quote, and swallowed the real closing `)`. The mount was silently dropped.

## Changes
- `matching_paren` now tracks a backslash-escape flag inside the in-quote arm: a `\` consumes the following byte unconditionally, so `\'` / `\"` can no longer close the quote state prematurely.
- Documented the `parse_literal` decision inline: inner content is returned **raw** (no quote-type-aware unescaping). A correct unescape would have to distinguish the single- vs double-quote escape tables — out of scope for the reported drop-bug; documented either way per AC.
- Added a direct `matching_paren` unit test (single- and double-quote escapes) and a `parse_folio_mounts` test asserting the escaped-quote mount is kept.
- Fix is contained to `laravel-lsp/src/folio_discovery.rs` (+ its test submodule).

## Acceptance Criteria
- [x] `matching_paren` tracks a backslash-escape flag: inside a quoted string a `\` sets the flag and the next byte is skipped unconditionally, preventing `\'`/`\"` from closing the quote early
- [x] `Folio::path('app\'s/pages')` is correctly delimited: `matching_paren` returns the true closing `)`
- [x] `parse_literal` receives a well-formed quoted slice and returns the raw inner content; no change required — decision (no unescaping) documented inline
- [x] Unit test exercises `matching_paren` directly with a single-quoted argument containing `\'`, asserting the returned index points to the correct closing paren
- [x] Unit test for `parse_folio_mounts` passes `Folio::path('pages\'special')` and asserts exactly one mount is returned
- [x] All existing `folio_discovery` tests still pass; no regressions
- [x] Fix contained to `laravel-lsp/src/folio_discovery.rs` only

## Test Plan
- [x] `cargo test` — 2043 lib/unit tests pass, including the 2 new tests (42 folio_discovery tests, up from 40)
- [x] `cargo fmt --check` and `cargo clippy` clean
- [x] Pre-existing `integration_tests.rs` failures (8, missing `.env` Laravel fixture) confirmed identical on clean `origin/main` — not regressions

Fixes #103