### PR TITLE
Validate Flux component names before path construction (defense-in-depth)

### DIFF
--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2894,12 +2894,14 @@ impl LaravelConfigData {
     /// Resolve a component name to file path.
     ///
     /// Defense-in-depth (#109): the component name comes straight from a Blade
-    /// tag, and the dot→slash substitution below turns a leading-dot or empty
-    /// name into an absolute or empty filesystem path — `PathBuf::join`
-    /// discards the receiver when the argument is absolute, so
-    /// `<flux:.etc.passwd>` would otherwise yield `/etc/passwd`. We reject such
-    /// names up front and, as a backstop, drop any built candidate that escapes
-    /// `self.root` before returning.
+    /// tag, and the dot→slash substitution below turns a leading-dot, empty, or
+    /// slash-bearing name into an absolute, empty, or `..`-traversing
+    /// filesystem path — `PathBuf::join` discards the receiver when the
+    /// argument is absolute, so `<flux:.etc.passwd>` would otherwise yield
+    /// `/etc/passwd` and `<flux:foo/../../../etc/passwd>` would traverse out.
+    /// We reject such names up front and, as a backstop, drop any built
+    /// candidate that escapes `self.root` (after lexically resolving `..`)
+    /// before returning.
     pub fn resolve_component_path(&self, component_name: &str) -> Vec<PathBuf> {
         // Flux's `<flux:button>` sugar maps to the `flux` anonymous-component
         // namespace; rewrite the single-colon prefix to the `::` form so the
@@ -2910,16 +2912,24 @@ impl LaravelConfigData {
         // Reject names that would escape the project root before building any
         // path. The "actual" component is the part after a `::` namespace
         // prefix; its dots become slashes downstream, so bail out with no
-        // candidates when it is empty, starts with a dot, or turns absolute
-        // after the substitution. Covers `<flux:>` (empty), leading-dot names,
-        // and the `flux:.etc.passwd` → `/etc/passwd` attack shape.
+        // candidates when it is:
+        //   - empty             → `<flux:>` / bare `flux::` nonsense
+        //   - starts with a dot → leading-dot names and `../` traversals; also
+        //     the `flux:.etc.passwd` → `/etc/passwd` absolute attack shape
+        //   - contains a `/`    → a literal slash never appears in a real
+        //     Blade/Flux name (nesting uses dots, namespaces use `::`). It is
+        //     how an attacker smuggles a mid-path `..` traversal
+        //     (`flux::foo/../../../etc/passwd`) or an absolute `/etc/passwd`
+        //     past the dot→slash mapping, so rejecting the whole slash-bearing
+        //     class closes it at the source (Holmes, PR #150 review). This
+        //     subsumes the old `replace('.', "/").starts_with('/')` check.
         let actual_component = match component_name.find("::") {
             Some(pos) => &component_name[pos + 2..],
             None => component_name,
         };
         if actual_component.is_empty()
             || actual_component.starts_with('.')
-            || actual_component.replace('.', "/").starts_with('/')
+            || actual_component.contains('/')
         {
             return Vec::new();
         }
@@ -2929,15 +2939,18 @@ impl LaravelConfigData {
         // Canonicalize so a symlinked project root (`/var` → `/private/var` on
         // macOS) or a symlinked vendor dir doesn't spuriously fail the purely
         // textual `starts_with`. Speculative candidates that don't exist on
-        // disk can't be canonicalized, so they fall back to the textual prefix
-        // check — which keeps the in-root file guesses and still drops an
-        // absolute `/etc/passwd`-style escape. Mirrors `path_within_root` in
+        // disk can't be canonicalized, so they fall back to a *lexical*
+        // containment check: `normalize_path` collapses any interior `..`/`.`
+        // first, because `Path::starts_with` is component-wise and does NOT
+        // resolve `..` — without normalization a `root/sub/../../escape`
+        // candidate (e.g. from a misregistered component directory) keeps its
+        // `/`, `root` prefix and slips through. Mirrors `path_within_root` in
         // `main.rs` (issue #55).
         let mut paths = self.component_path_candidates(component_name);
         let canonical_root = self.root.canonicalize();
         paths.retain(|path| match (path.canonicalize(), &canonical_root) {
             (Ok(real_path), Ok(real_root)) => real_path.starts_with(real_root),
-            _ => path.starts_with(&self.root),
+            _ => normalize_path(path).starts_with(&self.root),
         });
         paths
     }

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2891,15 +2891,63 @@ impl LaravelConfigData {
         paths
     }
 
-    /// Resolve a component name to file path
+    /// Resolve a component name to file path.
+    ///
+    /// Defense-in-depth (#109): the component name comes straight from a Blade
+    /// tag, and the dot→slash substitution below turns a leading-dot or empty
+    /// name into an absolute or empty filesystem path — `PathBuf::join`
+    /// discards the receiver when the argument is absolute, so
+    /// `<flux:.etc.passwd>` would otherwise yield `/etc/passwd`. We reject such
+    /// names up front and, as a backstop, drop any built candidate that escapes
+    /// `self.root` before returning.
     pub fn resolve_component_path(&self, component_name: &str) -> Vec<PathBuf> {
-        let mut paths = Vec::new();
-
         // Flux's `<flux:button>` sugar maps to the `flux` anonymous-component
         // namespace; rewrite the single-colon prefix to the `::` form so the
-        // namespace resolution below treats it like `<x-flux::button>`.
+        // namespace resolution treats it like `<x-flux::button>`.
         let flux_normalized = normalize_flux_tag_name(component_name);
         let component_name = flux_normalized.as_deref().unwrap_or(component_name);
+
+        // Reject names that would escape the project root before building any
+        // path. The "actual" component is the part after a `::` namespace
+        // prefix; its dots become slashes downstream, so bail out with no
+        // candidates when it is empty, starts with a dot, or turns absolute
+        // after the substitution. Covers `<flux:>` (empty), leading-dot names,
+        // and the `flux:.etc.passwd` → `/etc/passwd` attack shape.
+        let actual_component = match component_name.find("::") {
+            Some(pos) => &component_name[pos + 2..],
+            None => component_name,
+        };
+        if actual_component.is_empty()
+            || actual_component.starts_with('.')
+            || actual_component.replace('.', "/").starts_with('/')
+        {
+            return Vec::new();
+        }
+
+        // Build the raw candidates, then enforce a project-root containment
+        // backstop: any path that escapes `self.root` is dropped before return.
+        // Canonicalize so a symlinked project root (`/var` → `/private/var` on
+        // macOS) or a symlinked vendor dir doesn't spuriously fail the purely
+        // textual `starts_with`. Speculative candidates that don't exist on
+        // disk can't be canonicalized, so they fall back to the textual prefix
+        // check — which keeps the in-root file guesses and still drops an
+        // absolute `/etc/passwd`-style escape. Mirrors `path_within_root` in
+        // `main.rs` (issue #55).
+        let mut paths = self.component_path_candidates(component_name);
+        let canonical_root = self.root.canonicalize();
+        paths.retain(|path| match (path.canonicalize(), &canonical_root) {
+            (Ok(real_path), Ok(real_root)) => real_path.starts_with(real_root),
+            _ => path.starts_with(&self.root),
+        });
+        paths
+    }
+
+    /// Build the raw component-file candidates for an already-Flux-normalized,
+    /// already-validated component name. Only [`resolve_component_path`] should
+    /// call this — it applies the name guard and root-containment filter that
+    /// keep the candidates from escaping the project root.
+    fn component_path_candidates(&self, component_name: &str) -> Vec<PathBuf> {
+        let mut paths = Vec::new();
 
         // Icon-set check first: <x-heroicon-o-clock> and friends resolve to a
         // concrete SVG file path. The blade-icons Factory registers each icon

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -553,6 +553,60 @@ fn normal_component_names_resolve_under_root() {
 }
 
 #[test]
+fn slash_bearing_name_yields_no_candidates() {
+    // Holmes's PR #150 review: a mid-path `..` traversal smuggled behind a
+    // literal slash — `flux::foo/../../../../etc/passwd` — is NOT caught by the
+    // leading-dot guard (no leading dot) nor by an absolute-after-substitution
+    // check (`replace('.', "/")` leaves a non-`/`-leading string). No real
+    // Blade/Flux component name contains a forward slash (nesting uses dots,
+    // namespaces use `::`), so the source guard now rejects the whole
+    // slash-bearing class — closing both the mid-path-traversal and the
+    // `evil::/etc/passwd` absolute shapes before any path is built.
+    let config = make_bare_config();
+    for name in [
+        "flux::foo/../../../../etc/passwd",
+        "flux:foo/../../../../etc/passwd",
+        "evil::foo/../bar",
+        "components/../../etc/passwd",
+        "evil::/etc/passwd",
+    ] {
+        assert!(
+            config.resolve_component_path(name).is_empty(),
+            "slash-bearing name `{name}` must produce zero candidates",
+        );
+    }
+}
+
+#[test]
+fn candidates_with_interior_parent_dir_escape_are_dropped() {
+    // Defense-in-depth backstop, independent of the source guard: a slash-free,
+    // dot-free component name (`evil::layout`) sails past the front guard, but
+    // the *registered* directory itself carries an interior `..`. A
+    // misregistered `anonymousComponentPath` of `/project/sub/../../escape`
+    // lexically resolves to `/escape`, outside the root. A plain component-wise
+    // `starts_with("/project")` is fooled — the path's leading components are
+    // still `/`, `project` — so the backstop must lexically normalize first.
+    let config = make_config_with_anonymous_path("evil", "/project/sub/../../escape/components");
+
+    let paths = config.resolve_component_path("evil::layout");
+
+    assert!(
+        paths
+            .iter()
+            .all(|p| !crate::route_discovery::normalize_path(p).starts_with("/escape")),
+        "candidates that lexically escape the project root must be dropped: {:?}",
+        paths,
+    );
+    // The in-root vendor-publish guesses still survive, so the filter isn't
+    // just dropping everything.
+    assert!(
+        paths.iter().any(|p| p.starts_with("/project")),
+        "in-root candidates should still resolve: {:?}",
+        paths,
+    );
+}
+
+#[test]
 fn unregistered_anonymous_prefix_does_not_borrow_registered_directory() {
     let config = make_config_with_anonymous_path(
         "backstage",

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -135,15 +135,19 @@ fn make_config_with_icon(tag: &str, svg_path: &str) -> LaravelConfigData {
 
 #[test]
 fn icon_tag_resolves_to_svg_path() {
+    // The svg path lives under the project root — `scan_vendor_for_icon_sets`
+    // always walks `root/vendor`, so registered icon paths are in-tree. This
+    // also satisfies the #109 root-containment backstop, which drops any
+    // candidate outside `self.root`.
     let config = make_config_with_icon(
         "heroicon-o-clock",
-        "/abs/vendor/blade-ui-kit/blade-heroicons/resources/svg/o-clock.svg",
+        "/project/vendor/blade-ui-kit/blade-heroicons/resources/svg/o-clock.svg",
     );
     let paths = config.resolve_component_path("heroicon-o-clock");
     assert_eq!(paths.len(), 1);
     assert_eq!(
         paths[0],
-        PathBuf::from("/abs/vendor/blade-ui-kit/blade-heroicons/resources/svg/o-clock.svg"),
+        PathBuf::from("/project/vendor/blade-ui-kit/blade-heroicons/resources/svg/o-clock.svg"),
     );
 }
 
@@ -429,6 +433,123 @@ fn flux_namespace_tag_resolves_same_as_single_colon() {
         "namespace form must resolve via the Flux fallback: {:?}",
         paths,
     );
+}
+
+// ─── Component-name validation & root containment (issue #109) ─────────
+
+#[test]
+fn empty_component_name_yields_no_candidates() {
+    let config = make_bare_config();
+    assert!(
+        config.resolve_component_path("").is_empty(),
+        "an empty component name must produce zero path candidates",
+    );
+}
+
+#[test]
+fn flux_empty_name_yields_no_candidates() {
+    // `<flux:>` normalizes to the bare `flux::` namespace prefix with an empty
+    // component — it must not resolve to `.blade.php` nonsense paths.
+    let config = make_bare_config();
+    assert!(
+        config.resolve_component_path("flux:").is_empty(),
+        "`<flux:>` (empty component) must produce zero candidates",
+    );
+    // The already-namespaced bare form behaves identically.
+    assert!(
+        config.resolve_component_path("flux::").is_empty(),
+        "bare `flux::` must produce zero candidates",
+    );
+}
+
+#[test]
+fn leading_dot_component_name_yields_no_candidates() {
+    // The `<flux:.etc.passwd>` attack shape: the dot→slash substitution would
+    // turn `.etc.passwd` into the absolute `/etc/passwd`, which `PathBuf::join`
+    // resolves outside the project root. Reject it at the source.
+    let config = make_bare_config();
+    assert!(
+        config.resolve_component_path("flux:.etc.passwd").is_empty(),
+        "a leading-dot component name must produce zero candidates",
+    );
+    // Same guard via an explicit namespace prefix.
+    assert!(
+        config.resolve_component_path("evil::.hidden").is_empty(),
+        "a leading-dot namespaced component must produce zero candidates",
+    );
+}
+
+#[test]
+fn absolute_component_name_yields_no_candidates() {
+    // A name that becomes an absolute path after dot→slash substitution must be
+    // rejected — here a literal leading slash in the component part.
+    let config = make_bare_config();
+    assert!(
+        config
+            .resolve_component_path("evil::/etc/passwd")
+            .is_empty(),
+        "a component that resolves to an absolute path must produce zero candidates",
+    );
+}
+
+#[test]
+fn parent_dir_traversal_name_yields_no_candidates() {
+    // A `../` traversal in the component name starts with a dot, so the source
+    // guard rejects it before any path is built — it never reaches the
+    // filesystem.
+    let config = make_bare_config();
+    assert!(
+        config
+            .resolve_component_path("flux::../../../../etc/passwd")
+            .is_empty(),
+        "a `../` traversal component name must produce zero candidates",
+    );
+}
+
+#[test]
+fn candidates_escaping_root_are_dropped() {
+    // Root-containment backstop: even when a registered directory sits outside
+    // the project root, any candidate built under it is dropped before return,
+    // while the in-root vendor-publish guesses survive.
+    let config = make_config_with_anonymous_path("evil", "/outside/root/components");
+
+    let paths = config.resolve_component_path("evil::layout");
+
+    assert!(!paths.is_empty(), "in-root candidates should still resolve");
+    assert!(
+        paths.iter().all(|p| p.starts_with("/project")),
+        "every returned candidate must stay under the project root: {:?}",
+        paths,
+    );
+    assert!(
+        paths.iter().all(|p| !p.starts_with("/outside")),
+        "candidates under an out-of-root registered directory must be dropped: {:?}",
+        paths,
+    );
+}
+
+#[test]
+fn normal_component_names_resolve_under_root() {
+    // Regression guard for the #109 changes: ordinary names still resolve, and
+    // every candidate stays in-tree.
+    let config = make_bare_config();
+    for name in [
+        "forms.input",
+        "flux::button",
+        "courier::alert",
+        "flux:button",
+    ] {
+        let paths = config.resolve_component_path(name);
+        assert!(
+            !paths.is_empty(),
+            "`{name}` should still resolve to candidates"
+        );
+        assert!(
+            paths.iter().all(|p| p.starts_with("/project")),
+            "`{name}` candidates must stay under the project root: {:?}",
+            paths,
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Implements #109 — defense-in-depth validation of Flux/Blade component names before `resolve_component_path` constructs filesystem paths.

A leading-dot or empty component name (`<flux:.etc.passwd>`) survives `normalize_flux_tag_name`, and the `replace('.', "/")` dot→slash mapping yields the absolute `/etc/passwd`, which `PathBuf::join` resolves **outside** the project root (join discards the receiver on an absolute argument). The `.blade.php` suffix defangs it today, so there's no live vuln — but the containment invariant belonged at the source.

## Changes
- **Name guard at the source** — `resolve_component_path` now rejects, before building any path, a component whose name (after stripping the `::` namespace prefix) is empty, starts with a dot, or **contains a forward slash**. No real Blade/Flux name has a slash (nesting uses dots, namespaces use `::`), so this closes the whole slash-bearing class — both the mid-path `..` traversal (`flux::foo/../../../etc/passwd`) and the absolute `evil::/etc/passwd` shape — at the source. Returns zero candidates. (Subsumes the earlier `replace('.', "/").starts_with('/')` check.)
- **Root-containment backstop** — every built candidate is filtered through a `starts_with(self.root)` check; any path escaping the project root is dropped before the `Vec` is returned. Canonicalized on both sides to survive symlinked roots (`/var`→`/private/var`); the textual fallback for speculative (non-existent) candidates **lexically normalizes** (`route_discovery::normalize_path`) before the prefix check, so an interior `..` from a misregistered component directory can't fool the component-wise `starts_with`. Mirrors the existing `main.rs::path_within_root` (#55).
- **Refactor** — candidate construction extracted into a private `component_path_candidates` helper so the public method owns the guard + filter as a single exit point.
- Updated the `icon_tag_resolves_to_svg_path` fixture to a realistic in-root path (production icon paths always live under `root/vendor`).

## Acceptance Criteria
- [x] `resolve_component_path` rejects any component name that is empty (or reduces to empty after stripping the namespace prefix), returning no candidates
- [x] Rejects any component name whose dot→slash substitution yields an absolute path — covers `flux:.etc.passwd` → `/etc/passwd`
- [x] Rejects any component name that starts with a dot before substitution (leading-dot names)
- [x] All generated `PathBuf` candidates filtered through a `starts_with(self.root)` containment check; escaping paths dropped before return
- [x] `<flux:>` (empty component, only the `flux::` prefix) produces zero candidates — not `.blade.php` nonsense
- [x] Normal names (`forms.input`, `flux::button`, `courier::alert`) resolve identically to pre-fix behaviour
- [x] Unit tests cover: empty name, leading-dot, absolute-after-replace, `../` traversal, and `<flux:>` empty-name

## Holmes review (PR #150) — addressed
- 🔴 **Mid-path `..` traversal slipped past both layers.** `flux::foo/../../../../etc/passwd` had no leading dot and wasn't absolute after dot→slash, so the front guard passed; the backstop's textual `starts_with` is component-wise and didn't resolve `..`. **Fixed in both layers** (slash rejection at the source + lexical normalization in the backstop) and added two tests: `slash_bearing_name_yields_no_candidates` (the named mid-path-slash shape) and `candidates_with_interior_parent_dir_escape_are_dropped` (backstop normalization via a config dir, independent of the source guard).
- 📋 Non-blocking follow-up (untested canonicalize *drop*-leg / symlink escape) spun out as #152.

## Test Plan
- [x] `cargo test --lib` — 1756 passed, 0 failed (9 #109 tests, +2 from this review round)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

Fixes #109
