### PR TITLE
Rename highlight: wire folio_name_decl_range's page read through path_within_root (read-path companion to #139)

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4843,6 +4843,16 @@ impl LaravelLanguageServer {
     /// (editor buffer or disk). Returns `None` when the cursor isn't on a Folio
     /// page's `name(...)` call.
     async fn folio_name_decl_range(&self, file_path: &Path, position: Position) -> Option<Range> {
+        // Defense-in-depth containment guard: refuse to read a page that sits
+        // outside the project root, even if the index were ever seeded with one.
+        // `path_within_root` canonicalizes both sides before comparing, so a
+        // symlink *under* the root that points outside it is rejected here —
+        // before any disk access — rather than slipping past a purely lexical
+        // prefix check. Mirrors the read-path sibling `folio_route_name_for_cursor`.
+        let root = self.root_path.read().await.clone()?;
+        if !path_within_root(file_path, &root) {
+            return None;
+        }
         let uri = Url::from_file_path(file_path).ok()?;
         let content = self.document_or_disk_content(&uri, file_path).await?;
         if !laravel_lsp::folio_discovery::cursor_on_page_name(

--- a/laravel-lsp/src/tests/folio_cursor_containment.rs
+++ b/laravel-lsp/src/tests/folio_cursor_containment.rs
@@ -1,10 +1,11 @@
-//! Tests for the explicit root-containment guard in
-//! `LaravelLanguageServer::folio_route_name_for_cursor` (issue #104).
+//! Tests for the explicit root-containment guards in
+//! `LaravelLanguageServer::folio_route_name_for_cursor` (issue #104) and its
+//! prepare-rename sibling `folio_name_decl_range` (issue #141).
 //!
 //! The guard is defense in depth: the route index already holds only mounts
-//! that stayed under the project root, but the method re-checks containment
+//! that stayed under the project root, but the methods re-check containment
 //! against `self.root_path` before reading the cursor file from disk. These
-//! tests drive the private method directly by building the server through
+//! tests drive the private methods directly by building the server through
 //! `tower_lsp::LspService` and reaching its inner value with `inner()`.
 
 use crate::LaravelLanguageServer;
@@ -12,7 +13,7 @@ use laravel_lsp::route_discovery::{RouteDefinition, RouteIndex, PRIORITY_APP};
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
-use tower_lsp::lsp_types::Position;
+use tower_lsp::lsp_types::{Position, Range};
 use tower_lsp::LspService;
 
 /// A bare Folio page that declares `name('contact')`. Cursor character 13 sits
@@ -137,5 +138,109 @@ async fn under_root_symlink_to_outside_target_returns_none() {
         "a page reached through an under-root symlink that resolves outside the \
          project root must not resolve — the canonicalize-based containment guard \
          refuses it even though the link path is lexically inside the root"
+    );
+}
+
+// --- folio_name_decl_range: prepare-rename highlight range (issue #141) ---
+//
+// `folio_name_decl_range` resolves the quote-excluded span of a Folio page's
+// own `name('...')` call straight from the page source (it does not consult the
+// route index), so these tests only need the page on disk plus `root_path` set.
+// The guard mirrors `folio_route_name_for_cursor`: refuse to read a page whose
+// canonical path falls outside the project root.
+
+/// The expected highlight range for `PAGE_SRC` — the `contact` argument content
+/// (columns 12..19 on line 0), quotes excluded.
+const DECL_RANGE: Range = Range {
+    start: Position {
+        line: 0,
+        character: 12,
+    },
+    end: Position {
+        line: 0,
+        character: 19,
+    },
+};
+
+#[tokio::test]
+async fn decl_range_out_of_root_page_returns_none() {
+    // The page lives outside the project root, yet exists on disk and has a
+    // valid `name(...)` call with the cursor on it. Without the guard the method
+    // would read it and return a range; the guard must refuse it on containment
+    // grounds alone.
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let page = outside.path().join("contact.blade.php");
+    fs::write(&page, PAGE_SRC).unwrap();
+
+    let server = test_server();
+    *server.root_path.write().await = Some(root.path().to_path_buf());
+
+    let result = server.folio_name_decl_range(&page, CURSOR).await;
+
+    assert_eq!(
+        result, None,
+        "an out-of-root page must not yield a decl range, even though it exists \
+         and the cursor is on its name() call — the containment guard refuses it"
+    );
+}
+
+#[tokio::test]
+async fn decl_range_in_tree_page_returns_range() {
+    // Positive control: a page inside the project root resolves to the correct
+    // highlight range, confirming the guard doesn't regress in-tree behavior.
+    let root = TempDir::new().unwrap();
+    let page = root.path().join("pages").join("contact.blade.php");
+    fs::create_dir_all(page.parent().unwrap()).unwrap();
+    fs::write(&page, PAGE_SRC).unwrap();
+
+    let server = test_server();
+    *server.root_path.write().await = Some(root.path().to_path_buf());
+
+    let result = server.folio_name_decl_range(&page, CURSOR).await;
+
+    assert_eq!(
+        result,
+        Some(DECL_RANGE),
+        "an in-tree page on its name() call must still yield the quote-excluded \
+         highlight range of its name argument"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn decl_range_under_root_symlink_to_outside_target_returns_none() {
+    // The discriminating case a lexical guard could not catch: the page path
+    // lives *under* the project root — a symlink at
+    // `<root>/pages/contact.blade.php` — yet it resolves to a file OUTSIDE the
+    // root. The target exists on disk (through the link) and the cursor sits on
+    // its `name(...)` call, so a missing file can't explain a `None` result. A
+    // purely lexical `starts_with` check would *admit* this path; only
+    // canonicalization — `path_within_root` resolving the symlink to its
+    // out-of-tree target — can reject it.
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+
+    // Real target file, outside the project root.
+    let target = outside.path().join("contact.blade.php");
+    fs::write(&target, PAGE_SRC).unwrap();
+
+    // Symlink under the root that points at the outside target.
+    let pages = root.path().join("pages");
+    fs::create_dir_all(&pages).unwrap();
+    let link = pages.join("contact.blade.php");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let server = test_server();
+    *server.root_path.write().await = Some(root.path().to_path_buf());
+
+    let result = server.folio_name_decl_range(&link, CURSOR).await;
+
+    assert_eq!(
+        result, None,
+        "a page reached through an under-root symlink that resolves outside the \
+         project root must not yield a decl range — the canonicalize-based \
+         containment guard refuses it even though the link path is lexically \
+         inside the root"
     );
 }


### PR DESCRIPTION
## Summary
Implements #141 — wires `folio_name_decl_range` (the Folio prepare-rename highlight helper) through the `path_within_root` containment guard before its page read, mirroring the read-path sibling `folio_route_name_for_cursor`. This closes the read-path half of the Folio-rename containment family (#139 covers the write path), so no Folio-rename code path reads outside the project root.

Defense-in-depth: the sole caller `prepare_rename` only computes a highlight `Range` (never a `WorkspaceEdit` or a write), so there is no realistic exposure — the guard matches the sibling's "even if the index were ever seeded with one" rationale.

## Changes
- `laravel-lsp/src/main.rs`: in `folio_name_decl_range`, before `document_or_disk_content`, read `self.root_path` and return `None` when `path_within_root(file_path, &root)` is false — identical to the guard in `folio_route_name_for_cursor`. When `root_path` is `None`, the `?` on `clone()` already returns `None`.
- `laravel-lsp/src/tests/folio_cursor_containment.rs`: three new tests (and an updated module doc) covering `folio_name_decl_range`.

## Acceptance Criteria
- [x] Before `document_or_disk_content`, add a root-containment guard reading `self.root_path` and calling `path_within_root(file_path, &root)`, returning `None` if outside root — mirroring `folio_route_name_for_cursor`.
- [x] When `self.root_path` is `None`, `folio_name_decl_range` returns `None` (via the `?` on `clone()`).
- [x] A test verifies `folio_name_decl_range` returns `None` for an on-disk file with a valid `name(...)` call whose path is outside the project root (`decl_range_out_of_root_page_returns_none`).
- [x] A test verifies it still returns the correct `Range` for an in-root file with a valid `name(...)` call (`decl_range_in_tree_page_returns_range`).
- [x] (Unix) A test verifies it returns `None` for an under-root symlink whose canonical path resolves outside root (`decl_range_under_root_symlink_to_outside_target_returns_none`).
- [x] All existing tests in `folio_cursor_containment.rs`, `folio_rename.rs`, `rename_integration.rs`, and the broader suite continue to pass.

## Test Plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --all-features` — full suite green (1749 + 300 + 80 passing, 0 failed) with the CI `test-project/.env` + Composer fixture bootstrapped
- [x] New tests cover out-of-root rejection, in-tree positive control, and under-root symlink escape

Fixes #141