### PR TITLE
Extract a shared const for the *(file not found)* hover trailer so tests can track the production string

### DIFF
--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -37,6 +37,13 @@ use crate::livewire_resolver::extract_blade_variable_at_cursor;
 use crate::salsa_impl::{ParsedPatternsData, PatternAtPosition};
 use std::path::Path;
 
+/// The italic [`HoverContent::trailer`] rendered when a hovered reference
+/// resolves to no file on disk (view, component, asset, url, … — every
+/// `if link.is_none()` arm in `main.rs`). Single source of truth for the
+/// string so tests can assert against the production value instead of
+/// re-typing the literal.
+pub const FILE_NOT_FOUND_TRAILER: &str = "*(file not found)*";
+
 /// Anything the cursor might be hovering. Pattern variants come straight from
 /// the Salsa position index; the Blade-variable variant is extracted by line
 /// scanning, and only matters in `.blade.php` files.

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -16744,7 +16744,7 @@ return [
             .as_deref()
             .and_then(laravel_lsp::blade_props::extract_props_directive);
         let trailer = if link.is_none() {
-            Some("*(file not found)*")
+            Some(hover::FILE_NOT_FOUND_TRAILER)
         } else {
             None
         };
@@ -17579,7 +17579,7 @@ return [
             .as_deref()
             .and_then(laravel_lsp::blade_props::extract_props_directive);
         let trailer = if link.is_none() {
-            Some("*(file not found)*")
+            Some(hover::FILE_NOT_FOUND_TRAILER)
         } else {
             None
         };
@@ -17636,7 +17636,7 @@ return [
             .as_deref()
             .and_then(laravel_lsp::php_class::extract_class_fqn);
         let trailer = if link.is_none() {
-            Some("*(file not found)*")
+            Some(hover::FILE_NOT_FOUND_TRAILER)
         } else {
             None
         };
@@ -17876,7 +17876,7 @@ return [
         use laravel_lsp::hover;
         let resolved = self.resolve_display_path_for_asset(asset).await;
         let trailer = if resolved.is_none() {
-            Some("*(file not found)*")
+            Some(hover::FILE_NOT_FOUND_TRAILER)
         } else {
             None
         };
@@ -17892,7 +17892,7 @@ return [
         use laravel_lsp::hover;
         let resolved = self.resolve_display_path_for_url(url_path).await;
         let trailer = if resolved.is_none() {
-            Some("*(file not found)*")
+            Some(hover::FILE_NOT_FOUND_TRAILER)
         } else {
             None
         };

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -1148,7 +1148,7 @@ fn flux_hover_without_vendor_file_shows_file_not_found() {
         crate::hover::source_link(&p.to_string_lossy(), url.as_str(), None)
     });
     let trailer = if link.is_none() {
-        Some("*(file not found)*")
+        Some(crate::hover::FILE_NOT_FOUND_TRAILER)
     } else {
         None
     };
@@ -1159,7 +1159,7 @@ fn flux_hover_without_vendor_file_shows_file_not_found() {
     });
 
     assert!(
-        rendered.contains("*(file not found)*"),
+        rendered.contains(crate::hover::FILE_NOT_FOUND_TRAILER),
         "absent flux source must render the file-not-found trailer: {rendered}",
     );
     assert!(

--- a/laravel-lsp/src/tests/flux_component_hover.rs
+++ b/laravel-lsp/src/tests/flux_component_hover.rs
@@ -19,7 +19,7 @@
 //!      link + props — and that the "not found" path renders the trailer instead.
 
 use laravel_lsp::blade_props::extract_props_directive;
-use laravel_lsp::hover::{self, CodeBlock, CodeLanguage, HoverContent};
+use laravel_lsp::hover::{self, CodeBlock, CodeLanguage, HoverContent, FILE_NOT_FOUND_TRAILER};
 use laravel_lsp::salsa_impl::{normalize_flux_tag_name, LaravelConfigData};
 use std::collections::HashMap;
 use std::fs;
@@ -35,15 +35,6 @@ const BUTTON_BLADE: &str =
 
 /// The `@props(...)` directive `BUTTON_BLADE` should yield verbatim.
 const BUTTON_PROPS: &str = "@props(['variant' => 'default', 'size' => null])";
-
-/// The italic trailer the anonymous-component arm of `hover_for_component`
-/// renders when no candidate file exists on disk (`main.rs`, the
-/// `if link.is_none()` branch). Kept as one constant so the not-found test
-/// drives *and* asserts against the same string instead of re-typing the
-/// literal. (Production still inlines this literal at several sites; sharing it
-/// across the module boundary would mean extracting a `pub const` there — a
-/// separate, cross-cutting refactor, out of scope for this additive test.)
-const FILE_NOT_FOUND: &str = "*(file not found)*";
 
 /// A `LaravelConfigData` rooted at `root`, optionally registering
 /// `anonymous_component_paths["flux"] -> flux_dir`. Mirrors `make_bare_config`
@@ -186,7 +177,7 @@ fn rendered_card_carries_source_link_and_props() {
         "the card carries the props text:\n{card}",
     );
     assert!(
-        !card.contains(FILE_NOT_FOUND),
+        !card.contains(FILE_NOT_FOUND_TRAILER),
         "a resolved file must not render the not-found trailer:\n{card}",
     );
 }
@@ -222,7 +213,7 @@ fn not_found_path_renders_trailer_without_link_or_props() {
     });
     let snippet = blade_path.as_deref().and_then(extract_props_directive);
     // The trailer is selected exactly as production does: `link.is_none()`.
-    let trailer = link.is_none().then_some(FILE_NOT_FOUND);
+    let trailer = link.is_none().then_some(FILE_NOT_FOUND_TRAILER);
 
     let card = hover::render(&HoverContent {
         code: snippet.as_deref().map(|s| CodeBlock {
@@ -235,7 +226,7 @@ fn not_found_path_renders_trailer_without_link_or_props() {
     });
 
     assert_eq!(
-        card, FILE_NOT_FOUND,
+        card, FILE_NOT_FOUND_TRAILER,
         "the card is the trailer alone — no other sections",
     );
     assert!(


### PR DESCRIPTION
## Summary
Implements #128. Promotes the inlined `*(file not found)*` hover trailer to a single shared `pub const hover::FILE_NOT_FOUND_TRAILER`, so production owns the string and the not-found hover tests assert against it instead of re-typing the literal. A regression that changes the production trailer now fails the tests.

## Changes
- Add `pub const FILE_NOT_FOUND_TRAILER: &str = "*(file not found)*"` to `laravel-lsp/src/hover.rs`, exported from the `hover` module with a doc comment.
- Replace all five inline `Some("*(file not found)*")` literals in `laravel-lsp/src/main.rs` (the `if link.is_none()` arms of the view / blade-component / class / asset / url hover paths) with `Some(hover::FILE_NOT_FOUND_TRAILER)`.
- Drop the duplicated local `FILE_NOT_FOUND` const in `laravel-lsp/src/tests/flux_component_hover.rs` and reference the shared `hover::FILE_NOT_FOUND_TRAILER` instead.
- Replace the duplicated literals in `laravel-lsp/src/salsa_impl/tests.rs` with `crate::hover::FILE_NOT_FOUND_TRAILER`.

## Acceptance Criteria
- [x] A `pub const` for the hover "file not found" trailer string (value `"*(file not found)*"`) is added in `laravel-lsp/src/hover.rs` and exported from the `hover` module
- [x] Every inline `Some("*(file not found)*")` literal in `laravel-lsp/src/main.rs` is replaced with a reference to the new shared const (actual sites: lines 16747, 17582, 17639, 17879, 17895)
- [x] Test files that defined their own local `FILE_NOT_FOUND` const / used the literal directly now use the shared `hover::FILE_NOT_FOUND_TRAILER`
- [x] `grep -r '"[*](file not found)[*]"' laravel-lsp/src/` returns only the single const declaration
- [x] `cargo test` passes with no regressions

## Test Plan
- [x] `cargo test --all-features` — 1749 (lib) + 300 (main) + 80 (integration) pass, 0 failures (fixture bootstrapped per CI: `cp test-project/.env.example test-project/.env` + `composer update`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] AC grep returns only the const declaration itself

Fixes #128