### PR TITLE
Internalize the root-containment invariant into locate_slot_in_view so callers can't reopen the traversal hole

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13705,7 +13705,7 @@ return [
             };
 
             let (target_line, target_col) =
-                locate_slot_in_view(&path, &slot.name).unwrap_or((0, 0));
+                locate_slot_in_view(&path, &slot.name, &config.root).unwrap_or((0, 0));
 
             let target_range = Range {
                 start: Position {

--- a/laravel-lsp/src/slot_navigation.rs
+++ b/laravel-lsp/src/slot_navigation.rs
@@ -261,9 +261,34 @@ pub fn find_slot_variable_line(view_source: &str, slot_name: &str) -> Option<(u3
 ///
 /// Convenience wrapper that combines file reading with the line search. Returns
 /// None when the file can't be read or no `{{ $slot_name }}` reference exists.
-pub fn locate_slot_in_view(view_path: &Path, slot_name: &str) -> Option<(u32, u32)> {
+///
+/// Before touching the disk it enforces the project-root containment invariant
+/// (`path_within_root`): a `view_path` that resolves outside `root` returns
+/// `None` immediately, with no `read_to_string`. A `loadViewsFrom`-style
+/// namespace can resolve a component to an absolute path that escapes the
+/// project root (issue #130), so internalizing the check here makes the
+/// invariant un-violable regardless of how many call sites exist — a future
+/// caller that forgets to pre-check can't reopen the out-of-root read
+/// (issue #149).
+pub fn locate_slot_in_view(view_path: &Path, slot_name: &str, root: &Path) -> Option<(u32, u32)> {
+    if !path_within_root(view_path, root) {
+        return None;
+    }
     let source = std::fs::read_to_string(view_path).ok()?;
     find_slot_variable_line(&source, slot_name)
+}
+
+/// True if `view_path` resolves to a location inside `root`. Both sides are
+/// canonicalized first so a symlink under the project can't resolve outside the
+/// root and slip past a purely textual `starts_with`. When either side can't be
+/// canonicalized (e.g. the file vanished mid-edit) we fall back to the textual
+/// prefix check rather than admitting an unverified path. Mirrors
+/// `path_within_root` in `main.rs` (issues #55, #130).
+fn path_within_root(view_path: &Path, root: &Path) -> bool {
+    match (view_path.canonicalize(), root.canonicalize()) {
+        (Ok(real_path), Ok(real_root)) => real_path.starts_with(&real_root),
+        _ => view_path.starts_with(root),
+    }
 }
 
 // ============================================================================

--- a/laravel-lsp/src/slot_navigation/tests.rs
+++ b/laravel-lsp/src/slot_navigation/tests.rs
@@ -154,3 +154,47 @@ fn find_enclosing_parent_component_skips_slot_ancestors() {
     // Inner <x-slot:icon> bubbles past <x-slot:header> to the real component.
     assert_eq!(parent.unwrap().name, "modal");
 }
+
+/// A parent view body that references `{{ $title }}` so `locate_slot_in_view`
+/// has a slot variable to pin navigation to. `$title` sits on line 1 (0-based)
+/// at character 7 — four spaces plus `{{ ` precede it.
+const VIEW_WITH_SLOT: &str = "<div>\n    {{ $title }}\n</div>\n";
+
+#[test]
+fn locate_slot_in_view_returns_none_for_out_of_root_path() {
+    // AC #4: a view file that exists on disk and references the slot variable,
+    // but resolves OUTSIDE the project root, must return None — the internal
+    // containment guard refuses it before any `read_to_string`. A missing file
+    // can't explain the None here: the file is written and present.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    let view = outside.path().join("components/card.blade.php");
+    std::fs::create_dir_all(view.parent().unwrap()).unwrap();
+    std::fs::write(&view, VIEW_WITH_SLOT).unwrap();
+
+    assert!(
+        locate_slot_in_view(&view, "title", root.path()).is_none(),
+        "an out-of-root view must not resolve, even though it exists on disk \
+         and references the slot variable — the containment guard refuses it"
+    );
+}
+
+#[test]
+fn locate_slot_in_view_resolves_in_root_path() {
+    // AC #5: a valid in-root view containing the named slot variable resolves
+    // to the exact (line, col) of the `{{ $title }}` usage.
+    let root = tempfile::TempDir::new().unwrap();
+
+    let view = root
+        .path()
+        .join("resources/views/components/card.blade.php");
+    std::fs::create_dir_all(view.parent().unwrap()).unwrap();
+    std::fs::write(&view, VIEW_WITH_SLOT).unwrap();
+
+    assert_eq!(
+        locate_slot_in_view(&view, "title", root.path()),
+        Some((1, 7)),
+        "an in-root view must resolve to the slot-variable line and column"
+    );
+}


### PR DESCRIPTION
## Summary
Implements #149. Internalizes the project-root containment invariant into `locate_slot_in_view` so the safety check no longer depends on every caller remembering to pre-guard.

Follow-up from Holmes's review of #130 (PR #143): #143 closed the slot-navigation traversal hole with a `path_within_root` guard at the single `create_slot_location` call site, but `locate_slot_in_view` itself was `pub` and read from disk with no internal check. A future caller that forgot the pre-check would silently reopen the same out-of-root read.

## Changes
- `locate_slot_in_view` signature extended with a `root: &Path` parameter.
- It now calls a local `path_within_root(view_path, root)` and returns `None` immediately for out-of-root paths — **no `read_to_string` occurs** for an out-of-root view.
- The helper mirrors `main.rs::path_within_root` (canonicalize both sides, textual-prefix fallback). The `laravel_lsp` library crate can't reach the binary's private `fn`, and the repo already duplicates this logic (main.rs + an inline copy in salsa_impl.rs), so a local helper is the minimal faithful implementation. A crate-wide extraction would be scope creep beyond this defense-in-depth issue.
- The `create_slot_location` call site passes `&config.root` as the third argument.
- The **existing call-site guard is intentionally kept**: it still prevents building a `LocationLink` to an out-of-root path (the `unwrap_or((0, 0))` fallback would otherwise leak it). The new internal check is defense-in-depth.

## Acceptance Criteria
- [x] `locate_slot_in_view` signature extended to accept a `root: &Path` parameter
- [x] `locate_slot_in_view` calls `path_within_root(view_path, root)` before `std::fs::read_to_string` and returns `None` immediately for out-of-root paths — no disk access occurs
- [x] The call site in `create_slot_location` (main.rs) passes `&config.root` as the third argument; compiles without the old two-argument form
- [x] Unit test asserts `locate_slot_in_view` returns `None` for a path outside root (even though the file exists on disk)
- [x] Unit test asserts `locate_slot_in_view` returns the correct `Some((line, col))` for a valid in-root path containing the named slot variable
- [x] All existing `slot_navigation` tests remain green
- [x] `cargo fmt --check` passes and `cargo clippy --all-targets` emits no new warnings

## Test Plan
- [x] `cargo test slot_navigation` — 20 unit tests (incl. 2 new) + 3 `slot_navigation_containment` integration tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` — no new warnings

Fixes #149