### PR TITLE
Rename path resolution: wire collect_route_declaration_targets' page-path read through path_within_root

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18719,6 +18719,16 @@ async fn collect_route_declaration_targets(
             .as_ref()
             .and_then(|idx| idx.get(target))
             .filter(|def| def.file.to_str().is_some_and(|s| s.ends_with(".blade.php")))
+            // Defense-in-depth containment guard (issue #139): refuse to read or
+            // rewrite a page whose canonical path falls outside the project root,
+            // even if the index were ever seeded with one. `path_within_root`
+            // canonicalizes both sides before comparing, so a symlink *under* the
+            // root that resolves outside it — or a `..` escape — is rejected here,
+            // before any disk access and before any `EditTarget` is emitted,
+            // rather than slipping past a purely lexical prefix check. Mirrors the
+            // read-path sibling `folio_route_name_for_cursor` (#151 covers the
+            // prepare-rename highlight read path).
+            .filter(|def| path_within_root(&def.file, root))
             .map(|def| def.file.clone())
     };
     if let Some(file) = folio_page {

--- a/laravel-lsp/src/tests/folio_rename.rs
+++ b/laravel-lsp/src/tests/folio_rename.rs
@@ -135,6 +135,96 @@ async fn decl_range_at_returns_none_when_cursor_off_the_name_call() {
     assert_eq!(range, None);
 }
 
+/// Seed the route index with `route_name` → `file` and set the project root,
+/// without writing `file` itself — the caller controls where it lives (inside
+/// or outside `root`) so the containment guard, not a missing index entry,
+/// decides the outcome. Mirrors `seed_folio_page` in `folio_cursor_containment`.
+async fn seed_index_for(
+    server: &LaravelLanguageServer,
+    root: &Path,
+    route_name: &str,
+    file: &Path,
+) {
+    let mut index = RouteIndex::new();
+    index.insert(
+        route_name.to_string(),
+        RouteDefinition {
+            file: file.to_path_buf(),
+            line: 0,
+            column: 0,
+            end_column: 0,
+            priority: PRIORITY_APP,
+            method: Some("get".to_string()),
+            uri: Some("/contact".to_string()),
+            action: None,
+        },
+    );
+    *server.route_index.write().await = Some(index);
+    *server.root_path.write().await = Some(root.to_path_buf());
+}
+
+#[tokio::test]
+async fn collect_targets_skips_an_out_of_root_folio_page() {
+    // Containment guard (issue #139): a Folio page that exists on disk and is
+    // indexed, but lives OUTSIDE the project root, must produce no decl
+    // `EditTarget`. Without the guard `collect_route_declaration_targets` would
+    // read it and emit a rename edit against an out-of-project file.
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let page = outside.path().join("contact.blade.php");
+    fs::write(&page, PAGE_SRC).unwrap();
+
+    let server = test_server();
+    seed_index_for(&server, root.path(), "contact", &page).await;
+
+    let targets =
+        collect_route_declaration_targets(&server, root.path(), "contact", "support").await;
+
+    assert!(
+        targets.is_empty(),
+        "an out-of-root Folio page must not produce a decl edit, even though it \
+         exists and is indexed — the containment guard refuses it"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn collect_targets_skips_an_under_root_symlink_resolving_outside() {
+    // The discriminating case a lexical guard could not catch: the page path
+    // lives *under* the project root — a symlink at
+    // `<root>/pages/contact.blade.php` — yet resolves to a file OUTSIDE the
+    // root. The target exists on disk (through the link) and is indexed under
+    // its in-root link path, so a missing entry can't explain an empty result. A
+    // purely lexical `starts_with` check would *admit* this path; only
+    // canonicalization — `path_within_root` resolving the symlink to its
+    // out-of-tree target — rejects it, so no decl edit is emitted.
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+
+    // Real target file, outside the project root.
+    let target = outside.path().join("contact.blade.php");
+    fs::write(&target, PAGE_SRC).unwrap();
+
+    // Symlink under the root that points at the outside target.
+    let pages = root.path().join("pages");
+    fs::create_dir_all(&pages).unwrap();
+    let link = pages.join("contact.blade.php");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let server = test_server();
+    seed_index_for(&server, root.path(), "contact", &link).await;
+
+    let targets =
+        collect_route_declaration_targets(&server, root.path(), "contact", "support").await;
+
+    assert!(
+        targets.is_empty(),
+        "a page reached through an under-root symlink that resolves outside the \
+         project root must produce no decl edit — the canonicalize-based guard \
+         refuses it even though the link path is lexically inside the root"
+    );
+}
+
 #[tokio::test]
 async fn collect_targets_rewrites_the_page_name_declaration() {
     // rename AC: the page's own `name('...')` declaration is rewritten so it


### PR DESCRIPTION
## Summary
Implements #139 — the write-path half of the Folio rename containment family.

The Folio branch of `collect_route_declaration_targets` (added in #100) resolved and read the page path with no `path_within_root` containment guard, unlike the sibling rename-time path resolutions. A symlink or `..` escape could therefore produce a rename `EditTarget` against a file **outside** the project root. This wires the Folio page lookup through the same canonicalizing guard, mirroring the read-path sibling `folio_route_name_for_cursor` and the prepare-rename read path closed by #151.

## Changes
- `laravel-lsp/src/main.rs` — add a `path_within_root(&def.file, root)` filter to the Folio-page resolution in `collect_route_declaration_targets`. An out-of-root page resolves to `None`, so the disk read and `EditTarget` emission are both skipped — no panic, no error, no target.
- `laravel-lsp/src/tests/folio_rename.rs` — two new containment tests plus a shared `seed_index_for` helper.

## Acceptance Criteria
- [x] A Folio branch is added to `collect_route_declaration_targets` (after the `routes/*.php` walk) that looks up `target` in `server.route_index` and, when the matching `RouteDefinition::file` ends with `.blade.php`, treats it as a Folio declaration site. *(present from #100; this PR guards it)*
- [x] Before emitting any `EditTarget` for a Folio page, the resolved `def.file` path is checked via `path_within_root(&def.file, root)`; out-of-root pages are silently skipped — no panic, no error, no target emitted.
- [x] The emitted `EditTarget` uses the route index entry's position and `new_text` equal to `new_name` with the mount `name_prefix` stripped (leaf-only rewrite via `rewritten_segment`). *(unchanged behaviour, still covered)*
- [x] The existing `routes/*.php` walk behaviour is unchanged; conventional routes are unaffected.
- [x] A test verifies an in-root Folio page produces a correct `EditTarget` with the right `new_text` — existing `collect_targets_rewrites_the_page_name_declaration` (positive control).
- [x] A test verifies a Folio page resolving outside the project root (out-of-root path **and** an under-root symlink escape) is silently skipped and produces no `EditTarget`.
- [x] All existing tests in `rename_integration.rs`, `folio_cursor_containment.rs`, and the broader suite continue to pass.

## Test Plan
- [x] `cargo test` — all Folio rename + containment tests green (9/9 in `folio_rename`). The only local failures are pre-existing `integration_tests.rs` cases that depend on the gitignored `test-project/.env` and composer `vendor/` fixtures, which CI bootstraps (`cp .env.example .env`, `composer update`); verified identical on the clean base and that 7/8 pass once `.env` is restored locally.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] Symlink-escape regression test (`#[cfg(unix)]`) proves canonicalization rejects a lexically-in-root path that resolves outside.

Fixes #139