### PR TITLE
Run slot-navigation containment guard before file_exists_cached to close out-of-root existence oracle

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13687,17 +13687,18 @@ return [
         let possible_paths = config.resolve_component_path(&parent.name);
 
         for path in possible_paths {
-            if !self.file_exists_cached(&path).await {
+            // Containment guard (issues #130, #145): a `loadViewsFrom`-style
+            // namespace can resolve a component to an absolute path that escapes
+            // the project root. This runs *first* — before `file_exists_cached`
+            // — so an out-of-root candidate is never `stat`ed on disk, closing
+            // the existence-oracle on paths outside the project root. Matches the
+            // Folio cursor flow (`folio_route_name_for_cursor`) and the blade-var
+            // rename flow. `continue` rather than `return None` so a later in-root
+            // candidate can still resolve.
+            if !path_within_root(&path, &config.root) {
                 continue;
             }
-            // Containment guard (issue #130): a `loadViewsFrom`-style namespace
-            // can resolve a component to an absolute path that escapes the
-            // project root. Refuse to read anything outside the root before the
-            // `locate_slot_in_view` disk read, matching the Folio cursor flow
-            // (`folio_route_name_for_cursor`) and the blade-var rename flow.
-            // `continue` rather than `return None` so a later in-root candidate
-            // can still resolve.
-            if !path_within_root(&path, &config.root) {
+            if !self.file_exists_cached(&path).await {
                 continue;
             }
             let Ok(target_uri) = Url::from_file_path(&path) else {

--- a/laravel-lsp/src/tests/slot_navigation_containment.rs
+++ b/laravel-lsp/src/tests/slot_navigation_containment.rs
@@ -113,6 +113,47 @@ async fn out_of_root_component_view_returns_none_without_disk_read() {
 }
 
 #[tokio::test]
+async fn out_of_root_candidate_is_never_stated() {
+    // Ordering proof for issue #145: the containment guard must run *before*
+    // `file_exists_cached`, so an out-of-root candidate is rejected without any
+    // disk `stat`, closing the out-of-root existence oracle. `file_exists_cached`
+    // writes a path into `file_exists_cache` only *after* it `stat`s the path, so
+    // that cache is a faithful record of which candidates were probed on disk.
+    //
+    // We resolve an out-of-root `card` view that exists on disk, run the lookup,
+    // and assert its path never entered the existence cache — i.e. the syscall
+    // was never made. This is what guards the ordering: the result-level
+    // `out_of_root_component_view_returns_none_without_disk_read` test passes
+    // under *either* loop order (the guard rejects the path eventually), so it
+    // can't catch a regression that reverts the guard back behind
+    // `file_exists_cached`. Asserting the absence of the `stat` can.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    let card = outside.path().join("components/card.blade.php");
+    write(&card, CARD_VIEW);
+
+    let server = test_server();
+    let source_uri =
+        Url::from_file_path(root.path().join("resources/views/page.blade.php")).unwrap();
+    let config = config_with_namespace(root.path(), outside.path());
+    seed(&server, config, &source_uri).await;
+
+    let result = server.create_slot_location(&source_uri, CURSOR).await;
+
+    assert!(
+        result.is_none(),
+        "an out-of-root component view must not resolve"
+    );
+    assert!(
+        !server.file_exists_cache.read().await.contains_key(&card),
+        "the out-of-root candidate must never be stat'ed: its path must not enter \
+         file_exists_cache. Its presence would mean file_exists_cached ran before \
+         the containment guard — the exact ordering bug #145 closes"
+    );
+}
+
+#[tokio::test]
 async fn in_root_component_view_still_resolves() {
     // Positive control: the `pkg` namespace points to a directory INSIDE the
     // project root, so the resolved `card` view passes containment and slot


### PR DESCRIPTION
## Summary
Implements #145. The slot-navigation goto-definition guard in `create_slot_location` (`laravel-lsp/src/main.rs`) ran `path_within_root` **after** `file_exists_cached`, so an out-of-root candidate — e.g. from a `loadViewsFrom(__DIR__ . '/../../etc', 'ns')`-style namespace — was still `stat`ed on disk before the containment guard rejected it. That probe is an existence oracle on paths outside the project root. Reversing the order closes it.

## Changes
- `create_slot_location`: moved the `path_within_root(&path, &config.root)` containment check to be the **first** statement in the `for path in possible_paths` loop body, ahead of `self.file_exists_cached(&path).await`. The pre-existing guard (added in #143) is relocated, not duplicated. In-root behaviour is unchanged.
- Updated the guard comment to document the new ordering and reference #145.
- Added regression test `out_of_root_candidate_is_never_stated` in `laravel-lsp/src/tests/slot_navigation_containment.rs`: it resolves an out-of-root `card` view that **exists on disk** and asserts the path never enters `file_exists_cache` (which is written only after a `stat`), proving the guard fires before the existence check. The existing result-level test passes under either ordering, so it can't guard the reorder on its own.

## Acceptance Criteria
- [x] `path_within_root(&path, &config.root)` is the **first** check in the loop, preceding `file_exists_cached` so no syscall is made for an out-of-root candidate; `config.root` comes from the in-scope `get_cached_config()` result
- [x] The guard already present from #143 is **moved** before `file_exists_cached`, not duplicated
- [x] A test in `slot_navigation_containment.rs` seeds a component whose resolved path **exists on disk** outside the project root and asserts `create_slot_location` returns `None` (existing `out_of_root_component_view_returns_none_without_disk_read`); strengthened by `out_of_root_candidate_is_never_stated`, which proves no `stat` is made
- [x] Slot goto-definition for an in-root component view still returns the correct file, line, and column (no regression — `in_root_component_view_still_resolves` and `slot_variable_resolution` tests green)
- [x] `cargo test slot_` passes green; `cargo fmt --check` and `cargo clippy --all-targets` are clean

## Test Plan
- [x] `cargo test slot_` — 21 + 10 tests pass (includes the new regression test)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets` — clean (no lint warnings)
- [x] New test covers the reorder; existing in-root/symlink/result-level tests guard against regression

Fixes #145