### PR TITLE
Consolidate the triplicated path_within_root containment helper into one shared module

### DIFF
--- a/laravel-lsp/src/blade_var_rename/tests.rs
+++ b/laravel-lsp/src/blade_var_rename/tests.rs
@@ -945,6 +945,41 @@ fn endphp_inside_nowdoc_does_not_close_block() {
 }
 
 #[test]
+fn endphp_inside_double_quoted_heredoc_does_not_close_block() {
+    // A *double-quoted*-label heredoc (`<<<"SQL"`) is a valid opener — its body
+    // runs until the closing label, so an `@endphp` inside it is literal text
+    // and the block closes only at the real `@endphp` after the label. Companion
+    // to the bare-label and nowdoc cases above: this exercises the quoted-label
+    // leg of `skip_heredoc`, which those don't reach.
+    let src = "\
+@php
+    $marker = <<<\"SQL\"
+    @endphp is just text in here
+    SQL;
+    $ghost = 5;
+@endphp
+{{ $user }}";
+    assert!(!is_template_variable(src, "ghost"));
+    assert!(is_template_variable(src, "user"));
+}
+
+#[test]
+fn endphp_inside_block_comment_does_not_close_block() {
+    // A literal `@endphp` inside a `/* … */` block comment does not close the
+    // block — the scanner skips to the comment's `*/` (companion to the `//`
+    // line-comment case above, which the existing apostrophe test exercises but
+    // the block-comment leg of `find_block_terminator` does not).
+    let src = "\
+@php
+    /* a stray @endphp lives in this block comment */
+    $ghost = 5;
+@endphp
+{{ $user }}";
+    assert!(!is_template_variable(src, "ghost"));
+    assert!(is_template_variable(src, "user"));
+}
+
+#[test]
 fn endphp_word_prefix_does_not_close_block() {
     // `@endphpunit` shares the `@endphp` prefix but is not the terminator — a
     // symmetric word boundary (mirroring the `@php` opener guard) keeps the

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -55,6 +55,7 @@ pub mod magic_dependency_index;
 pub mod magic_disk_cache;
 pub mod naming;
 pub mod parser;
+pub mod path_containment;
 pub mod pattern_disk_cache;
 pub mod pattern_indexer;
 pub mod php_class;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -27,6 +27,7 @@ use laravel_lsp::completion_format::CompletionDoc;
 use laravel_lsp::config::find_project_root;
 use laravel_lsp::middleware_parser::{middleware_base_alias, resolve_class_to_file};
 use laravel_lsp::migration_index::{build_migration_index, MigrationIndex};
+use laravel_lsp::path_containment::path_within_root;
 use laravel_lsp::route_discovery::{
     build_route_index, discover_route_files, normalize_path, RouteIndex,
 };
@@ -19070,31 +19071,6 @@ fn zero_anchor() -> Range {
             line: 0,
             character: 0,
         },
-    }
-}
-
-/// True if `path` resolves to a location inside `root`. Both sides are
-/// canonicalized first — `locate_view_file` builds the path by joining and
-/// `Path::starts_with` is purely textual, so a symlink under the project could
-/// otherwise resolve outside the root and leak an absolute, out-of-project path
-/// into a `WorkspaceEdit` (issue #55 cross-file binding rename).
-///
-/// **Fail-closed.** When either side can't be canonicalized this returns
-/// `false` rather than falling back to a textual prefix check (issue #134).
-/// The motivating case is a *dangling* under-root symlink — a symlink at
-/// `<root>/…` whose target no longer exists, so `canonicalize` returns
-/// `Err(ENOENT)`. A lexical `path.starts_with(root)` fallback would *admit*
-/// it (its link path is textually inside the root) even though its real
-/// target is unverifiable, a surprising fail-open default for a containment
-/// guard. Every caller uses this as a security guard, so an unprovable path is
-/// refused, not admitted.
-fn path_within_root(path: &std::path::Path, root: &std::path::Path) -> bool {
-    match (path.canonicalize(), root.canonicalize()) {
-        (Ok(real_path), Ok(real_root)) => real_path.starts_with(&real_root),
-        // Fail-closed: a path we can't canonicalize (missing, or a dangling
-        // symlink) is unverifiable, so refuse it rather than admit it via a
-        // textual prefix check that a dangling under-root symlink would pass.
-        _ => false,
     }
 }
 

--- a/laravel-lsp/src/path_containment.rs
+++ b/laravel-lsp/src/path_containment.rs
@@ -1,0 +1,173 @@
+//! Project-root containment guard — the single source of truth for the
+//! "does this path resolve inside the project root?" invariant.
+//!
+//! The check used to live in three independent copies (`main.rs`,
+//! `slot_navigation.rs`, and an inline `retain` in `salsa_impl.rs`), each with
+//! its own fallback behaviour that could drift apart (issue #156). They are
+//! consolidated here behind one canonical-first core ([`canonical_containment`])
+//! and **two** public entry points that differ only in what they do when a path
+//! can't be canonicalized:
+//!
+//! - [`path_within_root`] is **fail-closed**: an unverifiable path is refused.
+//!   It is the security guard — a `WorkspaceEdit` must never leak a path whose
+//!   real target escapes the project root, including a *dangling* under-root
+//!   symlink whose link path is textually inside the root but whose target is
+//!   missing (issues #55, #130, #134, #155). Used by `main.rs` and
+//!   `slot_navigation.rs`.
+//! - [`path_within_root_lexical`] falls back to a `normalize_path`-based lexical
+//!   prefix check. It is for *speculative* candidate paths that don't exist on
+//!   disk yet (so they can't canonicalize) — fail-closing them would drop every
+//!   not-yet-created candidate. Used by `salsa_impl.rs`'s component-candidate
+//!   filter, which must admit such paths while still refusing interior-`..`
+//!   escapes (`normalize_path` collapses `..`/`.` before the prefix test,
+//!   because `Path::starts_with` is component-wise and does NOT resolve `..`).
+
+use std::path::Path;
+
+use crate::route_discovery::normalize_path;
+
+/// Canonical-first containment: when both `path` and `root` canonicalize,
+/// compare their real (symlink-resolved) forms with `starts_with` and return
+/// `Some(result)`. Returns `None` when either side can't be canonicalized,
+/// leaving the fallback policy (refuse vs. lexical check) to the caller.
+///
+/// Canonicalizing both sides is what makes the guard real: `locate_view_file`
+/// builds candidate paths by joining and `Path::starts_with` is purely textual,
+/// so without canonicalization a symlink under the project could resolve outside
+/// the root and slip past the prefix test.
+fn canonical_containment(path: &Path, root: &Path) -> Option<bool> {
+    match (path.canonicalize(), root.canonicalize()) {
+        (Ok(real_path), Ok(real_root)) => Some(real_path.starts_with(&real_root)),
+        _ => None,
+    }
+}
+
+/// True if `path` resolves to a location inside `root`. **Fail-closed**: when
+/// either side can't be canonicalized (a missing file, or a dangling under-root
+/// symlink whose target no longer exists) this returns `false` rather than
+/// falling back to a textual prefix check that would admit it (issue #134).
+/// Every caller uses this as a security guard, so an unprovable path is refused,
+/// not admitted.
+pub fn path_within_root(path: &Path, root: &Path) -> bool {
+    canonical_containment(path, root).unwrap_or(false)
+}
+
+/// True if `path` is contained within `root`, with a **lexical** fallback for
+/// paths that can't be canonicalized. When canonicalization fails, the path is
+/// `normalize_path`-collapsed (interior `..`/`.` resolved) and tested against
+/// `root` with `starts_with`. This admits speculative candidates that don't yet
+/// exist on disk — the candidate filter in `salsa_impl.rs` relies on that — while
+/// still refusing a candidate whose normalized form escapes the root. Not a
+/// security guard: callers that read or emit the path must use
+/// [`path_within_root`] instead.
+pub fn path_within_root_lexical(path: &Path, root: &Path) -> bool {
+    canonical_containment(path, root).unwrap_or_else(|| normalize_path(path).starts_with(root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn in_root_path_is_contained() {
+        // A real file under the root: both sides canonicalize and the real path
+        // starts with the real root.
+        let root = TempDir::new().unwrap();
+        let child = root.path().join("resources").join("views");
+        std::fs::create_dir_all(&child).unwrap();
+        let file = child.join("home.blade.php");
+        std::fs::write(&file, "{{ $x }}").unwrap();
+
+        assert!(path_within_root(&file, root.path()));
+        assert!(path_within_root_lexical(&file, root.path()));
+    }
+
+    #[test]
+    fn sibling_root_path_is_refused() {
+        // A real file under a *sibling* root must not be reported as contained.
+        let parent = TempDir::new().unwrap();
+        let root = parent.path().join("project");
+        let sibling = parent.path().join("other");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&sibling).unwrap();
+        let escapee = sibling.join("secret.blade.php");
+        std::fs::write(&escapee, "{{ $x }}").unwrap();
+
+        assert!(!path_within_root(&escapee, &root));
+        assert!(!path_within_root_lexical(&escapee, &root));
+    }
+
+    #[test]
+    fn lexical_refuses_interior_dotdot_escape() {
+        // A speculative candidate that doesn't exist on disk (so it can't
+        // canonicalize) whose interior `..` escapes the root must be refused.
+        // `normalize_path` collapses `root/sub/../../escape` to `<parent>/escape`
+        // before the prefix test — a raw `starts_with` would be fooled by the
+        // textual `root/` prefix.
+        let parent = TempDir::new().unwrap();
+        let root = parent.path().join("project");
+        std::fs::create_dir_all(&root).unwrap();
+        let escaping = root
+            .join("sub")
+            .join("..")
+            .join("..")
+            .join("escape.blade.php");
+
+        assert!(
+            escaping.canonicalize().is_err(),
+            "candidate must not exist on disk"
+        );
+        assert!(
+            !path_within_root_lexical(&escaping, &root),
+            "an interior-`..` escape must be refused after normalization"
+        );
+    }
+
+    #[test]
+    fn lexical_admits_speculative_in_root_candidate() {
+        // A not-yet-created candidate that stays lexically inside the root must
+        // be admitted — this is the speculative-candidate case the security
+        // guard would wrongly fail-close.
+        let root = TempDir::new().unwrap();
+        let candidate = root
+            .path()
+            .join("resources")
+            .join("views")
+            .join("ghost.blade.php");
+
+        assert!(
+            candidate.canonicalize().is_err(),
+            "candidate must not exist on disk"
+        );
+        assert!(path_within_root_lexical(&candidate, root.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn guard_is_fail_closed_on_dangling_under_root_symlink() {
+        // A symlink at `<root>/dangling` whose target was never created:
+        // `canonicalize` fails, so the fail-closed guard must refuse it even
+        // though its link path is lexically inside the root (issues #134, #155).
+        let root = TempDir::new().unwrap();
+        let missing_target = root.path().join("never-created.blade.php");
+        let dangling = root.path().join("dangling");
+        std::os::unix::fs::symlink(&missing_target, &dangling).unwrap();
+
+        // Precondition: the link exists but can't be canonicalized, and it is
+        // lexically inside the root — exactly the path a textual fallback admits.
+        assert!(
+            dangling.canonicalize().is_err(),
+            "a dangling symlink must fail to canonicalize"
+        );
+        assert!(
+            dangling.starts_with(root.path()),
+            "the link path is lexically inside the root"
+        );
+
+        assert!(
+            !path_within_root(&dangling, root.path()),
+            "a dangling under-root symlink must be refused — the guard is fail-closed"
+        );
+    }
+}

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -30,6 +30,9 @@ use crate::queries::extract_all_php_patterns;
 // `route_discovery::normalize_path` pops only a preceding `Normal` segment and
 // preserves root / leading `..`. Every other module already delegates here.
 use crate::route_discovery::normalize_path;
+// The lexical (non-fail-closed) entry point of the shared containment guard —
+// admits speculative candidates that don't exist on disk yet (issue #156).
+use crate::path_containment::path_within_root_lexical;
 
 // ============================================================================
 // Database Definition
@@ -2936,22 +2939,17 @@ impl LaravelConfigData {
 
         // Build the raw candidates, then enforce a project-root containment
         // backstop: any path that escapes `self.root` is dropped before return.
-        // Canonicalize so a symlinked project root (`/var` → `/private/var` on
-        // macOS) or a symlinked vendor dir doesn't spuriously fail the purely
-        // textual `starts_with`. Speculative candidates that don't exist on
-        // disk can't be canonicalized, so they fall back to a *lexical*
-        // containment check: `normalize_path` collapses any interior `..`/`.`
-        // first, because `Path::starts_with` is component-wise and does NOT
-        // resolve `..` — without normalization a `root/sub/../../escape`
-        // candidate (e.g. from a misregistered component directory) keeps its
-        // `/`, `root` prefix and slips through. Mirrors `path_within_root` in
-        // `main.rs` (issue #55).
+        // This uses the *lexical* entry point of the shared containment guard
+        // (`path_containment::path_within_root_lexical`): when both sides
+        // canonicalize it compares the symlink-resolved real paths, but
+        // speculative candidates that don't exist on disk yet can't be
+        // canonicalized, so it falls back to a `normalize_path` lexical check
+        // (collapsing any interior `..`/`.` before the prefix test) rather than
+        // fail-closing — admitting the not-yet-created candidate while still
+        // refusing a `root/sub/../../escape`. The fail-closed `path_within_root`
+        // would wrongly drop every speculative candidate here.
         let mut paths = self.component_path_candidates(component_name);
-        let canonical_root = self.root.canonicalize();
-        paths.retain(|path| match (path.canonicalize(), &canonical_root) {
-            (Ok(real_path), Ok(real_root)) => real_path.starts_with(real_root),
-            _ => normalize_path(path).starts_with(&self.root),
-        });
+        paths.retain(|path| path_within_root_lexical(path, &self.root));
         paths
     }
 

--- a/laravel-lsp/src/slot_navigation.rs
+++ b/laravel-lsp/src/slot_navigation.rs
@@ -16,6 +16,10 @@ use std::path::Path;
 use tree_sitter::{Node, Tree};
 
 use crate::parser::parse_blade;
+// Project-root containment guard — now the shared, fail-closed
+// `path_containment::path_within_root` (was a local copy mirroring `main.rs`).
+// This upgrades the old raw-textual fallback to fail-closed (issue #156).
+use crate::path_containment::path_within_root;
 
 /// Information about a slot tag found at the cursor position.
 #[derive(Debug, Clone, PartialEq)]
@@ -276,19 +280,6 @@ pub fn locate_slot_in_view(view_path: &Path, slot_name: &str, root: &Path) -> Op
     }
     let source = std::fs::read_to_string(view_path).ok()?;
     find_slot_variable_line(&source, slot_name)
-}
-
-/// True if `view_path` resolves to a location inside `root`. Both sides are
-/// canonicalized first so a symlink under the project can't resolve outside the
-/// root and slip past a purely textual `starts_with`. When either side can't be
-/// canonicalized (e.g. the file vanished mid-edit) we fall back to the textual
-/// prefix check rather than admitting an unverified path. Mirrors
-/// `path_within_root` in `main.rs` (issues #55, #130).
-fn path_within_root(view_path: &Path, root: &Path) -> bool {
-    match (view_path.canonicalize(), root.canonicalize()) {
-        (Ok(real_path), Ok(real_root)) => real_path.starts_with(&real_root),
-        _ => view_path.starts_with(root),
-    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Implements #156 — consolidates the canonical-first root-containment check, which had drifted into **three** copies with three divergent fallbacks, into one shared `path_containment` module. Built to **Option 3** (Mike's call): one module, two entry points sharing a canonical-first core, so the security guards keep their #155 fail-closed behavior while `salsa_impl`'s speculative-candidate filter keeps its lexical fallback.

## Changes
- New `laravel-lsp/src/path_containment.rs`, declared `pub mod path_containment;` in `lib.rs`, with a shared canonical-first core (`canonical_containment`) and two public entry points:
  - `path_within_root` — **fail-closed** (canonicalize failure ⇒ `false`; preserves #155).
  - `path_within_root_lexical` — `normalize_path` lexical fallback that admits not-yet-created candidates.
- Removed the private `fn path_within_root` from `main.rs`; all call-sites (including the one #157 added in `collect_route_declaration_targets`) route through `laravel_lsp::path_containment::path_within_root`.
- Removed the private `fn path_within_root` from `slot_navigation.rs`; its caller now uses the shared guard — **upgrade**: raw-textual fallback → fail-closed.
- Replaced the inline containment check in `salsa_impl.rs` with `path_within_root_lexical` (preserves speculative-candidate admission — **not** fail-closed).
- Updated the stale "Mirrors `path_within_root` in main.rs" doc-comments to reference `path_containment`.
- **Bundled (Mike's call, unrelated area):** two `find_block_terminator` tests in `blade_var_rename/tests.rs` — a fake `@endphp` inside a `/* … */` block comment, and inside a double-quoted-label heredoc (`<<<"LABEL"`).

## Acceptance Criteria
- [x] New `laravel-lsp/src/path_containment.rs` module, declared `pub mod path_containment;` in `lib.rs`
- [x] Shared canonical-first core + two public entry points:
  - [x] `pub fn path_within_root(path, root) -> bool` — fail-closed (preserves #155)
  - [x] `pub fn path_within_root_lexical(path, root) -> bool` — `normalize_path` lexical fallback
- [x] Private `fn path_within_root` in `main.rs` removed; **all** call-sites use the shared guard (incl. #157's `collect_route_declaration_targets`)
- [x] Private `fn path_within_root` in `slot_navigation.rs` removed; caller upgraded raw-textual → fail-closed
- [x] `salsa_impl.rs` inline check replaced with `path_within_root_lexical` (not fail-closed)
- [x] `cargo build --release` passes — zero errors, zero new warnings
- [x] `path_containment` unit tests: in-root ⇒ `true`; sibling-root ⇒ `false`; `..`-escape via lexical ⇒ `false`; fail-closed (dangling under-root) via the guard ⇒ `false` (+ a lexical speculative-admit case)
- [x] All pre-existing tests pass (`cargo test` — lib suite 2179 green; the only integration failures are fixture-dependent, identical on `main`, and bootstrapped by CI)
- [x] Stale "Mirrors `path_within_root`" doc-comments updated to point to `path_containment`
- [x] **Bundled from #93/#164:** two `find_block_terminator` tests (block-comment `@endphp`; double-quoted heredoc `@endphp`)

## Test Plan
- [x] `cargo build --release` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --all-features` — lib suite green (2179 tests), incl. all containment tests now routing through the shared module; new `path_containment` tests (5) and bundled blade tests (2) pass
- [x] Verified the 8 integration-test failures are pre-existing and environment-only (gitignored `.env` + composer `vendor/`), identical on clean `origin/main`; CI bootstraps both

Fixes #156