### PR TITLE
harden: wire the view-rename flow's locate_view_file result through path_within_root

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -21484,8 +21484,9 @@ impl LanguageServer for LaravelLanguageServer {
                 // declaration. Rename = move the .blade.php + rewrite every
                 // `view('old')` call site (call sites already collected
                 // above into `targets`). New name validation, vendor-path
-                // refusal, and target-path computation surface as toasts
-                // via short-circuit errors rather than silent no-ops.
+                // refusal, root-containment refusal, and target-path
+                // computation surface as toasts via short-circuit errors
+                // rather than silent no-ops.
                 let trimmed_new = new_name.trim();
                 if let Err(e) =
                     laravel_lsp::view_declaration_locator::validate_view_name(trimmed_new)
@@ -21517,6 +21518,18 @@ impl LanguageServer for LaravelLanguageServer {
                     if laravel_lsp::view_declaration_locator::is_under_vendor(&current_path, root) {
                         return Err(laravel_lsp::rename::rename_error(
                             "cannot rename views located under vendor/.",
+                        ));
+                    }
+                    // Containment guard, mirroring the binding-rename arm's
+                    // `.filter(|p| path_within_root(p, &config.root))`. `locate_view_file`
+                    // only checks `is_file()`, so a live under-root symlink whose target
+                    // resolves OUTSIDE the project root is admitted (it's a real file on
+                    // disk). `path_within_root` canonicalizes both sides, so it refuses
+                    // such a path before `compute_target_path` could move an out-of-tree
+                    // file. Fail-closed: a path that can't be canonicalized is also refused.
+                    if !path_within_root(&current_path, root) {
+                        return Err(laravel_lsp::rename::rename_error(
+                            "cannot rename view: file resolves outside the project root.",
                         ));
                     }
                 }

--- a/laravel-lsp/src/tests/rename_integration.rs
+++ b/laravel-lsp/src/tests/rename_integration.rs
@@ -108,6 +108,65 @@ fn view_rename_refuses_vendor_view() {
     assert!(is_under_vendor(&vendor_view, root));
 }
 
+// View rename — live-symlink containment (issue #158).
+//
+// `locate_view_file` only checks `is_file()`, so a live symlink *under*
+// `resources/views` whose target resolves OUTSIDE the project root is admitted —
+// it's a real file on disk. The vendor guard does not catch it (it isn't under
+// `vendor/`), so the `path_within_root` guard added to the `SymbolRef::View`
+// rename arm is what refuses it, mirroring the binding-rename arm's
+// `.filter(|p| path_within_root(p, &config.root))`. Without that guard the
+// handler would feed the out-of-tree path into `compute_target_path` and move a
+// file outside the project. This is the live-symlink leg; the dangling-symlink
+// (canonicalize-fails) leg is covered by
+// `folio_cursor_containment::path_within_root_refuses_dangling_under_root_symlink`.
+#[cfg(unix)]
+#[test]
+fn view_rename_refuses_under_root_symlink_resolving_outside() {
+    use crate::path_within_root;
+    use laravel_lsp::view_declaration_locator::{is_under_vendor, locate_view_file};
+
+    // A real target file living entirely OUTSIDE the project root.
+    let outside = TempDir::new().unwrap();
+    let outside_target = outside.path().join("secret.blade.php");
+    write(&outside_target, "<h1>out of tree</h1>");
+
+    // The project root, with a `resources/views/escape.blade.php` symlink whose
+    // target is the out-of-tree file above. Canonicalizing the link escapes root.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let views = root.join("resources/views");
+    fs::create_dir_all(&views).unwrap();
+    let link = views.join("escape.blade.php");
+    std::os::unix::fs::symlink(&outside_target, &link).unwrap();
+
+    let config = fake_config(root);
+
+    // `locate_view_file` admits the symlink — it passes the `is_file()` check
+    // because the link resolves to a real file.
+    let current = locate_view_file("escape", &config).expect("symlinked view resolves on disk");
+    assert_eq!(current, link);
+
+    // The vendor guard does NOT catch it — the link lives under resources/views,
+    // not vendor/. So `path_within_root`, not `is_under_vendor`, is the guard
+    // that must refuse this rename.
+    assert!(!is_under_vendor(&current, root));
+
+    // Discriminating precondition: the link path is lexically inside the root, so
+    // a textual `starts_with(root)` check would have admitted it. Only the
+    // canonicalize-based `path_within_root` refuses it.
+    assert!(current.starts_with(root));
+
+    // The guard the rename arm now applies, BEFORE `compute_target_path`:
+    // canonicalizing the link escapes the root, so containment fails and the
+    // rename is refused — no `compute_target_path`, no file-system mutation.
+    assert!(
+        !path_within_root(&current, root),
+        "a live under-root symlink whose canonicalized target leaves the project \
+         root must be refused — path_within_root canonicalizes both sides"
+    );
+}
+
 // ============================================================================
 // Blade component rename — class-backed flavour (file moves + class decl)
 // ============================================================================


### PR DESCRIPTION
## Summary
Implements #158

The `SymbolRef::View` rename arm resolved the current view file with `locate_view_file` and then guarded it with **only** `is_under_vendor` — it never passed the resolved path through `path_within_root`, unlike the binding-rename arm at `main.rs` ~L19303 which filters with `.filter(|p| path_within_root(p, &config.root))`. Since `locate_view_file` only checks `is_file()`, a **live under-root symlink** whose target resolves *outside* the project root was admitted (it's a real file on disk), so the rename could compute a target against and move an out-of-tree file. This closes that containment leg on the rename path, restoring parity with the binding-rename arm.

## Changes
- Add a `path_within_root(&current_path, root)` containment guard to the `SymbolRef::View` rename arm in `laravel-lsp/src/main.rs`, inside the existing `if let Some(root) = root_path.as_ref()` block, alongside (and after) the preserved `is_under_vendor` check. Both guards must pass for the rename to proceed.
- The new guard returns a clear error toast — `cannot rename view: file resolves outside the project root.` — before `compute_target_path` runs, so no `WorkspaceEdit` or file-system mutation is produced for an out-of-tree path. `path_within_root` canonicalizes both sides and is fail-closed, so an unverifiable path is refused too.
- Add a `#[cfg(unix)]` regression test (`view_rename_refuses_under_root_symlink_resolving_outside` in `rename_integration.rs`) covering the live-symlink-escape leg.

## Acceptance Criteria
- [x] In `main.rs`, the `SymbolRef::View` rename arm adds a `path_within_root(&current_path, root)` check immediately after the existing `is_under_vendor` guard — inside the `if let Some(root) = root_path.as_ref()` block — and returns a clear error toast (`cannot rename view: file resolves outside the project root.`) when the check fails
- [x] A live in-tree symlink whose canonicalized target lies outside the project root is refused by the rename; no file-system mutation or `WorkspaceEdit` is produced for such a path
- [x] The `is_under_vendor` check is preserved unchanged alongside the new guard; both guards must pass for the rename to proceed
- [x] The fix is located at `laravel-lsp/src/main.rs` in the `SymbolRef::View` arm, mirroring the `.filter(|p| path_within_root(p, &config.root))` pattern in the binding-rename arm at ~L19303
- [x] A unit test exercises the symlink-escape scenario: `locate_view_file` returns a path whose canonicalized form leaves the root, and the rename is refused before reaching `compute_target_path`
- [x] All existing rename tests continue to pass after the change

## Test Plan
- [x] `cargo test` — new test `view_rename_refuses_under_root_symlink_resolving_outside` passes; all view-rename and `main.rs` unit tests green
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean
- [x] Existing rename tests continue to pass
- Note: the pre-existing `tests/integration_tests.rs` env/route fixtures require CI's bootstrap steps (`cp test-project/.env.example test-project/.env` + `composer update`); unrelated to this change

Fixes #158