### PR TITLE
perf: incremental (per-file) magic-member disk cache invalidation

### DIFF
--- a/laravel-lsp/src/magic_disk_cache.rs
+++ b/laravel-lsp/src/magic_disk_cache.rs
@@ -25,6 +25,13 @@
 //! sites). An earlier revision used an all-or-nothing guard instead,
 //! re-resolving the whole project after any edit-then-restart.
 //!
+//! Files **deleted** between sessions are pruned on restore ([`prune_deleted`],
+//! #67): they're absent from the project file list, so the changed-file
+//! re-resolve never touches them — without the prune their stale resolved
+//! entries would be resurrected from disk and outlive the file (inflating
+//! reference counts, pointing hovers at a missing path). This mirrors the
+//! live-delete path's `remove_file` eviction, applied at restore time.
+//!
 //! The cache is also re-saved (debounced) after live incremental refreshes,
 //! so it tracks the in-memory index across a working session instead of
 //! going stale at the first edit.
@@ -112,6 +119,25 @@ pub fn load(project_root: &Path) -> Option<MagicCacheData> {
         return None;
     }
     Some(cache.data)
+}
+
+/// Drop entries (and controller view-renders) for files that no longer exist
+/// on disk, returning the number of resolved-entry files evicted.
+///
+/// The warm restore imports the cache wholesale, then re-resolves only the
+/// files the pattern cache flagged as changed or new. A file *deleted* between
+/// sessions is in neither set — it's gone from the project file list, so it's
+/// never a changed path and never re-resolved — which without this prune would
+/// resurrect its stale resolved entries from `magic_cache.bin` and let them
+/// outlive the file (inflating reference counts, pointing hovers at a missing
+/// path). The `path.exists()` stats run inline on the caller's thread — call
+/// it from the blocking pool, alongside [`load`].
+pub fn prune_deleted(data: &mut MagicCacheData) -> usize {
+    let before = data.entries.len();
+    data.entries.retain(|(path, _, _)| path.exists());
+    let evicted = before - data.entries.len();
+    data.view_renders.retain(|(path, _)| path.exists());
+    evicted
 }
 
 /// Persist the resolved magic-member `data` for `project_root`. Written via
@@ -207,5 +233,53 @@ mod tests {
         assert!(b.2.contains("App\\Models\\Invoice"));
         assert_eq!(loaded.view_renders.len(), 1);
         assert_eq!(loaded.view_renders[0].1[0].view_name, "users.show");
+    }
+
+    /// A file deleted between sessions is pruned from a restored cache — both
+    /// its resolved entries and its controller view-renders — while files that
+    /// still exist on disk survive. Guards the deleted-file eviction AC (#67):
+    /// without the prune, the wholesale restore would resurrect the deleted
+    /// file's stale entries and inflate reference counts.
+    #[test]
+    fn prune_deleted_evicts_missing_files_only() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let present = dir.path().join("Present.php");
+        std::fs::write(&present, b"<?php").unwrap();
+        // `deleted` is never written to disk — it stands in for a file removed
+        // between sessions whose entry still lives in the persisted cache.
+        let deleted = dir.path().join("Deleted.php");
+
+        let entry = MagicMemberEntry {
+            fqcn: "App\\Models\\User".to_string(),
+            member: "email".to_string(),
+            line: 1,
+            column: 0,
+            end_column: 5,
+        };
+        let mut vars = std::collections::HashMap::new();
+        vars.insert("user".to_string(), "App\\Models\\User".to_string());
+        let render = |name: &str| ViewRender {
+            view_name: name.to_string(),
+            vars: vars.clone(),
+        };
+
+        let mut data = MagicCacheData {
+            entries: vec![
+                (present.clone(), vec![entry.clone()], HashSet::new()),
+                (deleted.clone(), vec![entry.clone()], HashSet::new()),
+            ],
+            view_renders: vec![
+                (present.clone(), vec![render("present.view")]),
+                (deleted.clone(), vec![render("deleted.view")]),
+            ],
+        };
+
+        let evicted = prune_deleted(&mut data);
+
+        assert_eq!(evicted, 1, "exactly the deleted entry file is evicted");
+        assert_eq!(data.entries.len(), 1);
+        assert_eq!(data.entries[0].0, present);
+        assert_eq!(data.view_renders.len(), 1);
+        assert_eq!(data.view_renders[0].0, present);
     }
 }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4578,13 +4578,27 @@ impl LaravelLanguageServer {
             let restored = {
                 let root_for_load = root_for_save.clone();
                 tokio::task::spawn_blocking(move || {
-                    laravel_lsp::magic_disk_cache::load(&root_for_load)
+                    laravel_lsp::magic_disk_cache::load(&root_for_load).map(|mut data| {
+                        // Evict files deleted between sessions before import:
+                        // they're gone from the project file list, so the
+                        // granular re-resolve below never touches them and
+                        // their stale entries would otherwise be resurrected
+                        // (#67). Stats stay on the blocking pool with the read.
+                        let evicted = laravel_lsp::magic_disk_cache::prune_deleted(&mut data);
+                        (data, evicted)
+                    })
                 })
                 .await
                 .ok()
                 .flatten()
             };
-            if let Some(data) = restored {
+            if let Some((data, evicted)) = restored {
+                if evicted > 0 {
+                    info!(
+                        "🪄 Magic-member restore: evicted {} deleted file(s) from cache",
+                        evicted
+                    );
+                }
                 let laravel_lsp::magic_disk_cache::MagicCacheData {
                     entries,
                     view_renders,
@@ -4669,6 +4683,12 @@ impl LaravelLanguageServer {
                         );
                         server_for_warm.refresh_files_magic(work).await;
                     }
+                }
+                // Deleted files were pruned from the live index above; the
+                // refresh only schedules a save when it had work, so persist
+                // the cleaned set here to converge the on-disk cache (#67).
+                if evicted > 0 {
+                    server_for_warm.schedule_magic_cache_save().await;
                 }
             } else {
                 // Resolve fresh, drive progress (the file-parse loop had nothing


### PR DESCRIPTION
## Summary

Implements #67. The incremental (per-file) magic-member restore this issue asks for was **largely delivered by #80** ("Dependency-tracked incremental magic refresh"): the warm flow already restores the cache whenever it exists and re-resolves only the files the pattern cache flags as changed/new, plus their blast radius. Verifying #67's ACs against `main` left **one genuine gap — deleted-file eviction** — which this PR closes, with a regression test.

## Changes

- `magic_disk_cache.rs`: add `prune_deleted(&mut MagicCacheData) -> usize` — drops resolved entries **and** controller view-renders for files no longer on disk, returning the eviction count. Mirrors the live-delete path's `remove_file` eviction, applied at restore time.
- `main.rs` warm restore: run `prune_deleted` on the blocking pool alongside the cache read, log evictions, and schedule a magic-cache save when any file was evicted so the on-disk cache converges (the granular refresh only saves when it had work).
- Unit test `prune_deleted_evicts_missing_files_only` + module-doc note.

### Why a file deleted between sessions leaked

The restore imports the persisted entries wholesale, then re-resolves only *changed/new* files. A file deleted while the LSP was down is in **neither** set — it's gone from the project file list, so it's never a changed path and never re-resolved — so its stale resolved entries were resurrected from `magic_cache.bin` and outlived the file (inflating reference counts, pointing hovers at a missing path).

## Acceptance Criteria

- [x] Persist per-file fingerprint (mtime or content hash) — *already satisfied by #80*: per-file mtime lives in `pattern_disk_cache.rs`; the magic restore keys off pattern-cache membership.
- [x] Restore all cached entries on warm, then re-parse only changed/new files — *already satisfied by #80*.
- [x] **Drop cache entries for deleted files during partial restore** — **closed here** (`prune_deleted`).
- [x] Bump `SCHEMA_VERSION` and gracefully ignore old cache files — *already satisfied by #80* (v3; `load()` returns `None` on mismatch). **Not re-bumped:** this change doesn't alter the on-disk format, and a needless bump would discard every user's cache and force a full (~135s) re-resolve.
- [x] Editing one file re-parses only that file's magic members — *already satisfied by #80* (granular restore + blast radius).
- [x] No regression to reference-count correctness after partial restore — deleted-file eviction removes the stale-entry inflation; covered by the new unit test.
- [x] Parse work remains in `spawn_blocking` / warm task — *already satisfied*; the prune stats run on the blocking pool with the cache read.
- [x] Honor existing semaphore throttle on parallel file work — *already satisfied by #80*.

## Test Plan

- [x] `cargo test` — 1761 lib + 301 integration pass; new `prune_deleted_evicts_missing_files_only` passes.
- [x] `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- [x] The 8 locally-failing integration tests are pre-existing fixture dependencies (gitignored `test-project/.env` + Composer vendor) that **CI provisions** (`cp .env.example .env`, `composer update`); none touch the magic cache. Verified by provisioning `.env` locally (cleared 7; the last needs the Fortify vendor package).

Fixes #67