### PR TITLE
fix: make @php/@endphp block masking string-literal safe

### DIFF
--- a/laravel-lsp/src/blade_var_rename.rs
+++ b/laravel-lsp/src/blade_var_rename.rs
@@ -229,7 +229,11 @@ fn mask_php_blocks(source: &str, out: &mut [u8]) {
             search_from = after_open;
             continue;
         }
-        let Some(rel_end) = source[after_open..].find("@endphp") else {
+        // Locate the closing `@endphp` with PHP-string awareness: a literal
+        // `@endphp` inside a string or comment in the block body does not close
+        // the block (a plain substring search would close it early, leaving the
+        // real PHP tail wrongly treated as renameable markup).
+        let Some(rel_end) = find_block_terminator(&source[after_open..]) else {
             break; // unclosed `@php` (inline `@php(...)`) — not a block.
         };
         let end = after_open + rel_end + "@endphp".len();
@@ -239,6 +243,156 @@ fn mask_php_blocks(source: &str, out: &mut [u8]) {
             }
         }
         search_from = end;
+    }
+}
+
+/// Within a `@php` block body, return the byte offset of the real `@endphp`
+/// terminator — the first `@endphp` token that lies in PHP *code*, not inside a
+/// string literal or comment. A literal `@endphp` inside a single-/double-quoted
+/// string, a heredoc/nowdoc body, or a `//`, `#`, or `/* … */` comment does not
+/// close the block. A symmetric word boundary (mirroring the `@php` opener guard)
+/// keeps `@endphpunit` from matching. Returns `None` when the block is unclosed.
+/// Single forward pass over the body — O(n), no backtracking.
+fn find_block_terminator(body: &str) -> Option<usize> {
+    let b = body.as_bytes();
+    let n = b.len();
+    let mut i = 0;
+    while i < n {
+        match b[i] {
+            b'\'' => i = skip_php_quoted(b, i, b'\''),
+            b'"' => i = skip_php_quoted(b, i, b'"'),
+            b'/' if b[i..].starts_with(b"//") => i = skip_to_line_end(b, i),
+            b'/' if b[i..].starts_with(b"/*") => i = skip_block_comment(b, i),
+            b'#' if !b[i..].starts_with(b"#[") => i = skip_to_line_end(b, i),
+            b'<' if b[i..].starts_with(b"<<<") => i = skip_heredoc(b, i).unwrap_or(i + 1),
+            b'@' if b[i..].starts_with(b"@endphp") => {
+                let after = i + "@endphp".len();
+                let at_boundary =
+                    after >= n || !(b[after].is_ascii_alphanumeric() || b[after] == b'_');
+                if at_boundary {
+                    return Some(i);
+                }
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// Index just past the closing `quote` of a PHP string opening at `start`
+/// (`b[start] == quote`). A backslash escapes the next byte — covering `\'`/`\\`
+/// in single-quoted and `\"`/`\\`/… in double-quoted strings — so an escaped
+/// quote does not terminate the string. The ASCII delimiters never collide with
+/// UTF-8 continuation bytes, so byte scanning is multi-byte safe. Unterminated →
+/// end of input.
+fn skip_php_quoted(b: &[u8], start: usize, quote: u8) -> usize {
+    let n = b.len();
+    let mut i = start + 1;
+    while i < n {
+        if b[i] == b'\\' {
+            i += 2; // skip the escaped byte
+        } else if b[i] == quote {
+            return i + 1;
+        } else {
+            i += 1;
+        }
+    }
+    n
+}
+
+/// Index of the next line feed at or after `i` (or end of input) — skips a `//`
+/// or `#` line comment so an `@endphp` inside it isn't mistaken for a string
+/// opener's apostrophe (`// don't …`) or treated as the terminator.
+fn skip_to_line_end(b: &[u8], i: usize) -> usize {
+    match b[i..].iter().position(|&c| c == b'\n') {
+        Some(off) => i + off,
+        None => b.len(),
+    }
+}
+
+/// Index just past the closing `*/` of a block comment opening at `i`
+/// (`b[i..]` begins with `/*`). Unterminated → end of input.
+fn skip_block_comment(b: &[u8], i: usize) -> usize {
+    let n = b.len();
+    let mut j = i + 2;
+    while j + 1 < n {
+        if b[j] == b'*' && b[j + 1] == b'/' {
+            return j + 2;
+        }
+        j += 1;
+    }
+    n
+}
+
+/// If a heredoc/nowdoc opens at `start` (`b[start..]` begins with `<<<`), return
+/// the index just past its closing label, skipping the whole body — any
+/// `@endphp` inside it is literal text. Mirrors PHP: optional spaces/tabs, an
+/// optional `"`/`'` wrapping the label (nowdoc uses `'`), then the label; the
+/// body runs until a line whose first non-whitespace content is the label
+/// followed by a non-identifier byte (PHP 7.3+ allows the closer to be
+/// indented). Returns `None` when `<<<` is not a valid opener, so the caller
+/// treats it as ordinary code.
+fn skip_heredoc(b: &[u8], start: usize) -> Option<usize> {
+    let n = b.len();
+    let mut i = start + 3; // past "<<<"
+    while i < n && (b[i] == b' ' || b[i] == b'\t') {
+        i += 1;
+    }
+    let quote = match b.get(i) {
+        Some(&q) if q == b'"' || q == b'\'' => {
+            i += 1;
+            Some(q)
+        }
+        _ => None,
+    };
+    let label_start = i;
+    if b.get(i)
+        .is_some_and(|&c| c.is_ascii_alphabetic() || c == b'_')
+    {
+        i += 1;
+        while b
+            .get(i)
+            .is_some_and(|&c| c.is_ascii_alphanumeric() || c == b'_')
+        {
+            i += 1;
+        }
+    } else {
+        return None; // no valid label → not a heredoc opener
+    }
+    let label = &b[label_start..i];
+    if let Some(q) = quote {
+        if b.get(i) == Some(&q) {
+            i += 1;
+        } else {
+            return None; // mismatched opening quote → not a heredoc opener
+        }
+    }
+    if b.get(i) == Some(&b'\r') {
+        i += 1;
+    }
+    if b.get(i) == Some(&b'\n') {
+        i += 1;
+    } else {
+        return None; // label not terminated by a newline → not a heredoc opener
+    }
+    // Scan body lines for the closing label.
+    loop {
+        let mut j = i;
+        while j < n && (b[j] == b' ' || b[j] == b'\t') {
+            j += 1;
+        }
+        if b[j..].starts_with(label) {
+            let after = j + label.len();
+            let at_boundary = after >= n || !(b[after].is_ascii_alphanumeric() || b[after] == b'_');
+            if at_boundary {
+                return Some(after);
+            }
+        }
+        match b[i..].iter().position(|&c| c == b'\n') {
+            Some(off) => i += off + 1,
+            None => return Some(n), // unterminated heredoc → consume to EOF
+        }
     }
 }
 

--- a/laravel-lsp/src/blade_var_rename/tests.rs
+++ b/laravel-lsp/src/blade_var_rename/tests.rs
@@ -798,6 +798,113 @@ fn php_word_prefix_does_not_anchor_a_mask_block() {
     assert!(is_template_variable(src, "total"));
 }
 
+// ── is_template_variable: string-literal-safe @php/@endphp masking (#93) ─────
+
+#[test]
+fn endphp_inside_single_quoted_php_string_does_not_close_block() {
+    // A literal `@endphp` inside a single-quoted PHP string must not close the
+    // masked region early. `$ghost` lives only in real PHP *after* that fake
+    // terminator, so it is a block-local, not a renameable template variable.
+    let src = "\
+@php
+    $marker = '@endphp';
+    $ghost = 5;
+@endphp
+{{ $user }}";
+    assert!(!is_template_variable(src, "ghost"));
+    // The real markup after the block is still recognized — the block masks
+    // only itself, not what follows.
+    assert!(is_template_variable(src, "user"));
+}
+
+#[test]
+fn endphp_inside_double_quoted_php_string_does_not_close_block() {
+    let src = "\
+@php
+    $marker = \"@endphp\";
+    $ghost = 5;
+@endphp
+{{ $user }}";
+    assert!(!is_template_variable(src, "ghost"));
+    assert!(is_template_variable(src, "user"));
+}
+
+#[test]
+fn endphp_inside_heredoc_does_not_close_block() {
+    // The `@endphp` inside the heredoc body is literal text; the block closes
+    // only at the real `@endphp` after the heredoc's closing label.
+    let src = "\
+@php
+    $marker = <<<SQL
+    @endphp is just text in here
+    SQL;
+    $ghost = 5;
+@endphp
+{{ $user }}";
+    assert!(!is_template_variable(src, "ghost"));
+    assert!(is_template_variable(src, "user"));
+}
+
+#[test]
+fn endphp_inside_nowdoc_does_not_close_block() {
+    let src = "\
+@php
+    $marker = <<<'TXT'
+    @endphp stays literal here
+    TXT;
+    $ghost = 5;
+@endphp
+{{ $user }}";
+    assert!(!is_template_variable(src, "ghost"));
+    assert!(is_template_variable(src, "user"));
+}
+
+#[test]
+fn endphp_word_prefix_does_not_close_block() {
+    // `@endphpunit` shares the `@endphp` prefix but is not the terminator — a
+    // symmetric word boundary (mirroring the `@php` opener guard) keeps the
+    // block open until the real `@endphp`.
+    let src = "\
+@php
+    $a = 1; @endphpunit
+    $ghost = 5;
+@endphp
+{{ $user }}";
+    assert!(!is_template_variable(src, "ghost"));
+    assert!(is_template_variable(src, "user"));
+}
+
+#[test]
+fn apostrophe_in_php_comment_does_not_break_block_masking() {
+    // A `//` comment containing an apostrophe must not be read as a string
+    // opener — otherwise the scanner would never find the real `@endphp` and
+    // would wrongly leave the block (and its locals) unmasked.
+    let src = "\
+@php
+    // don't treat this apostrophe as a string opener
+    $ghost = 5;
+@endphp
+{{ $user }}";
+    assert!(!is_template_variable(src, "ghost"));
+    assert!(is_template_variable(src, "user"));
+}
+
+#[test]
+fn escaped_quote_before_endphp_keeps_block_masked() {
+    // An escaped quote does not terminate its string, so a following `@endphp`
+    // stays inside the string and does not close the block — and the escapes
+    // resolve in a single forward pass (no quadratic backtracking).
+    let src = "\
+@php
+    $d = \"escaped \\\" quote then @endphp\";
+    $s = 'escaped \\' quote then @endphp';
+    $ghost = 5;
+@endphp
+{{ $user }}";
+    assert!(!is_template_variable(src, "ghost"));
+    assert!(is_template_variable(src, "user"));
+}
+
 // ── view_binding_key_at: ->with chains ──────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Implements #93.

`mask_php_blocks` located the closing `@endphp` with a plain substring search, so a literal `@endphp` inside a PHP string within a `@php … @endphp` block closed the masked region early — leaving the real PHP tail wrongly treated as renameable Blade markup (the over-broad-rename bug Holmes flagged in #55/PR #89).

## Changes
- Replace the `find("@endphp")` substring search in `mask_php_blocks` with **`find_block_terminator`** — a single-pass, O(n) scanner that finds the *real* `@endphp` in PHP **code**, skipping over:
  - single-quoted strings (`'…'`) and double-quoted strings (`"…"`), honoring backslash escapes (`\'`, `\"`, `\\`);
  - heredoc (`<<<LABEL … LABEL`) and nowdoc (`<<<'LABEL' … LABEL`) bodies, with PHP 7.3+ indented-closer support;
  - `//`, `#` (not `#[` attributes), and `/* … */` comments — so an apostrophe in a comment (`// don't …`) is never misread as a string opener.
- Add a **symmetric word-boundary guard** on `@endphp` (mirroring the existing `@php` opener guard) so `@endphpunit` no longer matches.
- Helpers `skip_php_quoted`, `skip_to_line_end`, `skip_block_comment`, `skip_heredoc` — all byte-level (multi-byte-UTF-8 safe, since the ASCII delimiters never collide with continuation bytes).

## Acceptance Criteria
- [x] `mask_php_blocks` is string-context aware — `@endphp` inside a single-quoted PHP string does **not** close the masked region
- [x] Same for double-quoted PHP strings
- [x] Same for heredoc strings — `@endphp` in the heredoc body is ignored
- [x] Same for nowdoc strings
- [x] Variables after a fake `@endphp` (before the true closer) are masked, not treated as renameable occurrences — see note below
- [x] `is_template_variable` returns `false` for a variable whose only occurrences fall in a `@php` block containing a string-literal `@endphp` before the real closer
- [x] Scanning remains O(n) — single forward pass, no backtracking (escapes, balanced quotes, nested interpolation handled without retry loops)
- [x] One unit test per string-context type (single, double, heredoc, nowdoc) in `blade_var_rename/tests.rs`, mirroring `php_word_prefix_does_not_anchor_a_mask_block`
- [x] All existing `blade_var_rename` tests pass unchanged

### ⚠️ Note on AC #5 (`variable_spans`) — review decision needed
AC #5 is worded as `variable_spans` returning no spans in the post-fake-`@endphp` region. But `variable_spans` (via `mask_non_code`) **intentionally does not mask `@php` blocks at all** — the existing test `php_block_variable_is_file_scoped` *requires* a `@php`-assigned `$total` to be returned as a span so a file-scoped rename rewrites its assignment. Masking `@php` blocks in `variable_spans` would break that.

The protection AC #5/#6 describe lives in **`is_template_variable`** → `mask_non_template` → `mask_php_blocks` (the `prepare_rename` admissibility gate), which is exactly what this PR fixes: a variable confined to the masked block is now correctly rejected at `prepare_rename`, so the rename never reaches span computation. I implemented and tested AC #5/#6 against that gate rather than changing `variable_spans`. Flagging in case you intended a broader `variable_spans` change.

## Test Plan
- [x] 7 new unit tests added (one per string type + `@endphp` word-boundary + comment-apostrophe regression + escaped-quote/no-backtracking)
- [x] `cargo test` — 1767 unit + 301 binary tests pass; all 50 `blade_var_rename` tests green
- [x] `cargo fmt --check` clean; `cargo clippy` clean (CI runs `-D warnings`)
- [ℹ] 8 pre-existing `integration_tests` failures (missing `test-project`/`.env` fixtures) reproduce identically on `origin/main` — unrelated to this change

Fixes #93