### PR TITLE
discovery: map the full boundary of string-keyed & cross-scope PHP-variable rename references

### DIFF
--- a/laravel-lsp/src/php_variable_rename.rs
+++ b/laravel-lsp/src/php_variable_rename.rs
@@ -64,6 +64,38 @@
 //! Constructor-promoted parameters (`__construct(private $name)`) are treated
 //! as ordinary locals within the constructor — the property side of promotion
 //! belongs to the deferred class-property rename pass, not here.
+//!
+//! ## Engine default: fail-open with a complete denylist
+//!
+//! The engine is **fail-open**: a rename proceeds by default — rewriting every
+//! `variable_name` bound to the scope — and refuses only for an explicit set of
+//! shapes that reach a local through something a scope-local edit can't follow
+//! (a string key, or a cross-scope alias). Issue #96 mapped the whole boundary
+//! of string-keyed and cross-scope references so the denylist is now complete for
+//! every shape detectable in a single file:
+//!
+//! - **Refused** — a string/alias reference the rename can't rewrite, so leaving
+//!   it behind would strand it: `global $x;`, `compact('x')` / `extract('x')`,
+//!   `${'x'}` (dynamic variable over a string literal), `$GLOBALS['x']`.
+//! - **Rewritten** — the reference *is* a real `variable_name` the engine
+//!   collects: `use ($x)` / `use (&$x)` captures, arrow-function captures,
+//!   `$$name` (the inner `$name` is a `variable_name`), string interpolation and
+//!   heredoc (`"$x"`, `"{$x}"`, `<<<EOT $x EOT`), and by-reference positions
+//!   (`&$x` — the `&` is a separate token). Nowdoc (`<<<'EOT'`) does *not*
+//!   interpolate, so its `$x` is literal text and is correctly left untouched.
+//! - **Deferred** — no literal name in the source, so undetectable in one file:
+//!   `extract($runtimeArray)`, `get_defined_vars()`, and fully dynamic
+//!   variable-variable indirection. These are the residual fail-open risk,
+//!   documented at their sites as `KNOWN LIMITATION`s.
+//!
+//! Fail-closed (refuse unless a variable's *entire* reference set is provably
+//! plain `variable_name` tokens) was considered and rejected. It would over-refuse
+//! the ordinary, safe renames that are the feature's whole point — any variable
+//! merely *near* a construct the analyzer doesn't fully model would become
+//! unrenameable — to buy protection against the three deferred dynamic forms
+//! above, which are rare and undetectable from source either way. The denylist
+//! delivers the same corruption safety for every *detectable* shape without that
+//! over-refusal tax, so fail-open stays.
 
 use std::path::Path;
 use tree_sitter::Node;
@@ -303,6 +335,14 @@ fn scope_references_compact_extract(scope: Node, name: &str, bytes: &[u8]) -> bo
             if let Some(args) = n.child_by_field_name("arguments") {
                 let mut ac = args.walk();
                 for arg in args.named_children(&mut ac) {
+                    // KNOWN LIMITATION (#96): only the string-literal argument form
+                    // is matched here. The dynamic `extract($runtimeArray)` form
+                    // names its variables from a runtime array with no literal in
+                    // the source, so it is undetectable in a single file and the
+                    // rename is deliberately not refused for it — a deferred,
+                    // documented fail-open case, not a partial-edit corruption (no
+                    // source reference is stranded by the rename's own edits).
+                    //
                     // tree-sitter wraps each call argument in an `argument` node;
                     // the string literal is its last named child.
                     let expr = if arg.kind() == "argument" {
@@ -318,6 +358,81 @@ fn scope_references_compact_extract(scope: Node, name: &str, bytes: &[u8]) -> bo
                     {
                         return true;
                     }
+                }
+            }
+        }
+        let mut c = n.walk();
+        for child in n.children(&mut c) {
+            stack.push(child);
+        }
+    }
+    false
+}
+
+/// Whether the variable `name`, as bound in `scope`, is referenced by a
+/// `${'name'}` dynamic-variable expression over a **string literal** within that
+/// same scope. `${'name'}` evaluates to `$name`, but the name lives in a `string`
+/// node (the `dynamic_variable_name`'s child), not a `variable_name`, so a
+/// scope-local rename can't rewrite it — renaming `$name` while leaving
+/// `${'name'}` behind silently strands the reference. Refuse, mirroring
+/// [`scope_references_compact_extract`].
+///
+/// Only the string-literal form is caught. `$$name` is *also* a
+/// `dynamic_variable_name`, but its child is a real `variable_name`, not a string,
+/// so it is collected and renamed normally and must not be refused here — the
+/// `string_literal_content` check is what distinguishes the two.
+///
+/// Resolution-aware, exactly like the other guards: in a function/closure scope
+/// the reference counts iff a plain `$name` at that site would bind to the same
+/// scope (by node id); at the top-level `program` scope any matching reference in
+/// the file counts.
+fn scope_references_dynamic_string_var(scope: Node, name: &str, bytes: &[u8]) -> bool {
+    let program_scope = scope.kind() == "program";
+    let mut stack = vec![scope];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "dynamic_variable_name" {
+            if let Some(inner) = n.named_child(0) {
+                if string_literal_content(inner, bytes) == Some(name)
+                    && (program_scope || resolve_binding_scope(n, name, bytes).id() == scope.id())
+                {
+                    return true;
+                }
+            }
+        }
+        let mut c = n.walk();
+        for child in n.children(&mut c) {
+            stack.push(child);
+        }
+    }
+    false
+}
+
+/// Whether the variable `name`, bound at the top-level **program** scope, is also
+/// reached through the `$GLOBALS['name']` superglobal. `$GLOBALS` indexes the
+/// global symbol table by string key, so `$GLOBALS['name']` is an alias of the
+/// program-scope `$name` — the `global $name;` situation in different dress,
+/// except the key lives in a `string` node a scope-local rename can't rewrite.
+/// Renaming the program global while leaving `$GLOBALS['name']` behind strands the
+/// reference, so the engine refuses, mirroring [`scope_aliases_global`].
+///
+/// Only the program scope is affected: a function-local `$name` (with no `global`
+/// import) is a *different* binding from `$GLOBALS['name']`, so an unrelated
+/// superglobal access never over-refuses a genuine local. A `$GLOBALS['name']`
+/// access is itself spelled as a `subscript_expression` whose base is the
+/// `variable_name` `GLOBALS` and whose index is a string literal.
+fn scope_references_globals_array(scope: Node, name: &str, bytes: &[u8]) -> bool {
+    if scope.kind() != "program" {
+        return false;
+    }
+    let mut stack = vec![scope];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "subscript_expression" {
+            if let (Some(base), Some(index)) = (n.named_child(0), n.named_child(1)) {
+                if base.kind() == "variable_name"
+                    && var_ident(base, bytes) == Some("GLOBALS")
+                    && string_literal_content(index, bytes) == Some(name)
+                {
+                    return true;
                 }
             }
         }
@@ -369,16 +484,28 @@ fn renameable_variable_at<'t>(
     }
     // Refuse a variable whose binding scope references it in a way the rename
     // can't follow, where a scope-local edit would leave a dangling reference:
-    //  - `global $x;` aliases it to the top-level global, and
-    //  - `compact('x')` / `extract('x')` name it by string.
-    // Both are checked here (not in `is_collectible`) so the *whole* rename is
+    //  - `global $x;` aliases it to the top-level global,
+    //  - `compact('x')` / `extract('x')` name it by string,
+    //  - `${'x'}` names it via a dynamic-variable over a string literal, and
+    //  - `$GLOBALS['x']` aliases the top-level global via the superglobal array.
+    // All are checked here (not in `is_collectible`) so the *whole* rename is
     // refused regardless of where the cursor lands — collecting only the
     // in-scope `variable_name` occurrences while leaving the alias or the string
     // behind is the exact partial-rename corruption this guards against.
+    //
+    // KNOWN LIMITATION (#96): the *dynamic* sibling forms cannot be guarded
+    // because they carry no literal name in the source — `extract($runtimeArray)`
+    // (runtime keys), `get_defined_vars()` (exposes every in-scope local by its
+    // runtime name), and fully variable-variable indirection. These are deferred,
+    // documented fail-open cases: the rename proceeds and strands no *source*
+    // reference of its own; only a runtime relationship the engine cannot see
+    // from one file is affected.
     let name = var_ident(var_node, bytes)?;
     let scope = resolve_binding_scope(var_node, name, bytes);
     if scope_aliases_global(scope, name, bytes)
         || scope_references_compact_extract(scope, name, bytes)
+        || scope_references_dynamic_string_var(scope, name, bytes)
+        || scope_references_globals_array(scope, name, bytes)
     {
         return None;
     }

--- a/laravel-lsp/src/php_variable_rename/tests.rs
+++ b/laravel-lsp/src/php_variable_rename/tests.rs
@@ -638,6 +638,36 @@ function f() {
     );
 }
 
+/// Over-refusal guard for the `${'x'}` shape: a *function-local* `$x` whose only
+/// `${'x'}` reference lives in a *nested closure* binds to that closure, not the
+/// outer function. `scope_references_dynamic_string_var` is resolution-aware
+/// (it fires only when the `${'x'}` resolves to *this* scope), so an unrelated
+/// dynamic-string access in an inner scope must NOT block renaming the local.
+/// This is the FALSE arm of `dynamic_string_variable_reference_is_refused` — the
+/// companion to `function_local_is_renamable_despite_unrelated_globals_access`.
+#[test]
+fn function_local_is_renamable_despite_dynamic_string_in_inner_scope() {
+    let src = "\
+<?php
+function f() {
+    $x = 1;
+    $g = function () { return ${'x'}; };
+    return $x;
+}
+";
+    // `f`'s `$x` (assignment + return) renames; the `${'x'}` inside the closure
+    // resolves to the closure scope, a separate binding, so it is neither a
+    // blocker nor rewritten.
+    let targets = rename(src, "$x", 0, "$y");
+    assert_eq!(targets.len(), 2, "only the two function-local sites");
+    assert!(targets.iter().all(|t| t.new_text == "$y"));
+    let edited = edited_offsets(src, &targets);
+    assert!(
+        !edited.contains(&abs_byte_of_match(src, "${'x'}", 0)),
+        "the ${{'x'}} in the inner closure stays put"
+    );
+}
+
 /// Shape: `$GLOBALS['x']` (superglobal array access). CLASSIFICATION: REFUSE.
 /// `$GLOBALS['x']` aliases the program-scope global `$x` through a string key the
 /// rename can't rewrite. Before #96 the `scope_aliases_global` guard only saw

--- a/laravel-lsp/src/php_variable_rename/tests.rs
+++ b/laravel-lsp/src/php_variable_rename/tests.rs
@@ -601,3 +601,259 @@ fn abs_byte_of_match(source: &str, needle: &str, nth: usize) -> usize {
         .unwrap_or_else(|| panic!("occurrence {nth} of {needle:?} not found"))
         .0
 }
+
+// ── #96: full boundary of string-keyed & cross-scope reference shapes ──────
+//
+// One fixture per reference shape enumerated in issue #96, each tagged with its
+// classification:
+//   • REWRITE — the reference is a real `variable_name`; the rename rewrites it.
+//   • REFUSE  — the rename is rejected rather than emit a partial (corrupting) edit.
+//   • DEFER   — undetectable in source (no literal name); documented fail-open.
+// See the module-level "Engine default: fail-open with a complete denylist".
+
+/// Shape: `${'x'}` (dynamic variable over a string literal). CLASSIFICATION:
+/// REFUSE. `${'x'}` evaluates to `$x`, but the name sits in a `string` node, not
+/// a `variable_name`, so a scope-local rename can't rewrite it. Before #96 this
+/// silently corrupted (renamed `$x`, stranded `${'x'}`); it is now guarded by
+/// `scope_references_dynamic_string_var`.
+#[test]
+fn dynamic_string_variable_reference_is_refused() {
+    let src = "\
+<?php
+function f() {
+    $x = 1;
+    return ${'x'};
+}
+";
+    let byte = cursor_byte(src, "$x", 0);
+    assert!(
+        variable_at_cursor(src, byte).is_none(),
+        "prepare must refuse: ${{'x'}} reference can't be rewritten"
+    );
+    assert!(
+        variable_rename_targets(src, &PathBuf::from("t.php"), byte, "$y")
+            .unwrap()
+            .is_empty(),
+        "rename must be a no-op, not a partial edit"
+    );
+}
+
+/// Shape: `$GLOBALS['x']` (superglobal array access). CLASSIFICATION: REFUSE.
+/// `$GLOBALS['x']` aliases the program-scope global `$x` through a string key the
+/// rename can't rewrite. Before #96 the `scope_aliases_global` guard only saw
+/// `global $x;` declarations, so this silently corrupted; it is now guarded by
+/// `scope_references_globals_array`.
+#[test]
+fn globals_array_referenced_variable_is_refused() {
+    let src = "\
+<?php
+$x = 1;
+echo $GLOBALS['x'];
+";
+    let byte = cursor_byte(src, "$x", 0); // top-level `$x = 1`
+    assert!(
+        variable_at_cursor(src, byte).is_none(),
+        "prepare must refuse: $GLOBALS['x'] aliases the program global"
+    );
+    assert!(
+        variable_rename_targets(src, &PathBuf::from("t.php"), byte, "$y")
+            .unwrap()
+            .is_empty(),
+        "rename must be a no-op, not a partial edit"
+    );
+}
+
+/// Over-refusal guard for the `$GLOBALS` shape: a *function-local* `$x` is a
+/// different binding from `$GLOBALS['x']` (which always names the program
+/// global), so an unrelated superglobal access must NOT block renaming the local.
+#[test]
+fn function_local_is_renamable_despite_unrelated_globals_access() {
+    let src = "\
+<?php
+function f() {
+    $x = 1;
+    $GLOBALS['x'] = 2;
+    return $x;
+}
+";
+    // The local `$x` (assignment + return) renames; `$GLOBALS['x']` names the
+    // *global* `$x`, a separate binding, and is neither collected nor a blocker.
+    let targets = rename(src, "$x", 0, "$y");
+    assert_eq!(targets.len(), 2, "only the two function-local sites");
+    assert!(targets.iter().all(|t| t.new_text == "$y"));
+    let edited = edited_offsets(src, &targets);
+    assert!(
+        !edited.contains(&abs_byte_of_match(src, "$GLOBALS", 0)),
+        "the $GLOBALS superglobal token stays put"
+    );
+}
+
+/// Shape: `extract($runtimeArray)` (runtime keys, no string literal).
+/// CLASSIFICATION: DEFER. The variable names come from a runtime array with no
+/// literal in the source, so the reference is undetectable in one file. The
+/// rename proceeds — it strands no *source* reference of its own — and the
+/// deferral is recorded as a KNOWN LIMITATION in `php_variable_rename.rs`.
+#[test]
+fn extract_runtime_array_does_not_refuse_rename() {
+    let src = "\
+<?php
+function f($data) {
+    $x = 1;
+    extract($data);
+    return $x;
+}
+";
+    // Contrast with `extract('x')` (string literal → REFUSE): the dynamic form
+    // carries no detectable name, so the rename is allowed to proceed.
+    let targets = rename(src, "$x", 0, "$y");
+    assert_eq!(
+        targets.len(),
+        2,
+        "assignment + return — rename proceeds (deferred)"
+    );
+    assert!(targets.iter().all(|t| t.new_text == "$y"));
+}
+
+/// Shape: `get_defined_vars()`. CLASSIFICATION: DEFER. The call returns an array
+/// keyed by every in-scope variable's runtime name; there is no source reference
+/// to `$x` to detect or rewrite, so the rename proceeds. Recorded as a KNOWN
+/// LIMITATION in `php_variable_rename.rs`.
+#[test]
+fn get_defined_vars_does_not_refuse_rename() {
+    let src = "\
+<?php
+function f() {
+    $x = 1;
+    return get_defined_vars();
+}
+";
+    let targets = rename(src, "$x", 0, "$y");
+    assert_eq!(
+        targets.len(),
+        1,
+        "the single assignment — rename proceeds (deferred)"
+    );
+    assert!(targets.iter().all(|t| t.new_text == "$y"));
+}
+
+/// Shape: `$$name` (variable-variables). CLASSIFICATION: REWRITE. The inner
+/// `$name` is a real `variable_name` (wrapped in a `dynamic_variable_name`), so
+/// renaming `$name` rewrites every occurrence — the binding, the `$$name` use,
+/// and the return — leaving the outer `$$` wrapper syntactically valid (`$$key`).
+/// The value `$$name` dereferences at runtime is a separate, truly-dynamic
+/// concern, out of scope here. (Also proves the dynamic-string guard does not
+/// over-refuse `$$name`: its inner child is a `variable_name`, not a string.)
+#[test]
+fn variable_variables_inner_name_renames_safely() {
+    let src = "\
+<?php
+function f() {
+    $name = 'a';
+    $$name = 1;
+    return $name;
+}
+";
+    let targets = rename(src, "$name", 0, "$key");
+    assert_eq!(targets.len(), 3, "binding + inner $name of $$name + return");
+    for t in &targets {
+        assert_eq!(target_text(src, t), "$name");
+        assert_eq!(t.new_text, "$key");
+    }
+    // The `$$name` use is rewritten on its inner `$name` (one byte past the outer
+    // `$`), so `$$name` becomes `$$key` with the leading `$` wrapper untouched.
+    let edited = edited_offsets(src, &targets);
+    let inner_of_dollar_dollar = src.match_indices("$$name").next().unwrap().0 + 1;
+    assert!(
+        edited.contains(&inner_of_dollar_dollar),
+        "inner $name of $$name is rewritten"
+    );
+}
+
+/// Shape: string interpolation + heredoc (`"$x"`, `"{$x}"`, `<<<EOT $x EOT`).
+/// CLASSIFICATION: REWRITE. Interpolated variables parse as `variable_name` nodes
+/// inside the `encapsed_string` / `heredoc_body`, so the rename rewrites them; the
+/// heredoc delimiter (`EOT`) is a separate token, left untouched. A nowdoc
+/// (`<<<'EOT'`) does NOT interpolate — its `$x` is literal text (`nowdoc_string`)
+/// and must NOT be rewritten.
+#[test]
+fn interpolation_and_heredoc_are_rewritten_nowdoc_is_not() {
+    let src = "\
+<?php
+function f() {
+    $x = 1;
+    $a = \"Hello $x\";
+    $b = \"V {$x}\";
+    $h = <<<EOT
+val $x
+EOT;
+    $n = <<<'EOT'
+raw $x
+EOT;
+    return $a . $b . $h . $n;
+}
+";
+    let targets = rename(src, "$x", 0, "$y");
+    // assignment + "Hello $x" + "{$x}" + heredoc $x = 4 sites. The nowdoc `$x` is
+    // literal text and is NOT among them.
+    assert_eq!(targets.len(), 4, "assignment + 2 interpolations + heredoc");
+    for t in &targets {
+        assert_eq!(target_text(src, t), "$x");
+        assert_eq!(t.new_text, "$y");
+    }
+    // The nowdoc occurrence (5th `$x`, 0-based index 4) stays literal.
+    let edited = edited_offsets(src, &targets);
+    assert!(
+        !edited.contains(&abs_byte_of_match(src, "$x", 4)),
+        "nowdoc $x is literal, not rewritten"
+    );
+}
+
+/// Shape: by-reference positions (`&$x`). CLASSIFICATION: REWRITE. Whether `$x`
+/// is bound by a by-reference parameter (`function f(&$x)`) or passed by reference
+/// at a call site, the `$x` is a plain `variable_name` and the `&` is a separate
+/// `reference_modifier` token. The rename rewrites the `$x` occurrences and leaves
+/// every `&` intact.
+#[test]
+fn by_reference_positions_rename_and_keep_the_ampersand() {
+    // (a) by-reference PARAMETER — the idiomatic modern form.
+    let param_src = "\
+<?php
+function bump(&$counter) {
+    $counter = $counter + 1;
+    return $counter;
+}
+";
+    let targets = rename(param_src, "$counter", 0, "$total");
+    assert_eq!(targets.len(), 4, "by-ref param + three body uses");
+    for t in &targets {
+        assert_eq!(target_text(param_src, t), "$counter");
+        assert_eq!(t.new_text, "$total");
+    }
+    assert!(
+        !edited_offsets(param_src, &targets)
+            .contains(&param_src.match_indices('&').next().unwrap().0),
+        "the & reference marker is a separate token, never edited"
+    );
+
+    // (b) call-site `f(&$x)` (legacy call-time pass-by-reference). tree-sitter
+    // still parses it as `argument` → `reference_modifier` + `variable_name`, so
+    // the `$x` is collected and the `&` left intact, identical to (a).
+    let call_src = "\
+<?php
+function f() {
+    $x = 1;
+    process(&$x);
+    return $x;
+}
+";
+    let call_targets = rename(call_src, "$x", 0, "$y");
+    assert_eq!(call_targets.len(), 3, "assignment + &-arg + return");
+    for t in &call_targets {
+        assert_eq!(target_text(call_src, t), "$x");
+    }
+    assert!(
+        !edited_offsets(call_src, &call_targets)
+            .contains(&call_src.match_indices('&').next().unwrap().0),
+        "the & at the call site is untouched"
+    );
+}


### PR DESCRIPTION
## Summary
Implements #96 — the proactive discovery pass over the PHP `$variable` rename engine ([#87](https://github.com/mike-bronner/zed-laravel/issues/87) shipped the scope-aware core). Enumerates every reference shape a single-file scope-local rename can encounter, classifies each, closes the two latent silent-corruption paths it found, and records the fail-open-vs-fail-closed decision so the denylist stops being discovered one corruption at a time.

## Changes
- **Two new guards** (refuse rather than emit a partial edit that strands a string reference):
  - `scope_references_dynamic_string_var` — refuses `${'x'}` (dynamic variable over a string literal). `$$name` is deliberately *not* caught (its inner `$name` is a real `variable_name` and renames safely).
  - `scope_references_globals_array` — refuses `$GLOBALS['x']` at program scope (it aliases the global through a string key). Resolution-aware: a function-local `$x` with an unrelated `$GLOBALS['x']` still renames.
- **Two `// KNOWN LIMITATION` notes** at the relevant sites for the deferred dynamic forms — `extract($runtimeArray)` and `get_defined_vars()` — which carry no source literal and are undetectable in one file.
- **Module-doc decision** (`//!`): stay **fail-open** with a now-complete denylist, with the rationale for rejecting fail-closed.
- **Seven test fixtures**, one per shape, each tagged REWRITE / REFUSE / DEFER, plus an over-refusal guard test for `$GLOBALS`.

## Classification (the discovery result)
| Shape | Class | Behaviour |
|---|---|---|
| `${'x'}` (string-literal dynamic var) | **REFUSE** | was silent corruption → now guarded |
| `$GLOBALS['x']` | **REFUSE** | was silent corruption (only `global $x;` was guarded) → now guarded |
| `extract($runtimeArray)` | **DEFER** | no source literal — rename proceeds, documented |
| `get_defined_vars()` | **DEFER** | no source reference — rename proceeds, documented |
| `$$name` (variable-variables) | **REWRITE** | inner `$name` renamed, `$$` wrapper stays valid |
| heredoc / interpolation (`"$x"`, `"{$x}"`) | **REWRITE** | interpolated vars rewritten; nowdoc `$x` left literal; delimiter untouched |
| by-ref `f(&$x)` | **REWRITE** | `$x` rewritten, `&` reference token preserved |

## Acceptance Criteria
- [x] Test fixture for `${'x'}` — current behaviour asserted, classification recorded as a comment in `tests.rs`.
- [x] Test fixture for `$GLOBALS['x']` — corruption path exposed; guard added (`scope_references_globals_array`); now refused.
- [x] Test fixture for `extract($array)` runtime form — rename not refused; `// KNOWN LIMITATION` at the call site in `php_variable_rename.rs`.
- [x] Test fixture for `get_defined_vars()` — rename proceeds; `// KNOWN LIMITATION` documenting the undetectable reference.
- [x] Test fixture for `$$name` — inner `$name` rewritten correctly, `$$` wrapper valid.
- [x] Test fixture for heredoc / nowdoc with interpolation — interpolated vars rewritten, nowdoc left literal, delimiter untouched.
- [x] Test fixture for by-ref `f(&$x)` — `$x` collected and rewritten, `&` intact (by-ref param + call-site forms).
- [x] All seven shapes recorded in `tests.rs` with a REWRITE / REFUSE / DEFER comment.
- [x] Decision comment in the module `//!` doc: fail-open with rationale.
- [x] No silent-corruption paths left open — `${'x'}` and `$GLOBALS['x']` both guarded.

## Test Plan
- [x] `cargo test --lib php_variable_rename` — 33 passed (25 existing + 8 new).
- [x] `cargo test` (full lib) — 1768 passed. (8 pre-existing `integration_tests` failures are environmental — missing `test-project`/`.env` fixtures in a fresh clone — and fail identically on `main`, unrelated to this diff.)
- [x] `cargo fmt` clean, `cargo clippy --lib --tests` clean.

Fixes #96