### PR TITLE
Folio completion: add a handler-level test asserting Folio routes are offered

### DIFF
--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -1213,3 +1213,53 @@ fn normalize_path_unchanged_without_parent_dir() {
         PathBuf::from("/app/views/home.php")
     );
 }
+
+// ============================================================================
+// Folio pages surface through the handler-level index (issue #101)
+// ============================================================================
+//
+// `folio_discovery::inject_folio_routes` is unit-tested in
+// `folio_discovery/tests.rs`, but nothing exercised the layer the completion
+// handler actually reads: `build_route_index` over `discover_route_files`, the
+// same pair `rebuild_route_index` calls at runtime. `build_route_index`
+// injects Folio routes as its final step, so a named Folio page must surface in
+// the resulting `RouteIndex` — name, URI, and method — without any `Route::`
+// call. This guards the wiring above the unit test: a regression that dropped
+// the `inject_folio_routes` call (or mangled the entry) would fail here.
+
+#[test]
+fn folio_named_page_surfaces_in_handler_route_index() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // A project that uses Folio, with one named page at the default mount.
+    std::fs::write(
+        root.join("composer.json"),
+        r#"{"require": {"laravel/folio": "^1.0"}}"#,
+    )
+    .unwrap();
+    let page = root.join("resources/views/pages/users/[id].blade.php");
+    std::fs::create_dir_all(page.parent().unwrap()).unwrap();
+    std::fs::write(&page, "<?php name('users.show'); ?>").unwrap();
+
+    // Exactly what `rebuild_route_index` runs at runtime — discover the route
+    // files, then build the index over them. Folio injection happens inside
+    // `build_route_index`, so the page surfaces even though no `routes/` file
+    // (and thus no discovered route file) exists.
+    let index = build_route_index(root, &discover_route_files(root));
+
+    let route = index
+        .get("users.show")
+        .expect("named Folio route must surface via build_route_index");
+    // The name would be offered by `get_all_route_names()`, and goto resolves
+    // to the page file.
+    assert!(
+        route.file.ends_with("users/[id].blade.php"),
+        "Folio route must point at the page file, got {:?}",
+        route.file
+    );
+    // URI and method must be carried so a future regression that omits either
+    // is caught at this layer.
+    assert_eq!(route.uri.as_deref(), Some("/users/{id}"));
+    assert_eq!(route.method.as_deref(), Some("get"));
+}


### PR DESCRIPTION
## Summary
Implements #101 — adds a handler-level test asserting Laravel Folio routes are offered through the same index the completion handler reads.

`folio_discovery::inject_folio_routes` was unit-tested in isolation, but nothing exercised the layer above it: `build_route_index` over `discover_route_files` — the pair `rebuild_route_index` calls at runtime. A regression that dropped the `inject_folio_routes` call inside `build_route_index` (or mangled the entry) would not have been caught. This closes that gap.

## Changes
- Add `folio_named_page_surfaces_in_handler_route_index` to `laravel-lsp/src/route_discovery/tests.rs`, under a new "Folio pages surface through the handler-level index" section.
- The test builds a temp project (`composer.json` declaring `laravel/folio`, a named page `resources/views/pages/users/[id].blade.php` with `name('users.show')`), then calls `build_route_index(root, &discover_route_files(root))` and asserts the Folio route surfaces in the `RouteIndex` with the correct file, URI, and method.

## Acceptance Criteria
- [x] New test in `route_discovery/tests.rs` creates a temp project with `composer.json` declaring `laravel/folio` and a named Folio page (`users/[id].blade.php` with `name('users.show')`) under `resources/views/pages/`.
- [x] The test calls `build_route_index(&root, &discover_route_files(&root))` — the same call `rebuild_route_index` makes at runtime.
- [x] Asserts the named Folio route (`users.show`) is present in the resulting `RouteIndex`.
- [x] Asserts the entry carries the correct URI (`/users/{id}`) and `method = "get"`.
- [x] No unnamed-page test added — already covered by `discover_folio_routes_resolves_named_pages_default_mount`.

## Test Plan
- [x] New test passes: `cargo test folio_named_page_surfaces_in_handler_route_index`.
- [x] Full unit suite green: 2062 tests pass (`cargo test`).
- [x] `cargo fmt --check` clean; `cargo clippy --tests` clean.
- Note: 8 pre-existing `integration_tests` failures (`test-project/.env` fixture absent locally) fail identically on clean `main` — unrelated to this change.

Fixes #101