### PR TITLE
refactor: extract a generic dotted-name validator across view/livewire/component locators

### DIFF
--- a/laravel-lsp/src/component_declaration_locator.rs
+++ b/laravel-lsp/src/component_declaration_locator.rs
@@ -22,7 +22,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::naming;
+use crate::naming::{self, DottedNameError};
 use crate::salsa_impl::LaravelConfigData;
 
 /// Reasons a new component name was rejected.
@@ -63,33 +63,25 @@ impl ComponentNameError {
     }
 }
 
+impl From<DottedNameError> for ComponentNameError {
+    fn from(error: DottedNameError) -> Self {
+        match error {
+            DottedNameError::Empty => Self::Empty,
+            DottedNameError::Namespaced => Self::NamespacedNotSupported,
+            DottedNameError::ContainsSlash => Self::ContainsSlash,
+            DottedNameError::EmptySegment => Self::EmptySegment,
+            DottedNameError::HasExtension => Self::HasExtension,
+            DottedNameError::InvalidCharacter(c) => Self::InvalidCharacter(c),
+        }
+    }
+}
+
 /// Validate a user-typed new component name. Mirrors view-name rules plus an
 /// explicit refusal for `::` namespace prefixes.
 pub fn validate_component_name(name: &str) -> Result<(), ComponentNameError> {
-    let trimmed = name.trim();
-    if trimmed.is_empty() {
-        return Err(ComponentNameError::Empty);
-    }
-    if trimmed.contains("::") {
-        return Err(ComponentNameError::NamespacedNotSupported);
-    }
-    if trimmed.contains('/') || trimmed.contains('\\') {
-        return Err(ComponentNameError::ContainsSlash);
-    }
-    if trimmed.ends_with(".blade.php") || trimmed.ends_with(".blade") || trimmed.ends_with(".php") {
-        return Err(ComponentNameError::HasExtension);
-    }
-    for segment in trimmed.split('.') {
-        if segment.is_empty() {
-            return Err(ComponentNameError::EmptySegment);
-        }
-        for c in segment.chars() {
-            if !c.is_alphanumeric() && c != '-' && c != '_' {
-                return Err(ComponentNameError::InvalidCharacter(c));
-            }
-        }
-    }
-    Ok(())
+    // Blade-component renames refuse namespaced (`package::name`) targets up
+    // front, so the shared validator runs with the `::` check enabled.
+    naming::validate_dotted_name(name, true).map_err(ComponentNameError::from)
 }
 
 /// All the files participating in a discovered Blade-component definition,

--- a/laravel-lsp/src/livewire_declaration_locator.rs
+++ b/laravel-lsp/src/livewire_declaration_locator.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use crate::livewire_config::LivewireConfig;
 use crate::livewire_resolver::{resolve_component, LivewireComponent, LivewireComponentKind};
 use crate::livewire_version::LivewireVersion;
-use crate::naming;
+use crate::naming::{self, DottedNameError};
 
 /// Reasons a new Livewire-component name was rejected.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,32 +54,24 @@ impl LivewireNameError {
     }
 }
 
+impl From<DottedNameError> for LivewireNameError {
+    fn from(error: DottedNameError) -> Self {
+        match error {
+            DottedNameError::Empty => Self::Empty,
+            DottedNameError::Namespaced => Self::NamespacedNotSupported,
+            DottedNameError::ContainsSlash => Self::ContainsSlash,
+            DottedNameError::EmptySegment => Self::EmptySegment,
+            DottedNameError::HasExtension => Self::HasExtension,
+            DottedNameError::InvalidCharacter(c) => Self::InvalidCharacter(c),
+        }
+    }
+}
+
 /// Validate a user-typed new Livewire-component name.
 pub fn validate_livewire_name(name: &str) -> Result<(), LivewireNameError> {
-    let trimmed = name.trim();
-    if trimmed.is_empty() {
-        return Err(LivewireNameError::Empty);
-    }
-    if trimmed.contains("::") {
-        return Err(LivewireNameError::NamespacedNotSupported);
-    }
-    if trimmed.contains('/') || trimmed.contains('\\') {
-        return Err(LivewireNameError::ContainsSlash);
-    }
-    if trimmed.ends_with(".blade.php") || trimmed.ends_with(".blade") || trimmed.ends_with(".php") {
-        return Err(LivewireNameError::HasExtension);
-    }
-    for segment in trimmed.split('.') {
-        if segment.is_empty() {
-            return Err(LivewireNameError::EmptySegment);
-        }
-        for c in segment.chars() {
-            if !c.is_alphanumeric() && c != '-' && c != '_' {
-                return Err(LivewireNameError::InvalidCharacter(c));
-            }
-        }
-    }
-    Ok(())
+    // Livewire renames refuse namespaced (`package::name`) targets up front, so
+    // the shared validator runs with the `::` check enabled.
+    naming::validate_dotted_name(name, true).map_err(LivewireNameError::from)
 }
 
 /// All the artifacts participating in a discovered Livewire component,

--- a/laravel-lsp/src/naming.rs
+++ b/laravel-lsp/src/naming.rs
@@ -144,5 +144,77 @@ pub fn with_emoji(s: &str, enabled: bool) -> String {
     }
 }
 
+/// Reasons a dotted name (a view, Blade-component, or Livewire-component name)
+/// was rejected by [`validate_dotted_name`].
+///
+/// This is the single shared error vocabulary behind the three locators'
+/// `validate_*` functions. Each locator maps these back to its own
+/// noun-specific error type ([`crate::view_declaration_locator::ViewNameError`],
+/// [`crate::component_declaration_locator::ComponentNameError`],
+/// [`crate::livewire_declaration_locator::LivewireNameError`]) so user-facing
+/// message wording ("view name" / "component name" / "Livewire component name")
+/// stays per-noun. The variants here mirror that shared set; `Namespaced` is
+/// produced only when the caller opts in via `reject_namespaced`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DottedNameError {
+    /// The name was empty (or whitespace-only after trimming).
+    Empty,
+    /// The name carried a `::` namespace prefix (e.g. `package::view`). Only
+    /// produced when the caller passes `reject_namespaced = true`; otherwise
+    /// the `:` falls through to [`DottedNameError::InvalidCharacter`].
+    Namespaced,
+    /// The name used `/` or `\` where it should use `.` segment separators.
+    ContainsSlash,
+    /// The name carried a `.blade.php`, `.blade`, or `.php` file extension.
+    HasExtension,
+    /// A dotted segment was empty — a leading, trailing, or double dot.
+    EmptySegment,
+    /// A segment contained a character outside `[A-Za-z0-9_-]`.
+    InvalidCharacter(char),
+}
+
+/// Validate a user-typed dotted name (view / Blade-component / Livewire-component).
+///
+/// Returns `Ok(())` only when `name` is a well-formed dotted segment list — the
+/// shape Laravel's `view()` / Blade-component / Livewire resolution actually
+/// accepts at runtime. The check order is fixed so each rejection reports the
+/// most specific reason first: empty, then namespaced (opt-in), then slash,
+/// then extension, then a per-segment scan for empty segments and invalid
+/// characters.
+///
+/// `reject_namespaced` selects the one behavioural difference between the
+/// callers. The view locator passes `false` — it has no namespaced-rename
+/// support to refuse, so a `:` is reported as an invalid character. The Blade-
+/// and Livewire-component locators pass `true` — they refuse `package::name`
+/// up front with [`DottedNameError::Namespaced`] (their own
+/// `NamespacedNotSupported` variant) rather than letting it read as a stray
+/// invalid character.
+pub fn validate_dotted_name(name: &str, reject_namespaced: bool) -> Result<(), DottedNameError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(DottedNameError::Empty);
+    }
+    if reject_namespaced && trimmed.contains("::") {
+        return Err(DottedNameError::Namespaced);
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(DottedNameError::ContainsSlash);
+    }
+    if trimmed.ends_with(".blade.php") || trimmed.ends_with(".blade") || trimmed.ends_with(".php") {
+        return Err(DottedNameError::HasExtension);
+    }
+    for segment in trimmed.split('.') {
+        if segment.is_empty() {
+            return Err(DottedNameError::EmptySegment);
+        }
+        for c in segment.chars() {
+            if !c.is_alphanumeric() && c != '-' && c != '_' {
+                return Err(DottedNameError::InvalidCharacter(c));
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests;

--- a/laravel-lsp/src/naming/tests.rs
+++ b/laravel-lsp/src/naming/tests.rs
@@ -164,3 +164,93 @@ fn with_emoji_no_double_prefix() {
 fn with_emoji_disabled_on_plain_is_noop() {
     assert_eq!(with_emoji("create", false), "create");
 }
+
+// ---------- validate_dotted_name (shared validator) ----------
+
+#[test]
+fn validate_dotted_accepts_simple_and_nested_names() {
+    assert_eq!(validate_dotted_name("welcome", false), Ok(()));
+    assert_eq!(validate_dotted_name("admin.user-list", true), Ok(()));
+    assert_eq!(validate_dotted_name("admin.user_list", false), Ok(()));
+}
+
+#[test]
+fn validate_dotted_trims_before_checking() {
+    assert_eq!(validate_dotted_name("  users.profile  ", false), Ok(()));
+}
+
+#[test]
+fn validate_dotted_rejects_empty() {
+    assert_eq!(validate_dotted_name("", false), Err(DottedNameError::Empty));
+    assert_eq!(
+        validate_dotted_name("   ", true),
+        Err(DottedNameError::Empty)
+    );
+}
+
+#[test]
+fn validate_dotted_rejects_namespaced_only_when_opted_in() {
+    // reject_namespaced = true → the `::` is caught before the segment scan.
+    assert_eq!(
+        validate_dotted_name("billing::invoice", true),
+        Err(DottedNameError::Namespaced)
+    );
+    // reject_namespaced = false → the `:` falls through as an invalid character
+    // (the view locator relies on this).
+    assert_eq!(
+        validate_dotted_name("billing::invoice", false),
+        Err(DottedNameError::InvalidCharacter(':'))
+    );
+}
+
+#[test]
+fn validate_dotted_rejects_slashes() {
+    assert_eq!(
+        validate_dotted_name("users/profile", false),
+        Err(DottedNameError::ContainsSlash)
+    );
+    assert_eq!(
+        validate_dotted_name("users\\profile", true),
+        Err(DottedNameError::ContainsSlash)
+    );
+}
+
+#[test]
+fn validate_dotted_rejects_extensions() {
+    for name in ["a.blade.php", "a.blade", "a.php"] {
+        assert_eq!(
+            validate_dotted_name(name, false),
+            Err(DottedNameError::HasExtension),
+            "expected HasExtension for {name:?}"
+        );
+    }
+}
+
+#[test]
+fn validate_dotted_rejects_empty_segments() {
+    // Leading, trailing, and double-dot all collapse to EmptySegment.
+    assert_eq!(
+        validate_dotted_name(".users", false),
+        Err(DottedNameError::EmptySegment)
+    );
+    assert_eq!(
+        validate_dotted_name("users.", false),
+        Err(DottedNameError::EmptySegment)
+    );
+    assert_eq!(
+        validate_dotted_name("users..profile", true),
+        Err(DottedNameError::EmptySegment)
+    );
+}
+
+#[test]
+fn validate_dotted_rejects_invalid_characters() {
+    assert_eq!(
+        validate_dotted_name("users profile", false),
+        Err(DottedNameError::InvalidCharacter(' '))
+    );
+    assert_eq!(
+        validate_dotted_name("users@profile", true),
+        Err(DottedNameError::InvalidCharacter('@'))
+    );
+}

--- a/laravel-lsp/src/view_declaration_locator.rs
+++ b/laravel-lsp/src/view_declaration_locator.rs
@@ -13,6 +13,7 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::naming::{self, DottedNameError};
 use crate::salsa_impl::LaravelConfigData;
 
 /// Reasons a new view name was rejected. Each variant carries the data
@@ -51,6 +52,23 @@ impl ViewNameError {
     }
 }
 
+impl From<DottedNameError> for ViewNameError {
+    fn from(error: DottedNameError) -> Self {
+        match error {
+            DottedNameError::Empty => Self::Empty,
+            DottedNameError::ContainsSlash => Self::ContainsSlash,
+            DottedNameError::EmptySegment => Self::EmptySegment,
+            DottedNameError::HasExtension => Self::HasExtension,
+            DottedNameError::InvalidCharacter(c) => Self::InvalidCharacter(c),
+            // View names don't support namespaced renames, so `validate_view_name`
+            // never opts into the `::` check (it passes `reject_namespaced = false`)
+            // and this arm is unreachable in practice. Map it defensively to the
+            // invalid-character reason a bare `:` would otherwise produce.
+            DottedNameError::Namespaced => Self::InvalidCharacter(':'),
+        }
+    }
+}
+
 /// Validate a user-typed new view name. Returns `Ok(())` only when the name
 /// is a well-formed dotted segment list — what Laravel's `view()` helper
 /// actually resolves at runtime.
@@ -62,27 +80,10 @@ impl ViewNameError {
 /// rather than mis-resolving it. Supporting `package::view` would mean parsing
 /// the namespace segment against the registered view hints — a separate change.
 pub fn validate_view_name(name: &str) -> Result<(), ViewNameError> {
-    let trimmed = name.trim();
-    if trimmed.is_empty() {
-        return Err(ViewNameError::Empty);
-    }
-    if trimmed.contains('/') || trimmed.contains('\\') {
-        return Err(ViewNameError::ContainsSlash);
-    }
-    if trimmed.ends_with(".blade.php") || trimmed.ends_with(".blade") || trimmed.ends_with(".php") {
-        return Err(ViewNameError::HasExtension);
-    }
-    for segment in trimmed.split('.') {
-        if segment.is_empty() {
-            return Err(ViewNameError::EmptySegment);
-        }
-        for c in segment.chars() {
-            if !c.is_alphanumeric() && c != '-' && c != '_' {
-                return Err(ViewNameError::InvalidCharacter(c));
-            }
-        }
-    }
-    Ok(())
+    // View renames don't support namespaced (`package::view`) targets, so the
+    // shared validator runs without the `::` check — a `:` reads as an invalid
+    // character, matching this locator's historical behaviour.
+    naming::validate_dotted_name(name, false).map_err(ViewNameError::from)
 }
 
 /// Find the on-disk `.blade.php` file backing a dotted view name. Walks


### PR DESCRIPTION
## Summary
Implements #115 — collapses the three structurally-identical name validators in the view, Blade-component, and Livewire-component locators into a single shared routine in `naming.rs`.

## Changes
- **`naming.rs`**: new `DottedNameError` enum + `validate_dotted_name(name, reject_namespaced)` — the single shared dotted-name validator (trim → empty → namespaced (opt-in) → slash → extension → per-segment empty/invalid-char scan).
- **`view_declaration_locator.rs`**: `validate_view_name` now delegates with `reject_namespaced = false`; `ViewNameError` gains a `From<DottedNameError>` mapping.
- **`livewire_declaration_locator.rs`** / **`component_declaration_locator.rs`**: `validate_*` delegate with `reject_namespaced = true`; each error enum gains a `From<DottedNameError>` mapping (`Namespaced → NamespacedNotSupported`).
- The per-locator `*NameError` enums, their variants, `.message()` wording, and public `validate_*` signatures are all unchanged — only the duplicated control flow is removed.
- Added 7 direct unit tests for `validate_dotted_name` in `naming/tests.rs` covering both `reject_namespaced` modes and every rejection reason.

## Acceptance Criteria
- [x] A single shared dotted-name validation routine extracted into `naming.rs`, replacing the duplicated logic in `validate_view_name`, `validate_livewire_name`, and `validate_component_name`
- [x] The `NamespacedNotSupported` variant (absent from `ViewNameError`) handled without regressing — via the `reject_namespaced` parameter + `DottedNameError::Namespaced`, mapped per-locator through `From`
- [x] Shared error type preserves per-noun message wording (`view name` / `Livewire component name` / `component name`) — the existing enums and `.message()` are untouched
- [x] All three locators' existing validator tests pass unchanged — including `rejects_double_dot_segment_break` (view) and `rejects_empty_segment` (component/livewire) still asserting `EmptySegment` for `..`
- [x] No behavioural change to any validation outcome (empty, slash, empty-segment, extension, invalid-character)
- [x] `cargo check`, `cargo clippy`, and `cargo fmt --check` are clean

## Test Plan
- [x] All existing tests pass — `cargo test --lib`: **1768 passed, 0 failed**
- [x] New tests cover the shared validator (both `reject_namespaced` modes, all rejection reasons)
- [x] `cargo fmt --check` clean, `cargo clippy --lib` clean (only pre-existing build-script grammar-download notes)

Fixes #115