### PR TITLE
Test: add a prepare_rename handler-level dispatch test for a Folio .blade.php name('...') cursor

### DIFF
--- a/laravel-lsp/src/tests/folio_rename.rs
+++ b/laravel-lsp/src/tests/folio_rename.rs
@@ -29,8 +29,10 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
-use tower_lsp::lsp_types::{Position, Range, Url};
-use tower_lsp::LspService;
+use tower_lsp::lsp_types::{
+    Position, PrepareRenameResponse, Range, TextDocumentIdentifier, TextDocumentPositionParams, Url,
+};
+use tower_lsp::{LanguageServer, LspService};
 
 /// `<?php name('contact'); ?>` — the `contact` argument content occupies columns
 /// 12..=18, so its quote-excluded span is start 12, end 19. A cursor at column
@@ -133,6 +135,54 @@ async fn decl_range_at_returns_none_when_cursor_off_the_name_call() {
     .await;
 
     assert_eq!(range, None);
+}
+
+#[tokio::test]
+async fn prepare_rename_handler_dispatches_a_folio_name_cursor_to_a_valid_range() {
+    // Handler-level dispatch guard (issue #142, follow-up to #100 / PR #138).
+    //
+    // The tests above drive `decl_range_at` directly — the unit that computes the
+    // range. This one drives the whole `prepare_rename` HANDLER, pinning the
+    // dispatch glue that wires that range to a Folio cursor. The seam: a Folio
+    // page is a `.blade.php` file, so the handler's `.blade.php` early-return runs
+    // `prepare_blade_var_rename` FIRST (main.rs). The Folio rename only works
+    // because that helper returns `None` for a `name('...')` cursor — there is no
+    // `$variable` under the cursor — letting execution fall through to
+    // `classify_with_decl_fallback` → `decl_range_at`'s Folio fallback. A future
+    // change to the Blade var/scope rename path that began intercepting a Folio
+    // cursor would silently break rename with no red test; this is that test.
+    let root = TempDir::new().unwrap();
+    let server = test_server();
+    let page = seed_page(&server, root.path(), "contact").await;
+
+    let params = TextDocumentPositionParams {
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&page).unwrap(),
+        },
+        position: CURSOR,
+    };
+
+    let response = server
+        .prepare_rename(params)
+        .await
+        .expect("prepare_rename must not error for a Folio name('...') cursor")
+        .expect("the handler must offer a rename range, not fall through to None");
+
+    assert_eq!(
+        response,
+        PrepareRenameResponse::Range(Range {
+            start: Position {
+                line: 0,
+                character: NAME_START,
+            },
+            end: Position {
+                line: 0,
+                character: NAME_END,
+            },
+        }),
+        "the handler must return the quote-excluded `contact` span (start 12, end 19), \
+         proving the .blade.php early-return fell through to the Folio decl path"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Adds a handler-level dispatch test for `prepare_rename` on a Folio `.blade.php` page, pinning the glue that the existing `decl_range_at` unit tests don't cover. Follow-up from Holmes's review of #100 (PR #138).

## Changes
- Add `prepare_rename_handler_dispatches_a_folio_name_cursor_to_a_valid_range` to `laravel-lsp/src/tests/folio_rename.rs`, driving the `prepare_rename` handler directly on a seeded `LaravelLanguageServer` (no production code change).
- The test reuses the file's existing `seed_page` fixture and `CURSOR` constant; it asserts the handler returns `PrepareRenameResponse::Range` over the quote-excluded `contact` span.

## Why
A Folio page is a `.blade.php` file, so the handler's `.blade.php` early-return runs `prepare_blade_var_rename` first. The Folio rename only works because that helper returns `None` for a `name('...')` cursor, letting execution fall through to `classify_with_decl_fallback` → `decl_range_at`'s Folio fallback. The range math was already covered; this guards the dispatch path so a future Blade var/scope change can't silently intercept a Folio rename with no red test.

## Acceptance Criteria
- [x] A new `#[tokio::test]` drives `prepare_rename` at the dispatch level — calling `prepare_rename` directly on a `LaravelLanguageServer` (not `decl_range_at` alone)
- [x] Seeds a Folio page at a `.blade.php` path with `name('contact')` + a route-index entry for `contact` (existing `seed_page` fixture)
- [x] Cursor positioned inside the `contact` argument string (`Position { line: 0, character: 13 }` via `CURSOR`)
- [x] Asserts `PrepareRenameResponse::Range` with start column 12, end column 19 (quote-excluded `contact` span)
- [x] Test name + inline comment document the regression guarded (blade-var early-return returns `None` → falls through; future Blade-path change can't silently intercept)
- [x] `mod folio_rename;` present in `laravel-lsp/src/tests/mod.rs` (confirmed unchanged)
- [x] `cargo test` passes with the new test in the default suite (no `#[ignore]`)

## Test Plan
- [x] New test passes (`cargo test --bin laravel-lsp prepare_rename_handler_dispatches...`)
- [x] Full `folio_rename` module green (8 tests)
- [x] Full bin unit suites green (1760 + 302)
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean
- [x] Integration tests green where reachable locally (the env/`vendor/` fixtures are CI-bootstrapped per `.github/workflows/ci.yml`)

Fixes #142