### PR TITLE
Test the canonicalize drop-leg of resolve_component_path's root-containment backstop (symlink escape)

### DIFF
--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -625,6 +625,104 @@ fn unregistered_anonymous_prefix_does_not_borrow_registered_directory() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn symlink_escaping_candidate_is_dropped_by_canonicalize_backstop() {
+    // Issue #152: the canonicalize *drop*-leg of the root-containment backstop.
+    //
+    // The backstop in `resolve_component_path` has two arms (PR #150):
+    //
+    //     paths.retain(|path| match (path.canonicalize(), &canonical_root) {
+    //         (Ok(real_path), Ok(real_root)) => real_path.starts_with(real_root), // canonicalize
+    //         _ => normalize_path(path).starts_with(&self.root),                  // textual fallback
+    //     });
+    //
+    // Every #109 test runs against a fictional `/project` root, so its candidates
+    // never exist on disk and only the *textual-fallback* `_` arm ever fires. The
+    // canonicalize *keep*-leg (an in-root path that exists) is covered by the
+    // `TempDir` tests, but the *drop*-leg is not: a candidate that EXISTS on disk
+    // yet, once `canonicalize()` resolves its symlinks, points OUTSIDE the project
+    // root — a symlink escape (`{root}/vendor/evil` → an out-of-root directory).
+    // This pins that drop-leg. The registered directory is lexically in-root, so
+    // it sails past the textual guard; only canonicalization reveals the escape.
+    use std::os::unix::fs::symlink;
+
+    // A real project root, plus a second tempdir OUTSIDE it standing in for the
+    // attacker-controlled target (the moral equivalent of `/etc`).
+    let (_dir, root) = project_with_files(&[]);
+    let outside = TempDir::new().unwrap();
+
+    // A real component file inside the out-of-root target, so the candidate built
+    // through the symlink EXISTS on disk and `path.canonicalize()` returns
+    // `Ok(real_path)` — exercising the canonicalize arm, not the `_` fallback.
+    std::fs::write(
+        outside.path().join("widget.blade.php"),
+        "<div>escaped</div>\n",
+    )
+    .unwrap();
+
+    // Symlink an in-root path (`{root}/vendor/evil`) at the out-of-root target,
+    // then register THAT in-root directory as the `evil` anonymousComponentPath.
+    std::fs::create_dir_all(root.join("vendor")).unwrap();
+    let symlinked = root.join("vendor/evil");
+    symlink(outside.path(), &symlinked).unwrap();
+
+    let mut anon = HashMap::new();
+    anon.insert("evil".to_string(), symlinked.clone());
+    let config = LaravelConfigData {
+        root: root.clone(),
+        view_paths: vec![PathBuf::from("resources/views")],
+        component_paths: Vec::new(),
+        livewire_path: None,
+        has_livewire: false,
+        view_namespaces: HashMap::new(),
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths: anon,
+        anonymous_component_namespaces: HashMap::new(),
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+        class_component_files: HashMap::new(),
+    };
+
+    // Precondition: the escaping candidate really does exist on disk (via the
+    // symlink), so `canonicalize()` returns Ok and the canonicalize arm — not the
+    // textual fallback — is what must drop it. Guards against a vacuous pass.
+    let escaping = symlinked.join("widget.blade.php");
+    assert!(
+        escaping.exists(),
+        "precondition: the symlink-escaping candidate must exist on disk so \
+         `canonicalize()` returns Ok and the canonicalize arm runs: {:?}",
+        escaping,
+    );
+
+    let paths = config.resolve_component_path("evil::widget");
+
+    // The canonicalize drop-leg must remove every candidate whose canonicalized
+    // form escapes the project root. Non-existent speculative candidates can't be
+    // canonicalized and are treated as in-root (the textual fallback keeps them).
+    let canonical_root = root.canonicalize().unwrap();
+    assert!(
+        paths.iter().all(|p| match p.canonicalize() {
+            Ok(real) => real.starts_with(&canonical_root),
+            Err(_) => true,
+        }),
+        "every on-disk candidate must canonicalize inside the project root; a \
+         symlink-escaping candidate leaked: {:?}",
+        paths,
+    );
+
+    // Specifically, the candidate that escapes via the symlink must be gone —
+    // this is the drop-leg firing, not merely the absence of any candidate. We do
+    // NOT assert the result is empty: in-root vendor-publish guesses survive via
+    // the textual fallback.
+    assert!(
+        !paths.contains(&escaping),
+        "the symlink-escaping candidate must be dropped by the canonicalize \
+         backstop: {:?}",
+        paths,
+    );
+}
+
 // ─── PHP path-expression resolution ─────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Implements #152 — adds a regression test for the **canonicalize *drop*-leg** of the root-containment backstop in `LaravelConfigData::resolve_component_path`.

The backstop has two arms (PR #150):

```rust
paths.retain(|path| match (path.canonicalize(), &canonical_root) {
    (Ok(real_path), Ok(real_root)) => real_path.starts_with(real_root), // canonicalize arm
    _ => normalize_path(path).starts_with(&self.root),                  // textual fallback
});
```

Every #109 test runs against a fictional `/project` root, so candidates never exist on disk and only the *textual-fallback* arm fires. The canonicalize *keep*-leg is covered by the existing `TempDir` tests, but the *drop*-leg — a candidate that exists on disk yet canonicalizes **outside** the project root via a symlink escape — was untested. This PR closes that gap.

## Changes
- Added `#[cfg(unix)]` test `symlink_escaping_candidate_is_dropped_by_canonicalize_backstop` in `laravel-lsp/src/salsa_impl/tests.rs`.
- The test builds a `TempDir` project root + a second out-of-root `TempDir`, writes a real `widget.blade.php` in the out-of-root dir, symlinks `{root}/vendor/evil` → the out-of-root dir (`std::os::unix::fs::symlink`), registers the in-root symlink path as an `anonymousComponentPath`, resolves `evil::widget`, and asserts the symlink-escaping candidate is dropped while in-root speculative guesses survive.

## Acceptance Criteria
- [x] A `#[cfg(unix)]` test named `symlink_escaping_candidate_is_dropped_by_canonicalize_backstop` lives in `laravel-lsp/src/salsa_impl/tests.rs`
- [x] The test creates a `TempDir` project root (via `project_with_files`) and a second `TempDir` as the real out-of-root target directory
- [x] A real file is written inside the out-of-root directory so the candidate path exists on disk (forcing `path.canonicalize()` to return `Ok(real_path)`, exercising the canonicalize arm)
- [x] A symlink is created at `{project_root}/vendor/evil` pointing to the out-of-root `TempDir`, using `std::os::unix::fs::symlink`
- [x] The symlinked directory is registered as an `anonymousComponentPath` (with `root` set to the real `TempDir` root)
- [x] `resolve_component_path` is called with `"evil::widget"`
- [x] The test asserts the returned candidates contain no path whose canonicalized form escapes the project root
- [x] The test does **not** assert that all candidates are empty — only that escaping candidates are absent
- [x] `cargo test --lib` passes with the new test included (1761 passed)
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` remain clean

## Test Plan
- [x] `cargo test --lib` — 1761 passed, 0 failed
- [x] New test `symlink_escaping_candidate_is_dropped_by_canonicalize_backstop` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

Fixes #152