### PR TITLE
test: assert EmptySegment for a `..` double-dot livewire name (symmetry with view locator)

### DIFF
--- a/laravel-lsp/src/livewire_declaration_locator/tests.rs
+++ b/laravel-lsp/src/livewire_declaration_locator/tests.rs
@@ -72,6 +72,16 @@ fn rejects_empty_segment() {
     );
 }
 
+#[test]
+fn rejects_double_dot_segment_break() {
+    // "users..profile" splits to ["users", "", "profile"] — empty middle
+    // segment, caught before we ever look at the chars.
+    assert_eq!(
+        validate_livewire_name("users..profile"),
+        Err(LivewireNameError::EmptySegment)
+    );
+}
+
 // ---------- locate (V4 SFC) ----------
 
 #[test]


### PR DESCRIPTION
## Summary
Implements #172 — gives the livewire declaration locator a direct, symmetric assertion that a `..` double-dot name is rejected as an empty segment, mirroring the view locator's existing `rejects_double_dot_segment_break` test. Previously the `..`-via-livewire path was only covered indirectly through the shared `validate_dotted_name` test in `naming/tests.rs`; a future regression in the livewire mapping for double-dot input would not have been caught by livewire's own test module.

## Changes
- Added `rejects_double_dot_segment_break` to `laravel-lsp/src/livewire_declaration_locator/tests.rs`, in the `// ---------- validate_livewire_name ----------` section alongside the existing `rejects_empty_segment` test. It asserts `validate_livewire_name("users..profile")` returns `Err(LivewireNameError::EmptySegment)`, mirroring the view sibling (including the explanatory comment).
- Audited `component_declaration_locator/tests.rs`: the double-dot case is **already** covered directly by its existing `rejects_empty_segment` test (`"forms..input"` → `ComponentNameError::EmptySegment`). No change required there.

## Acceptance Criteria
- [x] Add a `rejects_double_dot_segment_break` test in `laravel-lsp/src/livewire_declaration_locator/tests.rs` that calls `validate_livewire_name` with a double-dot input (`"users..profile"`) and asserts `Err(LivewireNameError::EmptySegment)`
- [x] The new test lives in the `// ---------- validate_livewire_name ----------` section alongside the existing `rejects_empty_segment` test
- [x] The existing `rejects_empty_segment` test (leading-dot `".counter"` case) remains unchanged
- [x] Audit `component_declaration_locator/tests.rs` for the same gap and confirm it is already covered by its existing `rejects_empty_segment` test (`"forms..input"`) — no code change required there
- [x] No production code changes — test file only
- [x] All existing tests in all three locator test modules pass unchanged

## Test Plan
- [x] `cargo test --lib` — **1779 passed, 0 failed** (all three locator test modules green, including the new test)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --tests` — clean
- [x] Pre-existing integration-test failures in `tests/integration_tests.rs` (env/routes/architecture fixtures) are unrelated — they fail identically on `main` with this change stashed, and this PR touches no production code.

Fixes #172