### PR TITLE
Use unique TempDir in route_discovery tests instead of fixed shared temp paths

### DIFF
--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -143,14 +143,12 @@ fn route_index_keeps_lower_when_higher_does_not_redefine() {
 
 #[test]
 fn file_registers_named_routes_detects_macro_file() {
-    let dir = std::env::temp_dir().join("laravel-lsp-route-test");
-    let _ = std::fs::create_dir_all(&dir);
-    let path = dir.join("AuthRouteMethods.php");
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("AuthRouteMethods.php");
     let src = "<?php\nclass X {\n  public function auth() {\n    return function () {\n      $this->get('login')->name('login');\n    };\n  }\n}\n";
     std::fs::write(&path, src).unwrap();
 
     assert!(file_registers_named_routes(&path));
-    let _ = std::fs::remove_file(&path);
 }
 
 #[test]
@@ -187,13 +185,11 @@ fn content_registers_named_routes_rejects_only_name_calls() {
 
 #[test]
 fn file_registers_named_routes_rejects_unrelated_php() {
-    let dir = std::env::temp_dir().join("laravel-lsp-route-test-2");
-    let _ = std::fs::create_dir_all(&dir);
-    let path = dir.join("Plain.php");
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("Plain.php");
     std::fs::write(&path, "<?php\nclass Plain { public $name = 'x'; }\n").unwrap();
 
     assert!(!file_registers_named_routes(&path));
-    let _ = std::fs::remove_file(&path);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Implements #169 — switches the two `route_discovery` file tests that built fixtures under a fixed, shared temp directory to per-run `TempDir::new()`, matching the rest of the suite.

## Changes
- `file_registers_named_routes_detects_macro_file` (tests.rs ~146): `std::env::temp_dir().join("laravel-lsp-route-test")` → `TempDir::new()`.
- `file_registers_named_routes_rejects_unrelated_php` (tests.rs ~190): `std::env::temp_dir().join("laravel-lsp-route-test-2")` → `TempDir::new()`.
- Dropped the manual `std::fs::create_dir_all` and `std::fs::remove_file` calls in both — `TempDir` creates the dir and recursively cleans up on drop.
- Reuses the existing `use tempfile::TempDir` import (tests.rs:552, in scope for the whole `mod tests`); no new dependencies.

## Acceptance Criteria
- [x] `file_registers_named_routes_detects_macro_file` uses `TempDir::new()` instead of the fixed shared path
- [x] `file_registers_named_routes_rejects_unrelated_php` uses `TempDir::new()` instead of the fixed shared path
- [x] Both tests no longer call `std::fs::create_dir_all` or manually remove the temp file — `TempDir` handles creation and cleanup on drop
- [x] The existing `use tempfile::TempDir` import is reused — no new dependencies
- [x] `cargo test` passes with route_discovery tests green under `--test-threads=N` (N > 1) — no parallel-run collision

## Test Plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests` clean (no lint warnings)
- [x] `cargo test --lib route_discovery -- --test-threads=8` → 67 passed, 0 failed
- [x] Full suite: `cargo test --lib` → 1778 passed, 0 failed

Fixes #169