### PR TITLE
feat: Alpine.js support (directive/magic completion + hover, @event disambiguation; JS-resolution as follow-up)

### DIFF
--- a/laravel-lsp/src/alpine.rs
+++ b/laravel-lsp/src/alpine.rs
@@ -371,7 +371,7 @@ fn attr_word_before(before: &str, cursor: usize) -> (usize, &str) {
 /// attribute position.
 pub fn directive_completion_context(line: &str, cursor_col: u32) -> Option<AlpineContext> {
     let cursor = cursor_col as usize;
-    if cursor == 0 || cursor > line.len() {
+    if cursor == 0 || cursor > line.len() || !line.is_char_boundary(cursor) {
         return None;
     }
     let before = &line[..cursor];
@@ -437,7 +437,7 @@ fn in_alpine_expression(before: &str) -> bool {
 /// expression, so ordinary Blade/PHP `$variables` are never hijacked.
 pub fn magic_completion_context(line: &str, cursor_col: u32) -> Option<AlpineContext> {
     let cursor = cursor_col as usize;
-    if cursor == 0 || cursor > line.len() {
+    if cursor == 0 || cursor > line.len() || !line.is_char_boundary(cursor) {
         return None;
     }
     let before = &line[..cursor];
@@ -495,7 +495,7 @@ fn token_at(line: &str, cursor: usize, pred: impl Fn(char) -> bool) -> (usize, &
 /// `@event` / `:bind` shorthands) and `$`-magics inside Alpine expressions.
 pub fn hover_at(line: &str, character: u32) -> Option<String> {
     let cursor = character as usize;
-    if cursor > line.len() {
+    if cursor > line.len() || !line.is_char_boundary(cursor) {
         return None;
     }
     directive_hover_at(line, cursor).or_else(|| magic_hover_at(line, cursor))

--- a/laravel-lsp/src/alpine.rs
+++ b/laravel-lsp/src/alpine.rs
@@ -266,6 +266,27 @@ pub fn matching_events(prefix: &str) -> Vec<&'static str> {
         .collect()
 }
 
+/// Alpine events matching `prefix` that are safe to *add* to a Blade
+/// `@`-directive completion list, given the Blade directive names already
+/// offered (`blade_names`, matched case-insensitively).
+///
+/// A name can be **both** a Blade directive and an Alpine event — `error` is
+/// the live example: Laravel's compiler exposes `@error … @enderror`, and
+/// `error` is also a DOM event. Without deduping, `@err` would surface two
+/// `@error` entries (issue #61, AC5). The Blade directive wins — it reflects a
+/// directive that is actually registered in the project — so its event twin is
+/// dropped here, leaving exactly one `@error` in the merged list.
+pub fn mergeable_events(prefix: &str, blade_names: &[&str]) -> Vec<&'static str> {
+    let taken: std::collections::HashSet<String> =
+        blade_names.iter().map(|n| n.to_lowercase()).collect();
+    // `ALPINE_EVENTS` are already lowercase, so comparing against the lowercased
+    // Blade names is a straight set membership test.
+    matching_events(prefix)
+        .into_iter()
+        .filter(|ev| !taken.contains(*ev))
+        .collect()
+}
+
 /// Render a hover card for a directive by bare name, or `None` if unknown.
 pub fn directive_card(name: &str) -> Option<String> {
     entry_card(directive(name)?)

--- a/laravel-lsp/src/alpine.rs
+++ b/laravel-lsp/src/alpine.rs
@@ -1,0 +1,514 @@
+//! Alpine.js Tier-A support: static catalogs plus line-local context detection
+//! for directive/magic completion, hover cards, and `@event`-vs-Blade
+//! disambiguation.
+//!
+//! Alpine lives in HTML *attributes* inside Blade markup — directive names like
+//! `x-data` / `x-on:click`, the `@`/`:` shorthands, and `$`-prefixed magics
+//! inside the JS expressions in attribute values. None of that is PHP or Blade,
+//! so the static-analysis the rest of this LSP does doesn't reach it. This
+//! module supplies exactly the Tier-A surface: a curated catalog of the core
+//! directives and magics (no JS scanning, no goto), the context predicates the
+//! completion/hover handlers need, and the predicate the Blade directive
+//! highlighter uses to keep `@click="…"` from being mistaken for a Blade
+//! `@directive`.
+//!
+//! Everything here is pure and line-local so it can be unit-tested directly,
+//! mirroring `component_completion` — the handlers in `main.rs` only render the
+//! results into LSP types.
+
+use crate::hover::{render, source_link, HoverContent};
+
+/// One catalog entry — a directive (`x-data`) or magic (`$store`) with a
+/// one-line synopsis and its canonical docs anchor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlpineEntry {
+    /// The token as written in markup, e.g. `x-data` or `$store`.
+    pub name: &'static str,
+    /// One-line, hover-card synopsis.
+    pub summary: &'static str,
+    /// Canonical alpinejs.dev documentation URL.
+    pub url: &'static str,
+}
+
+/// The core Alpine directives (AC Tier A). Names are the bare directive without
+/// any `:argument` (`x-on`, not `x-on:click`) — argument forms resolve to their
+/// base for lookup.
+pub static ALPINE_DIRECTIVES: &[AlpineEntry] = &[
+    AlpineEntry {
+        name: "x-data",
+        summary: "Declare a new Alpine component and its reactive data.",
+        url: "https://alpinejs.dev/directives/data",
+    },
+    AlpineEntry {
+        name: "x-bind",
+        summary: "Bind an attribute (or class/style) to a JS expression. Shorthand `:`.",
+        url: "https://alpinejs.dev/directives/bind",
+    },
+    AlpineEntry {
+        name: "x-on",
+        summary: "Listen for a DOM event and run an expression. Shorthand `@`.",
+        url: "https://alpinejs.dev/directives/on",
+    },
+    AlpineEntry {
+        name: "x-model",
+        summary: "Two-way bind an input's value to a data property.",
+        url: "https://alpinejs.dev/directives/model",
+    },
+    AlpineEntry {
+        name: "x-text",
+        summary: "Set an element's text content to a JS expression.",
+        url: "https://alpinejs.dev/directives/text",
+    },
+    AlpineEntry {
+        name: "x-html",
+        summary: "Set an element's innerHTML to a JS expression (trusted content only).",
+        url: "https://alpinejs.dev/directives/html",
+    },
+    AlpineEntry {
+        name: "x-show",
+        summary: "Toggle an element's visibility via `display` based on an expression.",
+        url: "https://alpinejs.dev/directives/show",
+    },
+    AlpineEntry {
+        name: "x-if",
+        summary: "Conditionally add or remove an element from the DOM (use on a `<template>`).",
+        url: "https://alpinejs.dev/directives/if",
+    },
+    AlpineEntry {
+        name: "x-for",
+        summary: "Render a block for each item in an array (use on a `<template>`).",
+        url: "https://alpinejs.dev/directives/for",
+    },
+    AlpineEntry {
+        name: "x-ref",
+        summary: "Mark an element so it can be reached via the `$refs` magic.",
+        url: "https://alpinejs.dev/directives/ref",
+    },
+    AlpineEntry {
+        name: "x-init",
+        summary: "Run an expression when the element initializes.",
+        url: "https://alpinejs.dev/directives/init",
+    },
+    AlpineEntry {
+        name: "x-effect",
+        summary: "Re-run an expression whenever one of its reactive dependencies changes.",
+        url: "https://alpinejs.dev/directives/effect",
+    },
+    AlpineEntry {
+        name: "x-transition",
+        summary: "Apply transition classes when an element is shown or hidden.",
+        url: "https://alpinejs.dev/directives/transition",
+    },
+    AlpineEntry {
+        name: "x-cloak",
+        summary: "Hide an element until Alpine has finished initializing it.",
+        url: "https://alpinejs.dev/directives/cloak",
+    },
+    AlpineEntry {
+        name: "x-teleport",
+        summary: "Render a `<template>`'s content at another place in the DOM.",
+        url: "https://alpinejs.dev/directives/teleport",
+    },
+    AlpineEntry {
+        name: "x-ignore",
+        summary: "Tell Alpine to skip initializing an element and its children.",
+        url: "https://alpinejs.dev/directives/ignore",
+    },
+];
+
+/// The core Alpine magics (AC Tier A). Names include the leading `$`.
+pub static ALPINE_MAGICS: &[AlpineEntry] = &[
+    AlpineEntry {
+        name: "$el",
+        summary: "The current DOM element.",
+        url: "https://alpinejs.dev/magics/el",
+    },
+    AlpineEntry {
+        name: "$refs",
+        summary: "Access elements marked with `x-ref` within the component.",
+        url: "https://alpinejs.dev/magics/refs",
+    },
+    AlpineEntry {
+        name: "$store",
+        summary: "Access a global Alpine store registered with `Alpine.store()`.",
+        url: "https://alpinejs.dev/magics/store",
+    },
+    AlpineEntry {
+        name: "$watch",
+        summary: "Watch a component property and run a callback when it changes.",
+        url: "https://alpinejs.dev/magics/watch",
+    },
+    AlpineEntry {
+        name: "$dispatch",
+        summary: "Dispatch a custom browser event from the current element.",
+        url: "https://alpinejs.dev/magics/dispatch",
+    },
+    AlpineEntry {
+        name: "$nextTick",
+        summary: "Run a callback after Alpine has next updated the DOM.",
+        url: "https://alpinejs.dev/magics/nexttick",
+    },
+    AlpineEntry {
+        name: "$root",
+        summary: "The root element of the current component (nearest `x-data`).",
+        url: "https://alpinejs.dev/magics/root",
+    },
+    AlpineEntry {
+        name: "$data",
+        summary: "The current component's reactive data scope.",
+        url: "https://alpinejs.dev/magics/data",
+    },
+    AlpineEntry {
+        name: "$id",
+        summary: "Generate a component-scoped unique id (pairs with `x-id`).",
+        url: "https://alpinejs.dev/magics/id",
+    },
+    AlpineEntry {
+        name: "$persist",
+        summary: "Persist a property to localStorage across page loads.",
+        url: "https://alpinejs.dev/magics/persist",
+    },
+];
+
+/// Common DOM event names Alpine binds via `@event` / `x-on:event`. Used to tell
+/// an Alpine event binding (`@click`) apart from a Blade directive (`@class`):
+/// the sets are disjoint, so a name in here is never a Blade directive candidate.
+/// Tier A covers the common core; arbitrary custom events are a follow-up.
+pub static ALPINE_EVENTS: &[&str] = &[
+    "click",
+    "dblclick",
+    "mousedown",
+    "mouseup",
+    "mouseenter",
+    "mouseleave",
+    "mouseover",
+    "mouseout",
+    "mousemove",
+    "contextmenu",
+    "wheel",
+    "submit",
+    "change",
+    "input",
+    "focus",
+    "blur",
+    "focusin",
+    "focusout",
+    "keydown",
+    "keyup",
+    "keypress",
+    "scroll",
+    "resize",
+    "load",
+    "error",
+    "select",
+    "reset",
+    "drag",
+    "dragstart",
+    "dragend",
+    "dragover",
+    "drop",
+    "touchstart",
+    "touchend",
+    "touchmove",
+    "paste",
+    "copy",
+    "cut",
+];
+
+/// Look up a directive by its bare name (`x-data`, `x-on`). An argument form
+/// like `x-on:click` must be reduced to its base (`x-on`) by the caller.
+pub fn directive(name: &str) -> Option<&'static AlpineEntry> {
+    ALPINE_DIRECTIVES.iter().find(|e| e.name == name)
+}
+
+/// Look up a magic by its full name including the `$` (`$store`).
+pub fn magic(name: &str) -> Option<&'static AlpineEntry> {
+    ALPINE_MAGICS.iter().find(|e| e.name == name)
+}
+
+/// Whether `name` (a `@`-binding's event name, modifiers allowed) is a known
+/// Alpine DOM event. `click`, `submit.prevent`, `keyup.enter` → true; the base
+/// before the first `.` is matched, so modifiers don't defeat recognition.
+pub fn is_alpine_event(name: &str) -> bool {
+    let base = name.split('.').next().unwrap_or(name);
+    !base.is_empty() && ALPINE_EVENTS.contains(&base)
+}
+
+/// Directives whose name starts with `prefix` (case-insensitive), for offering
+/// completion candidates as the user types an `x-…` attribute.
+pub fn matching_directives(prefix: &str) -> Vec<&'static AlpineEntry> {
+    let p = prefix.to_lowercase();
+    ALPINE_DIRECTIVES
+        .iter()
+        .filter(|e| e.name.starts_with(&p))
+        .collect()
+}
+
+/// Magics whose name (compared *without* the leading `$`) starts with `prefix`.
+/// The caller passes the text already typed after the `$`, mirroring how Blade
+/// variable completion filters after the `$`.
+pub fn matching_magics(prefix: &str) -> Vec<&'static AlpineEntry> {
+    let p = prefix.to_lowercase();
+    ALPINE_MAGICS
+        .iter()
+        .filter(|e| e.name[1..].to_lowercase().starts_with(&p))
+        .collect()
+}
+
+/// Alpine event names starting with `prefix` (the text after the `@`,
+/// case-insensitive), for merging into `@`-directive completion.
+pub fn matching_events(prefix: &str) -> Vec<&'static str> {
+    let p = prefix.to_lowercase();
+    ALPINE_EVENTS
+        .iter()
+        .filter(|e| e.starts_with(&p))
+        .copied()
+        .collect()
+}
+
+/// Render a hover card for a directive by bare name, or `None` if unknown.
+pub fn directive_card(name: &str) -> Option<String> {
+    entry_card(directive(name)?)
+}
+
+/// Render a hover card for a magic by full `$`-name, or `None` if unknown.
+pub fn magic_card(name: &str) -> Option<String> {
+    entry_card(magic(name)?)
+}
+
+fn entry_card(e: &AlpineEntry) -> Option<String> {
+    let link = source_link("Alpine.js documentation", e.url, None);
+    Some(render(&HoverContent {
+        header: Some(e.name),
+        detail: Some(e.summary),
+        source_link: Some(&link),
+        ..Default::default()
+    }))
+}
+
+/// The replacement target + filter prefix for an Alpine completion, mirroring
+/// the `StringContext` shape used by the other completion-context helpers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlpineContext {
+    /// Text already typed (the filter prefix).
+    pub prefix: String,
+    /// 0-based column where the replacement starts.
+    pub start_col: u32,
+    /// 0-based column where the replacement ends (the cursor).
+    pub end_col: u32,
+}
+
+/// Characters that can appear in an Alpine attribute name (`x-on:click.prevent`,
+/// `@keyup.enter`, `:class`).
+fn is_attr_name_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '-' || c == '_' || c == ':' || c == '@' || c == '.'
+}
+
+/// Whether `byte_pos` sits inside an open HTML/Blade tag at an attribute
+/// position — there is an unclosed `<` before it and the cursor isn't inside a
+/// quoted attribute value. This is what tells an Alpine `@click` attribute apart
+/// from a Blade `@directive` written in text or a PHP block.
+pub fn at_attribute_position(line: &str, byte_pos: usize) -> bool {
+    if byte_pos > line.len() {
+        return false;
+    }
+    let before = &line[..byte_pos];
+    match before.rfind('<') {
+        Some(lt) if before.rfind('>').is_none_or(|gt| gt < lt) => {
+            let region = &before[lt..];
+            region.matches('"').count().is_multiple_of(2)
+                && region.matches('\'').count().is_multiple_of(2)
+        }
+        _ => false,
+    }
+}
+
+/// The maximal run of `is_attr_name_char` ending at `cursor`, plus the byte
+/// index where it starts. Empty run → `(cursor, "")`.
+fn attr_word_before(before: &str, cursor: usize) -> (usize, &str) {
+    let mut start = cursor;
+    for (i, c) in before.char_indices().rev() {
+        if is_attr_name_char(c) {
+            start = i;
+        } else {
+            break;
+        }
+    }
+    (start, &before[start..])
+}
+
+/// Detect the cursor typing an Alpine `x-…` directive name at an attribute
+/// position inside an open tag (`<div x-da│`, `<x-card x-│>`). Returns the
+/// partial word and replacement range, or `None` when not an `x-` directive
+/// attribute position.
+pub fn directive_completion_context(line: &str, cursor_col: u32) -> Option<AlpineContext> {
+    let cursor = cursor_col as usize;
+    if cursor == 0 || cursor > line.len() {
+        return None;
+    }
+    let before = &line[..cursor];
+    let (word_start, word) = attr_word_before(before, cursor);
+
+    // The attribute must be a separate token (preceded by whitespace) inside an
+    // open tag — otherwise it's part of the tag name or free text.
+    if !before[..word_start]
+        .chars()
+        .next_back()
+        .is_some_and(|c| c.is_whitespace())
+    {
+        return None;
+    }
+    if !at_attribute_position(line, word_start) {
+        return None;
+    }
+    // Only the `x`/`x-…` family completes to a directive list. `@`/`:` shorthands
+    // bind arbitrary attributes — recognized elsewhere, nothing to enumerate.
+    if !word.starts_with('x') {
+        return None;
+    }
+
+    Some(AlpineContext {
+        prefix: word.to_string(),
+        start_col: word_start as u32,
+        end_col: cursor as u32,
+    })
+}
+
+/// Byte index of the quote that is *currently open* at the end of `s`, or `None`
+/// when `s` ends outside any string.
+fn open_quote(s: &str) -> Option<usize> {
+    let mut q: Option<(char, usize)> = None;
+    for (i, c) in s.char_indices() {
+        match q {
+            None if c == '"' || c == '\'' => q = Some((c, i)),
+            Some((qc, _)) if c == qc => q = None,
+            _ => {}
+        }
+    }
+    q.map(|(_, i)| i)
+}
+
+/// Whether the byte offset `pos` sits inside the quoted value of an Alpine
+/// attribute (`x-…`, `@…`, or `:…`) — i.e. inside an Alpine JS expression, where
+/// `$`-magics are valid. `before` is the line text up to `pos`.
+fn in_alpine_expression(before: &str) -> bool {
+    let Some(oq) = open_quote(before) else {
+        return false;
+    };
+    let head = before[..oq].trim_end();
+    let Some(name_region) = head.strip_suffix('=') else {
+        return false;
+    };
+    let (_, attr) = attr_word_before(name_region, name_region.len());
+    attr.starts_with("x-") || attr.starts_with('@') || attr.starts_with(':')
+}
+
+/// Detect the cursor typing a `$`-magic inside an Alpine attribute expression
+/// (`@click="$dis│"`, `x-data="{ x: $st│ }"`). Returns the partial typed *after*
+/// the `$` and the replacement range. Returns `None` outside an Alpine
+/// expression, so ordinary Blade/PHP `$variables` are never hijacked.
+pub fn magic_completion_context(line: &str, cursor_col: u32) -> Option<AlpineContext> {
+    let cursor = cursor_col as usize;
+    if cursor == 0 || cursor > line.len() {
+        return None;
+    }
+    let before = &line[..cursor];
+
+    let mut dollar = None;
+    for (i, c) in before.char_indices().rev() {
+        if c == '$' {
+            dollar = Some(i);
+            break;
+        }
+        if !(c.is_alphanumeric() || c == '_') {
+            break;
+        }
+    }
+    let dollar = dollar?;
+    let after = &before[dollar + 1..];
+    if !after.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        return None;
+    }
+    if !in_alpine_expression(&before[..dollar]) {
+        return None;
+    }
+
+    Some(AlpineContext {
+        prefix: after.to_string(),
+        start_col: (dollar + 1) as u32,
+        end_col: cursor as u32,
+    })
+}
+
+/// The maximal token containing `cursor`, where membership is decided by `pred`.
+/// Returns `(start_byte, token)`.
+fn token_at(line: &str, cursor: usize, pred: impl Fn(char) -> bool) -> (usize, &str) {
+    let mut start = cursor;
+    for (i, c) in line[..cursor].char_indices().rev() {
+        if pred(c) {
+            start = i;
+        } else {
+            break;
+        }
+    }
+    let mut end = cursor;
+    for (i, c) in line[cursor..].char_indices() {
+        if pred(c) {
+            end = cursor + i + c.len_utf8();
+        } else {
+            break;
+        }
+    }
+    (start, &line[start..end])
+}
+
+/// Build the hover card for whatever Alpine token the cursor is on, or `None`.
+/// Recognizes `x-…` directive names (including `x-on:click` → `x-on` and the
+/// `@event` / `:bind` shorthands) and `$`-magics inside Alpine expressions.
+pub fn hover_at(line: &str, character: u32) -> Option<String> {
+    let cursor = character as usize;
+    if cursor > line.len() {
+        return None;
+    }
+    directive_hover_at(line, cursor).or_else(|| magic_hover_at(line, cursor))
+}
+
+fn directive_hover_at(line: &str, cursor: usize) -> Option<String> {
+    let (start, token) = token_at(line, cursor, is_attr_name_char);
+    if token.is_empty() || !at_attribute_position(line, start) {
+        return None;
+    }
+    // Reduce an argument form to its base directive: `x-on:click` → `x-on`.
+    let base = token.split(':').next().unwrap_or(token);
+
+    if base.starts_with("x-") {
+        return directive_card(base);
+    }
+    // `@event` is the `x-on` shorthand; `:attr` is the `x-bind` shorthand.
+    if let Some(event) = base.strip_prefix('@') {
+        if is_alpine_event(event) {
+            return directive_card("x-on");
+        }
+    }
+    if token.starts_with(':') {
+        return directive_card("x-bind");
+    }
+    None
+}
+
+fn magic_hover_at(line: &str, cursor: usize) -> Option<String> {
+    let (start, token) = token_at(line, cursor, |c| {
+        c == '$' || c.is_alphanumeric() || c == '_'
+    });
+    if !token.starts_with('$') {
+        return None;
+    }
+    magic(token)?;
+    if !in_alpine_expression(&line[..start]) {
+        return None;
+    }
+    magic_card(token)
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/alpine.rs
+++ b/laravel-lsp/src/alpine.rs
@@ -330,15 +330,22 @@ fn is_attr_name_char(c: char) -> bool {
 /// quoted attribute value. This is what tells an Alpine `@click` attribute apart
 /// from a Blade `@directive` written in text or a PHP block.
 pub fn at_attribute_position(line: &str, byte_pos: usize) -> bool {
-    if byte_pos > line.len() {
+    if byte_pos > line.len() || !line.is_char_boundary(byte_pos) {
         return false;
     }
     let before = &line[..byte_pos];
     match before.rfind('<') {
         Some(lt) if before.rfind('>').is_none_or(|gt| gt < lt) => {
+            // The cursor is at an attribute position only when it sits outside
+            // any open quoted value. Reuse the `open_quote` state machine (the
+            // same one the magic path relies on) instead of counting `"` and
+            // `'` independently: independent parity counts misfire whenever a
+            // quote of one kind sits inside an already-closed value of the other
+            // — e.g. the apostrophe in `<input placeholder="Don't" x-da│>` makes
+            // the `'` count odd even though the cursor is plainly outside any
+            // string, which would silently kill directive completion and hover.
             let region = &before[lt..];
-            region.matches('"').count().is_multiple_of(2)
-                && region.matches('\'').count().is_multiple_of(2)
+            open_quote(region).is_none()
         }
         _ => false,
     }

--- a/laravel-lsp/src/alpine/tests.rs
+++ b/laravel-lsp/src/alpine/tests.rs
@@ -323,6 +323,20 @@ fn directive_context_none_inside_attribute_value() {
     assert!(directive_completion_context(line, line.len() as u32).is_none());
 }
 
+#[test]
+fn directive_context_rejects_non_char_boundary() {
+    // Regression (issue #61): the cursor column arrives as a UTF-16-derived
+    // offset (the server advertises no positionEncoding, so LSP defaults to
+    // UTF-16). On a line with a non-ASCII char before the cursor that offset
+    // can land mid-codepoint; `&line[..cursor]` must not panic and crash the
+    // language server — it returns None instead.
+    let line = "<div café x-data>";
+    let cafe = line.find("caf").unwrap();
+    let mid_e = cafe + "caf".len() + 1; // inside the 2-byte 'é'
+    assert!(!line.is_char_boundary(mid_e));
+    assert!(directive_completion_context(line, mid_e as u32).is_none());
+}
+
 // ─── magic completion context ────────────────────────────────────────────
 
 #[test]
@@ -366,6 +380,17 @@ fn magic_context_none_in_non_alpine_attribute() {
     // A `$` inside a plain HTML attribute value isn't an Alpine expression.
     let line = "<input value=\"$st";
     assert!(magic_completion_context(line, line.len() as u32).is_none());
+}
+
+#[test]
+fn magic_context_rejects_non_char_boundary() {
+    // Regression (issue #61): a UTF-16-derived cursor offset that lands inside a
+    // multibyte char must return None, not panic on `&line[..cursor]`.
+    let line = "<button @click=\"café $st\">";
+    let cafe = line.find("caf").unwrap();
+    let mid_e = cafe + "caf".len() + 1; // inside the 2-byte 'é'
+    assert!(!line.is_char_boundary(mid_e));
+    assert!(magic_completion_context(line, mid_e as u32).is_none());
 }
 
 // ─── hover ───────────────────────────────────────────────────────────────
@@ -434,4 +459,16 @@ fn hover_none_on_unknown_attribute() {
     let line = "<div data-foo=\"x\">";
     let at = line.find("data-foo").unwrap() as u32;
     assert!(hover_at(line, at).is_none());
+}
+
+#[test]
+fn hover_rejects_non_char_boundary() {
+    // Regression (issue #61): a hover request whose UTF-16-derived character
+    // offset lands inside a multibyte char must return None rather than panic in
+    // `token_at`'s `&line[..cursor]` / `&line[start..end]` slices.
+    let line = "<div café x-data=\"{}\">";
+    let cafe = line.find("caf").unwrap();
+    let mid_e = cafe + "caf".len() + 1; // inside the 2-byte 'é'
+    assert!(!line.is_char_boundary(mid_e));
+    assert!(hover_at(line, mid_e as u32).is_none());
 }

--- a/laravel-lsp/src/alpine/tests.rs
+++ b/laravel-lsp/src/alpine/tests.rs
@@ -69,6 +69,48 @@ fn directive_and_event_names_are_disjoint() {
     }
 }
 
+#[test]
+fn mergeable_events_drops_blade_directive_collisions() {
+    // The *real* merge path is Blade directives × Alpine events, and they are
+    // NOT disjoint: `error` is both Laravel's `@error … @enderror` directive and
+    // a DOM event. `mergeable_events` must drop the Alpine `error` so the merged
+    // `@`-completion list shows it once, not twice (issue #61, AC5).
+    let blade_names = ["error", "if", "foreach"]; // names already offered by Blade
+    let events = mergeable_events("err", &blade_names);
+
+    assert!(
+        !events.contains(&"error"),
+        "the Alpine `error` event must be dropped — Blade already offers @error: {events:?}",
+    );
+
+    // Assemble the merged `@`-name set exactly as the handler does (Blade items
+    // that matched the prefix, then the deduped Alpine events) and prove there
+    // is exactly one `@error`.
+    let mut at_names: Vec<String> = blade_names
+        .iter()
+        .filter(|n| n.starts_with("err"))
+        .map(|n| format!("@{n}"))
+        .collect();
+    at_names.extend(events.iter().map(|e| format!("@{e}")));
+    assert_eq!(
+        at_names.iter().filter(|n| *n == "@error").count(),
+        1,
+        "exactly one @error entry in the merged list, got {at_names:?}",
+    );
+}
+
+#[test]
+fn mergeable_events_keeps_non_colliding_events() {
+    // A name that is only an Alpine event (no same-named Blade directive) is
+    // still offered. `@cli` → `click`, with no Blade `@click` to shadow it.
+    let blade_names = ["if", "foreach"];
+    let events = mergeable_events("cli", &blade_names);
+    assert!(
+        events.contains(&"click"),
+        "non-colliding Alpine events must survive the dedup: {events:?}",
+    );
+}
+
 // ─── is_alpine_event ─────────────────────────────────────────────────────
 
 #[test]

--- a/laravel-lsp/src/alpine/tests.rs
+++ b/laravel-lsp/src/alpine/tests.rs
@@ -1,0 +1,355 @@
+use super::*;
+
+// ─── catalogs & lookups ──────────────────────────────────────────────────
+
+#[test]
+fn directives_cover_the_ac_set() {
+    for name in [
+        "x-data",
+        "x-bind",
+        "x-on",
+        "x-model",
+        "x-text",
+        "x-html",
+        "x-show",
+        "x-if",
+        "x-for",
+        "x-ref",
+        "x-init",
+        "x-effect",
+        "x-transition",
+        "x-cloak",
+        "x-teleport",
+        "x-ignore",
+    ] {
+        assert!(directive(name).is_some(), "{name} should be catalogued");
+    }
+}
+
+#[test]
+fn magics_cover_the_ac_set() {
+    for name in [
+        "$el",
+        "$refs",
+        "$store",
+        "$watch",
+        "$dispatch",
+        "$nextTick",
+        "$root",
+        "$data",
+        "$id",
+        "$persist",
+    ] {
+        assert!(magic(name).is_some(), "{name} should be catalogued");
+    }
+}
+
+#[test]
+fn lookup_misses_return_none() {
+    assert!(directive("x-nope").is_none());
+    assert!(directive("class").is_none());
+    assert!(magic("$nope").is_none());
+    assert!(
+        magic("store").is_none(),
+        "magic lookup requires the leading $"
+    );
+}
+
+#[test]
+fn directive_and_event_names_are_disjoint() {
+    // The disambiguation rests on this: no name is both a Blade-shaped directive
+    // and an Alpine event, so a merged completion list never double-suggests.
+    for d in ALPINE_DIRECTIVES {
+        let bare = d.name.trim_start_matches("x-");
+        assert!(
+            !ALPINE_EVENTS.contains(&bare),
+            "{} collides with an event name",
+            d.name
+        );
+    }
+}
+
+// ─── is_alpine_event ─────────────────────────────────────────────────────
+
+#[test]
+fn recognizes_core_events_and_modifiers() {
+    assert!(is_alpine_event("click"));
+    assert!(is_alpine_event("submit"));
+    assert!(is_alpine_event("change"));
+    assert!(is_alpine_event("input"));
+    // Modifiers don't defeat recognition.
+    assert!(is_alpine_event("submit.prevent"));
+    assert!(is_alpine_event("keyup.enter"));
+    assert!(is_alpine_event("click.outside"));
+}
+
+#[test]
+fn rejects_blade_directive_names() {
+    // These are real Blade directives used inside tags — must NOT be events.
+    assert!(!is_alpine_event("class"));
+    assert!(!is_alpine_event("checked"));
+    assert!(!is_alpine_event("if"));
+    assert!(!is_alpine_event("foreach"));
+    assert!(!is_alpine_event(""));
+}
+
+// ─── matching_* filters ──────────────────────────────────────────────────
+
+#[test]
+fn matching_directives_filters_by_prefix() {
+    let names: Vec<_> = matching_directives("x-t").iter().map(|e| e.name).collect();
+    assert_eq!(names, vec!["x-text", "x-transition", "x-teleport"]);
+}
+
+#[test]
+fn matching_directives_empty_prefix_returns_all() {
+    assert_eq!(matching_directives("x-").len(), ALPINE_DIRECTIVES.len());
+}
+
+#[test]
+fn matching_magics_filters_after_the_dollar() {
+    // Prefix is the text typed after `$`.
+    let names: Vec<_> = matching_magics("re").iter().map(|e| e.name).collect();
+    assert_eq!(names, vec!["$refs"]);
+    let names: Vec<_> = matching_magics("d").iter().map(|e| e.name).collect();
+    assert_eq!(names, vec!["$dispatch", "$data"]);
+}
+
+#[test]
+fn matching_events_filters_by_prefix() {
+    assert!(matching_events("cl").contains(&"click"));
+    assert!(matching_events("sub").contains(&"submit"));
+    assert!(matching_events("zzz").is_empty());
+}
+
+// ─── hover cards ─────────────────────────────────────────────────────────
+
+#[test]
+fn directive_card_has_name_summary_and_docs_link() {
+    let card = directive_card("x-data").expect("x-data has a card");
+    assert!(card.contains("x-data"), "card shows the directive name");
+    assert!(
+        card.contains("reactive data"),
+        "card shows the synopsis: {card}"
+    );
+    assert!(
+        card.contains("https://alpinejs.dev/directives/data"),
+        "card links to the docs: {card}"
+    );
+}
+
+#[test]
+fn magic_card_has_name_summary_and_docs_link() {
+    let card = magic_card("$store").expect("$store has a card");
+    assert!(card.contains("$store"));
+    assert!(card.contains("global Alpine store"), "synopsis: {card}");
+    assert!(card.contains("https://alpinejs.dev/magics/store"));
+}
+
+#[test]
+fn cards_are_none_for_unknown_tokens() {
+    assert!(directive_card("x-bogus").is_none());
+    assert!(magic_card("$bogus").is_none());
+}
+
+// ─── at_attribute_position ───────────────────────────────────────────────
+
+#[test]
+fn attribute_position_inside_open_tag() {
+    let line = "<div x-data>";
+    let at = line.find('x').unwrap();
+    assert!(at_attribute_position(line, at));
+}
+
+#[test]
+fn not_attribute_position_in_plain_text() {
+    let line = "some x-data text";
+    let at = line.find('x').unwrap();
+    assert!(!at_attribute_position(line, at));
+}
+
+#[test]
+fn not_attribute_position_after_tag_closed() {
+    let line = "<div></div> x-data";
+    let at = line.rfind('x').unwrap();
+    assert!(!at_attribute_position(line, at));
+}
+
+#[test]
+fn not_attribute_position_inside_quoted_value() {
+    let line = "<div class=\"x-data";
+    let at = line.rfind('x').unwrap();
+    assert!(!at_attribute_position(line, at));
+}
+
+// ─── directive completion context ────────────────────────────────────────
+
+#[test]
+fn directive_context_bare_x() {
+    let line = "<div x";
+    let ctx = directive_completion_context(line, line.len() as u32)
+        .expect("typing `x` in a tag is a directive context");
+    assert_eq!(ctx.prefix, "x");
+    assert_eq!(ctx.start_col, "<div ".len() as u32);
+}
+
+#[test]
+fn directive_context_partial_name() {
+    let line = "<div x-da";
+    let ctx = directive_completion_context(line, line.len() as u32)
+        .expect("`x-da` is a directive context");
+    assert_eq!(ctx.prefix, "x-da");
+    // Filters down to x-data.
+    let names: Vec<_> = matching_directives(&ctx.prefix)
+        .iter()
+        .map(|e| e.name)
+        .collect();
+    assert_eq!(names, vec!["x-data"]);
+}
+
+#[test]
+fn directive_context_in_component_tag_includes_x_bind() {
+    // AC #7: x-data completes in a `<x-…>` component tag, and x-bind (the `:`
+    // shorthand directive) is among the offered directives.
+    let line = "<x-card x-";
+    let ctx = directive_completion_context(line, line.len() as u32)
+        .expect("`x-` in a component tag is a directive context");
+    assert_eq!(ctx.prefix, "x-");
+    assert_eq!(ctx.start_col, "<x-card ".len() as u32);
+    let names: Vec<_> = matching_directives(&ctx.prefix)
+        .iter()
+        .map(|e| e.name)
+        .collect();
+    assert!(names.contains(&"x-data"), "x-data offered: {names:?}");
+    assert!(names.contains(&"x-bind"), "x-bind offered: {names:?}");
+}
+
+#[test]
+fn directive_context_none_in_tag_name() {
+    // Still inside the tag name (no whitespace yet) — not an attribute position.
+    assert!(directive_completion_context("<xyz", 4).is_none());
+}
+
+#[test]
+fn directive_context_none_in_plain_text() {
+    assert!(directive_completion_context("just x-da here", 8).is_none());
+}
+
+#[test]
+fn directive_context_none_inside_attribute_value() {
+    let line = "<div class=\"x-da";
+    assert!(directive_completion_context(line, line.len() as u32).is_none());
+}
+
+// ─── magic completion context ────────────────────────────────────────────
+
+#[test]
+fn magic_context_inside_event_expression() {
+    let line = "<button @click=\"$di";
+    let ctx = magic_completion_context(line, line.len() as u32)
+        .expect("`$di` inside @click value is a magic context");
+    assert_eq!(ctx.prefix, "di");
+    assert_eq!(ctx.start_col, line.len() as u32 - 2);
+    let names: Vec<_> = matching_magics(&ctx.prefix)
+        .iter()
+        .map(|e| e.name)
+        .collect();
+    assert_eq!(names, vec!["$dispatch"]);
+}
+
+#[test]
+fn magic_context_inside_x_data_expression() {
+    let line = "<div x-data=\"{ open: false, total: $st";
+    let ctx = magic_completion_context(line, line.len() as u32)
+        .expect("`$st` inside x-data value is a magic context");
+    assert_eq!(ctx.prefix, "st");
+}
+
+#[test]
+fn magic_context_inside_bound_attribute() {
+    let line = "<span :title=\"$re";
+    let ctx = magic_completion_context(line, line.len() as u32)
+        .expect("`$re` inside a :bound value is a magic context");
+    assert_eq!(ctx.prefix, "re");
+}
+
+#[test]
+fn magic_context_none_in_plain_blade_echo() {
+    // A normal Blade `$variable` must NOT be treated as an Alpine magic.
+    assert!(magic_completion_context("{{ $us", 6).is_none());
+}
+
+#[test]
+fn magic_context_none_in_non_alpine_attribute() {
+    // A `$` inside a plain HTML attribute value isn't an Alpine expression.
+    let line = "<input value=\"$st";
+    assert!(magic_completion_context(line, line.len() as u32).is_none());
+}
+
+// ─── hover ───────────────────────────────────────────────────────────────
+
+#[test]
+fn hover_on_directive_name() {
+    let line = "<div x-data=\"{}\">";
+    let at = line.find("data").unwrap() as u32; // cursor on the directive
+    let card = hover_at(line, at).expect("hover over x-data");
+    assert!(card.contains("x-data"));
+}
+
+#[test]
+fn hover_on_event_argument_resolves_to_x_on() {
+    // Cursor on `click` in `x-on:click` → the x-on directive card.
+    let line = "<button x-on:click=\"go()\">";
+    let at = line.find("click").unwrap() as u32;
+    let card = hover_at(line, at).expect("hover over x-on:click");
+    assert!(card.contains("x-on"), "resolves to x-on: {card}");
+}
+
+#[test]
+fn hover_on_at_event_shorthand_resolves_to_x_on() {
+    let line = "<button @click=\"go()\">";
+    let at = line.find("click").unwrap() as u32;
+    let card = hover_at(line, at).expect("hover over @click");
+    assert!(card.contains("x-on"), "@event maps to x-on: {card}");
+}
+
+#[test]
+fn hover_on_colon_bind_shorthand_resolves_to_x_bind() {
+    let line = "<img :src=\"url\">";
+    let at = line.find("src").unwrap() as u32;
+    let card = hover_at(line, at).expect("hover over :src");
+    assert!(card.contains("x-bind"), ":attr maps to x-bind: {card}");
+}
+
+#[test]
+fn hover_on_magic_in_expression() {
+    let line = "<button @click=\"$dispatch('x')\">";
+    let at = line.find("dispatch").unwrap() as u32;
+    let card = hover_at(line, at).expect("hover over $dispatch");
+    assert!(card.contains("$dispatch"));
+}
+
+#[test]
+fn hover_none_on_at_blade_directive() {
+    // `@if` is a Blade directive, not an Alpine event — no Alpine hover.
+    let line = "<div>@if($x)";
+    let at = line.find("if").unwrap() as u32;
+    assert!(hover_at(line, at).is_none());
+}
+
+#[test]
+fn hover_none_on_plain_php_variable() {
+    let line = "<?php $store = 1;";
+    let at = line.find("store").unwrap() as u32;
+    assert!(
+        hover_at(line, at).is_none(),
+        "a plain $variable is not an Alpine magic"
+    );
+}
+
+#[test]
+fn hover_none_on_unknown_attribute() {
+    let line = "<div data-foo=\"x\">";
+    let at = line.find("data-foo").unwrap() as u32;
+    assert!(hover_at(line, at).is_none());
+}

--- a/laravel-lsp/src/alpine/tests.rs
+++ b/laravel-lsp/src/alpine/tests.rs
@@ -224,6 +224,46 @@ fn not_attribute_position_inside_quoted_value() {
     assert!(!at_attribute_position(line, at));
 }
 
+#[test]
+fn attribute_position_after_apostrophe_in_double_quoted_value() {
+    // Regression: an apostrophe inside an already-closed double-quoted value
+    // must not throw off attribute-position detection. Independent `'`/`"`
+    // parity counts saw an odd `'` here and wrongly returned false, silently
+    // killing Alpine directive completion + hover on the rest of the element.
+    let line = "<input placeholder=\"Don't\" x-data>";
+    let at = line.find("x-data").unwrap();
+    assert!(at_attribute_position(line, at));
+}
+
+#[test]
+fn attribute_position_after_double_quote_in_single_quoted_value() {
+    // Symmetric case: a `"` sitting inside an already-closed single-quoted
+    // value must not flip parity either.
+    let line = "<input data-label='say \"hi\"' x-data>";
+    let at = line.find("x-data").unwrap();
+    assert!(at_attribute_position(line, at));
+}
+
+#[test]
+fn not_attribute_position_with_unbalanced_quote_after_apostrophe() {
+    // The apostrophe is decoration inside the value; the cursor is genuinely
+    // inside the open `class="…"` string, so it is *not* an attribute position.
+    let line = "<input placeholder=\"Don't\" class=\"x-data";
+    let at = line.rfind("x-data").unwrap();
+    assert!(!at_attribute_position(line, at));
+}
+
+#[test]
+fn at_attribute_position_rejects_non_char_boundary() {
+    // Hardening: a byte offset landing inside a multibyte char must return
+    // false rather than panicking on the `&line[..byte_pos]` slice.
+    let line = "<div café x-data>";
+    let cafe = line.find("caf").unwrap();
+    let mid_e = cafe + "caf".len() + 1; // inside the 2-byte 'é'
+    assert!(!line.is_char_boundary(mid_e));
+    assert!(!at_attribute_position(line, mid_e));
+}
+
 // ─── directive completion context ────────────────────────────────────────
 
 #[test]

--- a/laravel-lsp/src/blade_directive_tokens.rs
+++ b/laravel-lsp/src/blade_directive_tokens.rs
@@ -56,6 +56,32 @@ fn in_comment(pos: usize, spans: &[(usize, usize)]) -> bool {
     spans.iter().any(|&(start, end)| pos >= start && pos < end)
 }
 
+/// Whether the `@word` ending at `word_end` is an attribute *binding* —
+/// `@word`, optionally followed by `.modifier` segments, then `=`. That is the
+/// Alpine event-binding shape (`@click="…"`, `@submit.prevent="…"`), which
+/// collides syntactically with Blade's `@directive`. No Blade directive is ever
+/// written as `@word=`, so this guard keeps Alpine bindings from lighting up as
+/// directives without risking a real directive (issue #61).
+fn is_attribute_binding(content: &str, word_end: usize) -> bool {
+    let bytes = &content.as_bytes()[word_end..];
+    let mut i = 0;
+    // Consume zero or more `.modifier` segments (`.prevent`, `.enter`, …).
+    while i < bytes.len() && bytes[i] == b'.' {
+        i += 1;
+        let mod_start = i;
+        while i < bytes.len()
+            && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_' || bytes[i] == b'-')
+        {
+            i += 1;
+        }
+        // A lone `.` with no modifier name isn't a binding suffix.
+        if i == mod_start {
+            return false;
+        }
+    }
+    i < bytes.len() && bytes[i] == b'='
+}
+
 /// Find the directives to highlight as 0-based `(line, start_column, length)`
 /// triples. A `@word` is included only when it is not inside a comment and its
 /// name is present in `known` (which must already be lowercased).
@@ -77,6 +103,12 @@ pub fn directive_token_positions(content: &str, known: &HashSet<String>) -> Vec<
 
         // Skip directives sitting inside a Blade/HTML comment.
         if in_comment(start_byte, &comment_spans) {
+            continue;
+        }
+
+        // Skip Alpine-style attribute bindings (`@click="…"`): a `@word(.mod)*=`
+        // is an event binding, not a Blade directive (issue #61).
+        if is_attribute_binding(content, mat.end()) {
             continue;
         }
 

--- a/laravel-lsp/src/blade_directive_tokens/tests.rs
+++ b/laravel-lsp/src/blade_directive_tokens/tests.rs
@@ -99,3 +99,21 @@ fn empty_when_no_known_directives_present() {
     assert!(directive_token_positions("plain text with no directives", &set).is_empty());
     assert!(extract_blade_directive_tokens("plain text", &set).is_empty());
 }
+
+#[test]
+fn skips_alpine_event_bindings(/* issue #61 */) {
+    // `@click="…"` is an Alpine event binding, not a Blade directive — even if a
+    // same-named custom directive were registered, the `@word=` shape excludes it.
+    let set = known(&["click", "submit", "if"]);
+    // Plain binding.
+    assert!(directive_token_positions("<button @click=\"go()\">", &set).is_empty());
+    // Binding with modifiers.
+    assert!(directive_token_positions("<form @submit.prevent=\"save()\">", &set).is_empty());
+    // A real Blade directive is untouched on the same line.
+    let positions = directive_token_positions("<button @click=\"go()\">@if($x)", &set);
+    assert_eq!(
+        positions,
+        vec![(0, 22, 3)],
+        "only the @if directive survives"
+    );
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::type_complexity)]
 
 // Core modules
+pub mod alpine;
 pub mod blade_directive_tokens;
 pub mod blade_embedded_php;
 pub mod blade_loops;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -22161,15 +22161,24 @@ impl LanguageServer for LaravelLanguageServer {
 
                     // Merge in Alpine `@event` bindings when the `@` sits at an
                     // HTML attribute position — `@click`, `@submit`, etc. are
-                    // Alpine, not Blade directives (issue #61). Event names and
-                    // Blade directive names are disjoint, so the merged list never
-                    // double-suggests the same entry.
+                    // Alpine, not Blade directives (issue #61). A handful of
+                    // names (`error` → Blade's `@error … @enderror`) are *both* a
+                    // Blade directive and an Alpine event, so the merge dedups by
+                    // name (`mergeable_events`): the Blade directive wins and its
+                    // event twin is dropped, leaving exactly one entry (AC5).
                     if let Some(at_byte) =
                         (position.character as usize).checked_sub(directive_prefix.len() + 1)
                     {
                         if laravel_lsp::alpine::at_attribute_position(line_text, at_byte) {
+                            // Names already offered as Blade directives (those that
+                            // matched the typed prefix, i.e. the items built above).
+                            let blade_names: Vec<&str> = directives
+                                .iter()
+                                .filter(|d| d.name.to_lowercase().starts_with(&prefix_lower))
+                                .map(|d| d.name.as_str())
+                                .collect();
                             items.extend(
-                                laravel_lsp::alpine::matching_events(&prefix_lower)
+                                laravel_lsp::alpine::mergeable_events(&prefix_lower, &blade_names)
                                     .into_iter()
                                     .map(|ev| CompletionItem {
                                         label: format!("@{ev}"),

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -20520,6 +20520,23 @@ impl LanguageServer for LaravelLanguageServer {
             .unwrap_or("")
             .to_string();
 
+        // Alpine.js directive/magic hover (issue #61). Checked before the Salsa
+        // pattern lookup: Alpine tokens (`x-data`, `x-on:click`, `$store`) live
+        // in HTML attributes the Laravel pattern index doesn't cover, and a hit
+        // here means the cursor is unambiguously on an Alpine token. Blade-only
+        // since Alpine markup lives in `.blade.php` views.
+        if is_blade {
+            if let Some(card) = laravel_lsp::alpine::hover_at(&line_text, position.character) {
+                return Ok(Some(Hover {
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: card,
+                    }),
+                    range: None,
+                }));
+            }
+        }
+
         // Salsa pattern lookup. The target dispatch in `find_hover_target`
         // tries patterns first and only falls back to Blade variables when
         // nothing matched at the cursor.
@@ -21950,6 +21967,84 @@ impl LanguageServer for LaravelLanguageServer {
             // Check for variable name context in Blade files (typing $user, $u, etc.)
             // This must come BEFORE model property context to avoid conflicts
             if uri.path().ends_with(".blade.php") {
+                // Alpine.js magic completion (`@click="$dis|"`, `x-data="{… $st|"`).
+                // Must precede the Blade `$variable` context below so a magic
+                // inside an Alpine expression wins over plain variable suggestions
+                // (issue #61). Gated to Alpine attribute expressions, so ordinary
+                // `$variables` fall straight through.
+                if let Some(ctx) =
+                    laravel_lsp::alpine::magic_completion_context(line_text, position.character)
+                {
+                    let items: Vec<CompletionItem> =
+                        laravel_lsp::alpine::matching_magics(&ctx.prefix)
+                            .into_iter()
+                            .map(|m| CompletionItem {
+                                label: m.name.to_string(),
+                                kind: Some(CompletionItemKind::VARIABLE),
+                                detail: Some("Alpine magic".to_string()),
+                                // The `$` is already typed — insert only the rest.
+                                insert_text: Some(m.name[1..].to_string()),
+                                documentation: Some(
+                                    CompletionDoc::new()
+                                        .header(m.name)
+                                        .summary(m.summary)
+                                        .section(format!("[Alpine.js docs]({})", m.url))
+                                        .into_documentation(),
+                                ),
+                                ..Default::default()
+                            })
+                            .collect();
+                    if !items.is_empty() {
+                        return Ok(Some(CompletionResponse::List(CompletionList {
+                            is_incomplete: false,
+                            items,
+                        })));
+                    }
+                }
+
+                // Alpine.js directive completion (`<div x-da|`, `<x-card x-|>`).
+                // Offers the core `x-…` directive names as attributes (issue #61).
+                if let Some(ctx) =
+                    laravel_lsp::alpine::directive_completion_context(line_text, position.character)
+                {
+                    let items: Vec<CompletionItem> =
+                        laravel_lsp::alpine::matching_directives(&ctx.prefix)
+                            .into_iter()
+                            .map(|d| CompletionItem {
+                                label: d.name.to_string(),
+                                kind: Some(CompletionItemKind::KEYWORD),
+                                detail: Some("Alpine directive".to_string()),
+                                documentation: Some(
+                                    CompletionDoc::new()
+                                        .header(d.name)
+                                        .summary(d.summary)
+                                        .section(format!("[Alpine.js docs]({})", d.url))
+                                        .into_documentation(),
+                                ),
+                                text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                                    range: Range {
+                                        start: Position {
+                                            line: position.line,
+                                            character: ctx.start_col,
+                                        },
+                                        end: Position {
+                                            line: position.line,
+                                            character: ctx.end_col,
+                                        },
+                                    },
+                                    new_text: d.name.to_string(),
+                                })),
+                                ..Default::default()
+                            })
+                            .collect();
+                    if !items.is_empty() {
+                        return Ok(Some(CompletionResponse::List(CompletionList {
+                            is_incomplete: false,
+                            items,
+                        })));
+                    }
+                }
+
                 if let Some(var_prefix) =
                     Self::get_variable_name_context(line_text, position.character)
                 {
@@ -22021,7 +22116,7 @@ impl LanguageServer for LaravelLanguageServer {
                     };
 
                     let prefix_lower = directive_prefix.to_lowercase();
-                    let items: Vec<CompletionItem> = directives
+                    let mut items: Vec<CompletionItem> = directives
                         .iter()
                         .filter(|d| d.name.to_lowercase().starts_with(&prefix_lower))
                         .map(|d| {
@@ -22063,6 +22158,41 @@ impl LanguageServer for LaravelLanguageServer {
                             }
                         })
                         .collect();
+
+                    // Merge in Alpine `@event` bindings when the `@` sits at an
+                    // HTML attribute position — `@click`, `@submit`, etc. are
+                    // Alpine, not Blade directives (issue #61). Event names and
+                    // Blade directive names are disjoint, so the merged list never
+                    // double-suggests the same entry.
+                    if let Some(at_byte) =
+                        (position.character as usize).checked_sub(directive_prefix.len() + 1)
+                    {
+                        if laravel_lsp::alpine::at_attribute_position(line_text, at_byte) {
+                            items.extend(
+                                laravel_lsp::alpine::matching_events(&prefix_lower)
+                                    .into_iter()
+                                    .map(|ev| CompletionItem {
+                                        label: format!("@{ev}"),
+                                        kind: Some(CompletionItemKind::EVENT),
+                                        detail: Some("Alpine event (x-on shorthand)".to_string()),
+                                        // The `@` is already typed — insert the rest.
+                                        insert_text: Some(ev.to_string()),
+                                        documentation: Some(
+                                            CompletionDoc::new()
+                                                .header(format!("@{ev}"))
+                                                .summary(
+                                                    "Alpine event binding (shorthand for x-on).",
+                                                )
+                                                .section(
+                                                    "[Alpine.js docs](https://alpinejs.dev/directives/on)",
+                                                )
+                                                .into_documentation(),
+                                        ),
+                                        ..Default::default()
+                                    }),
+                            );
+                        }
+                    }
 
                     debug!("   Returning {} directive completion items", items.len());
 


### PR DESCRIPTION
## Summary
Implements #61 — **Tier A** Alpine.js support (static, Blade-only; no JS execution). Tiers B (cross-language JS resolution) and C (diagnostics) remain follow-ups, as the issue scopes.

Everything lives in a new pure `laravel_lsp::alpine` module (catalogs + line-local context predicates + card builders), unit-tested directly; `main.rs` only renders results into LSP types — mirroring the existing `component_completion` split.

## Changes
- **New `src/alpine.rs`** — curated catalogs of the 16 core directives and 10 magics (synopsis + docs link each), the common-DOM `@event` name set, and pure line-local context detection (`directive_completion_context`, `magic_completion_context`, `at_attribute_position`, `hover_at`).
- **Completion** (`main.rs`):
  - `x-*` directive names complete in HTML attribute position, including inside `<x-…>` component tags.
  - `$`-magics complete inside Alpine expressions (attribute values of `x-`/`@`/`:` attributes), gated so plain Blade/PHP `$variables` are never hijacked.
  - `@event` bindings are merged into the existing Blade `@`-directive completion when the `@` is at an attribute position. Event and Blade-directive names are disjoint, so nothing is double-suggested.
- **Hover** (`main.rs`) — directive/magic cards, resolving the `x-on:click` argument form and the `@event`/`:bind` shorthands to `x-on`/`x-bind`. Checked before the Salsa lookup; Blade-only.
- **Highlighting** (`blade_directive_tokens.rs`) — the semantic-token directive scanner now skips `@word(.modifier)*=` attribute bindings (`@click="…"`), so an Alpine event is never highlighted as a Blade directive even if a same-named custom directive were registered.

## Acceptance Criteria
- [x] Alpine directive names (x-data … x-ignore) autocomplete in Blade attribute context
- [x] Alpine magic names ($el … $persist) autocomplete in Blade attribute context
- [x] Hover cards display documentation for all core Alpine directives and magics
- [x] @-prefixed Alpine event bindings (@click, @submit, …) are recognized as Alpine, not treated as Blade directive candidates in highlighting/completion
- [x] LSP completion does not double-suggest Alpine directives when both Alpine and custom-inline-directive logic would fire (disjoint name sets; merged once)
- [x] Unit tests cover directive/magic completion, hover card generation, and @event disambiguation per repo convention
- [x] Tests verify x-data attribute completion in component context (includes x-bind: prefix support)

## Test Plan
- [x] `cargo test` — 1815 lib + 307 bin unit tests pass (incl. 36 new `alpine` tests + the directive-highlighter guard test)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Integration tests pass once the CI fixture (`test-project/.env` + `composer install`) is bootstrapped — no new failures introduced

Fixes #61