### PR TITLE
feat: Flux slot-name completion (<flux:slot name="…">)

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -8140,6 +8140,14 @@ impl LaravelLanguageServer {
             // Get the text after <x-
             let after_prefix = &before_cursor[start_pos..];
 
+            // `<x-slot:name>` / `<x-slot …>` is Laravel slot syntax, not a
+            // component — don't offer component-name completions there. The
+            // downstream Flux slot-name context (issue #106) handles the
+            // colon form instead.
+            if after_prefix == "slot" || after_prefix.starts_with("slot:") {
+                return None;
+            }
+
             // Check that we haven't closed the tag or hit a space (which would mean attributes)
             // Component names can contain: letters, numbers, dots, and hyphens
             // If we hit a space, >, or /, we're past the component name
@@ -8289,6 +8297,204 @@ impl LaravelLanguageServer {
                 quote_char: ' ',
             },
         ))
+    }
+
+    /// Detect when the cursor sits inside a slot *name* being typed — the
+    /// trigger for Flux slot-name completion (issue #106). Two syntaxes:
+    ///
+    /// - the `name="…"` attribute value of a `<flux:slot …>` tag
+    ///   (`<flux:slot name="ti│">`), and
+    /// - the colon form `<x-slot:ti│>` (the name portion after the `:`).
+    ///
+    /// Returns the partial name typed so far (filters the offered slots) plus
+    /// the replacement column range. Returns `None` for the positions slot
+    /// completion must *not* fire in: the cursor in the `name` attribute *key*
+    /// (`<flux:slot name│="…">`), in tag content (between `>` and
+    /// `</flux:slot>`), or not inside a slot tag at all.
+    fn get_flux_slot_name_context(line_text: &str, character: u32) -> Option<StringContext> {
+        use lazy_static::lazy_static;
+        use regex::Regex;
+        lazy_static! {
+            // The `name="` / `name='` opener of a slot tag's name attribute.
+            // The trailing capture is the opening quote so we know which quote
+            // closes the value.
+            static ref SLOT_NAME_ATTR_RE: Regex = Regex::new(r#"\bname\s*=\s*("|')"#).unwrap();
+        }
+
+        let cursor = character as usize;
+        if cursor > line_text.len() {
+            return None;
+        }
+        let before_cursor = &line_text[..cursor];
+
+        // ── `<flux:slot name="│">` value form ──────────────────────────────
+        if let Some(tag_pos) = before_cursor.rfind("<flux:slot") {
+            let after_tag = &before_cursor[tag_pos + "<flux:slot".len()..];
+            // A real tag boundary (`<flux:slot ` / `<flux:slot\t`), not a
+            // longer name like `<flux:slotx`; and the tag must still be open
+            // (no `>` before the cursor → otherwise we're in tag content).
+            let boundary_ok =
+                after_tag.is_empty() || after_tag.starts_with(|c: char| c.is_whitespace());
+            if boundary_ok && !after_tag.contains('>') {
+                // The last `name=` opener before the cursor is the active value.
+                if let Some(m) = SLOT_NAME_ATTR_RE.find_iter(after_tag).last() {
+                    // The capture is the opening quote (`"` or `'`) — the one
+                    // that closes the value.
+                    let quote = m.as_str().chars().last().unwrap();
+                    // Byte index (in the whole line) of the content right after
+                    // the opening quote.
+                    let content_start = tag_pos + "<flux:slot".len() + m.end();
+                    let typed = &line_text[content_start..cursor];
+                    // A closing quote between the opener and the cursor means
+                    // the value already closed — the cursor isn't inside it.
+                    if !typed.contains(quote) {
+                        let end_col = Self::find_string_end(line_text, content_start, quote);
+                        return Some(StringContext {
+                            prefix: typed.to_string(),
+                            start_col: content_start as u32,
+                            end_col,
+                            quote_char: quote,
+                        });
+                    }
+                }
+            }
+        }
+
+        // ── `<x-slot:│>` colon form ────────────────────────────────────────
+        if let Some(tag_pos) = before_cursor.rfind("<x-slot:") {
+            let start_pos = tag_pos + "<x-slot:".len();
+            let after_colon = &before_cursor[start_pos..];
+            // The name runs until whitespace / `>` / `/`. An `=` or quote means
+            // we're past the bare name (into an attribute or value).
+            let past_name = after_colon.contains(char::is_whitespace)
+                || after_colon.contains('>')
+                || after_colon.contains('/')
+                || after_colon.contains('=')
+                || after_colon.contains('"')
+                || after_colon.contains('\'');
+            if !past_name
+                && after_colon
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+            {
+                return Some(StringContext {
+                    prefix: after_colon.to_string(),
+                    start_col: start_pos as u32,
+                    end_col: cursor as u32,
+                    quote_char: ' ',
+                });
+            }
+        }
+
+        None
+    }
+
+    /// Convert a 0-based `(line, character)` LSP position into a byte offset
+    /// into `content`. Columns are treated as byte offsets within the line —
+    /// the convention used throughout this file's line-local context helpers.
+    /// `\r` (in `\r\n` line endings) stays part of its line segment, so the
+    /// offset math holds for both `\n` and `\r\n` files.
+    fn line_char_to_offset(content: &str, line: u32, character: u32) -> Option<usize> {
+        let mut offset = 0usize;
+        for (current_line, segment) in content.split('\n').enumerate() {
+            if current_line as u32 == line {
+                return Some(offset + (character as usize).min(segment.len()));
+            }
+            offset += segment.len() + 1; // + the '\n' that `split` consumed
+        }
+        None
+    }
+
+    /// Walk the document's component open/close tags up to `position` and
+    /// return the name (e.g. `flux:modal`) of the nearest still-open
+    /// `<flux:…>` component that *owns* a slot tag being typed at the cursor.
+    ///
+    /// The walk replays every fully-formed tag before the cursor onto an
+    /// open-tag stack: opening tags push, matching closing tags pop (dropping
+    /// any unclosed inner tags with them), self-closing tags are leaves. The
+    /// owner is then the innermost stack entry that is a `flux:…` component but
+    /// not itself a slot tag — `flux:slot` / `x-slot` entries and intervening
+    /// non-Flux tags are skipped. Returns `None` when no Flux component wraps
+    /// the cursor (e.g. a bare `<x-slot:…>` outside any Flux component — see
+    /// issue #106 AC).
+    fn enclosing_flux_component(content: &str, position: Position) -> Option<String> {
+        use lazy_static::lazy_static;
+        use regex::Regex;
+        lazy_static! {
+            // Opening / self-closing component tags. Capture 1 = tag name,
+            // capture 2 = trailing `/` for self-closing. Mirrors the proven
+            // patterns in `document_symbols::extract_blade_symbols`.
+            static ref OPEN_TAG_RE: Regex = Regex::new(
+                r#"<((?:x-[a-z][a-z0-9._:-]*)|(?:livewire:[a-z][a-z0-9._-]*)|(?:flux:[a-z][a-z0-9._-]*))\b[^>]*?(/?)>"#,
+            )
+            .unwrap();
+            static ref CLOSE_TAG_RE: Regex = Regex::new(
+                r#"</((?:x-[a-z][a-z0-9._:-]*)|(?:livewire:[a-z][a-z0-9._-]*)|(?:flux:[a-z][a-z0-9._-]*))>"#,
+            )
+            .unwrap();
+        }
+
+        let cursor = Self::line_char_to_offset(content, position.line, position.character)?;
+
+        // Tag events that fully precede the cursor, in source order.
+        enum Tag<'a> {
+            Open(&'a str),
+            SelfClose,
+            Close(&'a str),
+        }
+        let mut events: Vec<(usize, Tag)> = Vec::new();
+        for cap in OPEN_TAG_RE.captures_iter(content) {
+            let m = cap.get(0).expect("regex match always has group 0");
+            if m.end() > cursor {
+                continue; // includes the slot tag the cursor sits inside
+            }
+            let name = cap.get(1).map(|x| x.as_str()).unwrap_or_default();
+            let self_close = cap.get(2).map(|x| x.as_str() == "/").unwrap_or(false);
+            events.push((
+                m.start(),
+                if self_close {
+                    Tag::SelfClose
+                } else {
+                    Tag::Open(name)
+                },
+            ));
+        }
+        for cap in CLOSE_TAG_RE.captures_iter(content) {
+            let m = cap.get(0).expect("regex match always has group 0");
+            if m.end() > cursor {
+                continue;
+            }
+            let name = cap.get(1).map(|x| x.as_str()).unwrap_or_default();
+            events.push((m.start(), Tag::Close(name)));
+        }
+        events.sort_by_key(|(start, _)| *start);
+
+        // Replay onto an open-tag stack.
+        let mut stack: Vec<&str> = Vec::new();
+        for (_, tag) in &events {
+            match tag {
+                Tag::Open(name) => stack.push(name),
+                Tag::SelfClose => {}
+                Tag::Close(name) => {
+                    // Pop the nearest matching open tag, discarding any unclosed
+                    // inner tags opened after it (forgiving of malformed nesting).
+                    if let Some(pos) = stack.iter().rposition(|t| t == name) {
+                        stack.truncate(pos);
+                    }
+                }
+            }
+        }
+
+        // Innermost-first: the owner is the nearest `flux:…` component that
+        // isn't itself a slot tag.
+        stack.iter().rev().find_map(|t| {
+            let is_slot = *t == "flux:slot" || *t == "x-slot" || t.starts_with("x-slot:");
+            if !is_slot && t.starts_with("flux:") {
+                Some((*t).to_string())
+            } else {
+                None
+            }
+        })
     }
 
     /// Check if cursor is inside a Livewire component tag like `<livewire:...` or `@livewire('...')`
@@ -22586,6 +22792,81 @@ impl LanguageServer for LaravelLanguageServer {
                     .collect();
 
                 debug!("   Returning {} Flux prop completion items", items.len());
+
+                return if items.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(CompletionResponse::List(CompletionList {
+                        is_incomplete: false,
+                        items,
+                    })))
+                };
+            }
+
+            // Flux slot-name context (`<flux:slot name="│">` or `<x-slot:│>`):
+            // offer the *enclosing* Flux component's named slots — the slots
+            // half of issue #60's props/slots criterion. Ordered after the Flux
+            // attribute (props) block and before Livewire, per issue #106.
+            if let Some(slot_ctx) = Self::get_flux_slot_name_context(line_text, position.character)
+            {
+                debug!(
+                    "   Flux slot-name context, filter prefix: '{}'",
+                    slot_ctx.prefix
+                );
+
+                // Resolve the wrapping `<flux:…>` component and enumerate its
+                // named slots from the backing Blade. No Flux parent (e.g. a
+                // bare `<x-slot:…>`) → no completions.
+                let slot_names: Vec<(String, String)> =
+                    match Self::enclosing_flux_component(&content, position) {
+                        Some(component_name) => {
+                            match self.resolve_component_file(&component_name).await {
+                                Some(path) => {
+                                    let file_content =
+                                        std::fs::read_to_string(&path).unwrap_or_default();
+                                    Self::extract_slot_variable_usages(&file_content)
+                                        .into_iter()
+                                        .map(|(name, _ty)| (name, component_name.clone()))
+                                        .collect()
+                                }
+                                None => Vec::new(),
+                            }
+                        }
+                        None => Vec::new(),
+                    };
+
+                let prefix_lower = slot_ctx.prefix.to_lowercase();
+                let items: Vec<CompletionItem> = slot_names
+                    .into_iter()
+                    .filter(|(name, _)| name.to_lowercase().starts_with(&prefix_lower))
+                    .map(|(name, component_name)| CompletionItem {
+                        label: name.clone(),
+                        kind: Some(CompletionItemKind::FIELD),
+                        detail: Some(format!("<{}> slot", component_name)),
+                        documentation: Some(
+                            CompletionDoc::new()
+                                .header(format!("{} (slot)", name))
+                                .summary("Flux component slot.")
+                                .into_documentation(),
+                        ),
+                        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                            range: Range {
+                                start: Position {
+                                    line: position.line,
+                                    character: slot_ctx.start_col,
+                                },
+                                end: Position {
+                                    line: position.line,
+                                    character: slot_ctx.end_col,
+                                },
+                            },
+                            new_text: name.clone(),
+                        })),
+                        ..Default::default()
+                    })
+                    .collect();
+
+                debug!("   Returning {} Flux slot completion items", items.len());
 
                 return if items.is_empty() {
                     Ok(None)

--- a/laravel-lsp/src/tests/flux_slot_name_context.rs
+++ b/laravel-lsp/src/tests/flux_slot_name_context.rs
@@ -1,0 +1,278 @@
+//! Flux slot-name completion-context detection and enclosing-component
+//! resolution (issue #106 — follow-up from Holmes's review of #60 / PR #99).
+//!
+//! Three pieces feed `<flux:slot>` / `<x-slot:>` slot-name completion:
+//! - `get_flux_slot_name_context` — is the cursor inside a slot *name* being
+//!   typed (`<flux:slot name="│">` or `<x-slot:│>`), and what's the partial?
+//! - `enclosing_flux_component` — which wrapping `<flux:…>` component owns that
+//!   slot tag (walked over the full document's open-tag stack)?
+//! - `extract_slot_variable_usages` — the owner's named slots, read from its
+//!   backing Blade (already covered in `slot_variable_resolution`; re-exercised
+//!   here through the full round-trip).
+//!
+//! `get_blade_component_context`'s slot exclusion is covered too: without it,
+//! the `<x-slot:│>` colon form would be swallowed as a Blade *component* name
+//! before reaching the slot-name block.
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::salsa_impl::LaravelConfigData;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::Position;
+
+// ─── context detection: `<flux:slot name="…">` value form ────────────────
+
+#[test]
+fn flux_slot_context_at_empty_value() {
+    let line = "    <flux:slot name=\"";
+    let ctx = LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32)
+        .expect("cursor inside an empty `name=\"\"` value is a slot-name context");
+    assert_eq!(ctx.prefix, "", "no partial typed yet → offer all slots");
+    assert_eq!(
+        ctx.start_col,
+        line.len() as u32,
+        "replacement starts right after the opening quote",
+    );
+}
+
+#[test]
+fn flux_slot_context_with_partial_value() {
+    let line = "<flux:slot name=\"ti";
+    let ctx = LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32)
+        .expect("a partial `name=\"ti` value is a slot-name context");
+    assert_eq!(ctx.prefix, "ti");
+    // `<flux:slot name="` is 17 bytes; content (the `t`) starts at col 17.
+    assert_eq!(ctx.start_col, 17);
+}
+
+#[test]
+fn flux_slot_context_accepts_single_quotes() {
+    let line = "<flux:slot name='foo";
+    let ctx = LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32)
+        .expect("single-quoted name value is detected too");
+    assert_eq!(ctx.prefix, "foo");
+    assert_eq!(ctx.quote_char, '\'');
+}
+
+// ─── context detection: `<x-slot:│>` colon form ──────────────────────────
+
+#[test]
+fn x_slot_colon_context_at_bare_prefix() {
+    let line = "<x-slot:";
+    let ctx = LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32)
+        .expect("`<x-slot:` is a slot-name context");
+    assert_eq!(ctx.prefix, "");
+    assert_eq!(
+        ctx.start_col, 8,
+        "replacement starts right after `<x-slot:`"
+    );
+}
+
+#[test]
+fn x_slot_colon_context_with_partial_name() {
+    let line = "    <x-slot:ti";
+    let ctx = LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32)
+        .expect("partial `<x-slot:ti` is a slot-name context");
+    assert_eq!(ctx.prefix, "ti");
+}
+
+// ─── no-match cases ───────────────────────────────────────────────────────
+
+#[test]
+fn no_context_in_name_attribute_key() {
+    // Cursor in the attribute *key*, before the `=` — not inside the value.
+    let line = "<flux:slot name";
+    assert!(
+        LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32).is_none(),
+        "the `name` key position is not a slot-name value context",
+    );
+    // Right after `=` but before any quote is still not inside the value.
+    let line = "<flux:slot name=";
+    assert!(
+        LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32).is_none(),
+        "between `=` and the opening quote is not inside the value",
+    );
+}
+
+#[test]
+fn no_context_in_tag_content() {
+    // The tag has closed (`>` before the cursor) — the cursor is in content,
+    // not in the `name` value.
+    let line = "<flux:slot name=\"title\">";
+    assert!(
+        LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32).is_none(),
+        "a closed slot tag puts the cursor in content, not the name value",
+    );
+    let line = "<flux:slot name=\"title\">{{ ";
+    assert!(
+        LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32).is_none(),
+        "inside tag content there is no slot-name completion",
+    );
+}
+
+#[test]
+fn no_context_outside_any_slot_tag() {
+    let line = "<flux:button variant=\"pri";
+    assert!(
+        LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32).is_none(),
+        "a non-slot Flux tag is not a slot-name context",
+    );
+    let line = "    just some text";
+    assert!(LaravelLanguageServer::get_flux_slot_name_context(line, line.len() as u32).is_none());
+}
+
+#[test]
+fn blade_component_context_excludes_slot_syntax() {
+    // The coupled fix: `<x-slot:` / `<x-slot` must NOT register as a Blade
+    // component-name context, or the earlier component block would swallow the
+    // colon form before the slot-name block runs.
+    assert!(
+        LaravelLanguageServer::get_blade_component_context("<x-slot:", 8).is_none(),
+        "`<x-slot:` is slot syntax, not a component-name context",
+    );
+    assert!(
+        LaravelLanguageServer::get_blade_component_context("<x-slot:ti", 10).is_none(),
+        "`<x-slot:ti` is slot syntax, not a component-name context",
+    );
+    assert!(
+        LaravelLanguageServer::get_blade_component_context("<x-slot", 7).is_none(),
+        "bare `<x-slot` is slot syntax, not a component-name context",
+    );
+    // Regression guard: a real component whose name merely starts with "slot"
+    // is still a component context.
+    assert!(
+        LaravelLanguageServer::get_blade_component_context("<x-slot-machine", 15).is_some(),
+        "a component named `slot-machine` is unaffected by the exclusion",
+    );
+}
+
+// ─── enclosing-Flux-component resolution ──────────────────────────────────
+
+/// Byte `(line, character)` of the caret marker `│` in `doc`, with the marker
+/// stripped. Columns are byte offsets within the line — the convention the
+/// production helpers use.
+fn caret(doc: &str) -> (String, Position) {
+    let idx = doc.find('│').expect("fixture must contain a `│` caret");
+    let before = &doc[..idx];
+    let line = before.matches('\n').count() as u32;
+    let line_start = before.rfind('\n').map(|p| p + 1).unwrap_or(0);
+    let character = (idx - line_start) as u32;
+    (doc.replace('│', ""), Position { line, character })
+}
+
+#[test]
+fn enclosing_resolves_direct_flux_parent() {
+    let (doc, pos) =
+        caret("<flux:modal>\n    <flux:slot name=\"│\">\n    </flux:slot>\n</flux:modal>\n");
+    assert_eq!(
+        LaravelLanguageServer::enclosing_flux_component(&doc, pos).as_deref(),
+        Some("flux:modal"),
+    );
+}
+
+#[test]
+fn enclosing_skips_self_closed_and_closed_siblings() {
+    // A self-closing Flux tag and a fully-closed Flux sibling before the slot
+    // must NOT be mistaken for the owner — only the still-open `<flux:card>` is.
+    let (doc, pos) = caret(
+        "<flux:icon name=\"x\" />\n\
+         <flux:button>Go</flux:button>\n\
+         <flux:card>\n    <flux:slot name=\"│\">\n</flux:card>\n",
+    );
+    assert_eq!(
+        LaravelLanguageServer::enclosing_flux_component(&doc, pos).as_deref(),
+        Some("flux:card"),
+    );
+}
+
+#[test]
+fn enclosing_returns_none_without_flux_ancestor() {
+    // `<x-slot:title>` inside a non-Flux `<x-card>` — AC: no Flux parent → None,
+    // so bare `<x-slot>` usage outside Flux yields no completions.
+    let (doc, pos) = caret("<x-card>\n    <x-slot:│>\n</x-card>\n");
+    assert!(
+        LaravelLanguageServer::enclosing_flux_component(&doc, pos).is_none(),
+        "no wrapping `<flux:…>` component → no owner",
+    );
+}
+
+// ─── integration round-trip: slot tag → owner → its named slots ───────────
+
+/// A `LaravelConfigData` whose `flux` anonymous-component directory is `dir`.
+/// Mirrors `flux_config` in `flux_component_hover` — every other field empty.
+fn flux_config(dir: PathBuf) -> LaravelConfigData {
+    let mut anonymous_component_paths = HashMap::new();
+    anonymous_component_paths.insert("flux".to_string(), dir.clone());
+    LaravelConfigData {
+        root: dir,
+        view_paths: vec![PathBuf::from("resources/views")],
+        component_paths: Vec::new(),
+        livewire_path: None,
+        has_livewire: false,
+        view_namespaces: HashMap::new(),
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths,
+        anonymous_component_namespaces: HashMap::new(),
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+        class_component_files: HashMap::new(),
+    }
+}
+
+/// A `<flux:modal>` backing Blade that fills two named slots (`$title`,
+/// `$footer`) and the default `$slot`. The default slot must be excluded.
+const MODAL_BLADE: &str = "@props(['name' => null])\n\
+    <div class=\"modal\">\n\
+    <header>{{ $title }}</header>\n\
+    <div class=\"body\">{{ $slot }}</div>\n\
+    @if($footer->isNotEmpty())<footer>{{ $footer }}</footer>@endif\n\
+    </div>\n";
+
+#[test]
+fn round_trip_offers_owner_named_slots_excluding_default_slot() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("modal.blade.php"), MODAL_BLADE).unwrap();
+    let config = flux_config(dir.path().to_path_buf());
+
+    // The consumer document: a `<flux:slot name="│">` nested in `<flux:modal>`.
+    let (doc, pos) = caret(
+        "<flux:modal name=\"edit\">\n    <flux:slot name=\"│\">\n    </flux:slot>\n</flux:modal>\n",
+    );
+
+    // 1. The cursor is recognised as a slot-name context.
+    let line = doc.lines().nth(pos.line as usize).unwrap();
+    let ctx = LaravelLanguageServer::get_flux_slot_name_context(line, pos.character)
+        .expect("cursor sits in the `name` value → slot-name context");
+    assert_eq!(ctx.prefix, "", "empty value → all slots offered");
+
+    // 2. The wrapping Flux component is resolved to `flux:modal`.
+    let owner = LaravelLanguageServer::enclosing_flux_component(&doc, pos)
+        .expect("the `<flux:modal>` ancestor owns the slot");
+    assert_eq!(owner, "flux:modal");
+
+    // 3. `flux:modal` resolves to the backing Blade on disk.
+    let path = config
+        .resolve_component_path(&owner)
+        .into_iter()
+        .find(|p| p.exists())
+        .expect("the registered Flux modal file resolves");
+    assert_eq!(path, dir.path().join("modal.blade.php"));
+
+    // 4. Its named slots are enumerated — `title` and `footer`, never `$slot`.
+    let content = fs::read_to_string(&path).unwrap();
+    let slots = LaravelLanguageServer::extract_slot_variable_usages(&content);
+    assert!(
+        slots.iter().any(|(n, _)| n == "title"),
+        "named slot `title` is offered",
+    );
+    assert!(
+        slots.iter().any(|(n, _)| n == "footer"),
+        "named slot `footer` is offered",
+    );
+    assert!(
+        !slots.iter().any(|(n, _)| n == "slot"),
+        "the default `$slot` is excluded",
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod diagnostic_severity;
 mod dynamic_where_sparseness;
 mod flux_component_context;
 mod flux_component_hover;
+mod flux_slot_name_context;
 mod folio_cursor_containment;
 mod folio_rename;
 mod generic_type_parsing;


### PR DESCRIPTION
## Summary
Implements #106 — Flux slot-name completion. Offers an enclosing Flux component's named slots when the cursor sits inside a slot tag's name (`<flux:slot name="│">` or `<x-slot:│>`). This is the **slots** half of #60's props/slots criterion, deferred from PR #99 (which shipped prop completion at the attribute position).

## Changes
- **`get_flux_slot_name_context`** — detects the cursor inside a `<flux:slot name="…">` attribute value or the `<x-slot:…>` colon form; returns the partial name typed plus the replacement column range.
- **`enclosing_flux_component`** — walks the full document's open-tag stack up to the cursor to find the nearest wrapping `<flux:…>` component that owns the slot, skipping `<flux:slot>`/`<x-slot>` tags, self-closed and already-closed tags; returns `None` when no Flux ancestor exists.
- **`line_char_to_offset`** — small helper converting an LSP `(line, character)` to a byte offset (byte-column convention, `\n`/`\r\n` safe).
- **`completion()` wiring** — new slot-name block, ordered **after** the Flux attribute (props) block and **before** Livewire. Resolves the parent via `resolve_component_file("flux:<component>")`, enumerates its named slots with `extract_slot_variable_usages`, and offers them as `CompletionItemKind::FIELD` with detail `<flux:component> slot`.
- **`get_blade_component_context`** — excludes `<x-slot>`/`<x-slot:>` slot syntax so the colon form reaches the slot block instead of being swallowed as a Blade component name.

## Acceptance Criteria
- [x] `get_flux_slot_name_context` detects the cursor in a `<flux:slot …>` `name="…"` value and returns the partial + replacement range
- [x] Same detector fires for the `<x-slot:│>` colon form (name after `:` as the partial)
- [x] Enclosing-Flux-tag resolver walks the open-tag stack to the nearest wrapping `<flux:…>`; slot tags and already-closed tags skipped; `None` when no Flux parent
- [x] `resolve_component_file("flux:<component>")` called on the resolved parent name
- [x] Named slots extracted via `extract_slot_variable_usages`; offered as `CompletionItemKind::FIELD` with detail `<flux:component> slot`
- [x] Both cursor positions trigger completion in `completion()`, ordered after the Flux attribute block and before Livewire
- [x] Cursor in the `name` attribute *key*, or in tag content, does **not** trigger
- [x] `<x-slot:name>` not wrapped in any `<flux:…>` ancestor returns no completions
- [x] Unit tests: context detection (both forms), no-match cases (key, content, no Flux parent), slot enumeration from a fixture Flux Blade
- [x] Integration-style round-trip: `<flux:modal>…<flux:slot name="│">…</flux:modal>` returns the modal's named slots (`title`, `footer`) excluding `$slot`

## Test Plan
- [x] 13 new tests pass (`cargo test flux_slot_name_context`)
- [x] Full suite green except 8 pre-existing `integration_tests.rs` failures (missing gitignored `test-project/.env` fixtures — identical on the pristine base, unrelated to this change)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean (no new warnings)

Fixes #106