### PR TITLE
Make @foreach paren-matching comment-aware so a `)` inside a comment doesn't falsely mark a loop unresolved

### DIFF
--- a/laravel-lsp/src/blade_loops.rs
+++ b/laravel-lsp/src/blade_loops.rs
@@ -136,16 +136,21 @@ fn balanced_directive_arguments(lines: &[&str], start_line: usize, open: usize) 
         return Some(lines[start_line][open..=close].to_string());
     }
 
-    // Slow path: the header wraps. Accumulate continuation lines (joined by a
-    // single space, so a binding split as `… as` ⏎ `$user` still parses) until
-    // the parens balance.
+    // Slow path: the header wraps. Accumulate continuation lines until the
+    // parens balance. Lines are joined with `\n` (not a space) so `matching_paren`
+    // can see the physical line boundaries — a `//`/`#` comment on one line must
+    // end at its own line break, not swallow the closing `)` further down
+    // (issue #166). The `\n` join is internal: the returned argument string
+    // collapses each `\n` back to a single space, preserving the documented
+    // format (and the ` as ` split that recovers a binding wrapped as
+    // `… as` ⏎ `$user`).
     let mut buf = lines[start_line][open..].to_string();
     for line in &lines[start_line + 1..] {
-        buf.push(' ');
+        buf.push('\n');
         buf.push_str(line.trim_start());
         if let Some(close) = matching_paren(&buf, 0) {
             buf.truncate(close + 1);
-            return Some(buf);
+            return Some(buf.replace('\n', " "));
         }
     }
     None
@@ -160,7 +165,11 @@ fn balanced_directive_arguments(lines: &[&str], start_line: usize, open: usize) 
 /// - single- or double-quoted string literals (`'…'`, `"…"`), honouring `\`
 ///   escapes;
 /// - `/* … */` block comments;
-/// - `//` and `#` line comments — everything from the marker to the end of `s`.
+/// - `//` and `#` line comments — from the marker to the end of the physical
+///   line (the next `\n`), or to the end of `s` when it has no newline. The
+///   multi-line slow path in [`balanced_directive_arguments`] joins lines with
+///   `\n` precisely so a line comment on a wrapped header ends at its own line
+///   break instead of swallowing the closing `)` further down.
 ///
 /// Without comment-awareness a `)` inside a header comment — e.g.
 /// `@foreach ($users /* :) */ as $user)` — would close the depth counter early,
@@ -171,6 +180,14 @@ fn balanced_directive_arguments(lines: &[&str], start_line: usize, open: usize) 
 /// always lands on a char boundary.
 fn matching_paren(s: &str, open: usize) -> Option<usize> {
     let bytes = s.as_bytes();
+    // The no-underflow of `depth` (a `usize`, decremented on every `)`) and the
+    // char-boundary safety of the caller's `buf.truncate(close + 1)` both rely on
+    // `open` indexing a literal `(`. Every caller passes the `(` of a loop head;
+    // assert it so a future caller that violates the contract fails loudly here.
+    debug_assert!(
+        bytes.get(open) == Some(&b'('),
+        "matching_paren expects `open` to index a literal '('"
+    );
     let mut depth = 0usize;
     let mut quote: Option<u8> = None;
     let mut in_block_comment = false;
@@ -205,11 +222,19 @@ fn matching_paren(s: &str, open: usize) -> Option<usize> {
                     in_block_comment = true;
                     i += 1;
                 }
-                // `//` or `#` begins a line comment: the rest of `s` is
-                // commentary, so no later byte can affect paren depth. Stop —
-                // the parens are unbalanced on this input.
-                b'/' if bytes.get(i + 1) == Some(&b'/') => return None,
-                b'#' => return None,
+                // `//` or `#` begins a line comment. In PHP it runs to the end
+                // of the *physical* line, so on the `\n`-joined multi-line buffer
+                // (the slow path) it ends at the next `\n` and scanning resumes
+                // on the following line — the real closing `)` further down is
+                // still counted. On a single-line input there is no `\n`, so the
+                // rest is commentary and the parens can't balance: stop.
+                b'#' | b'/' if c == b'#' || bytes.get(i + 1) == Some(&b'/') => {
+                    match s[i..].find('\n') {
+                        // Jump to the `\n`; the `i += 1` below steps past it.
+                        Some(rel_nl) => i += rel_nl,
+                        None => return None,
+                    }
+                }
                 b'(' => depth += 1,
                 b')' => {
                     depth -= 1;
@@ -398,6 +423,22 @@ mod tests {
     }
 
     #[test]
+    fn matching_paren_ends_a_line_comment_at_the_newline() {
+        // On the `\n`-joined multi-line buffer that the slow path of
+        // `balanced_directive_arguments` builds, a `//` / `#` comment ends at the
+        // next newline — the real closing `)` on a later line is still found,
+        // instead of being swallowed as if the comment ran to end of input
+        // (the issue #166 review regression).
+        let slashes = "($users // active only\nas $user)";
+        let close = matching_paren(slashes, 0).expect("the `)` on the next line is found");
+        assert_eq!(close, slashes.len() - 1);
+
+        let hash = "($users # active only\nas $user)";
+        let close = matching_paren(hash, 0).expect("the `)` on the next line is found");
+        assert_eq!(close, hash.len() - 1);
+    }
+
+    #[test]
     fn matching_paren_lone_slash_star_is_unterminated() {
         // `/*/` is an open block comment, not open-then-close; it never ends, so
         // the surrounding paren never balances.
@@ -421,6 +462,35 @@ mod tests {
             vars,
             vec![("user".to_string(), "mixed".to_string())],
             "the bound variable survives the comment in the header"
+        );
+    }
+
+    #[test]
+    fn wrapped_header_with_a_first_line_comment_resolves_the_binding() {
+        // A `//` (or `#`) line comment on the FIRST physical line of a wrapped
+        // header ends at the line break, so the binding on the next line is still
+        // parsed — the comment doesn't swallow the rest of the joined buffer
+        // (issue #166 review fix). The returned argument string keeps the comment
+        // text (like the block-comment case) but collapses the line join to a
+        // single space.
+        let lines = vec!["@foreach ($users // active only", "    as $user)"];
+        let open = lines[0].find('(').unwrap();
+        let args = balanced_directive_arguments(&lines, 0, open).unwrap();
+        assert_eq!(args, "($users // active only as $user)");
+        assert_eq!(
+            parse_foreach_variables(&args),
+            vec![("user".to_string(), "mixed".to_string())],
+            "the `// …`-commented first line doesn't lose the binding"
+        );
+
+        let lines = vec!["@foreach ($users # active only", "    as $user)"];
+        let open = lines[0].find('(').unwrap();
+        let args = balanced_directive_arguments(&lines, 0, open).unwrap();
+        assert_eq!(args, "($users # active only as $user)");
+        assert_eq!(
+            parse_foreach_variables(&args),
+            vec![("user".to_string(), "mixed".to_string())],
+            "the `# …`-commented first line doesn't lose the binding"
         );
     }
 }

--- a/laravel-lsp/src/blade_loops.rs
+++ b/laravel-lsp/src/blade_loops.rs
@@ -153,16 +153,42 @@ fn balanced_directive_arguments(lines: &[&str], start_line: usize, open: usize) 
 
 /// Given the byte index of an opening `(` in `s`, return the byte index of its
 /// matching `)`, balancing nested parens and ignoring any parens that sit
-/// inside single- or double-quoted string literals. Returns `None` when the
-/// parens are unbalanced on this line. `(`, `)`, `'`, `"`, `\` are ASCII, so
-/// the returned indices always land on char boundaries.
+/// inside string literals **or PHP comments**. Returns `None` when the parens
+/// are unbalanced on this input.
+///
+/// Skipped spans (a `)` inside any of these never counts toward depth):
+/// - single- or double-quoted string literals (`'…'`, `"…"`), honouring `\`
+///   escapes;
+/// - `/* … */` block comments;
+/// - `//` and `#` line comments — everything from the marker to the end of `s`.
+///
+/// Without comment-awareness a `)` inside a header comment — e.g.
+/// `@foreach ($users /* :) */ as $user)` — would close the depth counter early,
+/// truncating the arguments before ` as $user`. The binding would then be lost,
+/// the loop treated as opaque, and a legitimate rename refused (issue #166).
+///
+/// `(`, `)`, `'`, `"`, `\`, `/`, `*`, `#` are all ASCII, so the returned index
+/// always lands on a char boundary.
 fn matching_paren(s: &str, open: usize) -> Option<usize> {
     let bytes = s.as_bytes();
     let mut depth = 0usize;
     let mut quote: Option<u8> = None;
+    let mut in_block_comment = false;
     let mut i = open;
     while i < bytes.len() {
         let c = bytes[i];
+
+        if in_block_comment {
+            // Inside `/* … */`: every byte (including `)`) is skipped until the
+            // closing `*/`.
+            if c == b'*' && bytes.get(i + 1) == Some(&b'/') {
+                in_block_comment = false;
+                i += 1; // also consume the closing '/'
+            }
+            i += 1;
+            continue;
+        }
+
         match quote {
             Some(q) => {
                 if c == b'\\' {
@@ -173,6 +199,17 @@ fn matching_paren(s: &str, open: usize) -> Option<usize> {
             }
             None => match c {
                 b'\'' | b'"' => quote = Some(c),
+                // `/*` opens a block comment; its bytes are skipped above. Also
+                // consume the `*` so a lone `/*/` isn't read as open-then-close.
+                b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                    in_block_comment = true;
+                    i += 1;
+                }
+                // `//` or `#` begins a line comment: the rest of `s` is
+                // commentary, so no later byte can affect paren depth. Stop —
+                // the parens are unbalanced on this input.
+                b'/' if bytes.get(i + 1) == Some(&b'/') => return None,
+                b'#' => return None,
                 b'(' => depth += 1,
                 b')' => {
                     depth -= 1;
@@ -322,4 +359,68 @@ pub fn get_enclosing_loops(content: &str, cursor_line: usize) -> Vec<BladeLoopBl
 
     enclosing.sort_by_key(|b| std::cmp::Reverse(b.start_line));
     enclosing
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── matching_paren: comment-awareness (issue #166) ──────────────────────
+
+    #[test]
+    fn matching_paren_ignores_parens_in_a_block_comment() {
+        // The `)` inside `/* :) */` must NOT close the depth counter early; the
+        // match is the final `)`, not the one inside the comment.
+        let s = "@foreach ($users /* :) */ as $user)";
+        let open = s.find('(').unwrap();
+        let close = matching_paren(s, open).unwrap();
+        assert_eq!(
+            close,
+            s.len() - 1,
+            "match is the trailing `)`, not the one in the comment"
+        );
+    }
+
+    #[test]
+    fn matching_paren_still_ignores_parens_in_strings() {
+        // Pre-existing quote-awareness is preserved by the comment changes.
+        let s = "($users->where('a)b', true) as $user)";
+        let close = matching_paren(s, 0).unwrap();
+        assert_eq!(close, s.len() - 1);
+    }
+
+    #[test]
+    fn matching_paren_treats_line_comments_as_skipping_the_rest() {
+        // `//` and `#` start a line comment: everything past the marker — the
+        // closing `)` included — is skipped, so the parens never balance.
+        assert_eq!(matching_paren("($users // ) comment", 0), None);
+        assert_eq!(matching_paren("($users # ) comment", 0), None);
+    }
+
+    #[test]
+    fn matching_paren_lone_slash_star_is_unterminated() {
+        // `/*/` is an open block comment, not open-then-close; it never ends, so
+        // the surrounding paren never balances.
+        assert_eq!(matching_paren("($x /*/ as $y)", 0), None);
+    }
+
+    // ── balanced_directive_arguments + parse_foreach_variables (issue #166) ──
+
+    #[test]
+    fn commented_header_yields_full_arguments_and_the_bound_variable() {
+        // The header `@foreach ($users /* :) */ as $user)` parses end-to-end:
+        // the full argument list survives the comment, and `$user` is recovered.
+        let line = "@foreach ($users /* :) */ as $user)";
+        let lines = vec![line];
+        let open = line.find('(').unwrap();
+        let args = balanced_directive_arguments(&lines, 0, open).unwrap();
+        assert_eq!(args, "($users /* :) */ as $user)");
+
+        let vars = parse_foreach_variables(&args);
+        assert_eq!(
+            vars,
+            vec![("user".to_string(), "mixed".to_string())],
+            "the bound variable survives the comment in the header"
+        );
+    }
 }

--- a/laravel-lsp/src/blade_var_rename/tests.rs
+++ b/laravel-lsp/src/blade_var_rename/tests.rs
@@ -246,15 +246,54 @@ fn commented_out_loop_does_not_create_a_phantom_binding_block() {
 }
 
 #[test]
-fn opaque_loop_refuses_rename_rather_than_clobbering() {
-    // A PHP block comment inside the header desyncs the paren scan, so the
-    // binding can't be resolved — an opaque loop. A rename whose cursor sits
-    // inside it is refused (no spans) rather than falling through to the
-    // file-scope arm and clobbering every `$user`. `cursor_in_unresolved_loop`
-    // gates prepare_rename identically.
+fn commented_foreach_header_is_resolved_and_renameable() {
+    // issue #166: a `)` inside a PHP comment in the header no longer desyncs the
+    // paren scan. The loop binding (`$user`) is recovered, so the block is NOT
+    // opaque, the cursor is NOT in an unresolved region, and a rename is offered
+    // (scoped to the loop) instead of being refused.
     let src = "\
 {{ $user }}
 @foreach ($users /* :) */ as $user)
+    {{ $user->name }}
+@endforeach
+{{ $user }}";
+
+    // The header parses into a foreach block that binds `$user` — not opaque.
+    let block = find_loop_blocks(src)
+        .into_iter()
+        .find(|b| b.loop_type == BladeLoopType::Foreach)
+        .expect("the commented header still forms a foreach block");
+    assert!(
+        block.variables.iter().any(|(v, _)| v == "user"),
+        "the bound `$user` is recovered from the commented header"
+    );
+    assert!(!is_opaque_loop(&block), "a resolved binding is not opaque");
+
+    // A cursor inside the loop body is not in an unresolved region…
+    assert!(
+        !cursor_in_unresolved_loop(src, 2),
+        "the loop scope is resolved, so the cursor is not unresolved"
+    );
+    // …and the rename is offered, scoped to the loop (directive + body).
+    let spans = in_scope_spans(src, "user", 2);
+    let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+    assert_eq!(
+        lines,
+        vec![1, 2],
+        "rename offered and scoped to the loop, not refused"
+    );
+}
+
+#[test]
+fn opaque_loop_refuses_rename_rather_than_clobbering() {
+    // A `@foreach` with no resolvable ` as $var` binding is an opaque loop — the
+    // parser recovers no loop variable, so its scope is unknown. A rename whose
+    // cursor sits inside it is refused (no spans) rather than falling through to
+    // the file-scope arm and clobbering every `$user`. `cursor_in_unresolved_loop`
+    // gates prepare_rename identically.
+    let src = "\
+{{ $user }}
+@foreach ($users)
     {{ $user }}
 @endforeach
 {{ $user }}";
@@ -316,10 +355,12 @@ fn blade_comment_inside_a_multiline_header_still_scopes() {
 #[test]
 fn file_scoped_rename_skips_an_opaque_loop() {
     // A file-scoped rename (cursor outside any loop) must not clobber INTO an
-    // opaque loop whose scope is unknown — those occurrences are left alone.
+    // opaque loop whose scope is unknown — those occurrences are left alone. The
+    // opaque loop here has no resolvable ` as $var` binding (issue #166 reworked
+    // this away from a comment-embedded `)`, which now parses correctly).
     let src = "\
 {{ $user }}
-@foreach ($users /* :) */ as $user)
+@foreach ($users)
     {{ $user }}
 @endforeach
 {{ $user }}";

--- a/laravel-lsp/src/blade_var_rename/tests.rs
+++ b/laravel-lsp/src/blade_var_rename/tests.rs
@@ -285,6 +285,50 @@ fn commented_foreach_header_is_resolved_and_renameable() {
 }
 
 #[test]
+fn wrapped_header_with_a_php_line_comment_is_resolved_and_renameable() {
+    // issue #166 review fix: a `//` / `#` PHP comment on the first physical line
+    // of a WRAPPED `@foreach` header must end at the line break, not swallow the
+    // closing `)` on the next line. Before the fix the joined buffer treated the
+    // comment as running to end of input, the binding (`$user`) was lost, the
+    // loop was treated as unresolved, and a legitimate rename was refused. (A
+    // Blade `{{-- --}}` comment is masked upstream; a PHP `//`/`#` is not, so it
+    // reaches the paren scan — hence this dedicated case.)
+    for header in [
+        "@foreach ($users // active only\n    as $user)",
+        "@foreach ($users # active only\n    as $user)",
+    ] {
+        let src = String::from("{{ $user }}\n")
+            + header
+            + "\n    {{ $user->name }}\n@endforeach\n{{ $user }}";
+
+        // The header parses into a foreach block that binds `$user` — not opaque.
+        let block = find_loop_blocks(&src)
+            .into_iter()
+            .find(|b| b.loop_type == BladeLoopType::Foreach)
+            .expect("the line-commented wrapped header still forms a foreach block");
+        assert!(
+            block.variables.iter().any(|(v, _)| v == "user"),
+            "the bound `$user` is recovered despite the first-line comment: {header:?}"
+        );
+        assert!(!is_opaque_loop(&block), "a resolved binding is not opaque");
+
+        // A cursor in the loop body (line 3) is not unresolved, and the rename is
+        // offered, scoped to the binding line + body (lines 2 and 3) — not refused.
+        assert!(
+            !cursor_in_unresolved_loop(&src, 3),
+            "the loop scope is resolved, so the cursor is not unresolved: {header:?}"
+        );
+        let spans = in_scope_spans(&src, "user", 3);
+        let lines: Vec<u32> = spans.iter().map(|s| s.line).collect();
+        assert_eq!(
+            lines,
+            vec![2, 3],
+            "rename offered and scoped to the loop, not refused: {header:?}"
+        );
+    }
+}
+
+#[test]
 fn opaque_loop_refuses_rename_rather_than_clobbering() {
     // A `@foreach` with no resolvable ` as $var` binding is an opaque loop — the
     // parser recovers no loop variable, so its scope is unknown. A rename whose

--- a/laravel-lsp/src/tests/blade_var_rename_handler.rs
+++ b/laravel-lsp/src/tests/blade_var_rename_handler.rs
@@ -110,15 +110,16 @@ async fn prepare_accepts_file_scoped_variable_and_excludes_the_sigil() {
 
 #[tokio::test]
 async fn prepare_rejects_cursor_in_unresolved_loop() {
-    // An opaque `@foreach`: the inline comment inside the header desyncs the
-    // paren scan, so the loop's binding can't be resolved. Even though `$user`
-    // *does* surface in markup (so the `is_template_variable` gate passes), a
-    // cursor inside the loop must be refused by the `cursor_in_unresolved_loop`
-    // gate — a scope-local rename there risks a file-wide clobber.
+    // An opaque `@foreach`: the header has no resolvable ` as $var` binding, so
+    // the loop's scope can't be determined. Even though `$user` *does* surface
+    // in markup (so the `is_template_variable` gate passes), a cursor inside the
+    // loop must be refused by the `cursor_in_unresolved_loop` gate — a
+    // scope-local rename there risks a file-wide clobber. (Issue #166 reworked
+    // this fixture off a comment-embedded `)`, which now parses correctly.)
     let dir = TempDir::new().unwrap();
     let backend = minimal_backend();
     let src = "{{ $user }}\n\
-               @foreach ($users /* :) */ as $user)\n\
+               @foreach ($users)\n\
                \x20   {{ $user }}\n\
                @endforeach\n\
                {{ $user }}\n";


### PR DESCRIPTION
## Summary
Implements #166.

A `)` inside a PHP comment within a `@foreach`/`@forelse` header — e.g. `@foreach ($users /* :) */ as $user)` — closed the paren-depth counter early in `matching_paren`, truncating the directive arguments before ` as $user`. The binding was then lost, the loop was treated as **opaque**, and `prepare_blade_var_rename` / `blade_var_rename_edit` refused a legitimate variable rename for the cursor inside that loop.

`matching_paren` is now **comment-aware**: it skips PHP comment spans the same way it already skips quoted strings, so a `)` inside a comment no longer counts toward paren depth.

## Changes
- `blade_loops.rs` — `matching_paren` now tracks `/* … */` block comments (bytes inside, including `)`, are not counted) and treats `//` / `#` as line-comment markers (the rest of the input is skipped). Quote-awareness and escape handling are unchanged. Doc comment updated.
- `blade_loops.rs` — added a `tests` module covering block-comment skipping, line-comment skipping, the `/*/` unterminated-open edge, preserved string-awareness, and end-to-end parsing of the commented header through `balanced_directive_arguments` + `parse_foreach_variables`.
- `blade_var_rename/tests.rs` — added `commented_foreach_header_is_resolved_and_renameable` (binding recovered, loop **not** opaque, cursor **not** unresolved, rename offered and loop-scoped).
- `blade_var_rename/tests.rs` + `tests/blade_var_rename_handler.rs` — reworked the three fixtures that relied on the old comment-desync (`opaque_loop_refuses_rename_rather_than_clobbering`, `file_scoped_rename_skips_an_opaque_loop`, `prepare_rejects_cursor_in_unresolved_loop`) to construct their unresolved loop with a genuinely unparseable binding (no ` as $var` clause).

## Acceptance Criteria
- [x] `matching_paren` tracks `/* … */` block-comment spans; bytes inside (including `)`) are not counted toward paren depth
- [x] `matching_paren` treats `//` and `#` as single-line comment markers outside a string or block comment — the rest of `s` past the marker is skipped
- [x] `@foreach ($users /* :) */ as $user)` is parsed correctly: `balanced_directive_arguments` returns the full argument string, `parse_foreach_variables` returns `["user"]`, and the loop block is **not** opaque (`is_opaque_loop` → `false`)
- [x] A unit test verifies a cursor inside `@foreach ($users /* :) */ as $user)` is **not** in an unresolved loop and that `in_scope_spans` returns spans (rename not refused)
- [x] `opaque_loop_refuses_rename_rather_than_clobbering` reworked to use a genuinely unresolvable binding, not a comment-embedded `)`
- [x] `file_scoped_rename_skips_an_opaque_loop` reworked on the same grounds
- [x] All existing tests pass

## Test Plan
- [x] `cargo test --lib` — 1784 passed, 0 failed (includes the new `blade_loops` and `blade_var_rename` tests)
- [x] `cargo test --bins` — 307 passed, 0 failed (includes the reworked handler test)
- [x] `cargo clippy --lib --bins` — clean (exit 0)
- [x] `cargo fmt` applied
- [ ] Pre-existing `integration_tests` failures (8) are environment-only — they need the gitignored `test-project/.env` fixture and vendor packages absent from a fresh clone; unrelated to this change

Fixes #166

---

## Review round 2 — addressing Holmes's `CHANGES_REQUESTED`

**Blocker 1 (regression):** the `//`/`#` line-comment arms did `return None`,
which is right for a single-line header but wrong on `balanced_directive_arguments`'s
*space-joined* multi-line buffer — a `//`/`#` on a wrapped header's first line
swallowed the real `)` on a later line, turning an offered rename into a refused
one. Fixed: `matching_paren` now ends a line comment at the next `\n` (or end of
input when there is none — the single-line behaviour is unchanged), and the slow
path joins continuation lines with `\n` so the physical line boundaries are
visible, collapsing each `\n` back to a single space in the returned string.

**Blocker 2 (missing test):** added `wrapped_header_with_a_php_line_comment_is_resolved_and_renameable`
(`blade_var_rename`) plus `matching_paren_ends_a_line_comment_at_the_newline` and
`wrapped_header_with_a_first_line_comment_resolves_the_binding` (`blade_loops`).
All three fail without the fix.

**Non-blocking follow-up:** folded in — added a `debug_assert!` to `matching_paren`
documenting that `open` must index a literal `(` (the no-underflow and
char-boundary invariants depend on it). Trivial and adjacent to the function
already being changed.

- [x] `cargo test --lib` — 1787 passed, 0 failed
- [x] `cargo test --bins` — 307 passed, 0 failed
- [x] `cargo clippy --lib --bins` — clean
- [x] `cargo fmt --check` — clean
