### PR TITLE
Refresh folio_rename.rs module doc to note prepare_rename is now handler-fixtured

### DIFF
--- a/laravel-lsp/src/tests/folio_rename.rs
+++ b/laravel-lsp/src/tests/folio_rename.rs
@@ -14,10 +14,15 @@
 //!
 //! Both are driven directly on a server built through `tower_lsp::LspService`,
 //! with the route index seeded the way the route-index build seeds it — the
-//! same harness `folio_cursor_containment.rs` uses. The async `rename` handler
-//! itself isn't fixtured (it depends on the Salsa actor for call-site
-//! `find_references`, covered by the symbol-index tests); these exercise the
-//! Folio decl logic the handler composes.
+//! same harness `folio_cursor_containment.rs` uses. `prepare_rename` is now also
+//! pinned end-to-end at the handler level by
+//! `prepare_rename_handler_dispatches_a_folio_name_cursor_to_a_valid_range`
+//! (added in PR #171), which drives the whole handler and proves a Folio
+//! `name('...')` cursor falls through its `.blade.php` early-return to this decl
+//! path. The full `rename` *apply* handler still isn't fixtured — it depends on
+//! the Salsa actor for call-site `find_references`, covered by the symbol-index
+//! tests — so the remaining tests here exercise the Folio decl logic that
+//! handler composes.
 
 use crate::{collect_route_declaration_targets, decl_range_at, LaravelLanguageServer};
 use laravel_lsp::references::SymbolRef;


### PR DESCRIPTION
## Summary
Implements #174 — a doc-only refresh of the module-level doc comment in `laravel-lsp/src/tests/folio_rename.rs`. The comment claimed the rename handler "isn't fixtured" and that the file's tests only exercise the Folio decl logic the handler composes. PR #171 added `prepare_rename_handler_dispatches_a_folio_name_cursor_to_a_valid_range`, which drives `prepare_rename` end-to-end at the handler level, making that framing stale.

## Changes
- Reword lines ~16–24 of the `folio_rename.rs` module doc to state that `prepare_rename` is now pinned end-to-end at the handler level by `prepare_rename_handler_dispatches_a_folio_name_cursor_to_a_valid_range` (added in PR #171).
- Keep the accurate qualifier that the full `rename` *apply* handler is still unfixtured (Salsa actor dependency for call-site `find_references`, covered by the symbol-index tests).
- No logic, test, or non-doc changes — doc comment only.

## Acceptance Criteria
- [x] The module-level doc comment is updated to state `prepare_rename` **is** now exercised at the handler level via `prepare_rename_handler_dispatches_a_folio_name_cursor_to_a_valid_range` (added in PR #171)
- [x] The comment retains the accurate qualifier that the full `rename` **apply** handler is not yet fixtured (Salsa actor dependency still applies)
- [x] The reworded comment does not imply handler-level coverage is missing or needs to be added — `prepare_rename` dispatch reads as already pinned
- [x] No logic, test, or non-doc changes are introduced — doc-only commit
- [x] CI passes (no compilation errors from the comment change)

## Test Plan
- [x] `cargo fmt --check` clean
- [x] `cargo check --tests` compiles cleanly (doc-only change, no behavior change)
- [ ] CI green

Fixes #174