### PR TITLE
Make seed_page filename track its route_name argument to remove a latent test trap

### DIFF
--- a/laravel-lsp/src/tests/folio_rename.rs
+++ b/laravel-lsp/src/tests/folio_rename.rs
@@ -50,16 +50,25 @@ fn test_server() -> LaravelLanguageServer {
     service.inner().clone()
 }
 
-/// Write a Folio page under `root/pages/contact.blade.php`, seed the route index
-/// with `route_name` pointing at it, set the project root, and return the page
-/// path. Mirrors how `inject_folio_routes` seeds named pages (top-of-file
-/// anchor) so the decl logic must re-read the page to find the `name(...)` span.
+/// Write a Folio page under `root/pages/<leaf>.blade.php`, where `<leaf>` is the
+/// last dot-segment of `route_name` (the whole name when it has no dot), seed the
+/// route index with `route_name` pointing at that file, set the project root, and
+/// return the page path. Deriving the filename from `route_name` keeps the on-disk
+/// file leaf and the route-index key consistent: a caller passing `"admin.contact"`
+/// gets `pages/contact.blade.php`, and one passing `"dashboard"` gets
+/// `pages/dashboard.blade.php` — never a hardcoded `contact.blade.php` that
+/// silently disagrees with its index key (issue #175). Mirrors how
+/// `inject_folio_routes` seeds named pages (top-of-file anchor) so the decl logic
+/// must re-read the page to find the `name(...)` span.
 async fn seed_page(
     server: &LaravelLanguageServer,
     root: &Path,
     route_name: &str,
 ) -> std::path::PathBuf {
-    let page = root.join("pages").join("contact.blade.php");
+    // The page's own `name('...')` helper owns only the leaf segment, so the
+    // on-disk file is named for that leaf — `admin.contact` → `contact.blade.php`.
+    let leaf = route_name.rsplit('.').next().unwrap_or(route_name);
+    let page = root.join("pages").join(format!("{leaf}.blade.php"));
     fs::create_dir_all(page.parent().unwrap()).unwrap();
     fs::write(&page, PAGE_SRC).unwrap();
 
@@ -80,6 +89,51 @@ async fn seed_page(
     *server.route_index.write().await = Some(index);
     *server.root_path.write().await = Some(root.to_path_buf());
     page
+}
+
+#[tokio::test]
+async fn seed_page_filename_tracks_the_route_name_leaf() {
+    // Guards the helper invariant (issue #175): `seed_page` derives the on-disk
+    // filename from the leaf segment of `route_name` rather than hardcoding
+    // `contact.blade.php`. With the old hardcode, a caller passing a name whose
+    // leaf differs from `contact` would write a file whose leaf disagrees with the
+    // route-index key — a logically-inconsistent fixture that could pass for the
+    // wrong reason. This pins the derivation so the trap can't return.
+    let root = TempDir::new().unwrap();
+    let server = test_server();
+
+    // No dot — the whole name is the leaf.
+    let page = seed_page(&server, root.path(), "dashboard").await;
+    assert_eq!(
+        page.file_name().unwrap().to_str().unwrap(),
+        "dashboard.blade.php",
+        "a dotless route name uses the whole name as the file stem"
+    );
+    assert!(
+        page.exists(),
+        "the derived page file must be written to disk"
+    );
+
+    // Dotted — only the leaf segment names the file.
+    let page = seed_page(&server, root.path(), "admin.dashboard").await;
+    assert_eq!(
+        page.file_name().unwrap().to_str().unwrap(),
+        "dashboard.blade.php",
+        "a dotted route name uses only its leaf segment as the file stem"
+    );
+
+    // AC2: the index entry's `file` points at the same derived path, so the index
+    // key and the on-disk file stay consistent.
+    let index = server.route_index.read().await;
+    let def = index
+        .as_ref()
+        .unwrap()
+        .get("admin.dashboard")
+        .expect("the route index must carry the seeded name");
+    assert_eq!(
+        def.file, page,
+        "RouteDefinition.file must point at the derived leaf-based path"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
Implements #175. The `seed_page` Folio test helper in `folio_rename.rs` hardcoded the on-disk page filename to `contact.blade.php` regardless of the `route_name` argument it was given. When a caller passed a name whose leaf differed from `contact` (e.g. `"admin.dashboard"`), the file leaf disagreed with the route-index key — a logically-inconsistent fixture that worked only by coincidence and could pass for the wrong reason. This removes that latent trap (surfaced in Holmes's review of #142 / PR #171).

## Changes
- `seed_page` now derives the on-disk filename from the **leaf segment** of `route_name` (everything after the last `.`, or the whole name when there's no `.`) instead of hardcoding `contact.blade.php`. Because `RouteDefinition.file` is set from that same derived `page` path, the index key and the on-disk file stay consistent.
- Refreshed the now-stale `seed_page` doc comment to describe the derivation.
- Added `seed_page_filename_tracks_the_route_name_leaf` — a guard test proving a differing-leaf name (`"dashboard"`, `"admin.dashboard"`) names the file for its leaf and that the index entry's `file` points at the derived path.

## Acceptance Criteria
- [x] `seed_page` derives the on-disk filename from the leaf segment of `route_name` (`"contact"` → `contact.blade.php`, `"admin.contact"` → `contact.blade.php`, `"dashboard"` → `dashboard.blade.php`)
- [x] The `RouteDefinition.file` field points to the derived (leaf-based) path so the index key and the on-disk file remain consistent
- [x] All existing tests in `folio_rename.rs` pass without any assertion changes (current callers pass `"contact"` / `"admin.contact"`, both leaf `"contact"`, so the file path is unchanged)
- [x] A test verifies that `seed_page` with a route name whose leaf differs from `"contact"` creates a file whose stem matches the leaf — proving the hardcoded path is gone
- [x] No production source files are modified; all changes confined to the test helper/infrastructure in `folio_rename.rs`

## Test Plan
- [x] `cargo test folio_rename` — all 9 tests pass (8 existing + 1 new)
- [x] `cargo fmt` clean; `cargo clippy --all-targets` clean (no warnings)
- [x] Full `cargo test` reviewed: the only failures are pre-existing, environment-dependent integration tests (`test-project/.env` + Composer `vendor/`), which CI bootstraps; bootstrapping `.env` locally cleared all but the Composer-vendor-dependent Fortify route test. None touch the unit-test binary this change lives in.

Fixes #175