### PR TITLE
fix: byte offset used as char index in get_blade_directive_context (multibyte misread)

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -9504,7 +9504,13 @@ impl LaravelLanguageServer {
         // Make sure we're not inside a string or already completed directive
         // Check if @ is at start of line or preceded by whitespace/bracket
         if at_pos > 0 {
-            let char_before_at = before_cursor.chars().nth(at_pos - 1);
+            // `at_pos` is a *byte* offset (it comes from `char_indices()`), so we
+            // must read the char immediately before `@` via a byte-bounded slice.
+            // `chars().nth(at_pos - 1)` treated the byte offset as a char count,
+            // which misreads any line containing a multibyte char before `@`
+            // (e.g. `🎉 @if`) — see issue #180. Slicing at the byte boundary is
+            // always valid because `char_indices()` only yields char boundaries.
+            let char_before_at = before_cursor[..at_pos].chars().next_back();
             if let Some(c) = char_before_at {
                 // @ should be preceded by whitespace, start of tag, or at start of PHP block
                 if !c.is_whitespace() && c != '>' && c != '(' && c != '{' && c != ';' && c != '\t' {

--- a/laravel-lsp/src/tests/blade_directive_context.rs
+++ b/laravel-lsp/src/tests/blade_directive_context.rs
@@ -1,0 +1,51 @@
+use crate::LaravelLanguageServer;
+
+// `get_blade_directive_context` finds the `@` that starts a Blade directive and
+// then checks the char immediately before it (must be whitespace / `>` / `(` /
+// `{` / `;` / tab) to avoid firing inside an email, string, etc.
+//
+// `at_pos` (the `@`'s position) is a *byte* offset from `char_indices()`. The
+// guard used to read that char with `chars().nth(at_pos - 1)`, treating the byte
+// offset as a char count — so any line with a multibyte char before `@` inspected
+// the wrong character and a valid directive context was wrongly rejected. These
+// tests pin the byte-bounded behaviour (issue #180).
+
+/// Regression: an emoji (4-byte char) before `@` must not break detection.
+/// Old code: `chars().nth(at_pos - 1)` landed on `'f'` → `None`.
+#[test]
+fn emoji_before_at_is_still_a_directive_context() {
+    let line = "🎉 @if";
+    let ctx = LaravelLanguageServer::get_blade_directive_context(line, line.len() as u32)
+        .expect("`🎉 @if` should be a directive context — space precedes `@`");
+    assert_eq!(ctx, "if");
+}
+
+/// Regression: an accented (2-byte) char before `@` must not break detection.
+/// Old code: `chars().nth(at_pos - 1)` landed on `'@'` → `None`.
+#[test]
+fn accented_char_before_at_is_still_a_directive_context() {
+    let line = "é @foreach";
+    let ctx = LaravelLanguageServer::get_blade_directive_context(line, line.len() as u32)
+        .expect("`é @foreach` should be a directive context — space precedes `@`");
+    assert_eq!(ctx, "foreach");
+}
+
+/// The ASCII guard path is unaffected: a word char immediately before `@`
+/// (e.g. an email-like `foo@if`) must still be rejected.
+#[test]
+fn word_char_before_at_is_not_a_directive_context() {
+    let line = "foo@if";
+    assert!(
+        LaravelLanguageServer::get_blade_directive_context(line, line.len() as u32).is_none(),
+        "a word char immediately before `@` must not be a directive context",
+    );
+}
+
+/// Baseline happy path: plain ASCII whitespace before `@` is a directive context.
+#[test]
+fn ascii_whitespace_before_at_is_a_directive_context() {
+    let line = "  @if";
+    let ctx = LaravelLanguageServer::get_blade_directive_context(line, line.len() as u32)
+        .expect("`  @if` should be a directive context");
+    assert_eq!(ctx, "if");
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod array_context_detection;
 mod asset_path_resolution;
 mod blade_component_context;
+mod blade_directive_context;
 mod blade_var_rename_handler;
 mod cast_type_context;
 mod class_locator_and_properties;


### PR DESCRIPTION
## Summary
Implements #180.

`get_blade_directive_context` derived `at_pos` — the byte offset of the `@` that starts a Blade directive — from `char_indices()`, then fed `at_pos - 1` to `before_cursor.chars().nth(...)`, which treats its argument as a **char count**. On any line containing a multibyte char before the `@` (emoji, accented letter, etc.) the guard inspected the wrong character, so a valid `@`-directive completion context was wrongly rejected.

## Changes
- `laravel-lsp/src/main.rs`: read the char immediately before `@` via a byte-bounded slice — `before_cursor[..at_pos].chars().next_back()` — instead of `chars().nth(at_pos - 1)`. The slice boundary is always valid because `char_indices()` only yields char boundaries. Added an explanatory comment.
- `laravel-lsp/src/tests/blade_directive_context.rs` (new): regression tests for the multibyte cases and the ASCII guard path.
- `laravel-lsp/src/tests/mod.rs`: registered the new test module.

## Acceptance Criteria
- [x] In `get_blade_directive_context` (`laravel-lsp/src/main.rs`), replace `before_cursor.chars().nth(at_pos - 1)` with `before_cursor[..at_pos].chars().next_back()` so the char-before-`@` guard uses a byte-bounded slice instead of treating a byte offset as a char index
- [x] A new test file `laravel-lsp/src/tests/blade_directive_context.rs` covers at least two multibyte fixtures: one with an emoji before `@` (`🎉 @if`) and one with an accented char (`é @foreach`) — both return `Some(...)`, not `None`
- [x] A test asserts the ASCII guard path is unaffected: a word char immediately before `@` (`foo@if`) still returns `None`
- [x] `cargo test` passes with no new warnings or regressions

## Test Plan
- [x] New tests cover the changes — 4 tests in `blade_directive_context.rs` (emoji, accented, ASCII-word-reject, ASCII-whitespace baseline), all green
- [x] Full suite green under CI-equivalent conditions — `cargo test --all-features` with `test-project/.env` seeded from `.env.example` (as CI does); the bin/lib suites pass (1843 + 333). The only locally-skipped failure, `test_route_index_resolves_package_route`, needs `test-project/vendor/` which CI provisions via `composer update` — unrelated to this diff
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

Fixes #180