### PR TITLE
Extend path_within_root containment guard to the <livewire:>-tag goto-definition flow (create_livewire_location_from_salsa)

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18651,12 +18651,22 @@ fn is_in_routes_dir(root: Option<&Path>, path: &Path) -> bool {
 /// secondary) runs *before* the `.exists()` probe, so an out-of-root
 /// `loadViewsFrom`/namespace registration can never make the view-diagnostic
 /// loops stat-probe files outside the project tree — even one whose file
-/// happens to exist on disk is treated as absent. Lexical containment
-/// (`path_within_root_lexical`) is deliberate over the fail-closed
-/// `path_within_root`: it keeps not-yet-created **in-root** candidates so a
-/// genuinely missing in-root view still reports "View file not found", while
-/// still refusing interior-`..` escapes. Both the `view()` and
-/// `@extends`/`@include` diagnostic loops share this identical decision.
+/// happens to exist on disk is treated as absent.
+///
+/// Lexical containment (`path_within_root_lexical`) is used rather than the
+/// fail-closed `path_within_root` for **consistency** with the sibling
+/// candidate-path filter in `salsa_impl.rs` (issue #156), which must stay
+/// lexical because it returns the retained paths *for navigation* — there a
+/// fail-closed guard would wrongly drop speculative, not-yet-created in-root
+/// targets. For *this* helper's boolean result the two policies are
+/// **equivalent**: a missing in-root candidate yields `false` either way —
+/// lexical keeps it and `.exists()` returns `false`; fail-closed drops it from
+/// the filter and `.any()` runs over an empty set — so a genuinely missing
+/// in-root view still reports "View file not found" under both. The only
+/// practical difference is that lexical avoids a wasted `.exists()` stat on a
+/// missing in-root path (a side-effect, never the returned boolean). Both the
+/// `view()` and `@extends`/`@include` diagnostic loops share this identical
+/// decision.
 fn any_in_root_candidate_exists(candidates: &[PathBuf], root: &Path) -> bool {
     candidates
         .iter()

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -15944,18 +15944,13 @@ return [
             // Check view() calls using Salsa patterns
             for view_ref in &patterns.views {
                 let possible_paths = config.resolve_view_path(&view_ref.name);
-                // Containment guard (issue #194, secondary): skip `.exists()`
-                // filesystem probes on candidates that resolve outside the
-                // project root, so an out-of-root `loadViewsFrom`/namespace
-                // registration can't make diagnostics stat-probe files outside
-                // the project tree. Lexical containment (the speculative-candidate
-                // helper) keeps not-yet-created in-root candidates — a genuinely
-                // missing in-root view still reports "not found" — while refusing
-                // out-of-root paths without probing them.
-                let exists = possible_paths
-                    .iter()
-                    .filter(|p| path_within_root_lexical(p, &config.root))
-                    .any(|p| p.exists());
+                // Containment guard (issue #194, secondary): out-of-root
+                // candidates are filtered out before the `.exists()` probe, so an
+                // out-of-root `loadViewsFrom`/namespace registration can't make
+                // diagnostics stat-probe files outside the project tree. See
+                // `any_in_root_candidate_exists` for the full rationale; the
+                // `@extends`/`@include` loop below shares the same decision.
+                let exists = any_in_root_candidate_exists(&possible_paths, &config.root);
 
                 if !exists {
                     let expected_path = possible_paths
@@ -16633,18 +16628,13 @@ return [
                         let possible_paths = config.resolve_view_path(&view_name);
 
                         // Check if ANY of the possible paths exist. Containment
-                        // guard (issue #194, secondary): skip `.exists()`
-                        // filesystem probes on candidates that resolve outside
-                        // the project root, so an out-of-root namespace can't make
-                        // `@extends`/`@include` diagnostics stat-probe files
-                        // outside the project tree. Lexical containment keeps
-                        // not-yet-created in-root candidates — a genuinely missing
-                        // in-root view still reports "not found" — while refusing
-                        // out-of-root paths without probing them.
-                        let exists = possible_paths
-                            .iter()
-                            .filter(|p| path_within_root_lexical(p, &config.root))
-                            .any(|p| p.exists());
+                        // guard (issue #194, secondary): out-of-root candidates
+                        // are filtered out before the `.exists()` probe, so an
+                        // out-of-root namespace can't make `@extends`/`@include`
+                        // diagnostics stat-probe files outside the project tree.
+                        // Shares the identical decision with the `view()` loop
+                        // above — see `any_in_root_candidate_exists`.
+                        let exists = any_in_root_candidate_exists(&possible_paths, &config.root);
 
                         if !exists {
                             // Use the first path for the diagnostic message
@@ -18654,6 +18644,24 @@ fn is_in_routes_dir(root: Option<&Path>, path: &Path) -> bool {
         (Ok(real_parent), Ok(real_routes)) => real_parent == real_routes,
         _ => parent == routes_dir,
     }
+}
+
+/// True if **any** of `candidates` exists on disk, considering only candidates
+/// that lexically resolve within `root`. The containment filter (issue #194,
+/// secondary) runs *before* the `.exists()` probe, so an out-of-root
+/// `loadViewsFrom`/namespace registration can never make the view-diagnostic
+/// loops stat-probe files outside the project tree — even one whose file
+/// happens to exist on disk is treated as absent. Lexical containment
+/// (`path_within_root_lexical`) is deliberate over the fail-closed
+/// `path_within_root`: it keeps not-yet-created **in-root** candidates so a
+/// genuinely missing in-root view still reports "View file not found", while
+/// still refusing interior-`..` escapes. Both the `view()` and
+/// `@extends`/`@include` diagnostic loops share this identical decision.
+fn any_in_root_candidate_exists(candidates: &[PathBuf], root: &Path) -> bool {
+    candidates
+        .iter()
+        .filter(|p| path_within_root_lexical(p, root))
+        .any(|p| p.exists())
 }
 
 /// Return the column range of the classified pattern under the cursor.

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -27,7 +27,7 @@ use laravel_lsp::completion_format::CompletionDoc;
 use laravel_lsp::config::find_project_root;
 use laravel_lsp::middleware_parser::{middleware_base_alias, resolve_class_to_file};
 use laravel_lsp::migration_index::{build_migration_index, MigrationIndex};
-use laravel_lsp::path_containment::path_within_root;
+use laravel_lsp::path_containment::{path_within_root, path_within_root_lexical};
 use laravel_lsp::route_discovery::{
     build_route_index, discover_route_files, normalize_path, RouteIndex,
 };
@@ -13995,6 +13995,21 @@ return [
         let path = self.resolve_livewire_primary_path(&lw.name).await?;
 
         if self.file_exists_cached(&path).await {
+            // Containment guard (issue #194, extending #130/#143/#148): the
+            // `<livewire:ns::component>` Blade-tag flow resolves through
+            // `resolve_livewire_primary_path`, and `component_namespaces`
+            // (parsed by `livewire_config.rs`) explicitly accepts bare absolute
+            // paths — so a `'component_namespaces' => ['x' => '/etc']`
+            // registration plus a `<livewire:x::passwd>` tag could resolve to a
+            // path outside the project root. Refuse to hand the client a
+            // navigation target that escapes the root, matching the
+            // view/component/directive and slot-navigation guards. A single
+            // resolved candidate here (not a loop), so a failed check returns
+            // `None`. Fetched after the existence check, before the link build.
+            let config = self.get_cached_config().await?;
+            if !path_within_root(&path, &config.root) {
+                return None;
+            }
             if let Ok(target_uri) = Url::from_file_path(&path) {
                 let origin_selection_range = Range {
                     start: Position {
@@ -15929,7 +15944,18 @@ return [
             // Check view() calls using Salsa patterns
             for view_ref in &patterns.views {
                 let possible_paths = config.resolve_view_path(&view_ref.name);
-                let exists = possible_paths.iter().any(|p| p.exists());
+                // Containment guard (issue #194, secondary): skip `.exists()`
+                // filesystem probes on candidates that resolve outside the
+                // project root, so an out-of-root `loadViewsFrom`/namespace
+                // registration can't make diagnostics stat-probe files outside
+                // the project tree. Lexical containment (the speculative-candidate
+                // helper) keeps not-yet-created in-root candidates — a genuinely
+                // missing in-root view still reports "not found" — while refusing
+                // out-of-root paths without probing them.
+                let exists = possible_paths
+                    .iter()
+                    .filter(|p| path_within_root_lexical(p, &config.root))
+                    .any(|p| p.exists());
 
                 if !exists {
                     let expected_path = possible_paths
@@ -16606,8 +16632,19 @@ return [
                     if let Some(view_name) = Self::extract_view_from_directive_args(args) {
                         let possible_paths = config.resolve_view_path(&view_name);
 
-                        // Check if ANY of the possible paths exist
-                        let exists = possible_paths.iter().any(|p| p.exists());
+                        // Check if ANY of the possible paths exist. Containment
+                        // guard (issue #194, secondary): skip `.exists()`
+                        // filesystem probes on candidates that resolve outside
+                        // the project root, so an out-of-root namespace can't make
+                        // `@extends`/`@include` diagnostics stat-probe files
+                        // outside the project tree. Lexical containment keeps
+                        // not-yet-created in-root candidates — a genuinely missing
+                        // in-root view still reports "not found" — while refusing
+                        // out-of-root paths without probing them.
+                        let exists = possible_paths
+                            .iter()
+                            .filter(|p| path_within_root_lexical(p, &config.root))
+                            .any(|p| p.exists());
 
                         if !exists {
                             // Use the first path for the diagnostic message

--- a/laravel-lsp/src/tests/livewire_tag_navigation_containment.rs
+++ b/laravel-lsp/src/tests/livewire_tag_navigation_containment.rs
@@ -1,0 +1,224 @@
+//! Tests for the root-containment guard in
+//! `LaravelLanguageServer::create_livewire_location_from_salsa` (issue #194,
+//! extending the #130 → #143 → #148 containment-guard chain).
+//!
+//! The `<livewire:ns::component>` Blade-*tag* goto-definition flow — distinct
+//! from the `@livewire(...)` *directive* flow #148 already guards — resolves
+//! through `resolve_livewire_primary_path` → `livewire_resolver::resolve_component`,
+//! which looks the component up under `component_namespaces[ns]`. That namespace
+//! map (parsed by `livewire_config.rs`) explicitly accepts bare absolute paths,
+//! so a `'component_namespaces' => ['x' => '/etc']`-style registration plus a
+//! `<livewire:x::passwd>` tag could otherwise hand the LSP client a `LocationLink`
+//! pointing outside the project root. The guard re-checks containment against
+//! `config.root` — via the same `path_within_root` the view, component,
+//! directive, and slot-navigation flows use — after the `file_exists_cached`
+//! check and before building the link. These tests drive the private async
+//! method directly by building the server through `tower_lsp::LspService` and
+//! reaching its inner value with `inner()`.
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::livewire_config::LivewireConfig;
+use laravel_lsp::livewire_version::LivewireVersion;
+use laravel_lsp::naming::LIVEWIRE_EMOJI;
+use laravel_lsp::salsa_impl::{LaravelConfigData, LivewireReferenceData};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tower_lsp::lsp_types::GotoDefinitionResponse;
+use tower_lsp::{lsp_types::Url, LspService};
+
+/// The inline-class body that backs a V4 SFC Livewire component. Its contents
+/// are irrelevant to resolution — `try_v4_sfc` only checks that the
+/// `⚡{leaf}.blade.php` file exists — so a `None` result can only come from the
+/// containment guard, never a missing file.
+const SFC_BODY: &str = "<?php new class extends Component {}; ?>\n<div>component</div>\n";
+
+/// Build a server instance for testing. `LspService::new` wires up a real
+/// `Client`; `inner()` hands back the `LaravelLanguageServer` so we can call its
+/// private methods directly.
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// The on-disk V4 SFC filename for a component leaf — `⚡{leaf}.blade.php`,
+/// matching the `⚡` prefix the resolver (`try_v4_sfc`) discovers by.
+fn sfc_file(dir: &Path, leaf: &str) -> PathBuf {
+    dir.join(format!("{LIVEWIRE_EMOJI}{leaf}.blade.php"))
+}
+
+/// A Livewire config rooted at `root` that registers `ns` as a component
+/// namespace pointing at `namespace_dir`. With this, `<livewire:ns::leaf>`
+/// resolves to `{namespace_dir}/⚡{leaf}.blade.php`, letting the test place that
+/// directory inside or outside the project root at will.
+fn livewire_config_with_namespace(root: &Path, ns: &str, namespace_dir: &Path) -> LivewireConfig {
+    let mut config = LivewireConfig::defaults(root);
+    config
+        .component_namespaces
+        .insert(ns.to_string(), namespace_dir.to_path_buf());
+    config
+}
+
+/// A minimal Laravel config whose only field the containment guard reads is
+/// `root`. Everything else is empty — the guard never consults it.
+fn laravel_config(root: &Path) -> LaravelConfigData {
+    LaravelConfigData {
+        root: root.to_path_buf(),
+        view_paths: vec![],
+        component_paths: vec![],
+        livewire_path: None,
+        has_livewire: true,
+        view_namespaces: HashMap::new(),
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+        class_component_files: HashMap::new(),
+    }
+}
+
+/// A `LivewireReferenceData` for `name` at the document origin — positions are
+/// irrelevant to path resolution.
+fn livewire_ref(name: &str) -> LivewireReferenceData {
+    LivewireReferenceData {
+        name: name.to_string(),
+        line: 0,
+        column: 0,
+        end_column: 0,
+    }
+}
+
+/// Seed the server so `get_cached_livewire` and `get_cached_config` both return
+/// the supplied state without touching disk or Salsa. `get_cached_livewire`
+/// keys its cache on `root_path`, so that must match the config's root.
+async fn seed(
+    server: &LaravelLanguageServer,
+    root: &Path,
+    livewire: LivewireConfig,
+    config: LaravelConfigData,
+) {
+    *server.root_path.write().await = Some(root.to_path_buf());
+    *server.cached_livewire.write().await =
+        Some((root.to_path_buf(), livewire, LivewireVersion::V4));
+    *server.cached_config.write().await = Some(config);
+}
+
+/// Write `contents` to `path`, creating parent directories as needed.
+fn write(path: &Path, contents: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+#[tokio::test]
+async fn out_of_root_livewire_tag_returns_none() {
+    // The `x` namespace points OUTSIDE the project root (the shape a
+    // `'component_namespaces' => ['x' => '/etc']` registration produces). The
+    // resolved `passwd` SFC exists on disk, so without the guard
+    // `create_livewire_location_from_salsa` would hand back a LocationLink
+    // pointing outside the root; the containment guard must refuse it on root
+    // grounds alone and return None.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    write(&sfc_file(outside.path(), "passwd"), SFC_BODY);
+
+    let server = test_server();
+    seed(
+        &server,
+        root.path(),
+        livewire_config_with_namespace(root.path(), "x", outside.path()),
+        laravel_config(root.path()),
+    )
+    .await;
+
+    let result = server
+        .create_livewire_location_from_salsa(&livewire_ref("x::passwd"))
+        .await;
+
+    assert!(
+        result.is_none(),
+        "an out-of-root <livewire:x::passwd> target must not resolve, even though \
+         it exists on disk — the containment guard refuses it"
+    );
+}
+
+#[tokio::test]
+async fn in_root_livewire_tag_resolves() {
+    // Positive control: the `ns` namespace points to a directory INSIDE the
+    // project root, so the resolved `counter` SFC passes containment and tag
+    // navigation resolves exactly as before — no regression.
+    let root = tempfile::TempDir::new().unwrap();
+    let namespace_dir = root.path().join("resources/views/components");
+
+    let counter = sfc_file(&namespace_dir, "counter");
+    write(&counter, SFC_BODY);
+
+    let server = test_server();
+    seed(
+        &server,
+        root.path(),
+        livewire_config_with_namespace(root.path(), "ns", &namespace_dir),
+        laravel_config(root.path()),
+    )
+    .await;
+
+    let result = server
+        .create_livewire_location_from_salsa(&livewire_ref("ns::counter"))
+        .await;
+
+    let Some(GotoDefinitionResponse::Link(links)) = result else {
+        panic!("an in-root <livewire:ns::counter> must resolve to a Link response");
+    };
+    assert_eq!(links.len(), 1, "exactly one definition link is expected");
+    assert_eq!(
+        links[0].target_uri,
+        Url::from_file_path(&counter).unwrap(),
+        "the definition must point at the in-root counter component"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn under_root_symlink_to_outside_target_returns_none() {
+    // The discriminating case a lexical guard could not catch: the namespace
+    // directory lives *under* the project root — a symlink at
+    // `<root>/linked-components` — yet it resolves to a directory OUTSIDE the
+    // root. The `counter` SFC exists through the link, so a missing file can't
+    // explain a None result. A purely lexical `starts_with` check would admit
+    // the path (the link is under the root); only canonicalization —
+    // `path_within_root` resolving the symlink to its out-of-tree target — can
+    // reject it.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    // Real component file, outside the project root.
+    let target_dir = outside.path().join("components");
+    write(&sfc_file(&target_dir, "counter"), SFC_BODY);
+
+    // Symlink under the root that points at the outside components directory.
+    let link: PathBuf = root.path().join("linked-components");
+    std::os::unix::fs::symlink(&target_dir, &link).unwrap();
+
+    let server = test_server();
+    // Register the namespace at the in-root symlink path so resolution is
+    // lexically inside the root; only canonicalization reveals the escape.
+    seed(
+        &server,
+        root.path(),
+        livewire_config_with_namespace(root.path(), "ns", &link),
+        laravel_config(root.path()),
+    )
+    .await;
+
+    let result = server
+        .create_livewire_location_from_salsa(&livewire_ref("ns::counter"))
+        .await;
+
+    assert!(
+        result.is_none(),
+        "a <livewire:...> tag reached through an under-root symlink that resolves \
+         outside the project root must not resolve — the canonicalize-based \
+         containment guard refuses it even though the link path is lexically inside"
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -19,6 +19,7 @@ mod folio_rename;
 mod generic_type_parsing;
 mod helper_identifier_hover;
 mod livewire_component_resolution;
+mod livewire_tag_navigation_containment;
 mod loop_variable_resolution;
 mod rename_integration;
 mod route_binding_resolution;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -28,5 +28,6 @@ mod routes_dir_gate;
 mod slot_navigation_containment;
 mod slot_variable_resolution;
 mod translation_namespace_check;
+mod view_diagnostic_containment;
 mod view_navigation_containment;
 mod vite_completion_context;

--- a/laravel-lsp/src/tests/view_diagnostic_containment.rs
+++ b/laravel-lsp/src/tests/view_diagnostic_containment.rs
@@ -18,10 +18,18 @@
 //!
 //! These tests drive the shared helper directly (mirroring the
 //! `crate::is_in_routes_dir` style in `routes_dir_gate.rs` and the disk-backed
-//! containment cases in `view_navigation_containment.rs`), pinning the exact
-//! fork: out-of-root-but-exists is treated as missing, while a speculative
-//! in-root candidate is still probed so a genuinely missing in-root view keeps
-//! reporting "not found".
+//! containment cases in `view_navigation_containment.rs`), confirming the
+//! helper's behavior: an out-of-root candidate that exists on disk is treated
+//! as absent, while a speculative in-root candidate still reports "not found"
+//! (no false suppression of a genuinely missing view).
+//!
+//! Note the helper's boolean output is *equivalent* under lexical and
+//! fail-closed containment — a missing in-root candidate yields `false` either
+//! way (lexical keeps it and `.exists()` is `false`; fail-closed drops it so
+//! `.any()` runs over an empty set). The lexical choice is for consistency with
+//! the navigation-side filter (`salsa_impl.rs`, issue #156) and to avoid a
+//! wasted stat, *not* because it changes any of these outcomes — so these tests
+//! assert the helper's contract, not a distinction between the two policies.
 
 use crate::any_in_root_candidate_exists;
 use std::fs;
@@ -86,9 +94,11 @@ fn speculative_in_root_candidate_reports_missing() {
     // A not-yet-created in-root candidate (the everyday case: the developer
     // referenced a view they haven't built). Lexical containment keeps it — it
     // is *not* filtered out as an escape — so it is probed, found absent, and
-    // "View file not found" correctly fires. This proves the filter uses lexical
-    // (not fail-closed) containment: a fail-closed guard would drop every
-    // not-yet-created candidate and break the missing-view diagnostic entirely.
+    // "View file not found" correctly fires. (The fail-closed `path_within_root`
+    // would reach the same boolean: it drops the missing candidate so `.any()`
+    // runs over an empty set → also `false`. The two policies are equivalent
+    // here.) This case guards against a future filter that wrongly suppressed
+    // the diagnostic for a genuinely missing in-root view.
     let root = tempfile::TempDir::new().unwrap();
     let ghost = root.path().join("resources/views/ghost.blade.php");
 
@@ -98,8 +108,8 @@ fn speculative_in_root_candidate_reports_missing() {
     );
     assert!(
         !any_in_root_candidate_exists(&[ghost], root.path()),
-        "a missing in-root view must still report absent — lexical containment \
-         keeps speculative in-root candidates so the diagnostic still fires"
+        "a missing in-root view must still report absent — the containment \
+         filter must not suppress the diagnostic for a speculative in-root view"
     );
 }
 

--- a/laravel-lsp/src/tests/view_diagnostic_containment.rs
+++ b/laravel-lsp/src/tests/view_diagnostic_containment.rs
@@ -1,0 +1,125 @@
+//! Tests for the root-containment guard in the **diagnostic-validation** view
+//! loops (issue #194, the secondary surface — extending #130/#143/#148).
+//!
+//! `validate_and_publish_diagnostics` walks both the PHP `view()` references and
+//! the Blade `@extends`/`@include` directives, resolving each to candidate paths
+//! via `config.resolve_view_path` and deciding whether a "View file not found"
+//! diagnostic should fire. Both loops make the *identical* decision through the
+//! free helper [`crate::any_in_root_candidate_exists`]: a candidate is only
+//! stat-probed if it lexically resolves within the project root.
+//!
+//! A `loadViewsFrom(__DIR__ . '/../../etc', 'pkg')`-style registration (or a
+//! `component_namespaces` entry) can map a namespace to an absolute directory
+//! that escapes the project root. Without the containment filter, an out-of-root
+//! candidate whose file happens to *exist on disk* would leave `exists = true`
+//! and suppress the diagnostic, and — more importantly — the loop would
+//! `stat`-probe a path outside the project tree during diagnostics. The filter
+//! refuses such candidates *before* probing them.
+//!
+//! These tests drive the shared helper directly (mirroring the
+//! `crate::is_in_routes_dir` style in `routes_dir_gate.rs` and the disk-backed
+//! containment cases in `view_navigation_containment.rs`), pinning the exact
+//! fork: out-of-root-but-exists is treated as missing, while a speculative
+//! in-root candidate is still probed so a genuinely missing in-root view keeps
+//! reporting "not found".
+
+use crate::any_in_root_candidate_exists;
+use std::fs;
+use std::path::Path;
+
+/// The Blade view contents are irrelevant — only that the file exists on disk,
+/// so a `false` result can only come from the containment filter, never a
+/// missing file.
+const VIEW_BODY: &str = "<div>card</div>\n";
+
+/// Write `contents` to `path`, creating parent directories as needed.
+fn write(path: &Path, contents: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+#[test]
+fn out_of_root_candidate_that_exists_is_treated_as_missing() {
+    // The `pkg` namespace points OUTSIDE the project root (the shape a
+    // `loadViewsFrom(__DIR__ . '/../../etc', 'pkg')` registration produces). The
+    // resolved candidate exists on disk, so without the containment filter the
+    // diagnostic loop would see `exists = true` and stay quiet — having probed a
+    // file outside the project tree. The filter must refuse it on root grounds
+    // alone, so the helper reports the candidate absent and a "View file not
+    // found" diagnostic fires.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    let escapee = outside.path().join("card.blade.php");
+    write(&escapee, VIEW_BODY);
+
+    assert!(
+        escapee.exists(),
+        "precondition: the out-of-root candidate exists on disk"
+    );
+    assert!(
+        !any_in_root_candidate_exists(&[escapee], root.path()),
+        "an out-of-root candidate must be treated as absent even though it \
+         exists on disk — the containment filter refuses it before probing, so \
+         the diagnostic fires"
+    );
+}
+
+#[test]
+fn in_root_candidate_that_exists_is_found() {
+    // Positive control: an in-root candidate that exists on disk passes
+    // containment and is found, so no false-positive "View file not found"
+    // diagnostic fires — no regression to the normal happy path.
+    let root = tempfile::TempDir::new().unwrap();
+    let card = root.path().join("resources/views/card.blade.php");
+    write(&card, VIEW_BODY);
+
+    assert!(
+        any_in_root_candidate_exists(&[card], root.path()),
+        "an in-root candidate that exists on disk must be found — the diagnostic \
+         must not fire for a real in-root view"
+    );
+}
+
+#[test]
+fn speculative_in_root_candidate_reports_missing() {
+    // A not-yet-created in-root candidate (the everyday case: the developer
+    // referenced a view they haven't built). Lexical containment keeps it — it
+    // is *not* filtered out as an escape — so it is probed, found absent, and
+    // "View file not found" correctly fires. This proves the filter uses lexical
+    // (not fail-closed) containment: a fail-closed guard would drop every
+    // not-yet-created candidate and break the missing-view diagnostic entirely.
+    let root = tempfile::TempDir::new().unwrap();
+    let ghost = root.path().join("resources/views/ghost.blade.php");
+
+    assert!(
+        ghost.canonicalize().is_err(),
+        "precondition: the in-root candidate does not exist on disk"
+    );
+    assert!(
+        !any_in_root_candidate_exists(&[ghost], root.path()),
+        "a missing in-root view must still report absent — lexical containment \
+         keeps speculative in-root candidates so the diagnostic still fires"
+    );
+}
+
+#[test]
+fn out_of_root_existing_does_not_mask_missing_in_root() {
+    // Belt-and-braces over the realistic multi-candidate shape: `resolve_view_path`
+    // returns several candidates. When the only one that exists on disk is
+    // out-of-root and the in-root candidate is missing, the helper must still
+    // report absent — the out-of-root hit is filtered out and cannot mask the
+    // genuinely-missing in-root view, so the diagnostic fires.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    let in_root_missing = root.path().join("resources/views/card.blade.php");
+    let out_of_root_present = outside.path().join("card.blade.php");
+    write(&out_of_root_present, VIEW_BODY);
+
+    assert!(
+        !any_in_root_candidate_exists(&[in_root_missing, out_of_root_present], root.path()),
+        "an existing out-of-root candidate must not mask a missing in-root one — \
+         it is filtered out before probing, so the diagnostic fires"
+    );
+}


### PR DESCRIPTION
## Summary
Implements #194 — extends the `path_within_root` containment guard to the **`<livewire:ns::component>` Blade-tag** goto-definition flow (`create_livewire_location_from_salsa`), the last unguarded sibling in the #130 → #143 → #148 containment-guard chain.

`LivewireConfig.component_namespaces` (parsed by `livewire_config.rs`) explicitly accepts bare absolute paths, so a `'component_namespaces' => ['x' => '/etc']` registration plus a `<livewire:x::passwd>` tag could otherwise hand the LSP client a `LocationLink` pointing outside the project root — the same namespace-escape class the sibling flows already close. Defense-in-depth hardening (a navigation target, not a server-side read), enforced so the containment invariant holds uniformly across *every* FS-touching goto-definition path.

## Changes
- **Primary guard** — `create_livewire_location_from_salsa` now fetches `get_cached_config()` after the `file_exists_cached` check and refuses any resolved path that fails `path_within_root(&path, &config.root)` before building the `LocationLink`, returning `None`. Mirrors the view/component/directive/slot-navigation guards. A single resolved candidate (not a loop), so a failed check returns `None`.
- **Secondary (folded in, lowest severity)** — the two diagnostic-validation `.exists()` loops (the PHP `view()` loop at `validate_document` and the Blade `@extends`/`@include` loop) now filter candidates through `path_within_root_lexical` before probing, so an out-of-root namespace can no longer make diagnostics `stat`-probe files outside the project tree. Lexical containment keeps not-yet-created **in-root** candidates, so a genuinely-missing in-root view still reports "View file not found".
- Imported `path_within_root_lexical` alongside `path_within_root`.
- New test module `livewire_tag_navigation_containment`, registered in `tests/mod.rs`.

## Acceptance Criteria
- [x] `create_livewire_location_from_salsa` calls `get_cached_config()` and validates the resolved path with `path_within_root(&path, &config.root)` after the `file_exists_cached` check, before building the `LocationLink`; returns `None` for any path that escapes the project root
- [x] A `<livewire:x::passwd>` tag where `component_namespaces['x']` points to `/etc` (absolute, out-of-root) returns `None` — no `LocationLink` handed to the client
- [x] A `<livewire:ns::counter>` tag where `ns` maps to an in-root directory returns `Some(LocationLink)` pointing to the correct file (positive path unbroken)
- [x] A `<livewire:ns::counter>` tag resolved through a symlink anchored inside the root but resolving outside it returns `None` (symlink-escape blocked via `path_within_root` canonicalization)
- [x] New test module `livewire_tag_navigation_containment` added to `laravel-lsp/src/tests/` and registered in `tests/mod.rs`, covering the three cases (out-of-root → `None`, in-root positive → `Some`, symlink-under-root→outside → `None`); follows the `view_navigation_containment.rs` / `directive_navigation_containment.rs` structure
- [x] (Secondary) The diagnostic-validation loops skip `.exists()` filesystem probes on paths outside `config.root`; an out-of-root `resolve_view_path` candidate is not stat-probed during diagnostics

## Test Plan
- [x] New `livewire_tag_navigation_containment` module — 3 cases pass (incl. the `#[cfg(unix)]` under-root-symlink-to-outside case that only canonicalization can catch)
- [x] Full unit suite green: **1852 + 349** tests pass, no regressions
- [x] Integration suite: **79/80** pass locally after bootstrapping the gitignored `test-project/.env`; the 1 remaining (`test_route_index_resolves_package_route`) needs `composer`-provisioned vendor packages (Fortify), which **CI provisions** via `setup-php` + `composer update` — unrelated to this diff
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

Fixes #194