### PR TITLE
Discovery: unify route caches — synthetic benchmark + recommendation (#48)

### DIFF
--- a/docs/route-cache-unification.md
+++ b/docs/route-cache-unification.md
@@ -161,7 +161,9 @@ error in the bulk-index cost but are the *only* files that need rename/outline.
 The two strategies **both surface resources** — the original issue's "outline
 omits resources" premise was wrong (confirmed in code: `route_chain.rs`
 `ROUTE_VERBS` includes `"resource"`/`"apiResource"`, and `route_outline.rs`
-folds them into a `RESOURCE` leaf). The real difference is **granularity**:
+folds each into a resource-type leaf (`RESOURCE` / `APIRESOURCE`) — the verb is
+upper-cased verbatim, so `apiResource` surfaces as `APIRESOURCE`, not `RESOURCE`).
+The real difference is **granularity**:
 
 ```
 == Route::resource granularity (AC#4) ==

--- a/docs/route-cache-unification.md
+++ b/docs/route-cache-unification.md
@@ -1,0 +1,346 @@
+# Discovery: unifying the route caches
+
+> **Status:** discovery / recommendation for [#48](https://github.com/mike-bronner/zed-laravel/issues/48).
+> Gates a future implementation issue — no production code changed here.
+> Numbers below come from `cargo bench --bench route_cache` (a **synthetic**
+> corpus; see the caveat at the end).
+
+## TL;DR
+
+**Recommendation: B — hybrid, but deferred.** Unify the *first-party* route
+files onto the tree-sitter model (one parse feeding index + declarations +
+outline) and keep the byte-scan index for `vendor/`, where it is ~2.8× cheaper
+and the rich model is never needed. But the measured payoff is small — AC#4
+debunked the headline drift motivation — so treat B as a low-priority cleanup
+for whenever the route subsystem is next opened, not a now-task. Full
+unification (A) is ruled out by the numbers; status-quo (C) is an acceptable
+interim.
+
+## Background
+
+After the route-handling consolidation (PR #47) route data is still
+materialized into **three caches built by two parsing strategies**:
+
+| Store | Strategy | Scope / keying | Feeds |
+|---|---|---|---|
+| `route_index` (`build_route_index`) | byte-scan | whole project incl. `vendor/*/routes`; rebuilt on init + route-file save | hover, goto, completion, route diagnostic (`main.rs`, `folio_discovery`) |
+| `route_decl_cache` | tree-sitter (`route_chain`) | per-file, keyed by mtime | rename, find-references (`route_name_locator`) |
+| document-symbols | tree-sitter (`route_chain`) | per-file, mtime-keyed | outline (`route_outline`, `document_symbols`) |
+
+The two tree-sitter consumers already share one walker
+(`route_chain::extract_route_chains`). The remaining split is **byte-scan index
+vs. tree-sitter walkers**. The byte-scan index is a deliberate optimization: it
+bulk-indexes the whole project **including `vendor/`** (potentially thousands of
+route files), where byte-scanning is far cheaper than spinning up a tree-sitter
+parse per file.
+
+The question this discovery answers: is it worth collapsing onto one canonical
+per-file model, and if so, how — given that unifying onto tree-sitter likely
+**slows** the vendor-heavy bulk index but **speeds up** per-file ops?
+
+## What was measured
+
+A committed benchmark, `laravel-lsp/benches/route_cache.rs`, generates a
+synthetic corpus at three vendor scales (~500 / ~2000 / ~5000 vendor files,
+plus a fixed 12 first-party `routes/` files) whose files mimic real Laravel
+shapes — named routes, prefixed+named groups, nested groups, `Route::resource`,
+and unnamed closure routes. It then measures, with `extract_named_routes`
+(byte-scan) vs `extract_route_chains` (tree-sitter):
+
+1. **init path** — parse the whole corpus once, in memory, with each strategy;
+2. **route-save path** — re-parse a single representative project file;
+3. **realistic init** — the real `build_route_index` (discovery + disk I/O +
+   load-graph expansion + byte-scan), i.e. the cost paid today;
+4. **memory** — estimated heap footprint of caching the tree-sitter rich
+   per-file model (`Vec<RouteChainNode>`) for every file.
+
+Re-run it any time with `cargo bench --bench route_cache`. Override the scales
+with `ROUTE_BENCH_SCALES=200,1000 cargo bench --bench route_cache`.
+
+### Results
+
+```
+route-cache strategy benchmark (issue #48) — SYNTHETIC corpus
+project route files (fixed): 12 | files per vendor pkg: 6
+
+== Route::resource granularity (AC#4) ==
+source: Route::resource('photos', PhotoController::class);
+  byte-scan      -> 7 named routes: photos.create, photos.destroy, photos.edit, photos.index, photos.show, photos.store, photos.update
+  tree-sitter    -> 1 chain node(s), verb=Some("resource"), uri=Some("photos"), name=None
+
+========================================================
+SCALE: 500 vendor files + 12 project files = 512 total (97.7% vendor)
+--------------------------------------------------------
+[init / whole corpus, in-memory parse only]
+  byte-scan   :   18.62ms  (36.36 us/file, 7263 route-defs)
+  tree-sitter :   51.55ms  (100.69 us/file, 4066 chain nodes)
+  tree-sitter / byte-scan slowdown: 2.8x
+[route-save / single project file re-parse]
+  byte-scan   :   88.36µs
+  tree-sitter :  313.68µs
+  tree-sitter / byte-scan slowdown: 3.5x
+[realistic init / build_route_index, disk + discovery]
+  build_route_index:   38.04ms  (74.29 us/file, 3862 names indexed)
+[memory / cached tree-sitter rich model, all files]
+  estimated heap: 0.73 MiB  (1495 bytes/file)
+
+========================================================
+SCALE: 2000 vendor files + 12 project files = 2012 total (99.4% vendor)
+--------------------------------------------------------
+[init / whole corpus, in-memory parse only]
+  byte-scan   :   70.02ms  (34.80 us/file, 26692 route-defs)
+  tree-sitter :  192.80ms  (95.83 us/file, 15299 chain nodes)
+  tree-sitter / byte-scan slowdown: 2.8x
+[route-save / single project file re-parse]
+  byte-scan   :   88.54µs
+  tree-sitter :  318.88µs
+  tree-sitter / byte-scan slowdown: 3.6x
+[realistic init / build_route_index, disk + discovery]
+  build_route_index:  172.80ms  (85.88 us/file, 14359 names indexed)
+[memory / cached tree-sitter rich model, all files]
+  estimated heap: 2.74 MiB  (1430 bytes/file)
+
+========================================================
+SCALE: 5000 vendor files + 12 project files = 5012 total (99.8% vendor)
+--------------------------------------------------------
+[init / whole corpus, in-memory parse only]
+  byte-scan   :  171.65ms  (34.25 us/file, 65234 route-defs)
+  tree-sitter :  479.42ms  (95.65 us/file, 37743 chain nodes)
+  tree-sitter / byte-scan slowdown: 2.8x
+[route-save / single project file re-parse]
+  byte-scan   :   89.19µs
+  tree-sitter :  309.01µs
+  tree-sitter / byte-scan slowdown: 3.5x
+[realistic init / build_route_index, disk + discovery]
+  build_route_index:  368.46ms  (73.52 us/file, 35462 names indexed)
+[memory / cached tree-sitter rich model, all files]
+  estimated heap: 6.77 MiB  (1416 bytes/file)
+
+NOTE: synthetic corpus. Re-point build_route_index at a real
+vendor/ tree for literal per-project numbers (see module docs).
+```
+
+#### 1–2. Init throughput and route-save (AC#1, AC#2)
+
+| Scale (total files) | byte-scan init | tree-sitter init | TS/BS slowdown | byte-scan save | tree-sitter save | realistic `build_route_index` |
+|---|---|---|---|---|---|---|
+| ~500 vendor (512 total) | 18.62 ms | 51.55 ms | 2.8× | 88.36 µs | 313.68 µs | 38.04 ms |
+| ~2000 vendor (2012 total) | 70.02 ms | 192.80 ms | 2.8× | 88.54 µs | 318.88 µs | 172.80 ms |
+| ~5000 vendor (5012 total) | 171.65 ms | 479.42 ms | 2.8× | 89.19 µs | 309.01 µs | 368.46 ms |
+
+Init is parse-dominated, and tree-sitter costs a **flat ~2.8× more than
+byte-scan** at every scale — it does not amortize away with size (per-file
+throughput is a stable ~35 µs/file byte-scan vs ~96–100 µs/file tree-sitter).
+The realistic `build_route_index` (disk I/O + discovery + load-graph expansion +
+byte-scan) lands at ~73–86 µs/file, above the in-memory byte-scan figure because
+I/O and discovery add fixed overhead on top of the parse. The consequence for
+**design A**: replacing the byte-scan parse with the ~2.8×-costlier tree-sitter
+one across the whole corpus turns a 172 ms in-memory parse into 479 ms at 5000
+files — realistic init would climb from ~368 ms toward ~675 ms, paid on **every
+cold init and every route-file-save rebuild**, and worst exactly on the
+vendor-heavy projects the byte-scan index was built to serve. The route-save
+micro-bench shows the same ~3.5× gap for a single file (88 µs vs ~313 µs), but
+at single-file scale both are sub-millisecond and imperceptible.
+
+#### 3. Vendor vs project file ratio (AC#3)
+
+Real Laravel apps have a small, roughly constant set of first-party route files
+(`routes/web.php`, `api.php`, `console.php`, a handful of domain splits — call
+it ~5–15), while `vendor/` route files scale with installed packages. The
+synthetic corpus models this with a **fixed 12 project files** against
+500/2000/5000 vendor files, i.e. vendor is **97.7%–99.8%** of all
+indexed route files. This is the regime that matters: **the byte-scan index
+exists almost entirely to serve `vendor/`.** First-party files are a rounding
+error in the bulk-index cost but are the *only* files that need rename/outline.
+
+> Synthesised from composer patterns, not a measured count of one project. The
+> committed bench can be re-pointed at a real `vendor/` tree for literal numbers.
+
+#### 4. `Route::resource` granularity difference (AC#4)
+
+The two strategies **both surface resources** — the original issue's "outline
+omits resources" premise was wrong (confirmed in code: `route_chain.rs`
+`ROUTE_VERBS` includes `"resource"`/`"apiResource"`, and `route_outline.rs`
+folds them into a `RESOURCE` leaf). The real difference is **granularity**:
+
+```
+== Route::resource granularity (AC#4) ==
+source: Route::resource('photos', PhotoController::class);
+  byte-scan      -> 7 named routes: photos.create, photos.destroy, photos.edit, photos.index, photos.show, photos.store, photos.update
+  tree-sitter    -> 1 chain node(s), verb=Some("resource"), uri=Some("photos"), name=None
+```
+
+- **byte-scan** (`extract_resource_routes`, `route_discovery.rs`) expands a
+  resource into its named CRUD sub-routes — `photos.index`, `photos.create`,
+  `photos.store`, `photos.show`, `photos.edit`, `photos.update`,
+  `photos.destroy` (apiResource drops `create`/`edit`).
+- **tree-sitter** (`route_chain`) surfaces a **single** `RESOURCE` leaf with
+  `verb = "resource"`, `uri = "photos"`, `name = None`.
+
+**Is this a user-visible inconsistency?** Assessed per workflow:
+
+- **hover / goto / completion** — fed by the byte-scan `RouteIndex`, so
+  `route('photos.show')` resolves and completes. ✅ The granular names are
+  exactly what these features need; tree-sitter alone could not serve them
+  without re-deriving the CRUD expansion.
+- **outline** — fed by tree-sitter, shows one `RESOURCE photos` node rather
+  than seven rows. This is **defensible, not a bug**: an outline is a structural
+  map of the source file, and the source literally has one `Route::resource`
+  call. Expanding it to seven synthetic rows would *misrepresent* the file.
+- **rename / find-references** — fed by tree-sitter via `route_decl_cache`.
+  Resource sub-routes have **no `->name()` token to rename** (the names are
+  synthesised by Laravel, not written in source), so there is nothing for rename
+  to target. ✅ No inconsistency — the granularity gap is invisible here too.
+
+**Conclusion:** the granularity difference is **correct behaviour on both
+sides**, dictated by what each consumer needs, not drift. It does **not** by
+itself justify forcing both consumers onto one representation — if anything it
+argues *against* full unification, because the two views legitimately differ.
+
+#### 5. Memory footprint of a cached rich model (AC#5)
+
+| Scale (total files) | est. cached tree-sitter model | bytes/file |
+|---|---|---|
+| ~500 vendor | 0.73 MiB | 1495 B |
+| ~2000 vendor | 2.74 MiB | 1430 B |
+| ~5000 vendor | 6.77 MiB | 1416 B |
+
+This is the **folded** model (`Vec<RouteChainNode>` + owned strings), not the
+tree-sitter `Tree` — design A would drop the tree after folding. Even caching a
+rich model for *every* file (vendor included) costs ~1.4–1.5 KB/file and stays
+under 7 MiB at 5000 files. **Memory is not a constraint on any design** and
+does not argue for or against unification.
+
+## Candidate designs
+
+- **A. Full unify onto tree-sitter** — one per-file model cache, all views
+  (name→location index, declarations, outline) derived from it. Parse every
+  route file (incl. vendor) once with tree-sitter, cache by mtime, compute the
+  cross-file prefix graph from the models.
+  - Pros: one representation, one invalidation path; per-file ops stop
+    double-parsing.
+  - Cons: pays tree-sitter cost on the whole `vendor/` bulk — the ~2.8×
+    slower init regime, worst exactly where there are most files; and it must
+    *re-implement* the resource CRUD-name expansion (AC#4) on top of the
+    tree-sitter model, since the outline's single-leaf shape can't feed
+    hover/goto/completion.
+
+- **B. Hybrid** — one tree-sitter parse per **first-party** route file (reused
+  for the index entry + declarations + outline), keep **byte-scan only for
+  `vendor/`** bulk (which never needs rename or outline). Kills the
+  double-parse and the drift surface for first-party routes while preserving
+  vendor indexing speed.
+  - Pros: removes the per-file double-parse for the files that actually get
+    renamed/outlined; keeps the cheap byte-scan where it matters most (vendor);
+    canonical source for first-party routes.
+  - Cons: still two code paths (but split by a clear, stable boundary —
+    first-party vs vendor — rather than by view); must re-derive resource
+    CRUD-name expansion from the tree-sitter model for *first-party* resources
+    so hover/goto/completion keep resolving; the byte-scan resource expansion
+    stays for vendor.
+
+- **C. Status quo** — keep three caches; document the boundaries and accept the
+  (currently low) drift risk.
+  - Pros: zero risk, zero work; the caches already share the `route_chain`
+    walker across the two tree-sitter consumers.
+  - Cons: three representations + three invalidation paths remain a latent
+    place future edits can disagree.
+
+## Recommendation
+
+**Pick B (hybrid) — but defer it.** The measurements settle the *shape* and
+downgrade the *urgency*.
+
+**Why not A.** Tree-sitter is a flat ~2.8× slower than byte-scan on the bulk
+parse (35 µs → ~96 µs per file, stable across 500 / 2000 / 5000 files), and
+vendor is 97.7–99.8% of all indexed route files. Vendor files never need rename
+or outline, so parsing them with tree-sitter buys nothing and costs a ~2.8× init
+regression (≈368 ms → ≈675 ms at 5000 files) on every cold start and route-save
+rebuild — worst exactly on the vendor-heavy projects the byte-scan index exists
+to serve. **A is ruled out by the data.**
+
+**Why B over C.** The only files that need the rich model are the ~dozen
+first-party route files, and today those are parsed *twice* — once by the
+byte-scan index, once by tree-sitter for rename/outline — through two
+independent invalidation paths. B collapses the first-party side onto one
+tree-sitter model feeding all three views, removing the double-parse and the
+(small) first-party drift surface, while keeping byte-scan for the vendor bulk
+where it wins.
+
+**The honest caveat: the payoff is modest.** AC#4 debunked the headline drift
+motivation — both strategies already surface resources; the granularity
+difference (named CRUD sub-routes vs a single `RESOURCE` leaf) is correct-by-
+design per consumer, not drift. With that gone, B's remaining benefit is ~2.7 ms
+of init parse for a dozen files plus one fewer invalidation path — real, but not
+pressing, and it *adds* the first-party resource-expansion code path and a new
+first-party/vendor boundary to maintain. So: **adopt B as the target
+architecture whenever the route subsystem is next opened, but don't schedule it
+ahead of higher-value work.** C (status quo) is a fine interim — the one
+deliverable C still owes is *documentation*: record the first-party/vendor
+boundary and the resource-granularity-by-design finding (above) in the route
+modules so the next editor doesn't mistake the granularity gap for a bug.
+
+## Implementation sketch (for the recommended option)
+
+**Target: B (hybrid).** Estimated effort **Medium** — the split boundary is
+trivial; the risk is parity, making first-party index entries derived from the
+tree-sitter model match byte-scan exactly so existing tests stay green.
+
+**Affected modules**
+
+- `route_discovery.rs` — `discover_route_files` / `build_route_index`: partition
+  discovered files into **first-party** (`routes/` plus project files reached
+  through `->group(<path>)` external loads) vs **vendor** (`vendor/*/routes`).
+  Build vendor index entries with the existing byte-scan (`extract_named_routes`);
+  build first-party index entries from the tree-sitter model instead.
+- `route_chain.rs` — the per-file model (`extract_route_chains` →
+  `Vec<RouteChainNode>`) becomes the canonical first-party source. Add a
+  derivation that walks `RouteChainNode` (incl. `RESOURCE` leaves and
+  group-prefix accumulation) into `Vec<(Option<String>, RouteDefinition)>`
+  index entries, mirroring byte-scan's resource CRUD-name expansion so
+  `route('photos.show')` still resolves for first-party resources.
+- `route_decl_cache` / `document_symbols` / new index consumer — all three read
+  the **same** mtime-keyed per-file model for first-party files: one parse,
+  three views (this is the drift-surface kill).
+- `main.rs` / `salsa_impl.rs` — `did_save` rebuild path: a first-party
+  route-file save re-parses once (tree-sitter) and refreshes index + decl-cache +
+  outline from the one model; a vendor route-file save (rare) still byte-scans.
+
+**Key data-structure changes**
+
+- A canonical per-file `RouteFileModel { chains: Vec<RouteChainNode>, mtime }`
+  cache — ideally a Salsa `#[salsa::tracked]` query keyed by `SourceFile`, per
+  the repo's cache-invalidation convention — feeding the three derived views.
+- `fn index_entries_from_chains(&[RouteChainNode], inherited_prefixes: &[String])
+  -> Vec<(Option<String>, RouteDefinition)>` in `route_chain.rs`, including
+  resource expansion and group-prefix accumulation, replacing the first-party
+  portion of `extract_named_routes`.
+- A `is_vendor(path)` predicate (path under `vendor/` → byte-scan; else →
+  tree-sitter model) as the single split point.
+
+**Sequencing (rough)**
+
+1. Add `index_entries_from_chains` + a **parity test** asserting it produces the
+   same `(name, location)` set as `extract_named_routes` over the existing route
+   fixtures (this is where the effort lives — resource expansion + nested
+   group prefixes must match byte-scan bit-for-bit).
+2. Wire the first-party/vendor split into `build_route_index` and the `did_save`
+   rebuild; route first-party files through the model, keep vendor on byte-scan.
+3. Point `route_decl_cache` and document-symbols at the same cached model for
+   first-party files; delete the now-redundant first-party byte-scan pass.
+
+Net production LOC is modest; the parity test suite dominates the work. Because
+the payoff is small (per the recommendation), this can land opportunistically
+the next time someone is already in `route_discovery.rs`.
+
+---
+
+### Synthetic-data caveat
+
+The corpus is **synthetic**: route-file shapes approximate typical Laravel
+files, but the vendor/project ratio and per-file route counts are generator
+parameters, not measurements of any specific project. The committed bench is
+the deliverable that lets the team get literal numbers — re-point
+`build_route_index` at a real `vendor/` tree (the realistic-init harness already
+runs it against the synthetic root) to replace these representative ranges with
+project-specific figures.

--- a/laravel-lsp/Cargo.toml
+++ b/laravel-lsp/Cargo.toml
@@ -82,6 +82,13 @@ cc = "1.2"
 [dev-dependencies]
 tempfile = "3.27"
 
+# Discovery benchmark for issue #48 — compares the byte-scan vs tree-sitter
+# route-parsing strategies. Custom timing harness (no criterion dependency);
+# run with `cargo bench --bench route_cache`.
+[[bench]]
+name = "route_cache"
+harness = false
+
 [profile.release]
 lto = true
 opt-level = 3

--- a/laravel-lsp/benches/route_cache.rs
+++ b/laravel-lsp/benches/route_cache.rs
@@ -1,0 +1,402 @@
+//! Route-cache strategy benchmark — discovery for issue #48.
+//!
+//! Today route data is materialized into three caches built by two parsing
+//! strategies. This bench measures the two strategies head-to-head so the
+//! "unify onto one canonical source" decision rests on numbers, not intuition:
+//!
+//! * **byte-scan** — [`extract_named_routes`], the strategy behind
+//!   `build_route_index` (the whole-project name→location index, incl.
+//!   `vendor/`).
+//! * **tree-sitter** — [`extract_route_chains`], the strategy behind the
+//!   per-file declaration cache (rename / find-references) and the
+//!   document-symbols outline.
+//!
+//! It generates a synthetic corpus at three vendor scales (~500 / ~2000 /
+//! ~5000 files) whose route files mimic real-world shapes — named routes,
+//! prefixed/named groups, nested groups, `Route::resource`, unnamed closure
+//! routes — then measures:
+//!
+//! 1. **init path** — parse every file in the corpus once with each strategy
+//!    (in-memory, isolating parse cost from disk I/O);
+//! 2. **route-save path** — re-parse a single representative project file with
+//!    each strategy;
+//! 3. **realistic init** — the real `build_route_index` (discovery + disk I/O +
+//!    load-graph expansion + byte-scan) against the on-disk corpus, i.e. the
+//!    cost paid today;
+//! 4. **memory** — estimated heap footprint of caching the tree-sitter rich
+//!    per-file model (`Vec<RouteChainNode>`) for every route file.
+//!
+//! It also prints the `Route::resource` granularity difference (issue #48 AC#4).
+//!
+//! ## Running
+//!
+//! ```text
+//! cargo bench --bench route_cache
+//! ROUTE_BENCH_SCALES=200,1000 cargo bench --bench route_cache   # custom scales
+//! ```
+//!
+//! ## Synthetic-data caveat
+//!
+//! This corpus is **synthetic**. The route-file shapes approximate typical
+//! Laravel files, but the vendor/project ratio and per-file route counts are
+//! generator parameters, not measurements of any specific project. To get the
+//! literal numbers for a real codebase, point [`build_route_index`] at that
+//! project's `vendor/` tree (the realistic-init harness already does exactly
+//! that against the synthetic root).
+
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use laravel_lsp::route_chain::{extract_route_chains, RouteChainNode};
+use laravel_lsp::route_discovery::{
+    build_route_index, discover_route_files, extract_named_routes, PRIORITY_APP,
+};
+
+/// Files generated per synthetic vendor package (a package usually ships a
+/// handful of route files under its own `routes/` dir).
+const FILES_PER_PKG: usize = 6;
+/// Fixed number of first-party `routes/` files (real apps have a small,
+/// roughly constant set regardless of how many vendor packages they pull in).
+const PROJECT_FILES: usize = 12;
+/// Iterations for the single-file route-save micro-bench.
+const SAVE_ITERS: u32 = 500;
+
+/// Deterministic LCG so corpus shapes vary between files yet reproduce exactly
+/// across runs (no `rand` dependency, results are stable to compare over time).
+fn next_rand(state: &mut u64) -> u64 {
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    *state >> 33
+}
+
+/// Generate a first-party route file: a richer mix of named routes, nested
+/// prefixed+named groups, resources, and unnamed closure routes.
+fn project_route_file(seed: u64, idx: usize) -> String {
+    let mut s = seed ^ (idx as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    let mut out = String::from(
+        "<?php\n\nuse Illuminate\\Support\\Facades\\Route;\nuse App\\Http\\Controllers\\FooController;\n\n",
+    );
+    let routes = 8 + (next_rand(&mut s) % 24) as usize; // 8..=31
+    for r in 0..routes {
+        match next_rand(&mut s) % 10 {
+            0 | 1 => out.push_str(&format!(
+                "Route::resource('res{r}', FooController::class);\n"
+            )),
+            2 => {
+                out.push_str(&format!(
+                    "Route::prefix('grp{r}')->name('grp{r}.')->group(function () {{\n"
+                ));
+                let inner = 2 + (next_rand(&mut s) % 5) as usize;
+                for k in 0..inner {
+                    out.push_str(&format!(
+                        "    Route::get('/g{r}/{k}', [FooController::class, 'show'])->name('show{k}');\n"
+                    ));
+                }
+                out.push_str("});\n");
+            }
+            3 => out.push_str(&format!(
+                "Route::get('/anon{r}', function () {{ return view('x'); }});\n"
+            )),
+            _ => {
+                let verb =
+                    ["get", "post", "put", "patch", "delete"][(next_rand(&mut s) % 5) as usize];
+                out.push_str(&format!(
+                    "Route::{verb}('/path{r}', [FooController::class, 'act{r}'])->name('app.path{r}');\n"
+                ));
+            }
+        }
+    }
+    out
+}
+
+/// Generate a vendor package route file: a flat `Route::group([...], fn)` of
+/// mostly named routes plus the occasional resource, as packages typically ship.
+fn vendor_route_file(seed: u64, pkg: usize, idx: usize) -> String {
+    let mut s = seed ^ (pkg as u64).wrapping_mul(0x0100_0000_01B3) ^ (idx as u64);
+    let mut out = String::from("<?php\n\nuse Illuminate\\Support\\Facades\\Route;\n\n");
+    out.push_str(&format!(
+        "Route::group(['prefix' => 'pkg{pkg}', 'as' => 'pkg{pkg}.'], function () {{\n"
+    ));
+    let routes = 3 + (next_rand(&mut s) % 8) as usize; // 3..=10
+    for r in 0..routes {
+        if next_rand(&mut s).is_multiple_of(6) {
+            out.push_str(&format!(
+                "    Route::resource('vres{r}', 'Vendor\\\\Controller');\n"
+            ));
+        } else {
+            let verb = ["get", "post", "put", "delete"][(next_rand(&mut s) % 4) as usize];
+            out.push_str(&format!(
+                "    Route::{verb}('/v{r}', 'Vendor\\\\Controller@m{r}')->name('widget{r}');\n"
+            ));
+        }
+    }
+    out.push_str("});\n");
+    out
+}
+
+/// An on-disk synthetic project: `routes/*.php` (first-party) plus
+/// `vendor/acme/pkgN/routes/*.php` (package routes), shaped so
+/// [`discover_route_files`] finds every file.
+struct Corpus {
+    _dir: tempfile::TempDir, // kept alive so the tempdir isn't removed
+    root: PathBuf,
+    project_files: Vec<PathBuf>,
+    vendor_files: Vec<PathBuf>,
+}
+
+fn build_corpus(n_vendor: usize) -> Corpus {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let root = dir.path().to_path_buf();
+    let seed = 0x00C0_FFEE_u64;
+
+    let routes_dir = root.join("routes");
+    fs::create_dir_all(&routes_dir).expect("create routes/");
+    let mut project_files = Vec::with_capacity(PROJECT_FILES);
+    for i in 0..PROJECT_FILES {
+        let path = routes_dir.join(format!("group{i}.php"));
+        fs::write(&path, project_route_file(seed, i)).expect("write project route file");
+        project_files.push(path);
+    }
+
+    let pkgs = n_vendor.div_ceil(FILES_PER_PKG);
+    let mut vendor_files = Vec::with_capacity(n_vendor);
+    for pkg in 0..pkgs {
+        let pkg_routes = root
+            .join("vendor")
+            .join(format!("acme/pkg{pkg}"))
+            .join("routes");
+        fs::create_dir_all(&pkg_routes).expect("create vendor routes/");
+        for f in 0..FILES_PER_PKG {
+            if vendor_files.len() >= n_vendor {
+                break;
+            }
+            let path = pkg_routes.join(format!("routes{f}.php"));
+            fs::write(&path, vendor_route_file(seed, pkg, f)).expect("write vendor route file");
+            vendor_files.push(path);
+        }
+    }
+
+    Corpus {
+        _dir: dir,
+        root,
+        project_files,
+        vendor_files,
+    }
+}
+
+fn read_all(paths: &[PathBuf]) -> Vec<String> {
+    paths
+        .iter()
+        .map(|p| fs::read_to_string(p).unwrap_or_default())
+        .collect()
+}
+
+/// Recursively count every `Route::*` chain node (parity with the byte-scan
+/// route-definition count, modulo resource granularity — see AC#4 demo).
+fn count_chain_nodes(chains: &[RouteChainNode]) -> usize {
+    chains
+        .iter()
+        .map(|n| 1 + count_chain_nodes(&n.group_children))
+        .sum()
+}
+
+/// Estimated retained heap bytes of caching the tree-sitter rich per-file model
+/// (`Vec<RouteChainNode>` + owned strings), excluding the tree-sitter `Tree`
+/// itself (design A folds the tree into this model and drops the tree).
+fn model_heap_bytes(chains: &[RouteChainNode]) -> usize {
+    let mut bytes = std::mem::size_of_val(chains);
+    for n in chains {
+        bytes += n.verb.as_ref().map_or(0, String::capacity);
+        bytes += n.uri.as_ref().map_or(0, String::capacity);
+        bytes += n.prefix_arg.as_ref().map_or(0, String::capacity);
+        bytes += n.name.as_ref().map_or(0, |a| a.segment.capacity());
+        bytes += model_heap_bytes(&n.group_children);
+    }
+    bytes
+}
+
+/// Byte-scan the whole corpus in memory; returns (elapsed, route-defs found).
+fn bench_bytescan(contents: &[String]) -> (Duration, usize) {
+    let path = Path::new("routes/web.php");
+    let start = Instant::now();
+    let mut total = 0;
+    for c in contents {
+        total += black_box(extract_named_routes(c, path, PRIORITY_APP, &[])).len();
+    }
+    (start.elapsed(), total)
+}
+
+/// Tree-sitter the whole corpus in memory; returns (elapsed, chain nodes found,
+/// estimated cached-model bytes).
+fn bench_treesitter(contents: &[String]) -> (Duration, usize, usize) {
+    let start = Instant::now();
+    let mut nodes = 0;
+    let mut bytes = 0;
+    for c in contents {
+        let chains = black_box(extract_route_chains(c));
+        nodes += count_chain_nodes(&chains);
+        bytes += model_heap_bytes(&chains);
+    }
+    (start.elapsed(), nodes, bytes)
+}
+
+/// Single-file re-parse cost for each strategy (the route-save path).
+fn bench_single_file(content: &str) -> (Duration, Duration) {
+    let path = Path::new("routes/web.php");
+    let t0 = Instant::now();
+    for _ in 0..SAVE_ITERS {
+        black_box(extract_named_routes(
+            black_box(content),
+            path,
+            PRIORITY_APP,
+            &[],
+        ));
+    }
+    let bytescan = t0.elapsed() / SAVE_ITERS;
+    let t1 = Instant::now();
+    for _ in 0..SAVE_ITERS {
+        black_box(extract_route_chains(black_box(content)));
+    }
+    let treesitter = t1.elapsed() / SAVE_ITERS;
+    (bytescan, treesitter)
+}
+
+/// The real init cost paid today: discovery + disk read + load-graph expansion
+/// + byte-scan, via `build_route_index`.
+fn bench_realistic_init(root: &Path) -> (Duration, usize) {
+    let start = Instant::now();
+    let files = discover_route_files(root);
+    let index = build_route_index(root, &files);
+    (start.elapsed(), index.len())
+}
+
+fn per_file_us(elapsed: Duration, files: usize) -> f64 {
+    if files == 0 {
+        0.0
+    } else {
+        elapsed.as_secs_f64() * 1e6 / files as f64
+    }
+}
+
+/// AC#4 — demonstrate the `Route::resource` granularity difference directly.
+fn resource_granularity_demo() {
+    let src = "<?php\nuse Illuminate\\Support\\Facades\\Route;\nRoute::resource('photos', PhotoController::class);\n";
+    let bytescan = extract_named_routes(src, Path::new("routes/web.php"), PRIORITY_APP, &[]);
+    let treesitter = extract_route_chains(src);
+
+    println!("\n== Route::resource granularity (AC#4) ==");
+    println!("source: Route::resource('photos', PhotoController::class);");
+    let mut names: Vec<String> = bytescan.iter().filter_map(|(n, _)| n.clone()).collect();
+    names.sort();
+    println!(
+        "  byte-scan      -> {} named routes: {}",
+        names.len(),
+        names.join(", ")
+    );
+    println!(
+        "  tree-sitter    -> {} chain node(s), verb={:?}, uri={:?}, name={:?}",
+        treesitter.len(),
+        treesitter.first().and_then(|n| n.verb.clone()),
+        treesitter.first().and_then(|n| n.uri.clone()),
+        treesitter
+            .first()
+            .and_then(|n| n.name.as_ref().map(|a| a.segment.clone())),
+    );
+}
+
+fn parse_scales() -> Vec<usize> {
+    match std::env::var("ROUTE_BENCH_SCALES") {
+        Ok(raw) => raw
+            .split(',')
+            .filter_map(|s| s.trim().parse::<usize>().ok())
+            .collect(),
+        Err(_) => vec![500, 2000, 5000],
+    }
+}
+
+fn main() {
+    let scales = parse_scales();
+    println!("route-cache strategy benchmark (issue #48) — SYNTHETIC corpus");
+    println!(
+        "project route files (fixed): {PROJECT_FILES} | files per vendor pkg: {FILES_PER_PKG}\n"
+    );
+
+    resource_granularity_demo();
+
+    for &n_vendor in &scales {
+        let corpus = build_corpus(n_vendor);
+        let total_files = corpus.project_files.len() + corpus.vendor_files.len();
+        let vendor_pct = 100.0 * corpus.vendor_files.len() as f64 / total_files as f64;
+
+        let project_contents = read_all(&corpus.project_files);
+        let vendor_contents = read_all(&corpus.vendor_files);
+        let all_contents: Vec<String> = project_contents
+            .iter()
+            .cloned()
+            .chain(vendor_contents.iter().cloned())
+            .collect();
+
+        println!("\n========================================================");
+        println!(
+            "SCALE: {} vendor files + {} project files = {} total ({:.1}% vendor)",
+            corpus.vendor_files.len(),
+            corpus.project_files.len(),
+            total_files,
+            vendor_pct
+        );
+        println!("--------------------------------------------------------");
+
+        // 1. init path — whole corpus, in-memory, each strategy
+        let (bs_dur, bs_defs) = bench_bytescan(&all_contents);
+        let (ts_dur, ts_nodes, ts_bytes) = bench_treesitter(&all_contents);
+        println!("[init / whole corpus, in-memory parse only]");
+        println!(
+            "  byte-scan   : {:>9.2?}  ({:.2} us/file, {} route-defs)",
+            bs_dur,
+            per_file_us(bs_dur, total_files),
+            bs_defs
+        );
+        println!(
+            "  tree-sitter : {:>9.2?}  ({:.2} us/file, {} chain nodes)",
+            ts_dur,
+            per_file_us(ts_dur, total_files),
+            ts_nodes
+        );
+        println!(
+            "  tree-sitter / byte-scan slowdown: {:.1}x",
+            ts_dur.as_secs_f64() / bs_dur.as_secs_f64().max(f64::EPSILON)
+        );
+
+        // 2. route-save path — single representative project file
+        let (save_bs, save_ts) = bench_single_file(&project_contents[0]);
+        println!("[route-save / single project file re-parse]");
+        println!("  byte-scan   : {save_bs:>9.2?}");
+        println!("  tree-sitter : {save_ts:>9.2?}");
+        println!(
+            "  tree-sitter / byte-scan slowdown: {:.1}x",
+            save_ts.as_secs_f64() / save_bs.as_secs_f64().max(f64::EPSILON)
+        );
+
+        // 3. realistic init — build_route_index (discovery + I/O + byte-scan)
+        let (real_dur, indexed) = bench_realistic_init(&corpus.root);
+        println!("[realistic init / build_route_index, disk + discovery]");
+        println!(
+            "  build_route_index: {:>9.2?}  ({:.2} us/file, {} names indexed)",
+            real_dur,
+            per_file_us(real_dur, total_files),
+            indexed
+        );
+
+        // 4. memory — rich per-file model cache
+        let mb = ts_bytes as f64 / (1024.0 * 1024.0);
+        let bytes_per_file = ts_bytes as f64 / total_files as f64;
+        println!("[memory / cached tree-sitter rich model, all files]");
+        println!("  estimated heap: {mb:.2} MiB  ({bytes_per_file:.0} bytes/file)");
+    }
+
+    println!("\nNOTE: synthetic corpus. Re-point build_route_index at a real");
+    println!("vendor/ tree for literal per-project numbers (see module docs).");
+}


### PR DESCRIPTION
## Summary
Discovery for #48 — *measure perf before implementing*. **No production code.** Adds a committed synthetic `cargo bench` harness that pits the two route-parsing strategies head-to-head, then a written recommendation backed by its measured numbers.

## Changes
- **`laravel-lsp/benches/route_cache.rs`** — byte-scan (`extract_named_routes`) vs tree-sitter (`extract_route_chains`) over a synthetic corpus at three vendor scales (~500 / ~2000 / ~5000 files, fixed 12 first-party). Measures: init parse, route-save re-parse, realistic `build_route_index` (disk + discovery), cached rich-model memory, and the `Route::resource` granularity difference. Deterministic LCG corpus, custom timing harness (no `criterion` dependency).
- **`laravel-lsp/Cargo.toml`** — wire the `harness = false` `[[bench]]` entry.
- **`docs/route-cache-unification.md`** — full results, per-workflow AC#4 analysis, candidate-design comparison, recommendation, and an implementation sketch.

## Key findings
- Tree-sitter is a **flat ~2.8× slower** than byte-scan on the bulk parse, stable across all three scales; vendor is **97.7–99.8%** of all route files and never needs rename/outline. → **Design A (full unify) ruled out.**
- AC#4: both strategies **surface** resources; the granularity difference (named CRUD sub-routes vs a single `RESOURCE` leaf) is **correct-by-design per consumer, not drift** — debunking the issue's original "outline omits resources" premise.
- Memory is a non-factor (<7 MiB caching every file at 5000 scale).
- **Recommendation: B (hybrid), deferred** — unify first-party files onto the tree-sitter model, keep byte-scan for `vendor/`; correct target shape but low payoff/urgency given AC#4. C (status quo) acceptable interim.

## Acceptance Criteria
- [x] Synthetic `cargo bench` corpus at three vendor scales (~500/2000/5000), committed for re-run
- [x] Benchmark byte-scan vs tree-sitter on init + route-save paths; per-file throughput + wall-clock at each scale
- [x] Quantify vendor vs project file ratios as representative ranges
- [x] Document the `Route::resource` granularity difference + assess visible impact (hover/completion/rename)
- [x] Estimate memory footprint of caching a rich per-file model at each scale
- [x] Written recommendation (A/B/C/variant) backed by numbers + the resource finding, with trade-off reasoning
- [x] Implementation sketch for the chosen option: affected modules, data-structure changes, effort estimate

## Test Plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --all-features` — 80 passed, 0 failed (CI fixture bootstrapped: `.env` + `composer update`)
- [x] `cargo bench --bench route_cache` runs and produces the documented numbers

Fixes #48