### PR TITLE
Add the fail-closed path_within_root guard to resolve_component_file for containment-invariant uniformity

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -18402,9 +18402,23 @@ return [
     async fn resolve_component_file(&self, name: &str) -> Option<PathBuf> {
         let config = self.get_cached_config().await?;
         for path in config.resolve_component_path(name) {
-            if self.file_exists_cached(&path).await {
-                return Some(path);
+            if !self.file_exists_cached(&path).await {
+                continue;
             }
+            // Containment guard (issue #199) — the next sibling in the
+            // #130 → #143 → #148 → #194 containment-guard chain, whose invariant
+            // is that the fail-closed `path_within_root` check holds *uniformly*
+            // on every FS-touching resolution path. `resolve_component_path`
+            // already drops out-of-root candidates with the *lexical*
+            // `path_within_root_lexical` filter, so this is defense-in-depth: it
+            // re-checks containment with the same fail-closed guard the sibling
+            // `resolve_component_existing_file` (`:13878`) applies, against the
+            // same `config.root`. `continue` so a later in-root candidate can
+            // still resolve.
+            if !path_within_root(&path, &config.root) {
+                continue;
+            }
+            return Some(path);
         }
         None
     }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2475,12 +2475,20 @@ class {} extends Component
         // Containment backstop (issue #199) — the write/create seam of the
         // #130 → #143 → #148 → #194 containment-guard chain, whose invariant is
         // that no FS-touching path escapes the project root. Every create action
-        // (View, BladeComponent, Livewire, Inertia, …) materialises
-        // `self.target_path`, so refuse to *offer* the action when that target
-        // resolves outside `root` — return `None` rather than constructing an
-        // out-of-root `ResourceOp::Create`. `target_path` is server-authored from
-        // the diagnostic and already safe today; this is belt-and-suspenders
-        // against a forged or malformed diagnostic.
+        // materialises `self.target_path`, so refuse to *offer* the action when
+        // that target resolves outside `root` — return `None` rather than
+        // constructing an out-of-root `ResourceOp::Create`. `target_path` is
+        // server-authored from the diagnostic and already safe today; this is
+        // belt-and-suspenders against a forged or malformed diagnostic.
+        //
+        // NOT every type materialises *only* `target_path`: the multi-file types
+        // (`Livewire`, `BladeComponentWithClass`) each emit a SECOND create — a
+        // `view_uri` / `class_uri` derived from `self.name`, which is an
+        // independent diagnostic field, not coupled to `target_path`. Because
+        // `PathBuf::join`/`push` of an absolute-looking segment *replaces* the
+        // base, a forged `name` (e.g. `/etc/passwd`) escapes the root even when
+        // `target_path` is in-root. So each of those sibling paths is guarded at
+        // its own branch below, with the same primitive and the same `return None`.
         //
         // The guard uses `path_within_root_lexical`, NOT the fail-closed
         // `path_within_root` the sibling *read* paths use: a create target never
@@ -2503,6 +2511,12 @@ class {} extends Component
             // Livewire creates TWO files: PHP class and Blade view
             let root = root?;
             let view_path = self.get_livewire_view_path(root);
+            // Sibling create (issue #199): `view_path` is derived from
+            // `self.name`, an independent diagnostic field — guard it too, or a
+            // forged `name` escapes the root past the `target_path` check above.
+            if !path_within_root_lexical(&view_path, root) {
+                return None;
+            }
             let view_uri = Url::from_file_path(&view_path).ok()?;
             let view_template = Self::get_livewire_view_template();
 
@@ -2572,6 +2586,12 @@ class {} extends Component
             // Create both the Blade view and the PHP class
             let root = root?;
             let class_path = self.get_component_class_path(root);
+            // Sibling create (issue #199): `class_path` is derived from
+            // `self.name`, an independent diagnostic field — guard it too, or a
+            // forged `name` escapes the root past the `target_path` check above.
+            if !path_within_root_lexical(&class_path, root) {
+                return None;
+            }
             let class_uri = Url::from_file_path(&class_path).ok()?;
             let class_template = self.get_component_class_template();
             let view_template = "@props([])\n\n<div>\n    {{ $slot }}\n</div>\n".to_string();

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2472,6 +2472,32 @@ class {} extends Component
     ) -> Option<CodeActionOrCommand> {
         let file_uri = Url::from_file_path(&self.target_path).ok()?;
 
+        // Containment backstop (issue #199) — the write/create seam of the
+        // #130 → #143 → #148 → #194 containment-guard chain, whose invariant is
+        // that no FS-touching path escapes the project root. Every create action
+        // (View, BladeComponent, Livewire, Inertia, …) materialises
+        // `self.target_path`, so refuse to *offer* the action when that target
+        // resolves outside `root` — return `None` rather than constructing an
+        // out-of-root `ResourceOp::Create`. `target_path` is server-authored from
+        // the diagnostic and already safe today; this is belt-and-suspenders
+        // against a forged or malformed diagnostic.
+        //
+        // The guard uses `path_within_root_lexical`, NOT the fail-closed
+        // `path_within_root` the sibling *read* paths use: a create target never
+        // exists yet, so `path.canonicalize()` always fails for it, and the
+        // fail-closed guard would refuse *every* create — including legitimate
+        // in-root ones. The lexical guard refuses out-of-root and interior-`..`
+        // escapes while admitting a not-yet-created in-root target (and still
+        // canonicalizes to catch a symlink escape when the target does exist),
+        // which is exactly the contract a speculative emitted path needs. When the
+        // root is not yet known (`None`) there is nothing to check against, so
+        // pre-existing behaviour is preserved.
+        if let Some(root) = root {
+            if !path_within_root_lexical(&self.target_path, root) {
+                return None;
+            }
+        }
+
         // Handle different action types
         let workspace_edit = if let FileActionType::Livewire = self.action_type {
             // Livewire creates TWO files: PHP class and Blade view

--- a/laravel-lsp/src/tests/code_action_create_containment.rs
+++ b/laravel-lsp/src/tests/code_action_create_containment.rs
@@ -8,7 +8,11 @@
 //!
 //! The guard runs before any `ResourceOp::Create` is constructed: if the project
 //! root is known and `target_path` resolves outside it, `build_code_action`
-//! returns `None` (no action offered) instead of an out-of-root create.
+//! returns `None` (no action offered) instead of an out-of-root create. The
+//! multi-file types (`Livewire`, `BladeComponentWithClass`) emit a SECOND create
+//! beyond `target_path` — a view/class path derived from the independent `name`
+//! field — so each of those sibling paths is guarded the same way; a forged `name`
+//! cannot escape the root past the in-root `target_path` check.
 //!
 //! Why `path_within_root_lexical` and NOT the fail-closed `path_within_root` the
 //! sibling *read* paths use: a create target does not exist yet, so
@@ -61,6 +65,35 @@ fn view_action(target: PathBuf) -> FileAction {
     FileAction {
         action_type: FileActionType::View,
         name: "welcome".to_string(),
+        target_path: target,
+        file_exists: false,
+        copy_from: None,
+    }
+}
+
+/// A `Livewire` create action. This is a MULTI-FILE type: it emits `target_path`
+/// (the PHP class) AND a second create — the Blade view at
+/// `get_livewire_view_path`, which is derived from `name`, NOT from `target_path`.
+/// `name` and `target_path` are independent diagnostic fields, so they're set
+/// separately here to exercise the second-file containment guard.
+fn livewire_action(name: &str, target: PathBuf) -> FileAction {
+    FileAction {
+        action_type: FileActionType::Livewire,
+        name: name.to_string(),
+        target_path: target,
+        file_exists: false,
+        copy_from: None,
+    }
+}
+
+/// A `BladeComponentWithClass` create action. Also MULTI-FILE: it emits
+/// `target_path` (the Blade view) AND a second create — the PHP class at
+/// `get_component_class_path`, derived from `name`. Same independence of `name`
+/// and `target_path` as `livewire_action`.
+fn blade_component_with_class_action(name: &str, target: PathBuf) -> FileAction {
+    FileAction {
+        action_type: FileActionType::BladeComponentWithClass,
+        name: name.to_string(),
         target_path: target,
         file_exists: false,
         copy_from: None,
@@ -155,5 +188,93 @@ fn under_root_symlink_create_target_returns_none() {
         "a create target reached through an under-root symlink that resolves \
          outside the root must not be offered — canonicalization refuses it even \
          though the link path is lexically inside"
+    );
+}
+
+// --- Multi-file create actions (issue #199) -------------------------------
+//
+// `Livewire` and `BladeComponentWithClass` each emit a SECOND `ResourceOp::Create`
+// beyond `target_path` — a view/class path derived from the *independent* `name`
+// diagnostic field. The `target_path` guard alone does not cover it: because
+// `PathBuf::join`/`push` of an absolute-looking segment *replaces* the base, a
+// forged `name` escapes the root even when `target_path` is in-root. These tests
+// pin an in-root `target_path` (so the first guard passes) and an escaping `name`,
+// proving the second-file guard fires. Each negative would return `Some(_)` —
+// i.e. fail — if its sibling guard were removed, so none is vacuous.
+
+#[test]
+fn livewire_out_of_root_view_path_returns_none() {
+    // In-root `target_path` (passes the first guard), but `name = "/etc/passwd"`
+    // makes `get_livewire_view_path` emit `/etc/passwd.blade.php` — the absolute
+    // segment replaces the `resources/views/livewire` base, escaping the root. The
+    // second-file guard must refuse to offer the action.
+    let root = tempfile::TempDir::new().unwrap();
+    let target = root.path().join("app/Livewire/Counter.php");
+
+    assert!(
+        build(&livewire_action("/etc/passwd", target), root.path()).is_none(),
+        "a Livewire action whose name-derived view path escapes the root must not \
+         be offered, even when target_path is in-root — the second create is guarded"
+    );
+}
+
+#[test]
+fn blade_component_with_class_out_of_root_class_path_returns_none() {
+    // In-root `target_path` (the Blade view, passes the first guard), but
+    // `name = "/etc/passwd"` makes `get_component_class_path` emit `/etc/passwd.php`
+    // — the absolute segment replaces the `app/View/Components` base, escaping the
+    // root. The second-file guard must refuse to offer the action.
+    let root = tempfile::TempDir::new().unwrap();
+    let target = root
+        .path()
+        .join("resources/views/components/card.blade.php");
+
+    assert!(
+        build(
+            &blade_component_with_class_action("/etc/passwd", target),
+            root.path()
+        )
+        .is_none(),
+        "a BladeComponentWithClass action whose name-derived class path escapes the \
+         root must not be offered, even when target_path is in-root — the second \
+         create is guarded"
+    );
+}
+
+#[test]
+fn livewire_in_root_is_offered() {
+    // Positive control: both the in-root `target_path` (PHP class) and the
+    // name-derived view path (`resources/views/livewire/counter.blade.php`) stay
+    // inside the root, so the multi-file action IS offered — the sibling guard does
+    // not regress legitimate Livewire creates.
+    let root = tempfile::TempDir::new().unwrap();
+    let target = root.path().join("app/Livewire/Counter.php");
+
+    assert!(
+        build(&livewire_action("counter", target), root.path()).is_some(),
+        "a valid in-root Livewire create (both files under the root) must still be \
+         offered as a code action"
+    );
+}
+
+#[test]
+fn blade_component_with_class_in_root_is_offered() {
+    // Positive control: both the in-root `target_path` (Blade view) and the
+    // name-derived class path (`app/View/Components/Card.php`) stay inside the root,
+    // so the multi-file action IS offered — the sibling guard does not regress
+    // legitimate component-with-class creates.
+    let root = tempfile::TempDir::new().unwrap();
+    let target = root
+        .path()
+        .join("resources/views/components/card.blade.php");
+
+    assert!(
+        build(
+            &blade_component_with_class_action("card", target),
+            root.path()
+        )
+        .is_some(),
+        "a valid in-root BladeComponentWithClass create (both files under the root) \
+         must still be offered as a code action"
     );
 }

--- a/laravel-lsp/src/tests/code_action_create_containment.rs
+++ b/laravel-lsp/src/tests/code_action_create_containment.rs
@@ -1,0 +1,159 @@
+//! Tests for the fail-closed root-containment backstop at the **write/create
+//! seam** — `FileAction::build_code_action` (issue #199). This is the third
+//! surface in the #130 → #143 → #148 → #194 containment-guard chain, alongside
+//! the read/resolve paths: a file-create quick-fix (View, BladeComponent,
+//! Livewire, Inertia, …) must never be *offered* for a `target_path` that
+//! escapes the project root, so a forged or malformed `laravel` diagnostic can't
+//! coax the editor into creating a file outside the workspace.
+//!
+//! The guard runs before any `ResourceOp::Create` is constructed: if the project
+//! root is known and `target_path` resolves outside it, `build_code_action`
+//! returns `None` (no action offered) instead of an out-of-root create.
+//!
+//! Why `path_within_root_lexical` and NOT the fail-closed `path_within_root` the
+//! sibling *read* paths use: a create target does not exist yet, so
+//! `path.canonicalize()` always fails for it and the fail-closed guard would
+//! refuse **every** create — including legitimate in-root ones (the positive
+//! control below would fail). The lexical guard refuses out-of-root and
+//! interior-`..` escapes while admitting a not-yet-created in-root target, and
+//! still canonicalizes to catch a symlink escape when the target *does* exist —
+//! exactly the contract a speculative emitted path needs.
+//!
+//! These tests construct a `FileAction` directly (a private struct, reachable
+//! from the in-crate test module) and call the private `build_code_action`,
+//! asserting only on whether an action is offered. Each negative test would pass
+//! `Some(_)` — i.e. fail — if the guard were removed, so none is vacuous.
+
+use crate::{FileAction, FileActionType};
+use std::path::{Path, PathBuf};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+
+/// A minimal `laravel`-source diagnostic. `build_code_action` only clones it into
+/// the emitted `CodeAction`; the containment backstop runs before it is read, so
+/// its contents are irrelevant to what these tests assert.
+fn diagnostic() -> Diagnostic {
+    Diagnostic {
+        range: Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 0,
+            },
+        },
+        severity: Some(DiagnosticSeverity::WARNING),
+        code: None,
+        source: Some("laravel".to_string()),
+        message: "View file not found: 'welcome'".to_string(),
+        related_information: None,
+        tags: None,
+        code_description: None,
+        data: None,
+    }
+}
+
+/// A `View` create action targeting `target` — the simplest action type, routed
+/// through the standard file-creation branch. `file_exists: false` because the
+/// whole point of a create action is that the target does not exist yet.
+fn view_action(target: PathBuf) -> FileAction {
+    FileAction {
+        action_type: FileActionType::View,
+        name: "welcome".to_string(),
+        target_path: target,
+        file_exists: false,
+        copy_from: None,
+    }
+}
+
+fn build(action: &FileAction, root: &Path) -> Option<()> {
+    action
+        .build_code_action("<div></div>\n".to_string(), &diagnostic(), Some(root))
+        .map(|_| ())
+}
+
+#[test]
+fn out_of_root_create_action_returns_none() {
+    // The diagnostic's expected target lives OUTSIDE the project root (a forged or
+    // malformed `Expected at:` path). The create action must not be offered — the
+    // containment backstop refuses it before constructing the `ResourceOp::Create`.
+    // Would return `Some(_)` (fail) without the guard.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+    let target = outside.path().join("resources/views/welcome.blade.php");
+
+    assert!(
+        build(&view_action(target), root.path()).is_none(),
+        "a create action whose target escapes the project root must not be \
+         offered — the containment backstop refuses it before building the \
+         ResourceOp::Create"
+    );
+}
+
+#[test]
+fn interior_dotdot_create_target_returns_none() {
+    // A target that is textually prefixed by the root but escapes it through an
+    // interior `..` (`<root>/../escape.blade.php`). `Path::starts_with` is
+    // component-wise and would be fooled by the `<root>/` prefix; the lexical
+    // guard's `normalize_path` collapses the `..` first, so the escape is refused.
+    // Would return `Some(_)` (fail) without the guard.
+    let root = tempfile::TempDir::new().unwrap();
+    let target = root.path().join("..").join("escape.blade.php");
+
+    assert!(
+        build(&view_action(target), root.path()).is_none(),
+        "a create target escaping via interior `..` must not be offered — the \
+         lexical guard normalizes `..` before the containment check"
+    );
+}
+
+#[test]
+fn in_root_create_action_is_offered() {
+    // Positive control: a genuine in-root target that does not exist yet. The
+    // lexical guard admits a speculative (not-yet-created) in-root path, so the
+    // standard view-creation action IS offered. This proves the guard doesn't
+    // regress legitimate creates — and is exactly the case the fail-closed
+    // `path_within_root` would have wrongly refused (the create target can't
+    // canonicalize because it doesn't exist).
+    let root = tempfile::TempDir::new().unwrap();
+    let target = root.path().join("resources/views/welcome.blade.php");
+    assert!(
+        !target.exists(),
+        "the create target must not exist yet — that's what 'create' means"
+    );
+
+    assert!(
+        build(&view_action(target), root.path()).is_some(),
+        "a valid in-root create target must still be offered as a code action"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn under_root_symlink_create_target_returns_none() {
+    // The discriminating case a purely-textual check can't catch: the target is an
+    // existing under-root symlink (`<root>/resources/views/welcome.blade.php`)
+    // whose real target is OUTSIDE the root. The link path is lexically inside the
+    // root, so it passes the lexical gate — only canonicalization, resolving the
+    // symlink to its out-of-tree target, refuses it. Offering this create would
+    // let a forged diagnostic point a "create" at a path that escapes the
+    // workspace. Would return `Some(_)` (fail) without the canonicalize step.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    // A real file outside the root, and an under-root symlink pointing at it.
+    let outside_file = outside.path().join("welcome.blade.php");
+    std::fs::write(&outside_file, "<div></div>\n").unwrap();
+    let views = root.path().join("resources/views");
+    std::fs::create_dir_all(&views).unwrap();
+    let link = views.join("welcome.blade.php");
+    std::os::unix::fs::symlink(&outside_file, &link).unwrap();
+
+    assert!(
+        build(&view_action(link), root.path()).is_none(),
+        "a create target reached through an under-root symlink that resolves \
+         outside the root must not be offered — canonicalization refuses it even \
+         though the link path is lexically inside"
+    );
+}

--- a/laravel-lsp/src/tests/component_file_navigation_containment.rs
+++ b/laravel-lsp/src/tests/component_file_navigation_containment.rs
@@ -1,0 +1,180 @@
+//! Tests for the fail-closed root-containment guard in
+//! `LaravelLanguageServer::resolve_component_file` (issue #199) — the next
+//! sibling in the #130 → #143 → #148 → #194 containment-guard chain.
+//!
+//! `resolve_component_file` backs anonymous Blade component hover (the
+//! `@props([...])` snippet and file link) and component-prop completion. It
+//! resolves a `<x-tag>` to a `.blade.php` file via
+//! `LaravelConfigData::resolve_component_path`, which already drops out-of-root
+//! candidates with the *lexical* `path_within_root_lexical` filter. The guard
+//! added here re-checks the surviving candidate with the **fail-closed**
+//! `path_within_root` — the same check the sibling
+//! `resolve_component_existing_file` (#148) applies — so the containment
+//! invariant holds *uniformly* across every FS-touching component resolver.
+//!
+//! Because the lexical filter (and `file_exists_cached`, which follows symlinks)
+//! already close every escape vector that reaches `resolve_component_file`
+//! today, the new guard is defense-in-depth: not currently exploitable, but the
+//! backstop that holds the line if a future call site or a weakened upstream
+//! filter ever routes an unfiltered candidate through here. These tests pin the
+//! invariant at the `resolve_component_file` boundary — an out-of-root component
+//! file never resolves (whether it escapes lexically or through an under-root
+//! symlink that canonicalizes outside), while a genuine in-root file still
+//! resolves through the guard's allow branch. They drive the private async
+//! method directly via `tower_lsp::LspService` / `inner()`.
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::salsa_impl::LaravelConfigData;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use tower_lsp::LspService;
+
+/// Contents are irrelevant to resolution — only that the file exists, so a
+/// `None` result can come only from the containment guard, never a missing file.
+const CARD_BLADE: &str = "<div>{{ $message }}</div>\n";
+
+/// Build a server instance for testing. `LspService::new` wires up a real
+/// `Client`; `inner()` hands back the `LaravelLanguageServer` so we can call its
+/// private methods directly.
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// A minimal config rooted at `root` whose single conventional component
+/// directory is `components_dir`, so `<x-card>` resolves to
+/// `<components_dir>/card.blade.php`. Pointing `components_dir` outside `root`
+/// (directly or through a symlink) is the escape vector the guard must refuse.
+fn config_with_components_dir(root: &Path, components_dir: &Path) -> LaravelConfigData {
+    LaravelConfigData {
+        root: root.to_path_buf(),
+        view_paths: vec![root.join("resources/views")],
+        component_paths: vec![(String::new(), components_dir.to_path_buf())],
+        livewire_path: None,
+        has_livewire: false,
+        view_namespaces: HashMap::new(),
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+        class_component_files: HashMap::new(),
+    }
+}
+
+/// Seed `config` as the cached config and set the server root. `resolve_component_file`
+/// reads the cached config via `get_cached_config`; `root_path` is set for parity
+/// with the sibling component flow.
+async fn seed(server: &LaravelLanguageServer, root: &Path, config: LaravelConfigData) {
+    *server.cached_config.write().await = Some(config);
+    *server.root_path.write().await = Some(root.to_path_buf());
+}
+
+/// Write `contents` to `path`, creating parent directories as needed.
+fn write(path: &Path, contents: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+#[tokio::test]
+async fn out_of_root_component_file_returns_none() {
+    // The conventional components directory lives OUTSIDE the project root, and
+    // `card.blade.php` genuinely exists there — so a `None` result can only come
+    // from the containment refusal, never a missing file. `resolve_component_path`
+    // drops this lexically-out-of-root candidate; the fail-closed guard in
+    // `resolve_component_file` is the boundary backstop for the same invariant.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    let components_dir = outside.path().join("components");
+    write(&components_dir.join("card.blade.php"), CARD_BLADE);
+
+    let server = test_server();
+    seed(
+        &server,
+        root.path(),
+        config_with_components_dir(root.path(), &components_dir),
+    )
+    .await;
+
+    let result = server.resolve_component_file("card").await;
+
+    assert!(
+        result.is_none(),
+        "an out-of-root component file must not resolve, even though it exists \
+         on disk — the containment guard refuses it"
+    );
+}
+
+#[tokio::test]
+async fn in_root_component_file_still_resolves() {
+    // Positive control: a genuine in-root `card.blade.php` passes the lexical
+    // filter, exists on disk, and passes the fail-closed guard — so anonymous
+    // component resolution returns its path exactly as before. This drives the
+    // guard's allow branch, proving the new check doesn't regress in-root
+    // resolution.
+    let root = tempfile::TempDir::new().unwrap();
+    let components_dir = root.path().join("resources/views/components");
+    let card = components_dir.join("card.blade.php");
+    write(&card, CARD_BLADE);
+
+    let server = test_server();
+    seed(
+        &server,
+        root.path(),
+        config_with_components_dir(root.path(), &components_dir),
+    )
+    .await;
+
+    let result = server.resolve_component_file("card").await;
+
+    assert_eq!(
+        result.as_deref(),
+        Some(card.as_path()),
+        "an in-root component file must resolve to its path"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn under_root_symlink_to_outside_target_returns_none() {
+    // The discriminating case a purely-textual check could not catch: the
+    // conventional candidate `<root>/resources/views/components/card.blade.php`
+    // is an under-root symlink whose target is a real file OUTSIDE the root. The
+    // link path is lexically inside the root, and the target exists (so
+    // `file_exists_cached`, which follows symlinks, would pass) — only
+    // canonicalization, resolving the symlink to its out-of-tree target, can
+    // reject it. The lexical filter's canonicalize step catches it here, and the
+    // fail-closed `path_within_root` guard holds the same line at the resolver
+    // boundary.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    // Real component file, outside the project root.
+    let outside_card = outside.path().join("card.blade.php");
+    write(&outside_card, CARD_BLADE);
+
+    // Under-root conventional path, materialized as a symlink to the outside file.
+    let components_dir = root.path().join("resources/views/components");
+    fs::create_dir_all(&components_dir).unwrap();
+    let link = components_dir.join("card.blade.php");
+    std::os::unix::fs::symlink(&outside_card, &link).unwrap();
+
+    let server = test_server();
+    seed(
+        &server,
+        root.path(),
+        config_with_components_dir(root.path(), &components_dir),
+    )
+    .await;
+
+    let result = server.resolve_component_file("card").await;
+
+    assert!(
+        result.is_none(),
+        "a component file reached through an under-root symlink that resolves \
+         outside the project root must not resolve — canonicalization refuses it \
+         even though the link path is lexically inside"
+    );
+}

--- a/laravel-lsp/src/tests/component_file_navigation_containment.rs
+++ b/laravel-lsp/src/tests/component_file_navigation_containment.rs
@@ -22,6 +22,19 @@
 //! symlink that canonicalizes outside), while a genuine in-root file still
 //! resolves through the guard's allow branch. They drive the private async
 //! method directly via `tower_lsp::LspService` / `inner()`.
+//!
+//! NOTE on what the two negative tests prove (issue #199 escalation, Option 1):
+//! they assert the *invariant* — that an out-of-root or symlink-escaping
+//! component never resolves — not the new guard's reject branch in isolation.
+//! Through the public API that reject branch is **unreachable today**: the
+//! upstream `path_within_root_lexical` filter in `resolve_component_path`
+//! (`salsa_impl.rs`) canonicalizes lexically-in-root candidates and drops *both*
+//! negative-test candidates before this loop runs, so each negative `None`
+//! actually comes from that upstream filter, with the resolver guard sitting
+//! behind it as the documented innermost backstop. The positive control is what
+//! exercises the guard's reachable (allow) branch. An earlier draft's assert
+//! messages misattributed the `None` solely to the new guard; they're corrected
+//! below to name the invariant.
 
 use crate::LaravelLanguageServer;
 use laravel_lsp::salsa_impl::LaravelConfigData;
@@ -31,7 +44,8 @@ use std::path::Path;
 use tower_lsp::LspService;
 
 /// Contents are irrelevant to resolution — only that the file exists, so a
-/// `None` result can come only from the containment guard, never a missing file.
+/// `None` result can come only from the containment invariant, never a missing
+/// file.
 const CARD_BLADE: &str = "<div>{{ $message }}</div>\n";
 
 /// Build a server instance for testing. `LspService::new` wires up a real
@@ -81,9 +95,13 @@ fn write(path: &Path, contents: &str) {
 async fn out_of_root_component_file_returns_none() {
     // The conventional components directory lives OUTSIDE the project root, and
     // `card.blade.php` genuinely exists there — so a `None` result can only come
-    // from the containment refusal, never a missing file. `resolve_component_path`
-    // drops this lexically-out-of-root candidate; the fail-closed guard in
-    // `resolve_component_file` is the boundary backstop for the same invariant.
+    // from the containment invariant, never a missing file. On the reachable
+    // path the `None` is produced by the upstream `path_within_root_lexical`
+    // filter in `resolve_component_path`, which drops this lexically-out-of-root
+    // candidate before the loop runs; the fail-closed guard in
+    // `resolve_component_file` is the documented innermost backstop for the same
+    // invariant. This test pins the invariant at the resolver boundary, not the
+    // guard's (today unreachable) reject branch.
     let root = tempfile::TempDir::new().unwrap();
     let outside = tempfile::TempDir::new().unwrap();
 
@@ -102,8 +120,10 @@ async fn out_of_root_component_file_returns_none() {
 
     assert!(
         result.is_none(),
-        "an out-of-root component file must not resolve, even though it exists \
-         on disk — the containment guard refuses it"
+        "an out-of-root component file must never resolve, even though it exists \
+         on disk — the containment invariant refuses it (the upstream lexical \
+         filter drops the candidate; the resolver guard is the fail-closed \
+         backstop)"
     );
 }
 
@@ -143,11 +163,18 @@ async fn under_root_symlink_to_outside_target_returns_none() {
     // conventional candidate `<root>/resources/views/components/card.blade.php`
     // is an under-root symlink whose target is a real file OUTSIDE the root. The
     // link path is lexically inside the root, and the target exists (so
-    // `file_exists_cached`, which follows symlinks, would pass) — only
+    // `file_exists_cached`, which follows symlinks, would pass) — so only
     // canonicalization, resolving the symlink to its out-of-tree target, can
-    // reject it. The lexical filter's canonicalize step catches it here, and the
-    // fail-closed `path_within_root` guard holds the same line at the resolver
-    // boundary.
+    // reject it. That canonicalization happens FIRST in the upstream
+    // `path_within_root_lexical` filter (`resolve_component_path`): it admits the
+    // lexically-in-root link path, then canonicalizes it, sees the out-of-tree
+    // target, and drops the candidate before this loop runs — so the `None` comes
+    // from the upstream filter, not the new guard. The fail-closed
+    // `path_within_root` guard holds the same line at the resolver boundary as the
+    // documented backstop. (The original AC's premise that "only `path_within_root`
+    // catches this" was wrong — `path_within_root_lexical` canonicalizes too;
+    // hence this test asserts the invariant, not the guard's unreachable reject
+    // branch.)
     let root = tempfile::TempDir::new().unwrap();
     let outside = tempfile::TempDir::new().unwrap();
 
@@ -174,7 +201,9 @@ async fn under_root_symlink_to_outside_target_returns_none() {
     assert!(
         result.is_none(),
         "a component file reached through an under-root symlink that resolves \
-         outside the project root must not resolve — canonicalization refuses it \
-         even though the link path is lexically inside"
+         outside the project root must never resolve — canonicalization refuses \
+         it (in the upstream lexical filter, mirrored by the resolver's \
+         fail-closed backstop) even though the link path is lexically inside the \
+         root"
     );
 }

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -6,6 +6,7 @@ mod blade_var_rename_handler;
 mod cast_type_context;
 mod class_locator_and_properties;
 mod code_lens_opt_in;
+mod component_file_navigation_containment;
 mod component_navigation_containment;
 mod diagnostic_severity;
 mod directive_navigation_containment;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod blade_directive_context;
 mod blade_var_rename_handler;
 mod cast_type_context;
 mod class_locator_and_properties;
+mod code_action_create_containment;
 mod code_lens_opt_in;
 mod component_file_navigation_containment;
 mod component_navigation_containment;


### PR DESCRIPTION
## Summary

Implements #199 — extends the fail-closed containment invariant across **two**
FS-touching surfaces so it holds *uniformly* (the #130 → #143 → #148 → #194 chain):

1. **Read/resolve seam** — `resolve_component_file` (anonymous Blade component
   hover / prop completion) gains the containment guard mirroring the sibling
   `resolve_component_existing_file`.
2. **Write/create seam** — `FileAction::build_code_action` refuses to *offer* any
   file-create quick-fix (View, BladeComponent, Livewire, Inertia, …) whose target
   escapes the project root — including the **second** file the multi-file types
   emit (Livewire view, component PHP class).

## Changes

- **`main.rs` — `resolve_component_file`:** after `file_exists_cached`, refuse any
  candidate whose real path escapes `config.root` (`if !path_within_root(&path,
  &config.root) { continue; }`), mirroring `resolve_component_existing_file`.
- **`main.rs` — `build_code_action` (write/create seam, AC #5):** before any
  `ResourceOp::Create` is constructed, return `None` if `target_path` escapes the
  known project `root`. Uses `path_within_root_lexical` (see deviation note below).
- **`main.rs` — `build_code_action` multi-file sibling guards (round 2, Holmes review):**
  `Livewire` and `BladeComponentWithClass` each emit a *second* `ResourceOp::Create`
  (`view_uri` / `class_uri`) derived from `self.name` — an independent diagnostic
  field. Because `PathBuf::join`/`push` of an absolute segment replaces the base, a
  forged `name` (e.g. `/etc/passwd`) escaped the root past the `target_path` check.
  Each sibling path is now guarded with `path_within_root_lexical` + `return None`,
  and the guard comment claiming every create materialises only `target_path` is
  corrected.
- **No consumer changes** — every guard lives in the resolver / builder.
- **New test file** `src/tests/code_action_create_containment.rs` (write/create
  seam, incl. multi-file sibling-path coverage) and reframed
  `component_file_navigation_containment.rs` (resolve seam).

## Acceptance Criteria

- [x] **#1** Guard added in `resolve_component_file` after `file_exists_cached`,
  using `config.root` + `continue` — mirrors `resolve_component_existing_file`.
- [x] **#2** No changes to consumer call sites — the guard belongs in the resolver.
- [x] **#3** New integration test file in the `*_navigation_containment.rs` style:
  `out_of_root_component_file_returns_none`, `in_root_component_file_still_resolves`,
  `#[cfg(unix)] under_root_symlink_to_outside_target_returns_none`.
- [x] **#4** The guard's allow branch is exercised by the positive control; no
  existing tests regress. *(Reframed per the escalation — Option 1.)*
- [x] **#5** `build_code_action`'s `ResourceOp::Create` path gains a containment
  backstop before construction — no out-of-root create is offered for any action
  type, including the **second** create emitted by the multi-file types; returns
  `None` instead. *(Primitive deviation flagged below.)*
- [x] **#6** Containment test for the write/create seam: out-of-root `target_path`
  → `None`; valid in-root path still produces the code action (positive control);
  plus interior-`..`, `#[cfg(unix)]` under-root-symlink, and **multi-file
  sibling-path escape** cases (Livewire view + component class) with positive
  controls for both.

## Escalation resolution — Option 1 (AC #3/#4 reframe)

Per the adjudicated dispute (Mike: **Option 1**), the resolve-seam negative tests
now assert the **invariant** — an out-of-root / symlink-escaping component never
resolves — *not* the new guard's reject branch in isolation. Through the public
API that reject branch is unreachable today: the upstream `path_within_root_lexical`
filter in `resolve_component_path` canonicalizes lexically-in-root candidates and
drops *both* negative-test candidates before the loop runs, so each negative `None`
comes from that upstream filter, with the resolver guard as the documented innermost
backstop. The false "only `path_within_root` catches" premise and the misleading
assert messages are corrected.

## ⚠️ AC #5 primitive deviation — approved in review

AC #5 says "add a `path_within_root` backstop." Implemented with
**`path_within_root_lexical`** instead, because `path_within_root` is **fail-closed
on un-canonicalizable paths** (`canonical_containment(...).unwrap_or(false)`), and a
create target *never exists yet* — `path.canonicalize()` always fails for it. Using
`path_within_root` would refuse **every** create, including legitimate in-root ones
(the AC #6 positive control would fail). `path_within_root_lexical` is the
purpose-built primitive for a speculative emitted path: it refuses out-of-root and
interior-`..` escapes while admitting a not-yet-created in-root target, and still
canonicalizes to catch symlink escapes when the target *does* exist. Holmes approved
this choice in review (same class as the #3/#4 call); the AC wording should be
amended to name `path_within_root_lexical`.

## Test Plan

- [x] `cargo test --all-features` green: 1855 + 364 + 80 = **2299**, 0 failures
  (the 364 reflects the +4 multi-file sibling-path tests added this round), after
  bootstrapping the gitignored `test-project/.env` + composer fixtures exactly as CI does.
- [x] New multi-file sibling-path escape tests (Livewire view, component class) +
  their positive controls pass; each negative would return `Some`/resolve if its
  guard were removed — none is vacuous.
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean.

Fixes #199