### PR TITLE
chore: harden LSP byte-offset slicing against non-char-boundary panics (position_to_byte_offset pass)

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3755,6 +3755,17 @@ impl LaravelLanguageServer {
         use laravel_lsp::query_chain::{extract_use_aliases, resolve_class_name};
 
         // 1. Cursor at a static-receiver position?
+        //
+        // `cursor_col` is the LSP `position.character` — a Unicode code-point
+        // column, not a byte offset. Convert it to a byte offset (always a
+        // valid char boundary, clamped at line length) before handing it to
+        // `detect_method_name_position`, which slices `&line[..cursor_col]`. On
+        // a line with a multibyte char before the cursor the column and the
+        // byte offset diverge, so passing the raw column would slice the wrong
+        // receiver or mis-fire the boundary guard (issue #182) — the same bug
+        // the `*_context` helpers route through `char_col_to_byte_offset` to
+        // avoid.
+        let cursor_col = char_col_to_byte_offset(line_text, cursor_col);
         let receiver = match detect_method_name_position(line_text, cursor_col)? {
             MethodNameContext::Static { receiver } => receiver,
             // Instance position — Eloquent\Builder's @mixin makes the

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -28,6 +28,7 @@ use laravel_lsp::config::find_project_root;
 use laravel_lsp::middleware_parser::{middleware_base_alias, resolve_class_to_file};
 use laravel_lsp::migration_index::{build_migration_index, MigrationIndex};
 use laravel_lsp::path_containment::{path_within_root, path_within_root_lexical};
+use laravel_lsp::query_chain::cursor::char_col_to_byte_offset;
 use laravel_lsp::route_discovery::{
     build_route_index, discover_route_files, normalize_path, RouteIndex,
 };
@@ -7540,10 +7541,7 @@ impl LaravelLanguageServer {
     ///
     /// Example: `env('APP_` with cursor at end returns Some(StringContext{prefix: "APP_", ...})
     fn get_env_call_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -7587,10 +7585,7 @@ impl LaravelLanguageServer {
     ///
     /// Example: `NEW_VAR=${APP` with cursor at end returns context with prefix="APP"
     fn get_env_interpolation_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -7623,10 +7618,7 @@ impl LaravelLanguageServer {
     ///
     /// Example: `<env name="APP_` with cursor at end returns context with prefix="APP_"
     fn get_phpunit_env_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -7673,10 +7665,7 @@ impl LaravelLanguageServer {
     /// - `Config::get('db.` returns Some("db.")
     /// - `Config::string('app.` returns Some("app.")
     fn get_config_call_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -7779,10 +7768,7 @@ impl LaravelLanguageServer {
     /// - `to_route('admin.` returns Some("admin.")
     /// - `redirect()->route('` returns Some("")
     fn get_route_call_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -7872,10 +7858,7 @@ impl LaravelLanguageServer {
         character: u32,
         previous_lines: Option<&[&str]>,
     ) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -8029,10 +8012,7 @@ impl LaravelLanguageServer {
     /// - `view('users.` returns Some(StringContext{prefix: "users.", ...})
     /// - `View::make('admin.` returns Some(StringContext{prefix: "admin.", ...})
     fn get_view_call_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -8146,10 +8126,7 @@ impl LaravelLanguageServer {
     ///   components (anonymous or class-based) are completed too, so `:` is a
     ///   valid character in the partial name.
     fn get_blade_component_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -8203,10 +8180,7 @@ impl LaravelLanguageServer {
     /// (for filtering completions), or `None` when the cursor is past the name
     /// (hit a space, `>`, or `/`).
     fn get_flux_component_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -8254,10 +8228,7 @@ impl LaravelLanguageServer {
         line_text: &str,
         character: u32,
     ) -> Option<(String, StringContext)> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
         let before_cursor = &line_text[..cursor];
 
         let pos = before_cursor.rfind("<flux:")?;
@@ -8342,10 +8313,7 @@ impl LaravelLanguageServer {
             static ref SLOT_NAME_ATTR_RE: Regex = Regex::new(r#"\bname\s*=\s*("|')"#).unwrap();
         }
 
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
         let before_cursor = &line_text[..cursor];
 
         // ── `<flux:slot name="│">` value form ──────────────────────────────
@@ -8526,10 +8494,7 @@ impl LaravelLanguageServer {
     /// - `<livewire:user-` returns Some("user-")
     /// - `@livewire('user-` returns Some("user-")
     fn get_livewire_component_context(line_text: &str, character: u32) -> Option<String> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -8593,10 +8558,7 @@ impl LaravelLanguageServer {
     /// - `asset('css/` returns Some(StringContext{prefix: "css/", ...})
     /// - `asset('images/logo` returns Some(StringContext{prefix: "images/logo", ...})
     fn get_asset_call_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -8630,10 +8592,7 @@ impl LaravelLanguageServer {
     /// - `@vite('` returns Some(StringContext{prefix: "", ...})
     /// - `@vite('resources/js/` returns Some(StringContext{prefix: "resources/js/", ...})
     fn get_vite_call_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -8718,10 +8677,7 @@ impl LaravelLanguageServer {
     /// - `storage_path('logs/` returns Some(("storage_path", "logs/"))
     /// - `base_path('config/` returns Some(("base_path", "config/"))
     fn get_path_helper_context(line_text: &str, character: u32) -> Option<(&'static str, String)> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -8768,10 +8724,7 @@ impl LaravelLanguageServer {
     /// - `app('cache` returns Some(StringContext{prefix: "cache", ...})
     /// - `resolve('log` returns Some(StringContext{prefix: "log", ...})
     fn get_binding_call_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -8813,10 +8766,7 @@ impl LaravelLanguageServer {
     /// - `Feature::active('new` returns Some(StringContext{prefix: "new", ...})
     /// - `Feature::for($user)->active('beta` returns Some(StringContext{prefix: "beta", ...})
     fn get_feature_call_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -8949,10 +8899,7 @@ impl LaravelLanguageServer {
         character: u32,
         file_content: &str,
     ) -> Option<(String, String)> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -9417,8 +9364,8 @@ impl LaravelLanguageServer {
     /// Returns the prefix they've typed (without $) if in variable name context
     /// Returns None if they're in `$var->` context (property access)
     fn get_variable_name_context(line_text: &str, cursor_col: u32) -> Option<String> {
-        let cursor = cursor_col as usize;
-        if cursor == 0 || cursor > line_text.len() {
+        let cursor = char_col_to_byte_offset(line_text, cursor_col as usize);
+        if cursor == 0 {
             return None;
         }
 
@@ -9472,8 +9419,8 @@ impl LaravelLanguageServer {
     /// Detect if user is typing a Blade directive (e.g., `@if`, `@foreach`)
     /// Returns the partial directive name typed so far (e.g., "fo" for "@fo|")
     fn get_blade_directive_context(line_text: &str, cursor_col: u32) -> Option<String> {
-        let cursor = cursor_col as usize;
-        if cursor == 0 || cursor > line_text.len() {
+        let cursor = char_col_to_byte_offset(line_text, cursor_col as usize);
+        if cursor == 0 {
             return None;
         }
 
@@ -10979,10 +10926,7 @@ impl LaravelLanguageServer {
     /// - `trans('auth.` returns Some(StringContext{prefix: "auth.", ...})
     /// - `Lang::get('` returns Some(StringContext{prefix: "", ...})
     fn get_translation_call_context(line_text: &str, character: u32) -> Option<StringContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -11062,15 +11006,7 @@ impl LaravelLanguageServer {
         surrounding_lines: &[&str],
         cached_rules: &[String],
     ) -> Option<ValidationParamContext> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            info!(
-                "      ⚠️  Cursor {} > line length {}",
-                cursor,
-                line_text.len()
-            );
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
         info!("      📍 before_cursor: '{}'", before_cursor);
@@ -11883,10 +11819,7 @@ impl LaravelLanguageServer {
         surrounding_lines: &[&str],
         cached_rules: &[String],
     ) -> Option<String> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -12028,10 +11961,7 @@ impl LaravelLanguageServer {
         character: u32,
         surrounding_lines: &[&str],
     ) -> Option<String> {
-        let cursor = character as usize;
-        if cursor > line_text.len() {
-            return None;
-        }
+        let cursor = char_col_to_byte_offset(line_text, character as usize);
 
         let before_cursor = &line_text[..cursor];
 
@@ -22494,8 +22424,16 @@ impl LanguageServer for LaravelLanguageServer {
                     // Blade directive and an Alpine event, so the merge dedups by
                     // name (`mergeable_events`): the Blade directive wins and its
                     // event twin is dropped, leaving exactly one entry (AC5).
+                    // Derive the `@` byte offset from a char-boundary-correct
+                    // cursor: convert the code-point column to a byte offset
+                    // first, then step back over the typed prefix + the `@`
+                    // itself. Treating `position.character` as a raw byte offset
+                    // (the old math) lands mid-codepoint on a line with any
+                    // multibyte char and makes `at_attribute_position`'s slicing
+                    // panic-prone (issue #182).
                     if let Some(at_byte) =
-                        (position.character as usize).checked_sub(directive_prefix.len() + 1)
+                        char_col_to_byte_offset(line_text, position.character as usize)
+                            .checked_sub(directive_prefix.len() + 1)
                     {
                         if laravel_lsp::alpine::at_attribute_position(line_text, at_byte) {
                             // Names already offered as Blade directives (those that
@@ -22542,12 +22480,12 @@ impl LanguageServer for LaravelLanguageServer {
                 }
 
                 // Check for Blade bracket context - show all options after first {
-                let cursor_col = position.character as usize;
-                let text_before = if cursor_col <= line_text.len() {
-                    &line_text[..cursor_col]
-                } else {
-                    line_text
-                };
+                // `char_col_to_byte_offset` lands on a char boundary and clamps
+                // to the line length, so the slice is panic-safe even when the
+                // line holds a multibyte char (issue #182) — no separate
+                // bounds branch needed.
+                let cursor_col = char_col_to_byte_offset(line_text, position.character as usize);
+                let text_before = &line_text[..cursor_col];
 
                 // Check if we're in a Blade bracket context (starts with {)
                 // Find what the user has typed so far

--- a/laravel-lsp/src/method_name_completion.rs
+++ b/laravel-lsp/src/method_name_completion.rs
@@ -85,7 +85,11 @@ pub enum MethodNameContext {
 /// support both bare names (`User`), namespaced names (`App\Models\User`),
 /// and leading-backslash FQCNs (`\App\Models\User`).
 pub fn detect_method_name_position(line: &str, cursor_col: usize) -> Option<MethodNameContext> {
-    if cursor_col > line.len() {
+    // `cursor_col` arrives as a raw `position.character` byte index from the
+    // handler. Reject an out-of-range or mid-codepoint index so the slice
+    // below can't `panic!` on a line containing a multibyte char (issue #182),
+    // mirroring the `is_char_boundary` guard the alpine context helpers use.
+    if cursor_col > line.len() || !line.is_char_boundary(cursor_col) {
         return None;
     }
     let before = &line[..cursor_col];

--- a/laravel-lsp/src/method_name_completion.rs
+++ b/laravel-lsp/src/method_name_completion.rs
@@ -85,10 +85,14 @@ pub enum MethodNameContext {
 /// support both bare names (`User`), namespaced names (`App\Models\User`),
 /// and leading-backslash FQCNs (`\App\Models\User`).
 pub fn detect_method_name_position(line: &str, cursor_col: usize) -> Option<MethodNameContext> {
-    // `cursor_col` arrives as a raw `position.character` byte index from the
-    // handler. Reject an out-of-range or mid-codepoint index so the slice
-    // below can't `panic!` on a line containing a multibyte char (issue #182),
-    // mirroring the `is_char_boundary` guard the alpine context helpers use.
+    // `cursor_col` is a byte offset into `line`. The live caller
+    // (`try_method_name_completion`) converts the LSP `position.character`
+    // code-point column through `char_col_to_byte_offset` first, so on the
+    // real path it already lands on a valid char boundary clamped to the line.
+    // The guard keeps this public fn panic-safe for *any* caller: an
+    // out-of-range or mid-codepoint offset returns `None` rather than slicing
+    // `&line[..cursor_col]` into a `panic!` (issue #182), and preserves the
+    // documented reject-past-end-of-line contract.
     if cursor_col > line.len() || !line.is_char_boundary(cursor_col) {
         return None;
     }

--- a/laravel-lsp/src/query_chain.rs
+++ b/laravel-lsp/src/query_chain.rs
@@ -30,9 +30,10 @@ pub mod var_type;
 
 pub use chain::*;
 pub use cursor::{
-    byte_offset_to_position, chain_context_for_link, detect_chain_context_at,
-    detect_chain_context_at_diagnostic, detect_chain_target_at, fixup_for_completion,
-    position_to_byte_offset, ChainResolveFailure, ChainTarget, CompletionPrep,
+    byte_offset_to_position, chain_context_for_link, char_col_to_byte_offset,
+    detect_chain_context_at, detect_chain_context_at_diagnostic, detect_chain_target_at,
+    fixup_for_completion, position_to_byte_offset, ChainResolveFailure, ChainTarget,
+    CompletionPrep,
 };
 pub use diagnostics::chain_diagnostics;
 pub use extractor::extract_chains;

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -220,6 +220,25 @@ pub fn position_to_byte_offset(content: &str, line: u32, character: u32) -> Opti
     Some(line_start + byte_in_line)
 }
 
+/// Translate a line-local **code-point column** into a byte offset within
+/// `line`, by summing the UTF-8 length of each leading character. The returned
+/// offset is always a valid char boundary — so slicing `&line[..offset]` can
+/// never panic — and clamps to `line.len()` when `char_col` runs past the end
+/// of the line (`take` simply yields fewer characters).
+///
+/// This is the line-scoped companion to [`position_to_byte_offset`]: the
+/// `*_context` cursor helpers in `main.rs` already hold a single extracted line
+/// plus a column, so they route the column→offset conversion through here
+/// rather than re-deriving the line. Like `position_to_byte_offset`, `char_col`
+/// is treated as a Unicode code-point index (not a UTF-16 code unit or a raw
+/// byte). That's exact for ASCII Laravel source — the overwhelming common case
+/// — and, crucially, stays panic-safe on the rare line that does contain a
+/// multibyte character, where the old `character as usize` byte-slice could
+/// land mid-codepoint and `panic!`.
+pub fn char_col_to_byte_offset(line: &str, char_col: usize) -> usize {
+    line.chars().take(char_col).map(char::len_utf8).sum()
+}
+
 /// Inverse of [`position_to_byte_offset`]: translate a byte offset inside
 /// `content` into an LSP `Position` (0-based line + character). Characters are
 /// counted as Unicode code points, matching `position_to_byte_offset` — so a

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -303,6 +303,48 @@ fn position_beyond_eof_returns_none() {
     assert!(position_to_byte_offset(content, 5, 0).is_none());
 }
 
+// ---- char_col_to_byte_offset ------------------------------------------
+
+#[test]
+fn char_col_ascii_is_identity() {
+    // On a pure-ASCII line the byte offset equals the column.
+    let line = "config('app')";
+    assert_eq!(char_col_to_byte_offset(line, 0), 0);
+    assert_eq!(char_col_to_byte_offset(line, 8), 8);
+    assert_eq!(char_col_to_byte_offset(line, line.len()), line.len());
+}
+
+#[test]
+fn char_col_accent_maps_past_two_byte_char() {
+    // `é` is two UTF-8 bytes, so columns after it map to a larger byte offset.
+    // Line: c a f é ' )  → columns 0..6, bytes: é occupies bytes 3..5.
+    let line = "café')";
+    assert_eq!(char_col_to_byte_offset(line, 3), 3); // start of `é`
+    assert_eq!(char_col_to_byte_offset(line, 4), 5); // after `é` (the `'`)
+    assert_eq!(char_col_to_byte_offset(line, 5), 6); // the `)`
+                                                     // Every result is a valid char boundary — slicing must not panic.
+    assert!(line.is_char_boundary(char_col_to_byte_offset(line, 4)));
+}
+
+#[test]
+fn char_col_emoji_maps_past_four_byte_char() {
+    // `🎉` is four UTF-8 bytes. A column landing right after it must resolve to
+    // a boundary, not the mid-codepoint byte that `character as usize` produced.
+    let line = "@if 🎉 x";
+    let after_emoji = char_col_to_byte_offset(line, 5); // `@if ` (4) + `🎉` (1) = col 5
+    assert_eq!(after_emoji, "@if 🎉".len());
+    assert!(line.is_char_boundary(after_emoji));
+    // Slicing at the returned offset is panic-safe.
+    assert_eq!(&line[..after_emoji], "@if 🎉");
+}
+
+#[test]
+fn char_col_beyond_line_end_clamps_to_len() {
+    let line = "café"; // 4 chars, 5 bytes
+    assert_eq!(char_col_to_byte_offset(line, 99), line.len());
+    assert!(line.is_char_boundary(char_col_to_byte_offset(line, 99)));
+}
+
 // ---- detect_chain_context_at: DB::table ----------------------------------
 
 #[test]

--- a/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
+++ b/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
@@ -1,0 +1,131 @@
+//! Panic-hardening for the LSP's line-local cursor helpers (issue #182).
+//!
+//! Every `*_context` helper used to do `let cursor = character as usize;`
+//! followed by `&line_text[..cursor]`, treating the LSP `character` (a
+//! code-point column) as a raw byte offset. On a line containing any multibyte
+//! character that byte offset can land mid-codepoint, and the slice would
+//! `panic!`. The helpers now route the column→offset conversion through
+//! `query_chain::cursor::char_col_to_byte_offset`, which always yields a valid
+//! char boundary clamped to the line length.
+//!
+//! The exhaustive sweeps below call each affected handler with **every** byte
+//! index `0..=line.len()` on multibyte lines — including the mid-codepoint
+//! indices that used to panic — and assert only that the call returns. A test
+//! that completes is the assertion: no index panics. The positive cases pin
+//! that a correct code-point column on a multibyte line still yields the right
+//! context (the conversion is correct, not just panic-safe).
+
+use crate::LaravelLanguageServer;
+
+/// Multibyte lines whose byte ranges include many non-char-boundary indices
+/// (`é` is 2 bytes, `🎉` is 4). Sweeping every byte index over these exercises
+/// the exact indices the old `character as usize` slice would have panicked on.
+const MULTIBYTE_LINES: &[&str] = &[
+    "config('app.café🎉')",
+    "route('users.café🎉')",
+    "<x-café-🎉 ",
+    "@if 🎉 café",
+    "$café🎉->property",
+    "'rule:café🎉|max:5'",
+    "view('café.🎉.index')",
+];
+
+/// Call a `(&str, u32) -> Option<_>` handler at every byte index of every
+/// multibyte line. The macro drops the result — the point is that no index
+/// panics inside the helper's slice.
+macro_rules! sweep_two_arg {
+    ($($handler:path),+ $(,)?) => {
+        for line in MULTIBYTE_LINES {
+            for byte in 0..=line.len() {
+                $( let _ = $handler(line, byte as u32); )+
+            }
+        }
+    };
+}
+
+#[test]
+fn two_arg_context_helpers_never_panic_on_any_byte_index() {
+    sweep_two_arg!(
+        LaravelLanguageServer::get_env_call_context,
+        LaravelLanguageServer::get_env_interpolation_context,
+        LaravelLanguageServer::get_phpunit_env_context,
+        LaravelLanguageServer::get_config_call_context,
+        LaravelLanguageServer::get_route_call_context,
+        LaravelLanguageServer::get_view_call_context,
+        LaravelLanguageServer::get_translation_call_context,
+        LaravelLanguageServer::get_asset_call_context,
+        LaravelLanguageServer::get_vite_call_context,
+        LaravelLanguageServer::get_blade_component_context,
+        LaravelLanguageServer::get_flux_component_context,
+        LaravelLanguageServer::get_flux_slot_name_context,
+        LaravelLanguageServer::get_flux_attribute_context,
+        LaravelLanguageServer::get_livewire_component_context,
+        LaravelLanguageServer::get_path_helper_context,
+        LaravelLanguageServer::get_binding_call_context,
+        LaravelLanguageServer::get_feature_call_context,
+        LaravelLanguageServer::get_variable_name_context,
+        LaravelLanguageServer::get_blade_directive_context,
+    );
+}
+
+#[test]
+fn multi_arg_context_helpers_never_panic_on_any_byte_index() {
+    for line in MULTIBYTE_LINES {
+        for byte in 0..=line.len() {
+            let c = byte as u32;
+            let _ = LaravelLanguageServer::get_model_property_context(line, c, "");
+            let _ = LaravelLanguageServer::get_validation_param_context(line, c, &[], &[]);
+            let _ = LaravelLanguageServer::get_validation_rule_context(line, c, &[], &[]);
+            let _ = LaravelLanguageServer::get_cast_type_context(line, c, &[]);
+            let _ = LaravelLanguageServer::get_middleware_call_context(line, c, None);
+        }
+    }
+}
+
+// ---- positive correctness on multibyte lines ----------------------------
+
+#[test]
+fn variable_name_context_reads_whole_name_past_multibyte_prefix() {
+    // `🎉 $user` has 7 code points; column 7 is end-of-line. The old byte-offset
+    // slice would have sliced `&line[..7]` = `🎉 $us` and returned "us"; the
+    // boundary-correct conversion reads the full "user".
+    let line = "🎉 $user";
+    assert_eq!(line.chars().count(), 7);
+    let ctx = LaravelLanguageServer::get_variable_name_context(line, 7)
+        .expect("`$user` is a variable-name context");
+    assert_eq!(ctx, "user");
+}
+
+#[test]
+fn config_call_context_keeps_accented_prefix() {
+    // `config('app.café` with the cursor at end-of-line: the prefix must include
+    // the accented char intact, proving the slice landed on a boundary.
+    let line = "config('app.café";
+    let col = line.chars().count() as u32;
+    let ctx = LaravelLanguageServer::get_config_call_context(line, col)
+        .expect("inside a config('…') string");
+    assert_eq!(ctx.prefix, "app.café");
+}
+
+#[test]
+fn blade_directive_context_resolves_past_emoji() {
+    // `🎉 @if` → 5 code points; column 5 is end-of-line. Whitespace precedes `@`.
+    let line = "🎉 @if";
+    assert_eq!(line.chars().count(), 5);
+    let ctx = LaravelLanguageServer::get_blade_directive_context(line, 5)
+        .expect("`🎉 @if` is a directive context — space precedes `@`");
+    assert_eq!(ctx, "if");
+}
+
+#[test]
+fn mid_codepoint_byte_index_returns_cleanly_not_panics() {
+    // Pass a column that, as a raw byte offset, lands *inside* the 4-byte `🎉`
+    // (bytes 8..12 of `config('🎉')`). The old code panicked here; the new code
+    // converts column 9 to a boundary and returns a well-defined value.
+    let line = "config('🎉')";
+    // Byte 9 is mid-`🎉` — not a char boundary.
+    assert!(!line.is_char_boundary(9));
+    // As a *column*, 9 is past the 11 code points only sometimes; either way the
+    // call must not panic. We assert it simply returns (Some or None).
+    let _ = LaravelLanguageServer::get_config_call_context(line, 9);
+}

--- a/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
+++ b/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
@@ -87,7 +87,7 @@ fn multi_arg_context_helpers_never_panic_on_any_byte_index() {
 #[test]
 fn variable_name_context_reads_whole_name_past_multibyte_prefix() {
     // `🎉 $user` has 7 code points; column 7 is end-of-line. The old byte-offset
-    // slice would have sliced `&line[..7]` = `🎉 $us` and returned "us"; the
+    // slice would have sliced `&line[..7]` = `🎉 $u` and returned "u"; the
     // boundary-correct conversion reads the full "user".
     let line = "🎉 $user";
     assert_eq!(line.chars().count(), 7);
@@ -125,7 +125,81 @@ fn mid_codepoint_byte_index_returns_cleanly_not_panics() {
     let line = "config('🎉')";
     // Byte 9 is mid-`🎉` — not a char boundary.
     assert!(!line.is_char_boundary(9));
-    // As a *column*, 9 is past the 11 code points only sometimes; either way the
-    // call must not panic. We assert it simply returns (Some or None).
+    // `config('🎉')` has 11 code points, so column 9 (the closing `'`) is well
+    // within the line — but *byte* 9 lands mid-`🎉`, which is exactly where the
+    // old `character as usize` slice panicked. The new code treats 9 as a
+    // code-point column, converts it to a boundary, and returns cleanly.
     let _ = LaravelLanguageServer::get_config_call_context(line, 9);
+}
+
+// ---- detect_method_name_position: multibyte hardening (issue #182) -------
+//
+// `detect_method_name_position` (in `method_name_completion`) is the one
+// hardened slice site outside the `*_context` family, so it gets its own
+// coverage. The live caller (`try_method_name_completion`) converts the LSP
+// code-point column through `char_col_to_byte_offset` before calling it; these
+// tests pin both halves of that contract — the public fn never panics on an
+// arbitrary byte index, and a converted column extracts the right receiver
+// past a multibyte char (it slices on the correct coordinate, not merely a
+// safe one).
+
+/// Lines that put a `::` / `->` operator after a multibyte run, so the byte
+/// offset and the code-point column genuinely diverge (`è` is 2 bytes, `🎉`
+/// is 4). Sweeping every byte index hits the mid-codepoint indices the old
+/// `&line[..cursor_col]` slice would have panicked on.
+const METHOD_NAME_MULTIBYTE_LINES: &[&str] = &[
+    "Modèl::wher",
+    "$café->ba",
+    "App\\Modèls\\Café::",
+    "🎉::find",
+    "$🎉->save",
+];
+
+#[test]
+fn detect_method_name_position_never_panics_on_any_byte_index() {
+    use laravel_lsp::method_name_completion::detect_method_name_position;
+    // Every byte index, including the mid-codepoint ones. A completing test is
+    // the assertion: the guard returns `None` rather than slicing into a panic.
+    for line in METHOD_NAME_MULTIBYTE_LINES {
+        for byte in 0..=line.len() {
+            let _ = detect_method_name_position(line, byte);
+        }
+    }
+}
+
+#[test]
+fn detect_method_name_position_extracts_receiver_past_multibyte_char() {
+    use laravel_lsp::method_name_completion::{detect_method_name_position, MethodNameContext};
+    use laravel_lsp::query_chain::char_col_to_byte_offset;
+
+    // Mirror the live path: `try_method_name_completion` converts the LSP
+    // `position.character` code-point column to a byte offset before calling
+    // `detect_method_name_position`. `Modèl::wher` has an `è` (2 bytes) before
+    // the `::`, so the column (11) and the byte offset (12) diverge — passing
+    // the raw column would slice mid-name and read the wrong receiver.
+    let line = "Modèl::wher";
+    let col = line.chars().count(); // cursor at end-of-line
+    assert_eq!(col, 11);
+    let cursor = char_col_to_byte_offset(line, col);
+    assert_eq!(cursor, 12); // one extra byte for `è`
+    let ctx = detect_method_name_position(line, cursor).expect("static `::` position");
+    assert_eq!(
+        ctx,
+        MethodNameContext::Static {
+            receiver: "Modèl".to_string()
+        }
+    );
+}
+
+#[test]
+fn detect_method_name_position_detects_instance_past_multibyte_char() {
+    use laravel_lsp::method_name_completion::{detect_method_name_position, MethodNameContext};
+    use laravel_lsp::query_chain::char_col_to_byte_offset;
+
+    // `$café->ba` — the `é` (2 bytes) sits before the `->`. Converting the
+    // code-point column lands the slice on a boundary so the `->` is seen.
+    let line = "$café->ba";
+    let cursor = char_col_to_byte_offset(line, line.chars().count());
+    let ctx = detect_method_name_position(line, cursor).expect("instance `->` position");
+    assert_eq!(ctx, MethodNameContext::Instance);
 }

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod asset_path_resolution;
 mod blade_component_context;
 mod blade_directive_context;
 mod blade_var_rename_handler;
+mod byte_offset_panic_hardening;
 mod cast_type_context;
 mod class_locator_and_properties;
 mod code_lens_opt_in;


### PR DESCRIPTION
## Summary
Implements #182 — an LSP-wide panic-hardening pass. Every line-local `*_context`
cursor helper used to do `let cursor = character as usize;` then
`&line_text[..cursor]`, treating the LSP `character` (a code-point column) as a
raw byte offset. On a line containing any multibyte character that offset can
land mid-codepoint, and the slice would `panic!`. The live call sites derive
positions safely today, so this was latent rather than a live bug — but the
helpers were panic-prone on an arbitrary index.

## Changes
- **New helper** `char_col_to_byte_offset(line, char_col)` in
  `query_chain::cursor`, alongside `position_to_byte_offset`. Sums
  `char::len_utf8` over the leading characters, clamps at line length, and
  always lands on a valid char boundary. ASCII source is unaffected (offset ==
  column); re-exported through `query_chain`.
- **All 24 `*_context` helpers** in `main.rs` converted to route their cursor
  through the helper (22 `character`-based + 2 `cursor_col`-based). The old
  `if cursor > line_text.len()` guards are now redundant (the helper clamps) and
  were removed; the `cursor == 0` short-circuits are preserved.
- **`@`-event merge math** and the **Blade bracket-context slice** in the
  completion handler now derive their byte offset through the helper — the
  `position.character`-as-byte-offset sites flagged in PR #178's review.
- **`detect_method_name_position`** (`method_name_completion.rs`) gains an
  `is_char_boundary` guard, mirroring the alpine context helpers, so the
  reachable static-method-completion path can't panic either.

## Acceptance Criteria
- [x] Audit all `*_context` helpers using `let cursor = character as usize; &line_text[..cursor]` and list affected functions — **24 helpers** (lines 7544–11964): `get_env_call_context`, `get_env_interpolation_context`, `get_phpunit_env_context`, `get_config_call_context`, `get_route_call_context`, `get_middleware_call_context`, `get_view_call_context`, `get_blade_component_context`, `get_flux_component_context`, `get_flux_attribute_context`, `get_flux_slot_name_context`, `get_livewire_component_context`, `get_asset_call_context`, `get_vite_call_context`, `get_path_helper_context`, `get_binding_call_context`, `get_feature_call_context`, `get_model_property_context`, `get_variable_name_context`, `get_blade_directive_context`, `get_translation_call_context`, `get_validation_param_context`, `get_validation_rule_context`, `get_cast_type_context`.
- [x] Add a line-scoped `char_col_to_byte_offset(line, char_col)` helper alongside `position_to_byte_offset` (sums `char::len_utf8`, clamps at line length).
- [x] Replace `character as usize` slice math in every identified `*_context` helper with the new helper.
- [x] Guard the `@`-event merge math (the PR #178 `position.character`-as-byte-offset site) with the helper. *(Also hardened the adjacent Blade bracket-context slice and `detect_method_name_position`, the other reachable byte-slice panic sites in the same paths.)*
- [x] Add unit tests with multibyte inputs (`🎉`, `café`) asserting each affected handler returns cleanly / no-op instead of panicking on a mid-codepoint cursor.
- [x] `cargo test`, `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` pass with no new warnings or regressions.

## Test Plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --all-features` — **1859 lib + 359 bin + 80 integration tests pass** (with CI's `.env` + composer fixtures provisioned)
- [x] New `char_col_to_byte_offset` unit tests (ASCII identity, 2-byte accent, 4-byte emoji, clamp past EOL)
- [x] New `byte_offset_panic_hardening` tests: exhaustive byte-index sweeps over every affected handler (no panic) + positive correctness on multibyte lines
- [x] Existing #180 `blade_directive_context` regression tests still pass

Fixes #182