### PR TITLE
chore: route line_char_to_offset through code-point conversion (flux-region misclassification on multibyte lines)

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -8389,22 +8389,6 @@ impl LaravelLanguageServer {
         None
     }
 
-    /// Convert a 0-based `(line, character)` LSP position into a byte offset
-    /// into `content`. Columns are treated as byte offsets within the line —
-    /// the convention used throughout this file's line-local context helpers.
-    /// `\r` (in `\r\n` line endings) stays part of its line segment, so the
-    /// offset math holds for both `\n` and `\r\n` files.
-    fn line_char_to_offset(content: &str, line: u32, character: u32) -> Option<usize> {
-        let mut offset = 0usize;
-        for (current_line, segment) in content.split('\n').enumerate() {
-            if current_line as u32 == line {
-                return Some(offset + (character as usize).min(segment.len()));
-            }
-            offset += segment.len() + 1; // + the '\n' that `split` consumed
-        }
-        None
-    }
-
     /// Walk the document's component open/close tags up to `position` and
     /// return the name (e.g. `flux:modal`) of the nearest still-open
     /// `<flux:…>` component that *owns* a slot tag being typed at the cursor.
@@ -8434,7 +8418,11 @@ impl LaravelLanguageServer {
             .unwrap();
         }
 
-        let cursor = Self::line_char_to_offset(content, position.line, position.character)?;
+        let cursor = laravel_lsp::query_chain::position_to_byte_offset(
+            content,
+            position.line,
+            position.character,
+        )?;
 
         // Tag events that fully precede the cursor, in source order.
         enum Tag<'a> {

--- a/laravel-lsp/src/tests/flux_slot_name_context.rs
+++ b/laravel-lsp/src/tests/flux_slot_name_context.rs
@@ -150,15 +150,19 @@ fn blade_component_context_excludes_slot_syntax() {
 
 // ─── enclosing-Flux-component resolution ──────────────────────────────────
 
-/// Byte `(line, character)` of the caret marker `│` in `doc`, with the marker
-/// stripped. Columns are byte offsets within the line — the convention the
-/// production helpers use.
+/// `(line, character)` of the caret marker `│` in `doc`, with the marker
+/// stripped. The column is counted in Unicode code points, matching what an
+/// LSP client sends — and what `position_to_byte_offset` (the converter
+/// `enclosing_flux_component` now routes through) expects. On ASCII lines this
+/// equals the byte offset, so existing ASCII fixtures are unaffected; on a line
+/// with multibyte characters before the caret the two diverge, and the
+/// code-point count is the correct one.
 fn caret(doc: &str) -> (String, Position) {
     let idx = doc.find('│').expect("fixture must contain a `│` caret");
     let before = &doc[..idx];
     let line = before.matches('\n').count() as u32;
     let line_start = before.rfind('\n').map(|p| p + 1).unwrap_or(0);
-    let character = (idx - line_start) as u32;
+    let character = before[line_start..].chars().count() as u32;
     (doc.replace('│', ""), Position { line, character })
 }
 
@@ -195,6 +199,31 @@ fn enclosing_returns_none_without_flux_ancestor() {
     assert!(
         LaravelLanguageServer::enclosing_flux_component(&doc, pos).is_none(),
         "no wrapping `<flux:…>` component → no owner",
+    );
+}
+
+#[test]
+fn enclosing_correct_with_multibyte_prefix() {
+    // Regression for issue #206: the cursor line opens with multibyte chars
+    // (six `🎉`, 4 bytes each) before a self-contained `<flux:badge></flux:badge>`
+    // pair, then a `<flux:slot name="│">` holding the cursor. The owner is the
+    // outer `<flux:modal>`, because the inner `<flux:badge>` is opened *and*
+    // closed before the cursor.
+    //
+    // The old `character as usize` byte-offset shortcut computed a cursor offset
+    // too small (it counted each `🎉` as one byte, not four), so `</flux:badge>`'s
+    // `m.end()` landed *after* that bogus cursor and was skipped — leaving
+    // `flux:badge` on the open-tag stack and wrongly returned as the owner.
+    // Routing through `position_to_byte_offset` (code-point aware) places the
+    // cursor correctly, so the close tag pops the child and `flux:modal` wins.
+    let (doc, pos) = caret(
+        "<flux:modal>\n🎉🎉🎉🎉🎉🎉<flux:badge></flux:badge><flux:slot name=\"│\">\n</flux:modal>\n",
+    );
+    assert_eq!(
+        LaravelLanguageServer::enclosing_flux_component(&doc, pos).as_deref(),
+        Some("flux:modal"),
+        "the multibyte prefix must not cause the closed inner `<flux:badge>` to \
+         be mistaken for the enclosing component",
     );
 }
 


### PR DESCRIPTION
## Summary
Implements #206 — a follow-up from Holmes's review of #182 (PR #205).

`enclosing_flux_component` converted the LSP cursor `(line, character)` to a byte offset via a local `line_char_to_offset` helper that treated `character` as a **byte** offset. On a cursor line containing a multibyte character before the cursor, the `m.end() > cursor` comparisons ran against the wrong coordinate, so a fully-closed inner `<flux:…>` child's close tag could be skipped — leaving the child on the open-tag stack and returning the wrong (inner) enclosing component. No panic (there's no slice here), purely a misclassification, which is why it was deferred out of #205's panic-hardening scope into its own diff.

This routes the conversion through the code-point-aware `query_chain::position_to_byte_offset` — the same helper the rest of the file's LSP-position-to-byte conversions use.

## Changes
- Remove the byte-offset `line_char_to_offset` helper from `main.rs`.
- Replace its single call site in `enclosing_flux_component` with `laravel_lsp::query_chain::position_to_byte_offset(content, position.line, position.character)?`.
- Update the `caret` test helper in `flux_slot_name_context.rs` to count the cursor column in Unicode code points (`before[line_start..].chars().count()`) rather than bytes — matching what an LSP client sends. ASCII fixtures are unaffected; the doc comment is updated to match.
- Add `enclosing_correct_with_multibyte_prefix`, a regression test whose emoji-prefixed line would have returned the inner `flux:badge` under the old byte shortcut and now correctly returns the outer `flux:modal`.

## Acceptance Criteria
- [x] `line_char_to_offset` is removed from `main.rs`; its single call-site in `enclosing_flux_component` is replaced with `position_to_byte_offset(content, position.line, position.character)?`
- [x] `enclosing_flux_component` returns the correct enclosing flux component when the cursor line contains multibyte characters before a complete child-component open/close pair
- [x] The `caret` test helper counts the cursor column as Unicode code points rather than bytes; all existing ASCII-only tests pass unchanged
- [x] A new `#[test] fn enclosing_correct_with_multibyte_prefix()` asserts the outer component (`flux:modal`) is returned, not the inner one
- [x] `cargo test` is green with all pre-existing tests passing

## Test Plan
- [x] `cargo test --all-features` green — 2302 tests, 0 failures (with the CI fixture `.env` + Composer vendor bootstrapped locally, matching the CI workflow)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] New `enclosing_correct_with_multibyte_prefix` regression test verified to fail under the old byte-offset behavior and pass under the fix

Fixes #206