### PR TITLE
Route not found error for wildcard routes

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -15814,6 +15814,16 @@ return [
             return out;
         }
         for r in route_refs {
+            // Wildcard patterns (e.g. `players.*`, `players.competitions.*`)
+            // reference a *family* of registered routes — `Route::has`,
+            // `routeIs`, Ziggy, etc. — and never appear verbatim in the index,
+            // so flagging them as "not found" is a false positive. Suppress the
+            // diagnostic for any name containing `*` (issue #209). Applied here,
+            // in the pure function before any I/O, so both the PHP and Blade
+            // call sites inherit it with no LSP restart or cache flush.
+            if r.name.contains('*') {
+                continue;
+            }
             if index.get(&r.name).is_none() {
                 out.push(Diagnostic {
                     range: Range {

--- a/laravel-lsp/src/tests/route_diagnostics.rs
+++ b/laravel-lsp/src/tests/route_diagnostics.rs
@@ -66,3 +66,18 @@ fn all_known_routes_flag_nothing() {
         LaravelLanguageServer::route_not_found_diagnostics(Some(&idx), &[route_ref("home")]);
     assert!(diags.is_empty());
 }
+
+#[test]
+fn wildcard_route_names_flag_nothing() {
+    // Wildcard patterns (`players.*`, `players.competitions.*`) match a family
+    // of registered routes — `Route::has`, `routeIs`, Ziggy — and never appear
+    // verbatim in the index, so they must not be flagged as "not found" even
+    // against a non-empty index that holds no exact match for them (issue #209).
+    let idx = index_with(&["players.competitions.index", "players.competitions.create"]);
+    let refs = vec![route_ref("players.*"), route_ref("players.competitions.*")];
+    let diags = LaravelLanguageServer::route_not_found_diagnostics(Some(&idx), &refs);
+    assert!(
+        diags.is_empty(),
+        "wildcard route patterns must not be flagged as not found"
+    );
+}


### PR DESCRIPTION
## Summary
Implements #209 — wildcard route references (e.g. `route()->routeIs('players.*')`, `Route::has('players.competitions.*')`, Ziggy patterns) were being flagged with a false-positive "Route not found" ERROR, because a wildcard name never appears verbatim in the route index.

## Changes
- `route_not_found_diagnostics` (laravel-lsp/src/main.rs) now skips any `RouteReferenceData` whose `name` contains `*`, guarding before the index lookup. The guard sits in the pure function ahead of any I/O, so both the PHP and Blade call sites inherit it and no LSP restart or cache flush is needed.
- New regression test `wildcard_route_names_flag_nothing` in laravel-lsp/src/tests/route_diagnostics.rs.

## Acceptance Criteria
- [x] `route_not_found_diagnostics` skips any `RouteReferenceData` whose `name` contains `*` — no "Route not found" diagnostic is emitted for wildcard patterns
- [x] Suppression applies identically to both the PHP branch and the Blade branch (both call the same function, no separate fix needed)
- [x] A new test in `laravel-lsp/src/tests/route_diagnostics.rs` confirms a route_ref with a wildcard name (`players.*`, `players.competitions.*`) produces zero diagnostics against a non-empty index that contains no exact match
- [x] Existing "Route not found" diagnostics for non-wildcard exact misses (e.g. `does.not.exist`) continue to fire unchanged — verified by `flags_only_unknown_routes` still passing
- [x] No LSP restart or cache flush is required — the guard is applied in the pure function before any I/O

## Test Plan
- [x] `cargo test route_diagnostics` — all 5 pass (4 existing + 1 new)
- [x] `cargo test` — full unit suites green (1875 + 396 passing)
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — applied

> Note: 8 pre-existing failures in `tests/integration_tests.rs` (env-file / `test-project` fixture dependencies) are present on the base branch *unmodified* and are unrelated to this change — verified by re-running them with this PR's edits stashed.

Fixes #209