### PR TITLE
Column not found error

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3614,6 +3614,29 @@ impl LaravelLanguageServer {
             ctx
         };
 
+        // Step the effective model through any relationship hops the walker
+        // deferred — `User::query()->competitions()->where('|')` and the
+        // `$user->competitions->where('|')` receiver form. Runs before the
+        // post-`toBase()` table resolution, which reads `effective_model`.
+        let ctx = if ctx.pending_relation_hops.is_empty() {
+            ctx
+        } else {
+            let root_clone = self.initialized_root.read().await.clone();
+            match root_clone {
+                Some(root) => {
+                    let mut ctx = ctx;
+                    eloquent_completion::apply_relation_method_hops(&mut ctx, &root).await;
+                    ctx
+                }
+                None => {
+                    info!(
+                        "🔗 chain completion: relation hops need project root, not yet initialised"
+                    );
+                    return None;
+                }
+            }
+        };
+
         // Phase 6 post-toBase normalization: `User::where(...)->toBase()`
         // flips the chain mode to BaseBuilder, but we still know which
         // model was on the other side. effective_table stays None until
@@ -15097,6 +15120,10 @@ return [
                 Some(eloquent_completion::resolve_related_model(&parent, &rel, &root).await?);
             ctx.closure_relation_hop = None;
         }
+        // Step through any deferred relationship hops (`->competitions()->…` or
+        // a `$user->competitions->…` receiver) before resolving a post-`toBase`
+        // table from the effective model.
+        eloquent_completion::apply_relation_method_hops(&mut ctx, &root).await;
         if ctx.mode == BuilderMode::BaseBuilder && ctx.effective_table.is_none() {
             if let Some(model) = ctx.effective_model.clone() {
                 ctx.effective_table =

--- a/laravel-lsp/src/query_chain/chain.rs
+++ b/laravel-lsp/src/query_chain/chain.rs
@@ -84,6 +84,23 @@ pub enum EloquentReceiver {
         var: String,
         php_type: Option<String>,
     },
+    /// `$user->competitions->where(...)` — a relationship accessed as a
+    /// *property* (not a method call) eager-/lazy-loads it into a hydrated
+    /// `Collection` of the related model, so the chain runs in
+    /// `BuilderMode::EloquentCollection`. `base_type` is the declared FQCN of
+    /// the base variable (`$user` → `App\Models\User`), resolved synchronously
+    /// by the `var_type` resolver; `relation` is the property name
+    /// (`competitions`). The related model's FQCN can't be resolved in the
+    /// (synchronous) extractor pass — it needs a model-file read — so the
+    /// walker seeds `relation` as a pending relation hop
+    /// ([`ChainContext::pending_relation_hops`]) that the async finalize step
+    /// resolves into `effective_model`. `base_type` is `None` when the base
+    /// variable's type can't be determined, in which case completion no-ops.
+    RelationProperty {
+        var: String,
+        base_type: Option<String>,
+        relation: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -340,6 +357,19 @@ pub struct ChainContext {
     /// must resolve `rel` against it (one relation hop) to get the
     /// actual model to complete against.
     pub closure_relation_hop: Option<String>,
+    /// Relationship method calls the chain walked through *as builders*
+    /// (`User::query()->competitions()->whereIn('type', …)`) or a
+    /// relationship accessed as a property on the receiver
+    /// (`$user->competitions->where('type', …)`), in source order. Each is a
+    /// method/property name on the *running* `effective_model`; the synchronous
+    /// walker can't read model files, so it records the names here and the
+    /// async finalize step
+    /// ([`crate::query_chain::eloquent_completion::apply_relation_method_hops`])
+    /// walks them via `resolve_related_model`, advancing `effective_model` on
+    /// each successful hop. A name that doesn't resolve to a relationship is
+    /// skipped (it was an unrecognised builder call), leaving `effective_model`
+    /// unchanged — the `ChainEffect::None` fallback. Empty for the common case.
+    pub pending_relation_hops: Vec<String>,
     /// The quote character the user is typing inside (`'` or `"`). Used so the
     /// completion item doesn't double up quotes when inserting.
     pub quote: char,

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -11,7 +11,8 @@
 
 use super::chain::*;
 use super::methods::{
-    is_from_opaque, is_from_replace, is_from_sub, is_subquery_join, is_table_join,
+    is_from_opaque, is_from_replace, is_from_sub, is_known_builder_method, is_subquery_join,
+    is_table_join,
 };
 use std::sync::Arc;
 use tower_lsp::lsp_types::Position;
@@ -400,9 +401,61 @@ fn initial_receiver_context(
                 },
             }
         }
+        // `$user->competitions->where(...)` — start at the base variable's
+        // model in EloquentCollection mode (a relation read as a property is a
+        // hydrated collection). The relation→related-model hop is deferred: the
+        // walker seeds `relation` into `pending_relation_hops`, and the async
+        // finalize step advances `effective_model` to the related class. When
+        // the base type is unknown there's nothing to start from — no
+        // completion.
+        ChainReceiver::Eloquent(EloquentReceiver::RelationProperty { base_type, .. }) => (
+            BuilderMode::EloquentCollection,
+            None,
+            Some(base_type.clone()?),
+            None,
+        ),
         ChainReceiver::Unknown => return None,
     };
     Some(resolved)
+}
+
+/// The relationship hops the walker must apply (deferred to async finalize),
+/// assembled in source order: the receiver's property hop first (for a
+/// `$var->relation->…` chain), then every unrecognised method call seen *before*
+/// `up_to_idx` while the chain is still an `EloquentBuilder`. Collecting only in
+/// `EloquentBuilder` mode is deliberate — once the chain flips to a Collection
+/// or base builder, an unknown call is a Collection/array method, not a relation
+/// on the model.
+fn pending_relation_hops_through(
+    chain: &BuilderChain,
+    mode: BuilderMode,
+    up_to_idx: usize,
+) -> Vec<String> {
+    let mut hops = Vec::new();
+    if let ChainReceiver::Eloquent(EloquentReceiver::RelationProperty { relation, .. }) =
+        &chain.receiver
+    {
+        hops.push(relation.clone());
+    }
+    let mut running = mode;
+    for link in chain.links.iter().take(up_to_idx) {
+        match link.effect {
+            ChainEffect::FlipToBase => running = BuilderMode::BaseBuilder,
+            ChainEffect::FlipToCollection => {
+                if running == BuilderMode::EloquentBuilder {
+                    running = BuilderMode::EloquentCollection;
+                }
+            }
+            ChainEffect::Terminate => break,
+            ChainEffect::None => {
+                if running == BuilderMode::EloquentBuilder && !is_known_builder_method(&link.method)
+                {
+                    hops.push(link.method.clone());
+                }
+            }
+        }
+    }
+    hops
 }
 
 /// Resolve the chain context at a specific link index, applying the effects of
@@ -420,6 +473,7 @@ pub fn chain_context_for_link(
 ) -> Option<ChainContext> {
     let (mut mode, effective_table, effective_model, closure_relation_hop) =
         initial_receiver_context(chains, chain)?;
+    let initial_mode = mode;
     for link in chain.links.iter().take(link_idx) {
         match link.effect {
             ChainEffect::FlipToBase => mode = BuilderMode::BaseBuilder,
@@ -432,6 +486,7 @@ pub fn chain_context_for_link(
             ChainEffect::None => {}
         }
     }
+    let pending_relation_hops = pending_relation_hops_through(chain, initial_mode, link_idx);
     let arg = chain.links.get(link_idx)?.arg;
     let (mut joined_tables, mut from_clause) = scan_accessible_tables(chain);
     let mut join_parent_model = None;
@@ -453,6 +508,7 @@ pub fn chain_context_for_link(
         expecting: arg,
         dotted_prefix: None,
         closure_relation_hop,
+        pending_relation_hops,
         quote: '\'',
         joined_tables,
         from_clause,
@@ -488,6 +544,7 @@ fn detect_target_in_chain(
 ) -> Option<ChainTarget> {
     let (mut mode, effective_table, effective_model, closure_relation_hop) =
         initial_receiver_context(chains, chain)?;
+    let initial_mode = mode;
 
     // Walk links in source order. For each link, decide: (a) does the cursor
     // sit inside this link? (b) if not, apply this link's effect and move on.
@@ -514,7 +571,9 @@ fn detect_target_in_chain(
         }
     }
 
-    let cursor_link = &chain.links[cursor_link_idx?];
+    let cursor_idx = cursor_link_idx?;
+    let pending_relation_hops = pending_relation_hops_through(chain, initial_mode, cursor_idx);
+    let cursor_link = &chain.links[cursor_idx];
 
     // The cursor must be inside a string-literal arg of the cursor link.
     // `pluck` is `ArgKind::Column` even though it terminates the chain —
@@ -579,6 +638,7 @@ fn detect_target_in_chain(
             expecting,
             dotted_prefix,
             closure_relation_hop,
+            pending_relation_hops,
             quote,
             joined_tables,
             from_clause,

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -570,6 +570,24 @@ fn known_builder_methods_do_not_queue_relation_hops() {
 }
 
 #[test]
+fn eloquent_static_starter_methods_do_not_queue_relation_hops() {
+    // `withTrashed`, `limit` & friends live *only* in ELOQUENT_STATIC_STARTERS,
+    // so without that table in `is_known_builder_method` they would be mis-queued
+    // as relation-hop candidates mid-chain. Only the genuine relation accessor
+    // (`competitions`) may be queued — not the recognised builder methods that
+    // precede it.
+    let ctx =
+        detect("User::query()->withTrashed()->limit(10)->competitions()->where('ty|pe', 'x');")
+            .expect("ctx");
+    assert_eq!(
+        ctx.pending_relation_hops,
+        vec!["competitions".to_string()],
+        "only the relation accessor should be queued; got {:?}",
+        ctx.pending_relation_hops
+    );
+}
+
+#[test]
 fn relation_property_receiver_starts_collection_with_pending_hop() {
     // `$user->competitions->where('|')` — the relation read as a property is a
     // Collection of the related model; the property name is the first pending

--- a/laravel-lsp/src/query_chain/cursor/tests.rs
+++ b/laravel-lsp/src/query_chain/cursor/tests.rs
@@ -540,6 +540,59 @@ fn eloquent_static_with_first_arg_resolves_to_relation_completion() {
     assert_eq!(ctx.effective_model.as_deref(), Some("User"));
 }
 
+// ---- relation hops (issue #211) ------------------------------------------
+
+#[test]
+fn unknown_relation_method_call_queues_a_pending_hop() {
+    // `competitions()` isn't a known builder method, so in EloquentBuilder mode
+    // the walker queues it as a relation hop to resolve against the model. Mode
+    // stays EloquentBuilder (a relation method returns a builder).
+    let ctx = detect("User::query()->competitions()->whereIn('ty|pe', ['x']);").expect("ctx");
+    assert_eq!(ctx.mode, BuilderMode::EloquentBuilder);
+    assert_eq!(ctx.effective_model.as_deref(), Some("User"));
+    assert!(
+        ctx.pending_relation_hops
+            .contains(&"competitions".to_string()),
+        "competitions() should be queued as a relation hop; got {:?}",
+        ctx.pending_relation_hops
+    );
+}
+
+#[test]
+fn known_builder_methods_do_not_queue_relation_hops() {
+    // A chain of recognised builder methods queues no relation hops.
+    let ctx = detect("User::where('id', 1)->orderBy('id')->where('em|');").expect("ctx");
+    assert!(
+        ctx.pending_relation_hops.is_empty(),
+        "recognised methods must not queue hops; got {:?}",
+        ctx.pending_relation_hops
+    );
+}
+
+#[test]
+fn relation_property_receiver_starts_collection_with_pending_hop() {
+    // `$user->competitions->where('|')` — the relation read as a property is a
+    // Collection of the related model; the property name is the first pending
+    // hop and the chain runs in EloquentCollection mode.
+    let ctx = detect(
+        "use App\\Models\\User;\n/** @var User $user */\n$user->competitions->where('ty|pe', 'x');",
+    )
+    .expect("ctx");
+    assert_eq!(ctx.mode, BuilderMode::EloquentCollection);
+    assert_eq!(ctx.effective_model.as_deref(), Some("App\\Models\\User"));
+    assert_eq!(ctx.pending_relation_hops, vec!["competitions".to_string()]);
+}
+
+#[test]
+fn relation_property_receiver_without_known_base_type_is_unresolved() {
+    // No `@var` / typed param for `$user` → base type unknown → no context
+    // (completion silently no-ops rather than guessing the model).
+    assert!(
+        detect("$user->competitions->where('ty|pe', 'x');").is_none(),
+        "an untyped base variable must not resolve to a context"
+    );
+}
+
 #[test]
 fn eloquent_static_where_has_first_arg_resolves_to_closure_carrier() {
     // `User::whereHas('po|', closure)` — `whereHas` is in CLOSURE_CARRIERS

--- a/laravel-lsp/src/query_chain/diagnostics.rs
+++ b/laravel-lsp/src/query_chain/diagnostics.rs
@@ -45,8 +45,8 @@
 use super::chain::*;
 use super::cursor::{byte_offset_to_position, chain_context_for_link};
 use super::eloquent_completion::{
-    enrich_join_parent_tables, resolve_related_model, resolve_table_for_model, snake_pluralize,
-    walk_dotted_hops,
+    apply_relation_method_hops, enrich_join_parent_tables, resolve_related_model,
+    resolve_table_for_model, snake_pluralize, walk_dotted_hops,
 };
 use crate::class_locator::find_php_class_file;
 use crate::database::DatabaseSchemaProvider;
@@ -292,6 +292,12 @@ async fn finalize_context(mut ctx: ChainContext, root: &Path) -> Option<ChainCon
         let related = resolve_related_model(&parent, &rel, root).await?;
         ctx.effective_model = Some(related);
     }
+    // Step the effective model through any relationship hops the walker
+    // deferred (`->competitions()->…` or a `$user->competitions->…` receiver),
+    // so column validation runs against the related model's table — not the
+    // parent's. Must precede the post-`toBase()` table resolution below, which
+    // reads `effective_model`.
+    apply_relation_method_hops(&mut ctx, root).await;
     if ctx.mode == BuilderMode::BaseBuilder && ctx.effective_table.is_none() {
         if let Some(model) = ctx.effective_model.clone() {
             ctx.effective_table = resolve_table_for_model(&model, root).await;

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -500,6 +500,31 @@ async fn relationship_property_receiver_validates_against_related_table() {
 }
 
 #[tokio::test]
+async fn relationship_property_receiver_still_flags_unknown_column_on_related_table() {
+    // Symmetric negative for the property-access form: the hop narrows the table,
+    // it does not silence diagnostics. `emial` is a typo of a *users* column,
+    // gone after the property hop — on competitions it's unknown, so it's still
+    // flagged with the competitions table named (proving validation moved tables
+    // rather than being blanket-suppressed).
+    let (_dir, root, db) = competitions_project().await;
+    let source = "<?php\nuse App\\Models\\User;\n/** @var User $user */\n$user->competitions->where('emial', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "unknown column on competitions still flags via property access: {diags:?}"
+    );
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_COLUMN);
+    assert!(
+        diags[0].message.contains("competitions"),
+        "diagnostic should name the competitions table; got: {}",
+        diags[0].message
+    );
+}
+
+#[tokio::test]
 async fn flags_unknown_table_in_db_table() {
     let (_dir, root) = project_with_models(&[("User", USER_MODEL)]);
     let db = provider_with(root.clone(), &[("users", &[("id", "int")])]).await;

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -226,6 +226,23 @@ class User extends Model {
 }
 "#;
 
+/// A `User` with a single `competitions` hasMany relation — the issue #211
+/// shape, where the relation's table has columns the parent's doesn't.
+const USER_WITH_COMPETITIONS: &str = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function competitions() { return $this->hasMany(Competition::class); }
+}
+"#;
+
+const COMPETITION_MODEL: &str = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Competition extends Model {
+}
+"#;
+
 fn code_of(diag: &tower_lsp::lsp_types::Diagnostic) -> &str {
     match &diag.code {
         Some(NumberOrString::String(s)) => s.as_str(),
@@ -401,6 +418,84 @@ async fn valid_relation_produces_no_diagnostic() {
     assert!(
         diags.is_empty(),
         "valid relation must not be flagged: {diags:?}"
+    );
+}
+
+// ---- relationship hops (issue #211) ---------------------------------------
+
+/// Seed a project + schema for the issue #211 fixtures: a `User`/`Competition`
+/// model pair and their tables, where `type` lives on `competitions` but NOT on
+/// `users`.
+async fn competitions_project() -> (TempDir, PathBuf, DatabaseSchemaProvider) {
+    let (dir, root) = project_with_models(&[
+        ("User", USER_WITH_COMPETITIONS),
+        ("Competition", COMPETITION_MODEL),
+    ]);
+    let db = provider_with(
+        root.clone(),
+        &[
+            ("users", &[("id", "int"), ("email", "string")]),
+            ("competitions", &[("id", "int"), ("type", "string")]),
+        ],
+    )
+    .await;
+    (dir, root, db)
+}
+
+#[tokio::test]
+async fn relationship_method_hop_validates_against_related_table() {
+    // `User::query()->competitions()->whereIn('type', …)` — `competitions()`
+    // returns a builder for the related model, so `type` must validate against
+    // the competitions table. Before the hop this false-positived because
+    // `type` isn't a column on `users`.
+    let (_dir, root, db) = competitions_project().await;
+    let source = "<?php\nuse App\\Models\\User;\nUser::query()->competitions()->whereIn('type', ['squash'])->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "relationship hop must validate `type` against the competitions table: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn relationship_method_hop_still_flags_unknown_column_on_related_table() {
+    // The hop narrows the table; it does not silence diagnostics. `emial` is a
+    // typo of a *users* column, which is gone after the hop — on competitions
+    // it's unknown, so it's still flagged (proving validation moved tables).
+    let (_dir, root, db) = competitions_project().await;
+    let source =
+        "<?php\nuse App\\Models\\User;\nUser::query()->competitions()->where('emial', 1)->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "unknown column on competitions still flags: {diags:?}"
+    );
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_COLUMN);
+    assert!(
+        diags[0].message.contains("competitions"),
+        "diagnostic should name the competitions table; got: {}",
+        diags[0].message
+    );
+}
+
+#[tokio::test]
+async fn relationship_property_receiver_validates_against_related_table() {
+    // `$user->competitions->where('type', …)` — accessing the relation as a
+    // property yields a Collection of Competition, so `type` validates against
+    // the competitions table. `$user`'s type comes from the `@var` docblock.
+    let (_dir, root, db) = competitions_project().await;
+    let source = "<?php\nuse App\\Models\\User;\n/** @var User $user */\n$user->competitions->where('type', 'squash')->get();\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "property-access relation must validate `type` against competitions: {diags:?}"
     );
 }
 

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -738,6 +738,41 @@ pub async fn resolve_related_model(
     rel.related_model
 }
 
+/// Walk the relationship hops the chain walker deferred
+/// ([`ChainContext::pending_relation_hops`]) and advance `effective_model`
+/// through each one. Covers two shapes:
+///
+/// - method-call hops — `User::query()->competitions()->whereIn('type', …)`,
+///   where `competitions()` isn't a known builder method, so it's a relation
+///   the chain stepped into; and
+/// - a property-access receiver — `$user->competitions->where('type', …)`,
+///   whose `competitions` property hop is seeded as the first pending hop.
+///
+/// Each hop resolves against the *running* model via [`resolve_related_model`].
+/// A hop that doesn't name a relationship (an unrecognised builder method like
+/// `->limit()`, or a non-relation property) returns `None` and is skipped,
+/// leaving the model unchanged — the `ChainEffect::None` fallback. The mode is
+/// untouched: a relationship method returns a builder of the related model
+/// (`EloquentBuilder` stays `EloquentBuilder`), and the property form already
+/// entered the walker as `EloquentCollection`. No-op when there are no hops or
+/// the chain has no resolved model to start from.
+pub async fn apply_relation_method_hops(ctx: &mut ChainContext, project_root: &Path) {
+    if ctx.pending_relation_hops.is_empty() {
+        return;
+    }
+    let hops = std::mem::take(&mut ctx.pending_relation_hops);
+    let Some(mut current) = ctx.effective_model.clone() else {
+        return;
+    };
+    for hop in hops {
+        if let Some(related) = resolve_related_model(&current, &hop, project_root).await {
+            current = related;
+        }
+        // `None` → not a relationship; keep `current` and try the next hop.
+    }
+    ctx.effective_model = Some(current);
+}
+
 /// Phase 6 helper: resolve a model class to its table name.
 ///
 /// Used for the post-`->toBase()` case where the chain has flipped to

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -112,6 +112,7 @@ fn make_ctx(class: &str) -> ChainContext {
         expecting: ArgKind::Column,
         dotted_prefix: None,
         closure_relation_hop: None,
+        pending_relation_hops: Vec::new(),
         quote: '\'',
         joined_tables: Vec::new(),
         from_clause: FromClause::Inherit,
@@ -529,6 +530,94 @@ class User extends Model {
 }
 
 #[tokio::test]
+async fn relation_property_receiver_offers_related_collection_columns() {
+    // Issue #211: `$user->competitions->where('|')` resolves to an
+    // EloquentCollection over Competition with `competitions` queued as a
+    // pending relation hop. After the hop, collection completion must offer
+    // the competitions table's columns — not the users table's.
+    let user = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function competitions() { return $this->hasMany(Competition::class); }
+}
+"#;
+    let competition = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Competition extends Model {}
+"#;
+    let (_dir, root) =
+        project_with_models_helper(&[("User", user), ("Competition", competition)]).await;
+    let db = provider_with_table(
+        root.clone(),
+        "competitions",
+        vec![("id", "int"), ("type", "string"), ("name", "string")],
+    )
+    .await;
+
+    // The shape the chain walker produces for `$user->competitions->where('|')`.
+    let mut ctx = make_ctx("App\\Models\\User");
+    ctx.mode = BuilderMode::EloquentCollection;
+    ctx.pending_relation_hops = vec!["competitions".to_string()];
+
+    apply_relation_method_hops(&mut ctx, &root).await;
+    assert_eq!(
+        ctx.effective_model.as_deref(),
+        Some("App\\Models\\Competition"),
+        "the hop should advance effective_model to the related class"
+    );
+
+    let items = columns_for_collection(&ctx, &db, None, &root).await;
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"type"),
+        "must offer competitions.type; got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"name"),
+        "must offer competitions.name; got {labels:?}"
+    );
+}
+
+#[tokio::test]
+async fn apply_relation_method_hops_skips_unresolvable_names() {
+    // A hop that isn't a relationship (an unrecognised builder method like
+    // `query`) resolves to None and is skipped, leaving the model unchanged —
+    // the ChainEffect::None fallback.
+    let user = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function competitions() { return $this->hasMany(Competition::class); }
+}
+"#;
+    let competition = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Competition extends Model {}
+"#;
+    let (_dir, root) =
+        project_with_models_helper(&[("User", user), ("Competition", competition)]).await;
+    let db = provider_with_table(root.clone(), "competitions", vec![("id", "int")]).await;
+    let _ = &db;
+
+    let mut ctx = make_ctx("App\\Models\\User");
+    // `query` is not a relation → skipped; `competitions` resolves.
+    ctx.pending_relation_hops = vec!["query".to_string(), "competitions".to_string()];
+    apply_relation_method_hops(&mut ctx, &root).await;
+    assert_eq!(
+        ctx.effective_model.as_deref(),
+        Some("App\\Models\\Competition"),
+        "unresolvable hop skipped, real relation still applied"
+    );
+    assert!(
+        ctx.pending_relation_hops.is_empty(),
+        "hops consumed after application"
+    );
+}
+
+#[tokio::test]
 async fn columns_for_collection_falls_back_when_model_missing() {
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_path_buf();
@@ -699,6 +788,7 @@ class Post extends Model {
         expecting: ArgKind::Relation,
         dotted_prefix: Some("posts".to_string()),
         closure_relation_hop: None,
+        pending_relation_hops: Vec::new(),
         quote: '\'',
         joined_tables: Vec::new(),
         from_clause: FromClause::Inherit,
@@ -736,6 +826,7 @@ class User extends Model {
         expecting: ArgKind::Relation,
         dotted_prefix: Some("nonexistent".to_string()),
         closure_relation_hop: None,
+        pending_relation_hops: Vec::new(),
         quote: '\'',
         joined_tables: Vec::new(),
         from_clause: FromClause::Inherit,
@@ -798,6 +889,7 @@ fn base_ctx(
         expecting: ArgKind::Column,
         dotted_prefix: dotted_prefix.map(|s| s.to_string()),
         closure_relation_hop: None,
+        pending_relation_hops: Vec::new(),
         quote: '\'',
         joined_tables,
         from_clause,
@@ -1041,6 +1133,7 @@ fn eloquent_ctx(
         expecting: ArgKind::Column,
         dotted_prefix: dotted_prefix.map(|s| s.to_string()),
         closure_relation_hop: None,
+        pending_relation_hops: Vec::new(),
         quote: '\'',
         joined_tables,
         from_clause,

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -641,10 +641,60 @@ fn member_chain_receiver(node: Node, bytes: &[u8], aliases: &UseAliases) -> Chai
         // declaration) and route through the same EloquentBuilder path as
         // static calls.
         "parenthesized_expression" => parenthesized_receiver(node, bytes, aliases),
+        // `$user->competitions->where(...)` — a relationship read as a
+        // *property* (no `()`). Accessing a relation as a property returns the
+        // hydrated `Collection` of the related model, so the chain operates in
+        // `EloquentCollection` mode against the related model. We resolve the
+        // base variable's type synchronously (`$user` → `App\Models\User`) but
+        // defer the relation→related-model hop (`competitions` → `Competition`)
+        // to the async finalize step, since it needs a model-file read. The
+        // base must be a bare `$var`; nested receivers (`$this->user->rel`,
+        // `method()->rel`) stay Unknown for now.
+        "member_access_expression" => member_access_receiver(node, bytes, aliases),
         // (Future) `$this->prop->...`, `$obj->method()->...`, etc. fall
         // through. Lands alongside the var-type resolver in Phase 9.
         _ => ChainReceiver::Unknown,
     }
+}
+
+/// Resolve a `$var->relationName->...` receiver — a relationship accessed as a
+/// property. The deepest non-call node is the `member_access_expression`
+/// `$var->relationName`; its `object` is the base variable and its `name` is
+/// the property. We produce an [`EloquentReceiver::RelationProperty`] carrying
+/// the base variable's resolved type (sync) and the property name (the relation
+/// to hop, resolved async downstream).
+///
+/// Only a bare `$var` base is handled; any other object shape (nested member
+/// access, a method call, `$this->prop->rel`) returns `Unknown` so completion
+/// silently no-ops rather than guessing.
+fn member_access_receiver(node: Node, bytes: &[u8], aliases: &UseAliases) -> ChainReceiver {
+    let Some(object) = node.child_by_field_name("object") else {
+        return ChainReceiver::Unknown;
+    };
+    if object.kind() != "variable_name" {
+        return ChainReceiver::Unknown;
+    }
+    let Some(name_node) = node.child_by_field_name("name") else {
+        return ChainReceiver::Unknown;
+    };
+    let Some(relation) = node_text(name_node, bytes) else {
+        return ChainReceiver::Unknown;
+    };
+    let relation = relation.to_string();
+    let Some(raw_var) = node_text(object, bytes) else {
+        return ChainReceiver::Unknown;
+    };
+    let var = raw_var.trim_start_matches('$').to_string();
+    // Resolve `$var`'s declared class the same way the `$var->method()` form
+    // does (typed param / `@var` docblock / flow assignment). `None` is fine —
+    // it just means we couldn't determine the base model, so the receiver
+    // resolves to no completion downstream.
+    let base_type = super::var_type::resolve(object, bytes, &var, aliases);
+    ChainReceiver::Eloquent(EloquentReceiver::RelationProperty {
+        var,
+        base_type,
+        relation,
+    })
 }
 
 /// Resolve `(new X)->...` style receivers. The parens wrap exactly one

--- a/laravel-lsp/src/query_chain/methods.rs
+++ b/laravel-lsp/src/query_chain/methods.rs
@@ -451,10 +451,14 @@ pub fn is_eloquent_static_starter(name: &str) -> bool {
 /// keeps its existing classification and never triggers a hop.
 ///
 /// Covers every table consulted by [`arg_kind`] and [`chain_effect`] plus the
-/// closure-carrier, join, and `from*()` tables, so the only names left over are
-/// genuinely-unknown calls (relationship accessors, custom local scopes, or
-/// builder methods we simply don't model — all of which `resolve_related_model`
-/// safely returns `None` for when they aren't relationships).
+/// closure-carrier, join, `from*()`, and Eloquent static-starter tables, so the
+/// only names left over are genuinely-unknown calls (relationship accessors,
+/// custom local scopes, or builder methods we simply don't model — all of which
+/// `resolve_related_model` safely returns `None` for when they aren't
+/// relationships). `ELOQUENT_STATIC_STARTERS` is included because pagination /
+/// limit / soft-delete starters such as `limit`, `take`, `withTrashed`, and
+/// `inRandomOrder` live only there; without it they would be mis-queued as
+/// relation-hop candidates mid-chain.
 pub fn is_known_builder_method(name: &str) -> bool {
     COLUMN_METHODS.contains(&name)
         || RAW_METHODS.contains(&name)
@@ -470,6 +474,7 @@ pub fn is_known_builder_method(name: &str) -> bool {
         || COLLECTION_TERMINATORS.contains(&name)
         || CHAIN_TERMINATORS.contains(&name)
         || TRANSPARENT.contains(&name)
+        || ELOQUENT_STATIC_STARTERS.contains(&name)
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/query_chain/methods.rs
+++ b/laravel-lsp/src/query_chain/methods.rs
@@ -443,5 +443,34 @@ pub fn is_eloquent_static_starter(name: &str) -> bool {
     ELOQUENT_STATIC_STARTERS.contains(&name)
 }
 
+/// Whether `name` appears in any of the builder-method classification tables —
+/// i.e. it's a query/collection builder method we recognise. The chain walker
+/// uses the negation: an *unrecognised* method call in `EloquentBuilder` mode
+/// is treated as a candidate relationship hop (`User::query()->competitions()
+/// ->where(…)`), resolved against the effective model. A method that IS known
+/// keeps its existing classification and never triggers a hop.
+///
+/// Covers every table consulted by [`arg_kind`] and [`chain_effect`] plus the
+/// closure-carrier, join, and `from*()` tables, so the only names left over are
+/// genuinely-unknown calls (relationship accessors, custom local scopes, or
+/// builder methods we simply don't model — all of which `resolve_related_model`
+/// safely returns `None` for when they aren't relationships).
+pub fn is_known_builder_method(name: &str) -> bool {
+    COLUMN_METHODS.contains(&name)
+        || RAW_METHODS.contains(&name)
+        || RELATION_METHODS.contains(&name)
+        || CLOSURE_CARRIERS.contains(&name)
+        || SAME_MODEL_CLOSURE_CARRIERS.contains(&name)
+        || TABLE_JOIN_METHODS.contains(&name)
+        || FROM_REPLACE_METHODS.contains(&name)
+        || FROM_OPAQUE_METHODS.contains(&name)
+        || FROM_SUB_METHODS.contains(&name)
+        || SUBQUERY_JOIN_METHODS.contains(&name)
+        || MODE_FLIP_TO_BASE.contains(&name)
+        || COLLECTION_TERMINATORS.contains(&name)
+        || CHAIN_TERMINATORS.contains(&name)
+        || TRANSPARENT.contains(&name)
+}
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
Implements #211 — the chain walker resolved *past* a relationship instead of *into* it, so columns valid on the related table but absent from the parent model's table were false-flagged "Column not found". `User::…->competitions()->whereIn('type', …)` validated `type` against `users` (where it doesn't exist) instead of `competitions` (where it does).

## Changes
- **Method-call relationship hops** — in `EloquentBuilder` mode, an unrecognised method call (not in any known builder-method table) is queued on the new `ChainContext::pending_relation_hops` field. The async finalize step (diagnostics, completion, goto) walks each via `resolve_related_model`, advancing `effective_model` to the related class; the mode stays `EloquentBuilder`. Added `methods::is_known_builder_method` to gate the check.
- **Skip-on-miss fallback** — a queued name that isn't a relationship resolves to `None` and is skipped, leaving `effective_model` unchanged (the existing `ChainEffect::None` behaviour) — no regression on unrecognised calls.
- **Property-access receiver** — `member_chain_receiver` now recognises a `member_access_expression` base (`$user->competitions->where(…)`), resolves the base variable's type synchronously, and emits the new `EloquentReceiver::RelationProperty` variant, which starts the chain in `EloquentCollection` mode with the property name seeded as the first pending hop. (The related FQCN needs a model-file read, so — like the method-call hops — it's resolved in the async finalize step rather than in the synchronous extractor; `effective_model` ends up as the related class, per the AC's intent.)
- Wired the hop resolution into all three finalize sites: `diagnostics::finalize_context`, the completion handler, and goto-definition — each after the closure-relation hop and before the post-`toBase()` table resolution.

## Acceptance Criteria
- [x] In `EloquentBuilder` mode, a method whose name is in no known builder-method table is resolved as a relationship on `effective_model` via `resolve_related_model`
- [x] On a successful hop, `effective_model` updates to the related model; mode stays `EloquentBuilder`
- [x] Subsequent column diagnostics/completions use the related model's table, eliminating the false-positive
- [x] The hop is skipped (falls back to `ChainEffect::None`) when `resolve_related_model` returns `None`
- [x] Property-access receiver form handled in `member_chain_receiver` as a `member_access_expression`, producing the related model + `EloquentCollection` mode
- [x] Regression test: `User::…->competitions()->whereIn('type', …)` produces no diagnostic
- [x] Regression test: `$user->competitions->where('type', …)` offers competitions columns and emits no diagnostic

## Implementation note
AC5 specified `EloquentReceiver::InstanceVar` for the property-access form. The synchronous extractor can't resolve the relation→related-model hop (it needs a model-file read), so I added a dedicated `RelationProperty` variant that carries the base type + relation name and defers resolution to the async finalize step — reaching the same observable result (related model, `EloquentCollection` mode). Flagging the wording deviation for review.

## Test Plan
- [x] `cargo test --lib` — all query_chain tests pass (incl. 9 new)
- [x] `cargo clippy --lib --tests` — clean
- [x] `cargo fmt`
- Pre-existing integration-test failures (`.env`/`vendor` fixtures absent in a fresh clone) are unrelated to this diff, which is confined to `query_chain` + `main.rs`.

Fixes #211