### PR TITLE
Extend the path_within_root emit-safe guard to the translation/config (and middleware/feature/env) "Expected at:" diagnostic surfaces

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13772,18 +13772,27 @@ return [
     ///
     /// - `dotted_severity`: Severity for dotted keys (ERROR in PHP, WARNING in @lang)
     /// - Text keys always get INFORMATION severity
+    ///
+    /// The "Expected at:" path is routed through [`in_root_expected_path_hint`]
+    /// (issue #214): `check.expected_path` for a namespaced key is built from
+    /// `vendor_map.get(namespace)` — a user-registered, possibly out-of-root
+    /// absolute path — and this message is parsed back into a `CreateFile` target
+    /// by [`FileAction::from_diagnostic`]. The emit-safe guard keeps an out-of-root
+    /// vendor-map path (and a dangling under-root symlink) out of the hint,
+    /// falling back to `"unknown"`, while still admitting a genuinely-absent
+    /// in-root path (the hint is for a *missing* file). `root` is the project root.
     fn create_translation_diagnostic(
         translation_key: &str,
         check: &TranslationCheck,
         line: u32,
         column: u32,
         end_column: u32,
+        root: &Path,
     ) -> Diagnostic {
-        let expected_path_str = check
-            .expected_path
-            .as_ref()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default();
+        let expected_path_str = match check.expected_path.as_ref() {
+            Some(p) => in_root_expected_path_hint(std::slice::from_ref(p), root),
+            None => String::new(),
+        };
 
         let (severity, message) = if check.is_dotted_key {
             let action_hint = if check.file_exists {
@@ -13884,18 +13893,26 @@ return [
     }
 
     /// Create a diagnostic for a missing config
+    ///
+    /// The "Expected at:" path is routed through [`in_root_expected_path_hint`]
+    /// (issue #214) for the same `from_diagnostic → CreateFile` containment
+    /// invariant the translation/view/component surfaces hold. `check.expected_path`
+    /// is `root.join("config")`-rooted and so structurally in-root, but routing it
+    /// keeps the guarantee uniform across *every* "Expected at:" surface and
+    /// refuses a dangling under-root symlink the client could follow out of the
+    /// tree on create. `root` is the project root.
     fn create_config_diagnostic(
         config_key: &str,
         check: &ConfigCheck,
         line: u32,
         column: u32,
         end_column: u32,
+        root: &Path,
     ) -> Diagnostic {
-        let expected_path_str = check
-            .expected_path
-            .as_ref()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default();
+        let expected_path_str = match check.expected_path.as_ref() {
+            Some(p) => in_root_expected_path_hint(std::slice::from_ref(p), root),
+            None => String::new(),
+        };
 
         let action_hint = if check.file_exists {
             format!(
@@ -16251,6 +16268,19 @@ return [
                         .map(|p| p.exists())
                         .unwrap_or(false);
 
+                    // Emit-safe containment (issue #214): the "Expected at:" path
+                    // is parsed back into a `CreateFile` target by
+                    // `from_diagnostic`. `.env` is `root.join`-rooted, but routing
+                    // it through the guard keeps the invariant uniform across every
+                    // surface and refuses a dangling `.env` under-root symlink a
+                    // client `CreateFile` could follow out of the project tree.
+                    let env_expected_hint = match (root_for_env.as_ref(), env_path.as_ref()) {
+                        (Some(root), Some(p)) => {
+                            Some(in_root_expected_path_hint(std::slice::from_ref(p), root))
+                        }
+                        _ => None,
+                    };
+
                     // Build the message with Expected at: and optionally Copy from:
                     // Format varies based on whether .env file exists:
                     // - .env exists: "not found in file" → append to file
@@ -16269,8 +16299,8 @@ return [
                             )
                         };
                         // Add Expected at: for code action
-                        if let Some(ref p) = env_path {
-                            msg.push_str(&format!("\nExpected at: {}", p.display()));
+                        if let Some(ref hint) = env_expected_hint {
+                            msg.push_str(&format!("\nExpected at: {}", hint));
                         }
                         // If .env doesn't exist but .env.example does, add Copy from:
                         if !env_exists && env_example_exists {
@@ -16292,8 +16322,8 @@ return [
                             )
                         };
                         // Add Expected at: for code action
-                        if let Some(ref p) = env_path {
-                            msg.push_str(&format!("\nExpected at: {}", p.display()));
+                        if let Some(ref hint) = env_expected_hint {
+                            msg.push_str(&format!("\nExpected at: {}", hint));
                         }
                         // If .env doesn't exist but .env.example does, add Copy from:
                         if !env_exists && env_example_exists {
@@ -16413,7 +16443,16 @@ return [
                                         "Middleware '{}' not found\nClass: {}\nExpected at: {}\n\nThe middleware alias is registered but the class file doesn't exist.\n💡 Click to view where the alias is defined.",
                                         middleware_name,
                                         class_name,
-                                        mw_class_path.to_string_lossy()
+                                        // Emit-safe containment (issue #214): the
+                                        // class path is resolved via PSR-4 from a
+                                        // user-controlled class name and parsed
+                                        // back into a `CreateFile` target by
+                                        // `from_diagnostic`, so route it through
+                                        // the guard like the view/component hints.
+                                        in_root_expected_path_hint(
+                                            std::slice::from_ref(mw_class_path),
+                                            root
+                                        )
                                     ),
                                     related_information: None,
                                     tags: None,
@@ -16468,7 +16507,15 @@ return [
                                     message: format!(
                                         "Middleware '{}' not found\nExpected at: {}\n\nCreate the middleware or add an alias in bootstrap/app.php",
                                         middleware_name,
-                                        mw_file_path.to_string_lossy()
+                                        // Emit-safe containment (issue #214):
+                                        // `resolve_class_to_file` maps a
+                                        // user-controlled class name through PSR-4
+                                        // and the hint becomes a `CreateFile`
+                                        // target, so guard it.
+                                        in_root_expected_path_hint(
+                                            std::slice::from_ref(&mw_file_path),
+                                            root
+                                        )
                                     ),
                                     related_information: None,
                                     tags: None,
@@ -16526,6 +16573,7 @@ return [
                             trans_ref.line,
                             trans_ref.column,
                             trans_ref.end_column,
+                            root,
                         ));
                     }
                 }
@@ -16544,6 +16592,7 @@ return [
                             config_ref.line,
                             config_ref.column,
                             config_ref.end_column,
+                            root,
                         ));
                     }
                 }
@@ -16745,7 +16794,14 @@ return [
                                     message: format!(
                                         "Feature class not found: '{}'\nExpected at: {}",
                                         feature_ref.feature_name,
-                                        class_path.to_string_lossy()
+                                        // Emit-safe containment (issue #214): the
+                                        // class path is PSR-4-resolved from a
+                                        // user-controlled class reference and
+                                        // parsed back into a `CreateFile` target.
+                                        in_root_expected_path_hint(
+                                            std::slice::from_ref(&class_path),
+                                            root
+                                        )
                                     ),
                                     related_information: None,
                                     tags: None,
@@ -16783,7 +16839,13 @@ return [
                                 message: format!(
                                     "Feature not found: '{}'\nExpected at: {}",
                                     feature_ref.feature_name,
-                                    expected_path.to_string_lossy()
+                                    // Emit-safe containment (issue #214): keep the
+                                    // "Expected at:" → `CreateFile` invariant
+                                    // uniform across every feature surface.
+                                    in_root_expected_path_hint(
+                                        std::slice::from_ref(&expected_path),
+                                        root
+                                    )
                                 ),
                                 related_information: None,
                                 tags: None,
@@ -16848,6 +16910,7 @@ return [
                         trans_ref.line,
                         trans_ref.column,
                         trans_ref.end_column,
+                        root,
                     ));
                 }
             }
@@ -17041,6 +17104,7 @@ return [
                                     dir_ref.line,
                                     dir_ref.column,
                                     dir_ref.end_column,
+                                    root,
                                 ));
                             }
                         }
@@ -17093,7 +17157,14 @@ return [
                                     message: format!(
                                         "Feature not found: '{}'\nExpected at: {}",
                                         feature_name,
-                                        feature_path.to_string_lossy()
+                                        // Emit-safe containment (issue #214): same
+                                        // guard as the other "Expected at:" hints
+                                        // so the @feature directive surface can't
+                                        // leak an out-of-root create target.
+                                        in_root_expected_path_hint(
+                                            std::slice::from_ref(&feature_path),
+                                            root
+                                        )
                                     ),
                                     related_information: None,
                                     tags: None,

--- a/laravel-lsp/src/tests/diagnostic_severity.rs
+++ b/laravel-lsp/src/tests/diagnostic_severity.rs
@@ -19,8 +19,14 @@ fn missing_dotted_translation_is_a_warning_not_error() {
         file_exists: true,
         nested_key: Some("welcome".to_string()),
     };
-    let d =
-        LaravelLanguageServer::create_translation_diagnostic("messages.welcome", &check, 0, 0, 5);
+    let d = LaravelLanguageServer::create_translation_diagnostic(
+        "messages.welcome",
+        &check,
+        0,
+        0,
+        5,
+        std::path::Path::new("/p"),
+    );
     assert_eq!(d.severity, Some(DiagnosticSeverity::WARNING));
 }
 
@@ -35,6 +41,13 @@ fn missing_non_dotted_translation_stays_information() {
         file_exists: false,
         nested_key: None,
     };
-    let d = LaravelLanguageServer::create_translation_diagnostic("Welcome", &check, 0, 0, 5);
+    let d = LaravelLanguageServer::create_translation_diagnostic(
+        "Welcome",
+        &check,
+        0,
+        0,
+        5,
+        std::path::Path::new("/p"),
+    );
     assert_eq!(d.severity, Some(DiagnosticSeverity::INFORMATION));
 }

--- a/laravel-lsp/src/tests/expected_path_diagnostic_containment.rs
+++ b/laravel-lsp/src/tests/expected_path_diagnostic_containment.rs
@@ -1,0 +1,261 @@
+//! Emit-safe "Expected at:" containment for the remaining `from_diagnostic →
+//! CreateFile` diagnostic surfaces (issue #214), extending the view/component
+//! coverage in `view_diagnostic_containment.rs` (#194/#201).
+//!
+//! Every "not found" diagnostic in this family echoes an `Expected at: <path>`
+//! line back to the client, and [`crate::FileAction::from_diagnostic`] parses
+//! that line into a `CreateFile` target a client could follow. Issue #201 routed
+//! the four view/component surfaces through [`crate::in_root_expected_path_hint`]
+//! — the *emit-safe* guard ([`crate::path_containment::path_within_root_emit_safe`])
+//! that refuses an out-of-root candidate (and a dangling under-root symlink)
+//! while still admitting a genuinely-absent in-root path (the hint is for a
+//! *missing* file). This file closes the rest of the family so the invariant
+//! holds uniformly across *every* surface:
+//!
+//! | Surface     | `expected_path` source                              | Escape vector closed |
+//! |-------------|-----------------------------------------------------|----------------------|
+//! | Translation | `vendor_map.get(namespace)` (user-registered)       | out-of-root vendor lang dir |
+//! | Config      | `root.join("config")` (structurally in-root)        | uniform invariant + dangling symlink |
+//! | Middleware  | `resolve_class_to_file` (PSR-4 from class name)     | `..`-injected / out-of-root PSR-4 map |
+//! | Feature     | `resolve_class_to_file` + `root.join("app/Features")` | as middleware + uniform invariant |
+//! | Env         | `root.join(".env")` (structurally in-root)          | dangling `.env` symlink + uniform invariant |
+//!
+//! Each surface gets two cases, mirroring the #201 component test:
+//! a **regression** test (every candidate out-of-root → `"unknown"`, never a
+//! leaked absolute path) and a **positive control** (a single in-root but
+//! *missing* candidate is returned as-is, so the guard never drops a legitimate
+//! "Expected at:" hint for a normal not-yet-created file). All cases drive the
+//! shared helper directly, the same style the existing containment tests use.
+
+use crate::in_root_expected_path_hint;
+
+// ---------------------------------------------------------------------------
+// Translation "not found" — `check_translation_file` → `create_translation_diagnostic`
+// ---------------------------------------------------------------------------
+//
+// A namespaced key (`pkg::messages.hi`) builds `expected_path` from
+// `vendor_map.get("pkg")` — a user-registered path a package can point outside
+// the project root. That out-of-root absolute path must never reach the hint.
+
+#[test]
+fn translation_hint_is_unknown_when_all_candidates_out_of_root() {
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    // The shape a `Lang::addNamespace('pkg', '/abs/out/of/tree')` registration
+    // produces: the vendor lang dir resolves outside the project root.
+    let escapee = outside.path().join("pkg/en/messages.php");
+
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&escapee), root.path()),
+        "unknown",
+        "an out-of-root vendor-map translation path must never be echoed into the \
+         \"Expected at:\" hint — it falls back to \"unknown\""
+    );
+}
+
+#[test]
+fn translation_hint_keeps_in_root_missing_candidate() {
+    let root = tempfile::TempDir::new().unwrap();
+    // The everyday case: a published vendor lang file that doesn't exist yet.
+    let in_root = root.path().join("lang/vendor/pkg/en/messages.php");
+
+    assert!(
+        in_root.canonicalize().is_err(),
+        "precondition: the in-root translation candidate does not exist on disk"
+    );
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&in_root), root.path()),
+        in_root.to_string_lossy(),
+        "a genuinely-absent in-root translation path is a legitimate create \
+         target and must be surfaced unchanged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Config "not found" — `check_config_file` → `create_config_diagnostic`
+// ---------------------------------------------------------------------------
+//
+// `config_path` is `root.join("config")`-rooted, so structurally in-root, but
+// routing it keeps the guarantee uniform and refuses a dangling under-root
+// symlink the client could follow out of the tree on create.
+
+#[test]
+fn config_hint_is_unknown_when_all_candidates_out_of_root() {
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    let escapee = outside.path().join("config/app.php");
+
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&escapee), root.path()),
+        "unknown",
+        "an out-of-root config path must never be echoed into the \"Expected \
+         at:\" hint — it falls back to \"unknown\""
+    );
+}
+
+#[test]
+fn config_hint_keeps_in_root_missing_candidate() {
+    let root = tempfile::TempDir::new().unwrap();
+    let in_root = root.path().join("config/app.php");
+
+    assert!(
+        in_root.canonicalize().is_err(),
+        "precondition: the in-root config candidate does not exist on disk"
+    );
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&in_root), root.path()),
+        in_root.to_string_lossy(),
+        "a genuinely-absent in-root config path is a legitimate create target \
+         and must be surfaced unchanged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Middleware "not found" — `resolve_class_to_file` / registry class path
+// ---------------------------------------------------------------------------
+//
+// The class path is mapped from a user-controlled class name through PSR-4
+// (`App\Http\Middleware\X` → `app/Http/Middleware/X.php`). A `..`-injected name
+// or an out-of-root PSR-4 mapping can escape the root; the hint must not leak it.
+
+#[test]
+fn middleware_hint_is_unknown_when_all_candidates_out_of_root() {
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    let escapee = outside.path().join("app/Http/Middleware/Authenticate.php");
+
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&escapee), root.path()),
+        "unknown",
+        "an out-of-root middleware class path must never be echoed into the \
+         \"Expected at:\" hint — it falls back to \"unknown\""
+    );
+}
+
+#[test]
+fn middleware_hint_keeps_in_root_missing_candidate() {
+    let root = tempfile::TempDir::new().unwrap();
+    let in_root = root.path().join("app/Http/Middleware/Authenticate.php");
+
+    assert!(
+        in_root.canonicalize().is_err(),
+        "precondition: the in-root middleware candidate does not exist on disk"
+    );
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&in_root), root.path()),
+        in_root.to_string_lossy(),
+        "a genuinely-absent in-root middleware class path is a legitimate create \
+         target and must be surfaced unchanged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Feature "not found" — `resolve_class_to_file` / `root.join("app/Features")`
+// ---------------------------------------------------------------------------
+//
+// A Pennant feature class reference resolves through the same PSR-4 mapping as
+// middleware; the string-key/`@feature` forms build `root.join("app/Features")`.
+// The hint must hold the same containment guarantee.
+
+#[test]
+fn feature_hint_is_unknown_when_all_candidates_out_of_root() {
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    let escapee = outside.path().join("app/Features/NewApi.php");
+
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&escapee), root.path()),
+        "unknown",
+        "an out-of-root feature class path must never be echoed into the \
+         \"Expected at:\" hint — it falls back to \"unknown\""
+    );
+}
+
+#[test]
+fn feature_hint_keeps_in_root_missing_candidate() {
+    let root = tempfile::TempDir::new().unwrap();
+    let in_root = root.path().join("app/Features/NewApi.php");
+
+    assert!(
+        in_root.canonicalize().is_err(),
+        "precondition: the in-root feature candidate does not exist on disk"
+    );
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&in_root), root.path()),
+        in_root.to_string_lossy(),
+        "a genuinely-absent in-root feature class path is a legitimate create \
+         target and must be surfaced unchanged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Environment variable "not found" — `root.join(".env")`
+// ---------------------------------------------------------------------------
+//
+// The `.env` path is `root.join`-rooted (the variable name never enters the
+// path), so the path-string itself can't escape — but the emit-safe guard still
+// closes a dangling `.env` under-root symlink a malicious repo could ship, and
+// routing it keeps the invariant uniform across every surface. The
+// out-of-root regression case below documents the helper's contract for this
+// surface alongside the others.
+
+#[test]
+fn env_hint_is_unknown_when_all_candidates_out_of_root() {
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    let escapee = outside.path().join(".env");
+
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&escapee), root.path()),
+        "unknown",
+        "an out-of-root .env path must never be echoed into the \"Expected at:\" \
+         hint — it falls back to \"unknown\""
+    );
+}
+
+#[test]
+fn env_hint_keeps_in_root_missing_candidate() {
+    let root = tempfile::TempDir::new().unwrap();
+    let in_root = root.path().join(".env");
+
+    assert!(
+        in_root.canonicalize().is_err(),
+        "precondition: the in-root .env candidate does not exist on disk"
+    );
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&in_root), root.path()),
+        in_root.to_string_lossy(),
+        "a genuinely-absent in-root .env path is a legitimate create target and \
+         must be surfaced unchanged"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn env_hint_skips_dangling_under_root_symlink() {
+    // The narrow escape this surface's guard actually closes: a repo ships
+    // `.env` as a dangling under-root symlink whose target was never created.
+    // Its path is lexically inside the root, but a client `CreateFile` following
+    // the link could write outside the project tree, so the hint must refuse it
+    // and fall back to "unknown" rather than leak the dangling link path.
+    let root = tempfile::TempDir::new().unwrap();
+    let missing_target = root.path().join("../never-created.env");
+    let dangling = root.path().join(".env");
+    std::os::unix::fs::symlink(&missing_target, &dangling).unwrap();
+
+    assert!(
+        dangling.canonicalize().is_err(),
+        "precondition: the candidate is a dangling symlink (can't canonicalize)"
+    );
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&dangling), root.path()),
+        "unknown",
+        "a dangling under-root .env symlink must not be echoed into the hint — \
+         it falls back to \"unknown\""
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod component_navigation_containment;
 mod diagnostic_severity;
 mod directive_navigation_containment;
 mod dynamic_where_sparseness;
+mod expected_path_diagnostic_containment;
 mod flux_component_context;
 mod flux_component_hover;
 mod flux_goto_def_handler;


### PR DESCRIPTION
## Summary

Implements #214. Extends the `path_within_root` **emit-safe** containment guard (`in_root_expected_path_hint`, added in PR #202) to the remaining `from_diagnostic → CreateFile` diagnostic surfaces that #201 deliberately left out of scope: **translation**, **config**, **middleware**, **feature**, and **environment-variable** "not found" diagnostics.

Each surface echoed an unfiltered `expected_path` into its `Expected at:` message, which `FileAction::from_diagnostic` parses back into a `CreateFile` target a client could follow. A user-registered out-of-root path or a dangling under-root symlink could be echoed into the message **and** turned into a create target outside the project tree — the exact escape #201 closed for the view/component surfaces. Routing every hint through `in_root_expected_path_hint` falls back to `"unknown"` for any candidate that isn't emit-safe, while still admitting a genuinely-absent in-root create target.

## Audit findings (per surface)

| Surface | `expected_path` source | Out-of-root vector | Routed |
|---|---|---|---|
| **Translation** | `vendor_map.get(namespace)` | user-registered vendor lang dir | ✅ |
| **Config** | `root.join("config")` | structurally in-root; routed for the uniform invariant + dangling symlink | ✅ |
| **Middleware** | `resolve_class_to_file` (PSR-4) + registry class file | `..`-injected / out-of-root PSR-4 class name | ✅ |
| **Feature** | `resolve_class_to_file` + `root.join("app/Features")` | as middleware + uniform invariant | ✅ |
| **Env** | `root.join(".env")` | path string not user-controlled, but routed to close a dangling `.env` symlink + uniform invariant | ✅ |

The `Copy from:` (`.env.example`) line is left as-is — it is a copy *source* (read), structurally in-root, not the `from_diagnostic → CreateFile` *target*; out of this issue's scope.

## Changes

- `create_translation_diagnostic` / `create_config_diagnostic`: take a `root: &Path` and build the `Expected at:` string via `in_root_expected_path_hint` (guards all 3 translation message sites + the config site at one point).
- Middleware (2 sites), feature (3 sites): guard each inline `resolve_class_to_file` / `root.join` hint.
- Env (2 message branches): compute one guarded `env_expected_hint` and use it in both branches.
- New test file `src/tests/expected_path_diagnostic_containment.rs` (+ `mod` registration) with per-surface regression + positive-control tests mirroring the #201 component test, plus a dangling-`.env`-symlink case.

## Acceptance Criteria

- [x] Audit middleware "not found" arm; route `expected_path` through `in_root_expected_path_hint` (PSR-4-resolved class name — confirmed user-controllable).
- [x] Audit feature "not found" arm; route `expected_path` through the guard (PSR-4 + `root.join`).
- [x] Audit environment-variable arm; route through the guard (path is `root.join`-rooted, routed to close the dangling-`.env`-symlink vector and keep the invariant uniform).
- [x] Route the translation "not found" `expected_path` (`vendor_map.get(namespace)`) through the guard.
- [x] Route the config "not found" `expected_path` through the guard with the same guarantee.
- [x] Add an all-candidates-out-of-root → `"unknown"` regression test for each surface.
- [x] Add a positive-control test for each surface (single in-root missing candidate returned as-is).
- [x] All pre-existing tests in `view_diagnostic_containment.rs`, `view_navigation_containment.rs`, `component_navigation_containment.rs`, and `code_action_create_containment.rs` pass without modification.

## Test Plan

- [x] `cargo test --bin laravel-lsp` — **416 tests pass** (11 new), incl. the four AC-mandated suites unmodified.
- [x] `cargo clippy --all-targets` — clean.
- [x] `cargo fmt --check` — clean.

Fixes #214