### PR TITLE
Add the fail-closed path_within_root guard to find_php_class_file_by_fqcn (FQCN → file resolution containment)

### DIFF
--- a/laravel-lsp/src/class_locator.rs
+++ b/laravel-lsp/src/class_locator.rs
@@ -19,6 +19,8 @@ use std::path::{Path, PathBuf};
 
 use walkdir::WalkDir;
 
+use crate::path_containment::path_within_root;
+
 /// Locate the PHP source file for a given class name.
 ///
 /// Searches the project's `app/` directory recursively for `<ClassName>.php`,
@@ -111,7 +113,11 @@ pub fn find_php_class_file_in_app_or_vendor(class_name: &str, root: &Path) -> Op
 /// `search_vendor`: `true` consults the vendor heuristic only;
 /// `false` the App heuristic only. Callers chain both.
 ///
-/// Returns `None` if no candidate path exists on disk.
+/// Returns `None` if no candidate path exists on disk. Each candidate is gated
+/// by the fail-closed [`path_within_root`] guard before the on-disk check, so an
+/// FQCN whose `..` segments — or an under-root symlink in the constructed path —
+/// would resolve outside the project root is refused rather than read (issue
+/// #218, containment lineage #130 → #143 → #148 → #194 → #199 → #201 → #214).
 fn find_php_class_file_by_fqcn(
     fqcn: &str,
     project_root: &Path,
@@ -135,6 +141,14 @@ fn find_php_class_file_by_fqcn(
                     path = path.join(seg);
                 }
                 path = path.join(format!("{class_name}.php"));
+                // An FQCN segment may carry `..` (or the joined path may cross
+                // an under-root symlink), so the candidate can resolve outside
+                // the project root. Refuse it with the fail-closed guard before
+                // the read — a path that canonicalizes outside root (or can't be
+                // proven in-root) is skipped.
+                if !path_within_root(&path, project_root) {
+                    continue;
+                }
                 if path.exists() {
                     return Some(path);
                 }
@@ -162,6 +176,12 @@ fn find_php_class_file_by_fqcn(
             path = path.join(seg);
         }
         path = path.join(format!("{class_name}.php"));
+        // Same containment guard as the app branch: an FQCN with `..` segments
+        // (or an under-root symlink in the path) can escape the project root, so
+        // gate the candidate with the fail-closed guard before the read.
+        if !path_within_root(&path, project_root) {
+            continue;
+        }
         if path.exists() {
             return Some(path);
         }

--- a/laravel-lsp/src/tests/fqcn_resolution_containment.rs
+++ b/laravel-lsp/src/tests/fqcn_resolution_containment.rs
@@ -1,0 +1,211 @@
+//! FQCN → file resolution containment for the heuristic class locator (issue
+//! #218), extending the `path_within_root` containment lineage
+//! (#130 → #143 → #148 → #194 → #199 → #201 → #214) to the last FS-touching
+//! resolver that lacked the guard.
+//!
+//! `find_php_class_file_by_fqcn` (in `class_locator.rs`) maps an FQCN to a
+//! candidate path by splitting on `\` and `PathBuf::join`-ing the segments —
+//! and `join` does not resolve `..` on a non-absolute segment, it appends it
+//! literally. So an FQCN carrying `..` segments (e.g. `App\Models\..\..\etc\X`)
+//! yields a path like `<root>/app/Models/../../etc/X.php` that, once stat'd by
+//! `path.exists()`, can read a file *outside* the project root — a read
+//! primitive that escapes the tree. The same is true for a candidate whose path
+//! crosses an under-root symlink resolving outside the root.
+//!
+//! The fix gates every candidate with the fail-closed
+//! [`laravel_lsp::path_containment::path_within_root`] guard before the on-disk
+//! check, in both the app (`!search_vendor`) and vendor (`search_vendor`)
+//! branches. These tests pin that invariant.
+//!
+//! ## Why the public entry points, not the private helper
+//!
+//! `find_php_class_file_by_fqcn` is a *private* heuristic fallback — it has no
+//! reason to be part of the crate's public API, and `class_locator`'s existing
+//! tests (`class_locator_and_properties.rs`) likewise drive the public
+//! `find_php_class_file`. So these tests exercise the guard through the two
+//! public callers that reach the two branches:
+//!   - [`laravel_lsp::class_locator::find_php_class_file`] → the app branch
+//!     (`search_vendor = false`).
+//!   - [`laravel_lsp::class_locator::find_php_class_file_in_app_or_vendor`] →
+//!     the vendor branch (`search_vendor = true`); for a vendor-shaped FQCN the
+//!     app branch returns `None` first (its first namespace segment is not
+//!     `app`), so the vendor branch's guard is what decides the outcome.
+//!
+//! Each case is *discriminating*: the escaping file is written to disk OUTSIDE
+//! the root, so without the guard the resolver would `path.exists()` it and
+//! return `Some(<out-of-root path>)`. A `None` result can therefore only come
+//! from the containment guard, never from absence — the precondition assertions
+//! make that explicit.
+
+use laravel_lsp::class_locator::{find_php_class_file, find_php_class_file_in_app_or_vendor};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// App branch (`search_vendor = false`) — `find_php_class_file`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn app_fqcn_with_dotdot_escaping_root_is_refused() {
+    // Layout: an empty project root with an `app/` dir, and a secret PHP file
+    // OUTSIDE the root. The FQCN `App\..\..\secret` builds the candidate
+    // `<root>/app/../../secret.php`, which `PathBuf::join` leaves literal and
+    // canonicalizes to `<tmp>/secret.php` — outside the project root.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    std::fs::create_dir_all(root.join("app")).unwrap();
+    let secret = tmp.path().join("secret.php");
+    std::fs::write(&secret, "<?php\nclass secret {}").unwrap();
+
+    // Precondition: the candidate the app branch builds exists on disk and
+    // resolves OUTSIDE the root — so a `None` result proves the guard fired, not
+    // mere absence. (Without the guard, `path.exists()` returns true here and
+    // the resolver returns `Some`.)
+    let candidate = root.join("app").join("..").join("..").join("secret.php");
+    assert_eq!(
+        candidate.canonicalize().unwrap(),
+        secret.canonicalize().unwrap(),
+        "precondition: the `..` candidate resolves to the out-of-root secret file"
+    );
+
+    assert_eq!(
+        find_php_class_file("App\\..\\..\\secret", &root),
+        None,
+        "an FQCN whose `..` segments escape the project root must be refused by \
+         the fail-closed path_within_root guard, not read"
+    );
+}
+
+#[test]
+fn app_fqcn_in_root_resolves_to_some_path() {
+    // Positive control: a normal in-root FQCN with the file present must still
+    // resolve — the guard must not drop legitimate in-root candidates.
+    let root = TempDir::new().unwrap();
+    let user = root.path().join("app").join("Models").join("User.php");
+    std::fs::create_dir_all(user.parent().unwrap()).unwrap();
+    std::fs::write(&user, "<?php\nnamespace App\\Models;\nclass User {}").unwrap();
+
+    let found = find_php_class_file("App\\Models\\User", root.path())
+        .expect("a normal in-root FQCN must resolve to its file");
+    assert!(
+        found.ends_with("app/Models/User.php"),
+        "App\\Models\\User must resolve to app/Models/User.php; got {found:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn app_fqcn_through_under_root_symlink_escaping_root_is_refused() {
+    // An under-root path component is a symlink whose target is OUTSIDE the
+    // root. The FQCN `App\Evil\Secret` builds `<root>/app/Evil/Secret.php`,
+    // where `<root>/app/Evil` -> `<tmp>/outside`, so the candidate canonicalizes
+    // to `<tmp>/outside/Secret.php` — outside the root, the #55/#134 symlink
+    // escape leg the lexical fallback would admit.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    std::fs::create_dir_all(root.join("app")).unwrap();
+
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let secret = outside.join("Secret.php");
+    std::fs::write(&secret, "<?php\nclass Secret {}").unwrap();
+
+    let evil_link = root.join("app").join("Evil");
+    std::os::unix::fs::symlink(&outside, &evil_link).unwrap();
+
+    // Precondition: the candidate exists through the symlink and resolves
+    // outside the root — so `None` can only be the guard refusing it.
+    let candidate = root.join("app").join("Evil").join("Secret.php");
+    assert_eq!(
+        candidate.canonicalize().unwrap(),
+        secret.canonicalize().unwrap(),
+        "precondition: the candidate resolves through the symlink to the \
+         out-of-root file"
+    );
+    assert!(
+        !candidate
+            .canonicalize()
+            .unwrap()
+            .starts_with(root.canonicalize().unwrap()),
+        "precondition: the resolved target escapes the project root"
+    );
+
+    assert_eq!(
+        find_php_class_file("App\\Evil\\Secret", &root),
+        None,
+        "an FQCN candidate whose path crosses an under-root symlink resolving \
+         outside the root must be refused — the canonicalize-based guard catches \
+         the escape the lexical fallback would admit"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Vendor branch (`search_vendor = true`) — `find_php_class_file_in_app_or_vendor`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn vendor_fqcn_with_dotdot_escaping_root_is_refused() {
+    // The vendor branch builds `<root>/vendor/<vendor>/<pkg>[/src]/<rest>/<X>.php`.
+    // A vendor-shaped FQCN with enough `..` segments climbs out of the vendor
+    // tree and the root entirely: `Vendor\Pkg\..\..\..\..\secret` yields, for the
+    // no-`src` candidate, `<root>/vendor/vendor/pkg/../../../../secret.php`
+    // = `<tmp>/secret.php` — outside the root. (The app branch returns None
+    // first: the FQCN's first segment is `vendor`, not `app`.)
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    // The vendor candidate's base must exist so the `..` path canonicalizes.
+    std::fs::create_dir_all(root.join("vendor").join("vendor").join("pkg")).unwrap();
+    let secret = tmp.path().join("secret.php");
+    std::fs::write(&secret, "<?php\nclass secret {}").unwrap();
+
+    // Precondition: the no-`src` vendor candidate exists on disk and resolves
+    // OUTSIDE the root — so `None` proves the vendor-branch guard fired.
+    let candidate = root
+        .join("vendor")
+        .join("vendor")
+        .join("pkg")
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("secret.php");
+    assert_eq!(
+        candidate.canonicalize().unwrap(),
+        secret.canonicalize().unwrap(),
+        "precondition: the vendor `..` candidate resolves to the out-of-root file"
+    );
+
+    assert_eq!(
+        find_php_class_file_in_app_or_vendor("Vendor\\Pkg\\..\\..\\..\\..\\secret", &root),
+        None,
+        "a vendor-shaped FQCN whose `..` segments escape the project root must be \
+         refused by the fail-closed guard in the vendor branch"
+    );
+}
+
+#[test]
+fn vendor_fqcn_in_root_resolves_to_some_path() {
+    // Positive control for the vendor branch: a normal in-root vendor PSR-4 path
+    // must still resolve. (`find_php_class_file_in_app_or_vendor` is the only
+    // entry point that searches vendor.)
+    let root = TempDir::new().unwrap();
+    let token = root
+        .path()
+        .join("vendor")
+        .join("laravel")
+        .join("passport")
+        .join("src")
+        .join("Token.php");
+    std::fs::create_dir_all(token.parent().unwrap()).unwrap();
+    std::fs::write(
+        &token,
+        "<?php\nnamespace Laravel\\Passport;\nclass Token {}",
+    )
+    .unwrap();
+
+    let found = find_php_class_file_in_app_or_vendor("Laravel\\Passport\\Token", root.path())
+        .expect("a normal in-root vendor FQCN must resolve to its file");
+    assert!(
+        found.ends_with("vendor/laravel/passport/src/Token.php"),
+        "Laravel\\Passport\\Token must resolve to its PSR-4 path; got {found:?}"
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -20,6 +20,7 @@ mod flux_goto_def_handler;
 mod flux_slot_name_context;
 mod folio_cursor_containment;
 mod folio_rename;
+mod fqcn_resolution_containment;
 mod generic_type_parsing;
 mod helper_identifier_hover;
 mod inertia_code_action;


### PR DESCRIPTION
## Summary
Implements #218 — extends the fail-closed `path_within_root` containment lineage (#130 → #143 → #148 → #194 → #199 → #201 → #214) to `find_php_class_file_by_fqcn`, the last FS-touching resolver that lacked the guard.

`find_php_class_file_by_fqcn` maps an FQCN to a candidate path by splitting on `\` and `PathBuf::join`-ing each segment. `join` does **not** resolve `..` on a non-absolute segment — it appends it literally — so an FQCN carrying `..` segments yields a path like `<root>/app/../../etc/secret.php` that the subsequent `path.exists()`/read then stats: a read primitive that can escape the project root. The same holds for a candidate whose path crosses an under-root symlink resolving outside root.

## Changes
- `class_locator.rs`: gate every candidate with the fail-closed `path_within_root(&path, project_root)` guard **before** the `path.exists()` check, in both the app (`!search_vendor`) and vendor (`search_vendor`) branches. A candidate that canonicalizes outside root — or can't be proven in-root — is skipped. Doc comment updated to record the guard.
- `tests/fqcn_resolution_containment.rs` (new): `..`-escape negatives for both branches, an under-root-symlink escape negative (`#[cfg(unix)]`), and in-root positive controls. Each negative is *discriminating* — the escaping file is written to disk outside root, so `None` can only come from the guard, not absence (asserted via preconditions).
- `tests/mod.rs`: register the new module.

### Implementation note for review
The new tests drive the **public** entry points (`find_php_class_file` → app branch; `find_php_class_file_in_app_or_vendor` → vendor branch) rather than calling the private `find_php_class_file_by_fqcn` directly. Reaching the helper from the test module (which compiles into the binary crate and imports via `laravel_lsp::`) would require widening it to `pub` across the crate boundary. Keeping it private matches `class_locator`'s existing test style (`class_locator_and_properties.rs` drives the public `find_php_class_file`) and avoids exposing an internal heuristic fallback. The guard lives in the helper either way; the public callers exercise the exact branch each test targets. Open to making it `pub` and testing it directly if you'd prefer the AC-literal form.

## Acceptance Criteria
- [x] In `find_php_class_file_by_fqcn`, after constructing each candidate `PathBuf` and before `path.exists()`, apply the fail-closed `path_within_root(&path, project_root)` guard — `continue` when it returns `false`
- [x] Guard applies in both the app (`!search_vendor`) and vendor (`search_vendor`) branches
- [x] New `*_containment.rs` test file (`tests/fqcn_resolution_containment.rs`):
  - [x] Negative: FQCN with `..` segments resolving outside root → `None` (app + vendor branches)
  - [x] Positive control: a normal in-root FQCN with the file present → `Some(path)` (app + vendor)
  - [x] `#[cfg(unix)]` negative: an under-root symlink whose target resolves outside root → `None`
- [x] New tests registered in `tests/mod.rs`
- [x] No regression in existing `class_locator` unit tests
- [x] The Composer-autoload branch (`ComposerAutoload::resolve`) is unchanged — out of scope for this guard

## Test Plan
- [x] `cargo test --lib` — 1894 passed (includes existing `class_locator` unit tests)
- [x] `cargo test --bin laravel-lsp` — 421 passed (includes the 5 new containment tests)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt` — clean
- [ ] Note: 8 pre-existing failures in `tests/integration_tests.rs` are **unrelated** — they depend on a gitignored, untracked `test-project/.env` fixture absent from any fresh clone, and reference `class_locator` zero times. They fail on a clean `main` checkout regardless of this change.

Fixes #218