### PR TITLE
fix: route Inertia "page not found" diagnostic through emit-safe containment guard

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -15908,6 +15908,16 @@ return [
     /// server. The "Expected at" path is built with the project's `dominant`
     /// extension so the downstream create-page code action lands a file of the
     /// right type.
+    ///
+    /// The "Expected at:" path is routed through [`in_root_expected_path_hint`]
+    /// (issue #220): this message is parsed back into a `CreateFile` target by
+    /// [`FileAction::from_diagnostic`], and the emit-safe guard refuses a dangling
+    /// under-root symlink at the page path (whose target a client could follow out
+    /// of the tree on create) — falling back to `"unknown"` — while still admitting
+    /// a genuinely-absent in-root page (the normal create target). This keeps the
+    /// containment invariant uniform across *every* `from_diagnostic → CreateFile`
+    /// surface, matching the view/component/translation/config/middleware/feature/env
+    /// surfaces (#201/#214).
     fn inertia_not_found_diagnostic(
         page_ref: &laravel_lsp::salsa_impl::InertiaReferenceData,
         resolved: bool,
@@ -15920,6 +15930,12 @@ return [
         // An invalid (traversing) page name yields no expected path; skip it
         // rather than emit an unactionable diagnostic.
         let expected_path = laravel_lsp::inertia::page_create_path(root, &page_ref.name, dominant)?;
+        // Route the create-page target through the emit-safe containment guard
+        // before echoing it in the "Expected at:" line, the same routing every
+        // other `from_diagnostic → CreateFile` surface uses (#220). A dangling
+        // under-root symlink at the page path falls back to "unknown" rather than
+        // leaking a path a client could follow out of the tree on CreateFile.
+        let expected_hint = in_root_expected_path_hint(std::slice::from_ref(&expected_path), root);
         Some(Diagnostic {
             range: Range {
                 start: Position {
@@ -15936,8 +15952,7 @@ return [
             source: Some("laravel".to_string()),
             message: format!(
                 "Inertia page not found: '{}'\nExpected at: {}",
-                page_ref.name,
-                expected_path.to_string_lossy()
+                page_ref.name, expected_hint
             ),
             related_information: None,
             tags: None,

--- a/laravel-lsp/src/tests/expected_path_diagnostic_containment.rs
+++ b/laravel-lsp/src/tests/expected_path_diagnostic_containment.rs
@@ -19,6 +19,7 @@
 //! | Middleware  | `resolve_class_to_file` (PSR-4 from class name)     | `..`-injected / out-of-root PSR-4 map |
 //! | Feature     | `resolve_class_to_file` + `root.join("app/Features")` | as middleware + uniform invariant |
 //! | Env         | `root.join(".env")` (structurally in-root)          | dangling `.env` symlink + uniform invariant |
+//! | Inertia page | `page_create_path` → `root.join("resources/js/Pages")` (structurally in-root) | dangling page symlink + uniform invariant (issue #220) |
 //!
 //! Each surface gets two cases, mirroring the #201 component test:
 //! a **regression** test (every candidate out-of-root → `"unknown"`, never a
@@ -257,5 +258,79 @@ fn env_hint_skips_dangling_under_root_symlink() {
         "unknown",
         "a dangling under-root .env symlink must not be echoed into the hint — \
          it falls back to \"unknown\""
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Inertia "page not found" — `page_create_path` → `resources/js/Pages/<page>.<ext>`
+// ---------------------------------------------------------------------------
+//
+// `inertia_not_found_diagnostic` builds `expected_path` via
+// `inertia::page_create_path`, which `root.join`s an `is_valid_page_name`-validated
+// name under `resources/js/Pages` — so `..`-injection and absolute-path escapes are
+// already blocked structurally. The one residual the emit-safe guard closes here is
+// a dangling under-root symlink at the page path (e.g. `resources/js/Pages/Foo.vue`),
+// whose target a client could follow out of the tree on `CreateFile`. Routing it
+// keeps the containment invariant uniform across every surface (issue #220). The
+// out-of-root regression case below documents the helper's contract for this surface
+// alongside the others.
+
+#[test]
+fn inertia_page_hint_is_unknown_when_all_candidates_out_of_root() {
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+
+    let escapee = outside.path().join("resources/js/Pages/Dashboard.vue");
+
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&escapee), root.path()),
+        "unknown",
+        "an out-of-root Inertia page path must never be echoed into the \"Expected \
+         at:\" hint — it falls back to \"unknown\""
+    );
+}
+
+#[test]
+fn inertia_page_hint_keeps_in_root_missing_candidate() {
+    let root = tempfile::TempDir::new().unwrap();
+    // The everyday case: an Inertia page that doesn't exist on disk yet.
+    let in_root = root.path().join("resources/js/Pages/Auth/Login.vue");
+
+    assert!(
+        in_root.canonicalize().is_err(),
+        "precondition: the in-root Inertia page candidate does not exist on disk"
+    );
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&in_root), root.path()),
+        in_root.to_string_lossy(),
+        "a genuinely-absent in-root Inertia page path is a legitimate create \
+         target and must be surfaced unchanged"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn inertia_page_hint_skips_dangling_under_root_symlink() {
+    // A hostile repo ships `resources/js/Pages/Foo.vue` as a dangling under-root
+    // symlink (`→ ../../../outside`) whose target was never created. The link path
+    // is lexically inside the root, but a client `CreateFile` following it could
+    // write outside the project tree, so the hint must refuse it and fall back to
+    // "unknown" rather than leak the symlink's link path.
+    let root = tempfile::TempDir::new().unwrap();
+    let pages_dir = root.path().join("resources/js/Pages");
+    std::fs::create_dir_all(&pages_dir).unwrap();
+    let missing_target = std::path::Path::new("../../../outside");
+    let dangling = pages_dir.join("Foo.vue");
+    std::os::unix::fs::symlink(missing_target, &dangling).unwrap();
+
+    assert!(
+        dangling.canonicalize().is_err(),
+        "precondition: the candidate is a dangling symlink (can't canonicalize)"
+    );
+    assert_eq!(
+        in_root_expected_path_hint(std::slice::from_ref(&dangling), root.path()),
+        "unknown",
+        "a dangling under-root Inertia page symlink must not be echoed into the \
+         hint — it falls back to \"unknown\""
     );
 }


### PR DESCRIPTION
## Summary
Implements #220 — routes the Inertia "page not found" `Expected at:` diagnostic surface through the emit-safe containment guard, the last `from_diagnostic → CreateFile` sibling in the #130 → #143 → #148 → #194 → #201 → #214 lineage that still echoed an unguarded path.

`inertia_not_found_diagnostic` built `expected_path` via `inertia::page_create_path` and interpolated it directly with `.to_string_lossy()`. `page_create_path` already blocks `..`-injection and absolute escapes via `is_valid_page_name`, so the only residual was a **dangling under-root symlink** at the page path (e.g. `resources/js/Pages/Foo.vue`): it fails `canonicalize()`, the downstream `path_within_root_lexical` backstop admits it via `canonical_containment(...).unwrap_or(true)`, and a client following the link on `CreateFile` could write outside the project tree. `path_within_root_emit_safe` (reached through `in_root_expected_path_hint`) refuses exactly this case.

## Changes
- `main.rs` — route the `page_create_path` target through `in_root_expected_path_hint(std::slice::from_ref(&expected_path), root)` before interpolating it into the `"Expected at: …"` message, matching every other `from_diagnostic → CreateFile` surface. An unverifiable candidate now yields `"Expected at: unknown"` instead of leaking the raw path. Doc comment updated to record the routing.
- `expected_path_diagnostic_containment.rs` — added an Inertia-page section with a regression test (out-of-root → `"unknown"`), a positive-control test (in-root-missing `resources/js/Pages/Auth/Login.vue` returned unchanged), and a `#[cfg(unix)]` dangling-symlink test (`resources/js/Pages/Foo.vue → ../../../outside` → `"unknown"`). Module doc table extended with the Inertia row.

## Acceptance Criteria
- [x] `expected_path` is passed through `in_root_expected_path_hint(&[expected_path], root)` before interpolation — matching the other surfaces.
- [x] When the hint returns `"unknown"`, the message reads `"Expected at: unknown"` rather than echoing the raw absolute path.
- [x] Inertia-page **regression** test: out-of-root candidate → `"unknown"`.
- [x] Inertia-page **positive-control** test: in-root-missing page returned unchanged.
- [x] `#[cfg(unix)]` dangling-symlink test: lexically-in-root dangling symlink → `"unknown"`.
- [x] Existing tests in `expected_path_diagnostic_containment.rs`, `inertia_code_action.rs`, and `path_containment.rs` still pass without modification.

## Test Plan
- [x] `cargo test expected_path_diagnostic_containment` — 14 passed (incl. 3 new Inertia cases).
- [x] `cargo test path_containment` — 7 passed; `cargo test inertia_code_action` — passes.
- [x] Full unit suite green: 1894 + 424 passed, 0 failed.
- [x] `cargo fmt` clean; `cargo clippy --tests` clean.
- [ ] Note: 8 `integration_tests` failures are **pre-existing and environmental** — they require gitignored `.env` fixtures / full `test-project` setup absent in a fresh shallow clone, and fail identically on the pristine base commit (verified via `git stash`). Unrelated to this diff.

Fixes #220