### PR TITLE
fix(composer_autoload): add fail-closed path_within_root guard to resolve_namespace_dirs (#226)

### DIFF
--- a/laravel-lsp/src/component_completion.rs
+++ b/laravel-lsp/src/component_completion.rs
@@ -108,6 +108,20 @@ fn scan_dir(
 
     let want_blade = kind == CandidateKind::AnonymousView;
 
+    // Containment scope (issue #226): the `dir` reached via the PSR-4
+    // namespace→directory path (`ComposerAutoload::resolve_namespace_dirs` →
+    // `scan_class_dir`) is now containment-gated by the fail-closed
+    // `path_within_root` guard at its source, so the *root* of this walk can no
+    // longer be an out-of-root directory. What is NOT yet gated here is each
+    // *discovered* path under `follow_links(true)`: a symlink encountered
+    // *inside* an in-root `dir` whose target escapes the project root would be
+    // followed and its files emitted as candidates. That symlink-escape leg is
+    // deferred scope — `scan_dir` is shared by callers (e.g.
+    // `collect_flux_components`) whose `dir`s are constructed in-root by
+    // different means, so gating discovered paths uniformly belongs in a
+    // dedicated follow-up rather than this resolver-scoped change. Low practical
+    // risk under the LSP threat model: the scanned tree is the developer's own
+    // project, and the probe is a read.
     for entry in WalkDir::new(dir)
         .follow_links(true)
         .into_iter()

--- a/laravel-lsp/src/composer_autoload.rs
+++ b/laravel-lsp/src/composer_autoload.rs
@@ -36,15 +36,18 @@ use crate::path_containment::path_within_root;
 pub struct ComposerAutoload {
     /// (psr4_prefix_no_trailing_backslash, absolute_source_roots)
     prefixes: Vec<(String, Vec<PathBuf>)>,
-    /// The project root this autoload data was loaded for. Every candidate
-    /// `resolve` builds is gated against this with the fail-closed
-    /// [`path_within_root`] guard, so a `..`-bearing FQCN — or a PSR-4 mapping
-    /// / under-root symlink pointing outside the tree — can't yield a path that
-    /// escapes the root and is then `stat`'d and returned (issue #222,
-    /// containment lineage #130 → #143 → #148 → #194 → #199 → #201 → #214 →
-    /// #218). Stored at construction rather than threaded per-call so resolution
-    /// is bound to exactly the root the PSR-4 mappings were resolved against —
-    /// a caller can't hand `resolve` a mismatched root.
+    /// The project root this autoload data was loaded for. Every candidate that
+    /// [`resolve`](Self::resolve) (FQCN → file) and
+    /// [`resolve_namespace_dirs`](Self::resolve_namespace_dirs)
+    /// (namespace → directory) build is gated against this with the fail-closed
+    /// [`path_within_root`] guard, so a `..`-bearing FQCN / namespace — or a
+    /// PSR-4 mapping / under-root symlink pointing outside the tree — can't
+    /// yield a path that escapes the root and is then `stat`'d / walked and
+    /// returned (issues #222 for the FQCN branch and #226 for the directory
+    /// branch; containment lineage #130 → #143 → #148 → #194 → #199 → #201 →
+    /// #214 → #218 → #222). Stored at construction rather than threaded per-call
+    /// so resolution is bound to exactly the root the PSR-4 mappings were
+    /// resolved against — a caller can't hand a resolver a mismatched root.
     project_root: PathBuf,
 }
 
@@ -120,6 +123,18 @@ impl ComposerAutoload {
     /// the registered PHP namespace is turned into a directory whose class
     /// files become `<x-prefix::name>` candidates. Only directories that exist
     /// on disk are returned; a namespace with no matching prefix yields empty.
+    ///
+    /// Every candidate directory is gated by the fail-closed [`path_within_root`]
+    /// guard before the on-disk check (issue #226), the directory-resolution
+    /// sibling of the FQCN→file guard `resolve` carries (#222): a `..`-bearing
+    /// namespace, a PSR-4 mapping value pointing outside the tree, or an
+    /// under-root symlink along the path would otherwise yield a directory that
+    /// escapes [`Self::project_root`] and is then `stat`'d (`is_dir`) and walked
+    /// downstream (`scan_class_dir` → `scan_dir`'s `follow_links(true)`). A
+    /// candidate that canonicalizes outside the root — or can't be proven in-root
+    /// — is refused (skip to the next `source_root`), making the lineage's
+    /// invariant that the guard holds *uniformly* across every FS-touching
+    /// resolution path in `ComposerAutoload` actually true.
     pub fn resolve_namespace_dirs(&self, namespace: &str) -> Vec<PathBuf> {
         let normalized = namespace.trim_start_matches('\\').trim_end_matches('\\');
         let mut dirs = Vec::new();
@@ -144,6 +159,21 @@ impl ComposerAutoload {
             if let Some(rel) = rel {
                 for source_root in source_roots {
                     let dir = source_root.join(&rel);
+                    // The namespace remainder may carry `..` segments, which
+                    // `PathBuf::push`/`join` appends literally — or the mapped
+                    // `source_root` itself (an absolute / `..` PSR-4 value) or an
+                    // under-root symlink along the way may point outside the tree.
+                    // Either way the directory can escape the project root and be
+                    // `stat`'d (`is_dir`) here, then walked downstream by
+                    // `scan_class_dir` → `scan_dir`'s `follow_links(true)` traversal,
+                    // as an out-of-root read primitive. Gate it with the fail-closed
+                    // `path_within_root` guard before the on-disk check: a directory
+                    // that canonicalizes outside the root (or can't be proven
+                    // in-root) is skipped to the next `source_root` (issue #226),
+                    // mirroring the `resolve` / #222 pattern above.
+                    if !path_within_root(&dir, &self.project_root) {
+                        continue;
+                    }
                     if dir.is_dir() {
                         dirs.push(dir);
                     }

--- a/laravel-lsp/src/tests/composer_autoload_containment.rs
+++ b/laravel-lsp/src/tests/composer_autoload_containment.rs
@@ -1,7 +1,16 @@
-//! PSR-4 FQCN → file resolution containment for the Composer autoload resolver
-//! (issue #222), extending the `path_within_root` containment lineage
-//! (#130 → #143 → #148 → #194 → #199 → #201 → #214 → #218) to the
-//! higher-priority FS-touching resolver that still lacked the guard.
+//! PSR-4 resolution containment for the Composer autoload resolver, extending
+//! the `path_within_root` containment lineage
+//! (#130 → #143 → #148 → #194 → #199 → #201 → #214 → #218 → #222) across *both*
+//! FS-touching branches of `ComposerAutoload`:
+//!
+//! - `resolve` (FQCN → file, issue #222) — the higher-priority branch that ran
+//!   before the heuristic `find_php_class_file_by_fqcn` yet lacked the guard.
+//! - `resolve_namespace_dirs` (namespace → directory, issue #226) — the
+//!   directory-resolution sibling, with the same `source_root.join(rel)`
+//!   construction and the same out-of-root read-primitive shape (its dirs are
+//!   `stat`'d via `is_dir` and walked downstream by `scan_class_dir` →
+//!   `scan_dir`'s `follow_links(true)`). The `resolve_namespace_dirs_*` cases
+//!   below pin its guard.
 //!
 //! `ComposerAutoload::resolve` (in `composer_autoload.rs`) maps a PSR-4 FQCN to
 //! a candidate file by splitting the post-prefix remainder on `\` and
@@ -164,5 +173,204 @@ fn psr4_fqcn_through_under_root_symlink_escaping_root_is_refused() {
         "a PSR-4 FQCN candidate whose path crosses an under-root symlink resolving \
          outside the root must be refused — the canonicalize-based guard catches \
          the escape the lexical fallback would admit"
+    );
+}
+
+// ===========================================================================
+// resolve_namespace_dirs (namespace → directory) — issue #226
+//
+// The directory-resolution sibling of `resolve`. `resolve_namespace_dirs` joins
+// the post-prefix namespace remainder onto each mapped `source_root` and returns
+// every directory that passes `dir.is_dir()`. The same three escape vectors
+// apply — a `..`-bearing namespace, an out-of-root PSR-4 mapping value, and an
+// under-root symlink — and each is now gated by the fail-closed
+// `path_within_root` guard before the `is_dir` probe. Every negative case writes
+// the escaping directory to disk OUTSIDE the root, so without the guard
+// `is_dir()` would be true and the dir returned; an empty `Vec` can therefore
+// only come from the guard, never from absence — the precondition assertions
+// make that explicit.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Negative: `..` segments in the namespace escape the root
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resolve_namespace_dirs_with_dotdot_escaping_root_is_refused() {
+    // composer.json maps `App\` → `app/`. The namespace `App\..\..\outside`
+    // builds the candidate dir `<root>/app/../../outside`, which `PathBuf::push`
+    // leaves literal and canonicalizes to `<tmp>/outside` — outside the project
+    // root.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    // `app/` must exist so the `..` candidate canonicalizes (canonicalize
+    // resolves each component, so `app/..` requires `app` to be a real dir).
+    std::fs::create_dir_all(root.join("app")).unwrap();
+    write_file(
+        &root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#,
+    );
+
+    // The escaping directory exists on disk OUTSIDE the root.
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+
+    // Precondition: the candidate dir `resolve_namespace_dirs` builds exists as a
+    // directory and resolves OUTSIDE the root — so an empty result proves the
+    // guard fired, not mere absence. (Without the guard, `dir.is_dir()` is true
+    // and the dir is returned.)
+    let candidate = root.join("app").join("..").join("..").join("outside");
+    assert!(
+        candidate.is_dir(),
+        "precondition: the `..` candidate directory exists on disk"
+    );
+    assert_eq!(
+        candidate.canonicalize().unwrap(),
+        outside.canonicalize().unwrap(),
+        "precondition: the `..` candidate resolves to the out-of-root directory"
+    );
+    assert!(
+        !candidate
+            .canonicalize()
+            .unwrap()
+            .starts_with(root.canonicalize().unwrap()),
+        "precondition: the resolved directory escapes the project root"
+    );
+
+    let autoload = ComposerAutoload::load(&root);
+    assert_eq!(
+        autoload.resolve_namespace_dirs("App\\..\\..\\outside"),
+        Vec::<std::path::PathBuf>::new(),
+        "a namespace whose `..` segments escape the project root must be refused \
+         by the fail-closed path_within_root guard, not returned and walked"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative (unix): an under-root symlink in the namespace path escapes
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn resolve_namespace_dirs_through_under_root_symlink_escaping_root_is_refused() {
+    // An under-root path component is a symlink whose target is OUTSIDE the
+    // root. composer.json maps `App\` → `app/`; the namespace `App\Evil` builds
+    // `<root>/app/Evil`, where `<root>/app/Evil` -> `<tmp>/outside`, so the dir
+    // canonicalizes to `<tmp>/outside` — the symlink escape leg a lexical
+    // fallback would admit but the canonicalize-based fail-closed guard catches.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    std::fs::create_dir_all(root.join("app")).unwrap();
+    write_file(
+        &root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#,
+    );
+
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+
+    let evil_link = root.join("app").join("Evil");
+    std::os::unix::fs::symlink(&outside, &evil_link).unwrap();
+
+    // Precondition: the candidate dir exists through the symlink and resolves
+    // outside the root — so an empty result can only be the guard refusing it.
+    let candidate = root.join("app").join("Evil");
+    assert!(
+        candidate.is_dir(),
+        "precondition: the symlinked candidate resolves to a directory"
+    );
+    assert!(
+        !candidate
+            .canonicalize()
+            .unwrap()
+            .starts_with(root.canonicalize().unwrap()),
+        "precondition: the resolved directory escapes the project root"
+    );
+
+    let autoload = ComposerAutoload::load(&root);
+    assert_eq!(
+        autoload.resolve_namespace_dirs("App\\Evil"),
+        Vec::<std::path::PathBuf>::new(),
+        "a namespace dir whose path crosses an under-root symlink resolving \
+         outside the root must be refused — the canonicalize-based guard catches \
+         the escape the lexical fallback would admit"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative: an out-of-root PSR-4 mapping value escapes the root
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resolve_namespace_dirs_with_out_of_root_mapping_value_is_refused() {
+    // The PSR-4 mapping value itself points outside the tree:
+    // `"psr-4": { "Evil\\": "../outside/" }` makes `source_root` =
+    // `<root>/../outside`, so the namespace `Evil` (== prefix, empty remainder)
+    // resolves the dir straight to `<tmp>/outside` — already handled at runtime
+    // by the guard, but pinned separately here since neither resolver tested the
+    // mapping-value vector before.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    std::fs::create_dir_all(&root).unwrap();
+    write_file(
+        &root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "Evil\\": "../outside/" } } }"#,
+    );
+
+    // The mapped directory exists on disk OUTSIDE the root.
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+
+    // Precondition: the candidate dir (the bare mapped source_root) exists and
+    // resolves OUTSIDE the root — so an empty result proves the guard fired.
+    let candidate = root.join("..").join("outside");
+    assert!(
+        candidate.is_dir(),
+        "precondition: the out-of-root mapped directory exists on disk"
+    );
+    assert_eq!(
+        candidate.canonicalize().unwrap(),
+        outside.canonicalize().unwrap(),
+        "precondition: the mapped source_root resolves to the out-of-root directory"
+    );
+
+    let autoload = ComposerAutoload::load(&root);
+    assert_eq!(
+        autoload.resolve_namespace_dirs("Evil"),
+        Vec::<std::path::PathBuf>::new(),
+        "a namespace whose PSR-4 mapping value points outside the root must be \
+         refused by the fail-closed path_within_root guard"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive control: a normal in-root namespace still resolves to its directory
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resolve_namespace_dirs_in_root_resolves_to_directory() {
+    // The guard must not drop legitimate in-root candidates: a normal `App\`
+    // PSR-4 mapping with the directory present must still resolve.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write_file(
+        &root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#,
+    );
+    let components = root.join("app").join("View").join("Components");
+    std::fs::create_dir_all(&components).unwrap();
+
+    let autoload = ComposerAutoload::load(&root);
+    let dirs = autoload.resolve_namespace_dirs("App\\View\\Components");
+    assert_eq!(
+        dirs.len(),
+        1,
+        "a well-formed in-root namespace with a real directory must resolve to \
+         exactly that directory; got {dirs:?}"
+    );
+    assert!(
+        dirs[0].ends_with("app/View/Components"),
+        "App\\View\\Components must resolve to app/View/Components; got {:?}",
+        dirs[0]
     );
 }


### PR DESCRIPTION
## Summary

Implements #226. Adds the fail-closed `path_within_root` containment guard to `ComposerAutoload::resolve_namespace_dirs` — the PSR-4 **namespace → directory** branch — closing the out-of-root read-primitive surface that the FQCN → file branch (`resolve`) already guards (#222). This makes the containment lineage's invariant — that the guard holds *uniformly* across every FS-touching resolution path in `ComposerAutoload` — actually true.

Without the guard, a `..`-bearing namespace, an out-of-root PSR-4 mapping value, or an under-root symlink could resolve a directory that escapes the project root, which is then `stat`'d (`is_dir`) here and walked downstream by `scan_class_dir` → `scan_dir`'s `follow_links(true)` traversal.

## Changes

- **`composer_autoload.rs`** — gate every candidate in the `for source_root` loop of `resolve_namespace_dirs` with `path_within_root(&dir, &self.project_root)` before the `is_dir()` check; a candidate that fails is skipped to the next `source_root`. Reuses the existing struct-stored `self.project_root` — **no signature change, no new parameters, no call-site churn** (same approach #222/PR #225 used for `resolve`). Doc comments on the struct field and the method updated to cover both resolvers.
- **`component_completion.rs`** — code comment in `scan_dir` documenting the `follow_links(true)` **discovered-path** symlink-escape leg as deferred scope: the walk's *root* is now containment-gated upstream, but individually gating discovered paths belongs in its own follow-up since `scan_dir` is shared by callers (e.g. `collect_flux_components`) whose dirs are constructed in-root by other means.
- **`tests/composer_autoload_containment.rs`** — four `resolve_namespace_dirs`-targeted tests appended (the module now documents both resolvers).

## Acceptance Criteria

- [x] `path_within_root(&dir, &self.project_root)` guard added inside the `for source_root` loop, after `dir = source_root.join(&rel)` and before `dir.is_dir()` — a failing dir is skipped, not returned
- [x] Guard uses the existing `self.project_root` field — no signature change, no new parameters, no call-site churn
- [x] Address the `follow_links(true)` leg in `scan_dir` — documented as deferred scope with a code comment stating the rationale
- [x] Test (negative): a `..`-bearing namespace whose resolved dir exists OUTSIDE the root → empty `Vec`, with a precondition assertion that the dir exists (so an empty result can only be the guard)
- [x] Test (negative, `#[cfg(unix)]`): a namespace path traversing an under-root symlink whose target is outside the root → empty `Vec`, with precondition assertion
- [x] Test (negative): an out-of-root PSR-4 mapping value (`"psr-4": {"Evil\\": "../outside/"}`) where the mapped dir exists outside the root → empty `Vec`
- [x] Test (positive control): a well-formed in-root namespace with a real directory → returns that directory
- [x] New tests appended to `composer_autoload_containment.rs` and named to reflect the `resolve_namespace_dirs` surface

## Test Plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] All lib + bin unit tests pass (1894 + 433), including the 4 new containment tests and the 2 existing inline `resolve_namespace_dirs` tests
- [x] Integration tests pass once the gitignored `.env` fixture is bootstrapped (the same `cp test-project/.env.example test-project/.env` + `composer update` step CI runs); failures in a bare clone are pre-existing fixture-absence, not from this change

Fixes #226