### PR TITLE
Gate discovered paths in follow_links(true) directory walks against the project root

### DIFF
--- a/laravel-lsp/src/component_completion.rs
+++ b/laravel-lsp/src/component_completion.rs
@@ -16,6 +16,8 @@ use std::path::Path;
 
 use walkdir::WalkDir;
 
+use crate::path_containment::path_within_root_walk_entry;
+
 /// What backs a completion candidate — drives the LSP item kind and the
 /// dedup precedence when two sources produce the same tag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -75,30 +77,42 @@ pub fn relative_path_to_tag_body(relative: &Path) -> Option<String> {
 /// Walk `dir` for anonymous `.blade.php` components, emitting candidates named
 /// `{tag_prefix}{body}` (`tag_prefix` is `""` for the root component path or
 /// `"ns::"` for a namespaced one). `display_root` is the project root used to
-/// shorten the detail path.
+/// shorten the detail path; `root` is the project root the discovered entries
+/// are containment-gated against (issue #228) — the two coincide today but stay
+/// distinct so containment never rides on the display concern.
 pub fn scan_anonymous_dir(
     dir: &Path,
     tag_prefix: &str,
     display_root: &Path,
+    root: &Path,
 ) -> Vec<ComponentCandidate> {
-    scan_dir(dir, tag_prefix, display_root, CandidateKind::AnonymousView)
+    scan_dir(
+        dir,
+        tag_prefix,
+        display_root,
+        root,
+        CandidateKind::AnonymousView,
+    )
 }
 
 /// Walk `dir` for `.php` class-backed components (skipping `.blade.php` view
 /// files), emitting `{tag_prefix}{body}` candidates with PascalCase filenames
-/// kebab-cased.
+/// kebab-cased. `display_root` shortens the detail path; `root` is the project
+/// root the discovered entries are containment-gated against (issue #228).
 pub fn scan_class_dir(
     dir: &Path,
     tag_prefix: &str,
     display_root: &Path,
+    root: &Path,
 ) -> Vec<ComponentCandidate> {
-    scan_dir(dir, tag_prefix, display_root, CandidateKind::Class)
+    scan_dir(dir, tag_prefix, display_root, root, CandidateKind::Class)
 }
 
 fn scan_dir(
     dir: &Path,
     tag_prefix: &str,
     display_root: &Path,
+    root: &Path,
     kind: CandidateKind,
 ) -> Vec<ComponentCandidate> {
     let mut out = Vec::new();
@@ -108,20 +122,17 @@ fn scan_dir(
 
     let want_blade = kind == CandidateKind::AnonymousView;
 
-    // Containment scope (issue #226): the `dir` reached via the PSR-4
-    // namespace→directory path (`ComposerAutoload::resolve_namespace_dirs` →
-    // `scan_class_dir`) is now containment-gated by the fail-closed
-    // `path_within_root` guard at its source, so the *root* of this walk can no
-    // longer be an out-of-root directory. What is NOT yet gated here is each
-    // *discovered* path under `follow_links(true)`: a symlink encountered
-    // *inside* an in-root `dir` whose target escapes the project root would be
-    // followed and its files emitted as candidates. That symlink-escape leg is
-    // deferred scope — `scan_dir` is shared by callers (e.g.
-    // `collect_flux_components`) whose `dir`s are constructed in-root by
-    // different means, so gating discovered paths uniformly belongs in a
-    // dedicated follow-up rather than this resolver-scoped change. Low practical
-    // risk under the LSP threat model: the scanned tree is the developer's own
-    // project, and the probe is a read.
+    // Containment scope: the `dir` reached via the PSR-4 namespace→directory path
+    // (`ComposerAutoload::resolve_namespace_dirs` → `scan_class_dir`) is gated by
+    // the fail-closed `path_within_root` guard at its source (issue #226), so the
+    // *root* of this walk can no longer be an out-of-root directory. The
+    // *discovered* paths under `follow_links(true)` are gated below (issue #228):
+    // a symlink encountered *inside* an in-root `dir` whose target escapes the
+    // project root is still followed by `follow_links(true)`, so each emitted
+    // entry is checked against `root` before becoming a candidate. This closes the
+    // discovered-path leg #226 deferred and holds for every caller — including
+    // ones (e.g. `collect_flux_components`) whose `dir`s are constructed in-root
+    // by other means.
     for entry in WalkDir::new(dir)
         .follow_links(true)
         .into_iter()
@@ -141,6 +152,17 @@ fn scan_dir(
         }
         // Class scan: require a plain `.php` extension.
         if !is_blade && path.extension().and_then(|e| e.to_str()) != Some("php") {
+            continue;
+        }
+
+        // Containment gate (issue #228): drop any discovered entry whose real,
+        // symlink-resolved path escapes the project root — `follow_links(true)`
+        // would otherwise emit files reached through an under-root symlink whose
+        // target lives outside the tree. Runs after the cheap type/extension
+        // filters so only entries that would actually be emitted pay the
+        // `canonicalize` cost. Fail-closed and canonicalize-based, so an in-root
+        // symlink (target inside the root) still yields its candidates.
+        if !path_within_root_walk_entry(path, root) {
             continue;
         }
 
@@ -178,7 +200,7 @@ pub fn collect_flux_components(root: &Path) -> Vec<ComponentCandidate> {
     ];
     let mut out = Vec::new();
     for dir in &dirs {
-        out.extend(scan_anonymous_dir(dir, "", root));
+        out.extend(scan_anonymous_dir(dir, "", root, root));
     }
     dedup_and_sort(out)
 }

--- a/laravel-lsp/src/component_completion/tests.rs
+++ b/laravel-lsp/src/component_completion/tests.rs
@@ -57,7 +57,7 @@ fn scan_anonymous_dir_emits_namespaced_blade_components() {
     ]);
     let scan_dir = root.join("views/test/components");
 
-    let mut got = scan_anonymous_dir(&scan_dir, "test::", &root);
+    let mut got = scan_anonymous_dir(&scan_dir, "test::", &root, &root);
     got.sort_by(|a, b| a.name.cmp(&b.name));
 
     assert_eq!(names(&got), vec!["test::backstage", "test::forms.input"]);
@@ -67,14 +67,14 @@ fn scan_anonymous_dir_emits_namespaced_blade_components() {
 #[test]
 fn scan_anonymous_dir_with_empty_prefix_for_root_components() {
     let (_dir, root) = dir_with_files(&[("components/button.blade.php", "x")]);
-    let got = scan_anonymous_dir(&root.join("components"), "", &root);
+    let got = scan_anonymous_dir(&root.join("components"), "", &root, &root);
     assert_eq!(names(&got), vec!["button"]);
 }
 
 #[test]
 fn scan_missing_dir_is_empty() {
     let (_dir, root) = dir_with_files(&[]);
-    assert!(scan_anonymous_dir(&root.join("nope"), "", &root).is_empty());
+    assert!(scan_anonymous_dir(&root.join("nope"), "", &root, &root).is_empty());
 }
 
 // ─── class scan ─────────────────────────────────────────────────────────
@@ -89,7 +89,7 @@ fn scan_class_dir_emits_kebab_class_components_and_skips_blade() {
     ]);
     let scan_dir = root.join("app/View/Components");
 
-    let mut got = scan_class_dir(&scan_dir, "", &root);
+    let mut got = scan_class_dir(&scan_dir, "", &root, &root);
     got.sort_by(|a, b| a.name.cmp(&b.name));
 
     assert_eq!(names(&got), vec!["alert", "forms.input-text"]);

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -29,6 +29,7 @@ use laravel_lsp::middleware_parser::{middleware_base_alias, resolve_class_to_fil
 use laravel_lsp::migration_index::{build_migration_index, MigrationIndex};
 use laravel_lsp::path_containment::{
     path_within_root, path_within_root_emit_safe, path_within_root_lexical,
+    path_within_root_walk_entry,
 };
 use laravel_lsp::query_chain::cursor::char_col_to_byte_offset;
 use laravel_lsp::route_discovery::{
@@ -10995,6 +10996,15 @@ impl LaravelLanguageServer {
                     .unwrap_or(false)
             })
         {
+            // Containment gate (issue #228): the walk root is in-root, but
+            // `follow_links(true)` would follow a symlink *inside* it whose target
+            // escapes the project root and `read_to_string` its contents below —
+            // an out-of-root read primitive. Gate each discovered entry against the
+            // root before reading it; an in-root symlink (target inside the root)
+            // still passes.
+            if !path_within_root_walk_entry(entry.path(), root) {
+                continue;
+            }
             if let Ok(content) = std::fs::read_to_string(entry.path()) {
                 if let Some(type_name) =
                     Self::extract_view_variable_type(&content, view_name, var_name)
@@ -12396,7 +12406,15 @@ impl LaravelLanguageServer {
                 continue;
             }
 
-            // Walk the directory recursively
+            // Containment audit (issue #228): no walk-entry gate is needed here.
+            // A discovered path becomes only the `path` *display* string of a
+            // `ViewNameCompletion` — it is never read, opened, or resolved to an FS
+            // primitive at this site. Selecting a completion inserts its `name`;
+            // navigation later resolves that name through the independently
+            // containment-gated view resolver (`locate_view_file`,
+            // `path_within_root`). So even a `follow_links(true)` symlink escape
+            // could at most surface an out-of-root *display* string, never an
+            // out-of-root read.
             for entry in walkdir::WalkDir::new(&view_path)
                 .follow_links(true)
                 .into_iter()
@@ -12444,6 +12462,12 @@ impl LaravelLanguageServer {
                     continue;
                 }
 
+                // Containment audit (issue #228): no walk-entry gate is needed
+                // here, same as the `view_path` walk above — a discovered path
+                // becomes only the `path` *display* string of a
+                // `ViewNameCompletion`, never a read or an FS primitive at this
+                // site; navigation resolves by `name` through the gated view
+                // resolver.
                 for entry in walkdir::WalkDir::new(package_path)
                     .follow_links(true)
                     .into_iter()
@@ -12544,19 +12568,29 @@ impl LaravelLanguageServer {
         // 1. Root anonymous components — `resources/views/components/*.blade.php`
         //    (also where class-paired views live). No namespace prefix.
         for (_namespace, component_path) in &component_paths {
-            candidates.extend(scan_anonymous_dir(component_path, "", &root));
+            candidates.extend(scan_anonymous_dir(component_path, "", &root, &root));
         }
 
         // 2. Package view namespaces (loadViewsFrom) — `{path}/components/`.
         for (namespace, package_path) in &view_namespaces {
             let dir = package_path.join("components");
-            candidates.extend(scan_anonymous_dir(&dir, &format!("{namespace}::"), &root));
+            candidates.extend(scan_anonymous_dir(
+                &dir,
+                &format!("{namespace}::"),
+                &root,
+                &root,
+            ));
         }
 
         // 3. Anonymous component paths (Blade::anonymousComponentPath) — the
         //    registered directory IS the components dir.
         for (namespace, dir) in &anon_paths {
-            candidates.extend(scan_anonymous_dir(dir, &format!("{namespace}::"), &root));
+            candidates.extend(scan_anonymous_dir(
+                dir,
+                &format!("{namespace}::"),
+                &root,
+                &root,
+            ));
         }
 
         // 4. Anonymous component namespaces (Blade::anonymousComponentNamespace)
@@ -12564,7 +12598,12 @@ impl LaravelLanguageServer {
         for (namespace, rel_dir) in &anon_namespaces {
             for view_path in &view_paths {
                 let dir = root.join(view_path).join(rel_dir);
-                candidates.extend(scan_anonymous_dir(&dir, &format!("{namespace}::"), &root));
+                candidates.extend(scan_anonymous_dir(
+                    &dir,
+                    &format!("{namespace}::"),
+                    &root,
+                    &root,
+                ));
             }
         }
 
@@ -12574,7 +12613,12 @@ impl LaravelLanguageServer {
             let autoload = laravel_lsp::composer_autoload::ComposerAutoload::for_project(&root);
             for (namespace, php_namespace) in &class_namespaces {
                 for dir in autoload.resolve_namespace_dirs(php_namespace) {
-                    candidates.extend(scan_class_dir(&dir, &format!("{namespace}::"), &root));
+                    candidates.extend(scan_class_dir(
+                        &dir,
+                        &format!("{namespace}::"),
+                        &root,
+                        &root,
+                    ));
                 }
             }
         }
@@ -12582,7 +12626,12 @@ impl LaravelLanguageServer {
         // 6. Non-namespaced class components — `app/View/Components/*.php`.
         //    These have no blade file of their own when render() is inline, so
         //    they're invisible to the view scans above.
-        candidates.extend(scan_class_dir(&root.join("app/View/Components"), "", &root));
+        candidates.extend(scan_class_dir(
+            &root.join("app/View/Components"),
+            "",
+            &root,
+            &root,
+        ));
 
         dedup_and_sort(candidates)
     }
@@ -12623,7 +12672,13 @@ impl LaravelLanguageServer {
 
         let mut completions = Vec::new();
 
-        // Walk the Livewire directory recursively
+        // Containment audit (issue #228): no walk-entry gate is needed here. A
+        // discovered path becomes only the `path` *display* string of a
+        // `LivewireComponentCompletion` — never read, opened, or resolved to an FS
+        // primitive at this site. Selecting a completion inserts its `name`;
+        // navigation resolves that name through the independently
+        // containment-gated Livewire resolver. So a `follow_links(true)` escape
+        // could at most surface an out-of-root display string, never a read.
         for entry in walkdir::WalkDir::new(&livewire_path)
             .follow_links(true)
             .into_iter()
@@ -12686,6 +12741,13 @@ impl LaravelLanguageServer {
 
         let mut completions = Vec::new();
 
+        // Containment audit (issue #228): no walk-entry gate is needed here. Each
+        // discovered path is reduced to a `base_dir`-*relative* string
+        // (`FilePathCompletion.path`) used purely as completion label/detail text
+        // for asset/vite/path helpers — it is never read, opened, or resolved to
+        // an FS primitive at this site, and the absolute discovered path is
+        // discarded. A `follow_links(true)` symlink escape would at most surface a
+        // relative path string, never an out-of-root read.
         for entry in walkdir::WalkDir::new(base_dir)
             .follow_links(true)
             .into_iter()

--- a/laravel-lsp/src/path_containment.rs
+++ b/laravel-lsp/src/path_containment.rs
@@ -41,6 +41,17 @@
 //!   write outside the tree (issues #134/#155), so it is refused while a path
 //!   with nothing at all on disk is admitted. Used by `main.rs`'s
 //!   `in_root_expected_path_hint`.
+//! - [`path_within_root_walk_entry`] is the fail-closed guard for a path
+//!   **discovered during a `follow_links(true)` directory walk** (issue #228).
+//!   A `WalkDir` rooted at a containment-trusted in-root directory still follows
+//!   a symlink encountered *inside* it whose target escapes the root, surfacing
+//!   out-of-root files as entries; gating each discovered entry drops those
+//!   before they become a read primitive or an emitted candidate. It mirrors
+//!   [`path_within_root`] exactly — a discovered entry the walk just yielded
+//!   normally exists and canonicalizes, an under-root symlink resolving inside
+//!   the root passes, and anything that escapes (or can't be canonicalized) is
+//!   refused. Used by `scan_dir` in `component_completion.rs` and the
+//!   `controllers_dir` walk in `main.rs`.
 
 use std::path::Path;
 
@@ -70,6 +81,30 @@ fn canonical_containment(path: &Path, root: &Path) -> Option<bool> {
 /// not admitted.
 pub fn path_within_root(path: &Path, root: &Path) -> bool {
     canonical_containment(path, root).unwrap_or(false)
+}
+
+/// True if a `path` **discovered during a `follow_links(true)` directory walk**
+/// resolves inside `root`. The containment gate for entries a `WalkDir` yields
+/// while following symlinks: the walk root may itself be in-root and
+/// containment-trusted, yet `follow_links(true)` still descends a symlink
+/// encountered *inside* it whose target escapes the project root and surfaces the
+/// files under that target as entries. Gating each discovered entry against the
+/// root drops those escaping paths before they become a read primitive or an
+/// emitted candidate — the discovered-path leg the resolver guard in #226
+/// deferred (issue #228).
+///
+/// **Fail-closed**, delegating to [`path_within_root`]: the entry's real,
+/// symlink-resolved path is compared against the real root, and an entry that
+/// can't be canonicalized is refused, not admitted. A discovered entry the walk
+/// just yielded normally exists on disk and canonicalizes; the fail-closed arm
+/// only bites a path that vanishes mid-walk, which is correctly refused. An
+/// under-root symlink whose target stays *inside* the root passes, so legitimate
+/// in-root symlinked content is still discovered — the gate does not over-refuse.
+///
+/// Takes the entry's `&Path` (from `walkdir::DirEntry::path`) rather than the
+/// `DirEntry`, so `path_containment` carries no `walkdir` coupling.
+pub fn path_within_root_walk_entry(path: &Path, root: &Path) -> bool {
+    path_within_root(path, root)
 }
 
 /// True if `path` is contained within `root`, gated by a **lexical** check that
@@ -667,5 +702,110 @@ mod tests {
             "a dangling under-root symlink behind a no-search-permission parent \
              (lstat EACCES, not NotFound) must be refused — the guard fails closed"
         );
+    }
+
+    // ─── walk-entry gate (issue #228) ───────────────────────────────────────
+
+    #[test]
+    fn walk_entry_admits_in_root_file() {
+        // The everyday case: a real file the walk yields from inside the root
+        // canonicalizes under the root and must be admitted (the gate does not
+        // over-refuse ordinary discovered entries).
+        let root = TempDir::new().unwrap();
+        let file = root.path().join("app").join("View").join("Alert.php");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, "<?php\n").unwrap();
+
+        assert!(path_within_root_walk_entry(&file, root.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_entry_refuses_path_through_under_root_symlink_escaping_root() {
+        // The #228 escape: a symlink *inside* an in-root walk root points OUTSIDE
+        // the root, so `follow_links(true)` would descend it and surface
+        // `<root>/components/escape/secret.php` as an entry — whose real path is
+        // `<tmp>/outside/secret.php`. The walk-entry gate must refuse it.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("project");
+        std::fs::create_dir_all(root.join("components")).unwrap();
+
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let secret = outside.join("secret.php");
+        std::fs::write(&secret, "<?php\n").unwrap();
+
+        let escape_link = root.join("components").join("escape");
+        std::os::unix::fs::symlink(&outside, &escape_link).unwrap();
+
+        // Precondition: the entry exists through the symlink and resolves OUTSIDE
+        // the root, so `false` can only be the gate refusing it, not absence.
+        let entry = root.join("components").join("escape").join("secret.php");
+        assert_eq!(
+            entry.canonicalize().unwrap(),
+            secret.canonicalize().unwrap(),
+            "precondition: the discovered entry resolves through the symlink to the \
+             out-of-root file"
+        );
+        assert!(
+            !entry
+                .canonicalize()
+                .unwrap()
+                .starts_with(root.canonicalize().unwrap()),
+            "precondition: the resolved entry escapes the project root"
+        );
+
+        assert!(
+            !path_within_root_walk_entry(&entry, &root),
+            "a discovered entry whose path crosses an under-root symlink resolving \
+             outside the root must be refused by the fail-closed walk-entry gate"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn walk_entry_admits_path_through_in_root_symlink() {
+        // The positive control for the symlink case: a symlink inside the walk
+        // root whose target stays *inside* the root must still admit the entries
+        // reached through it — the gate refuses escapes, not all symlinks.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("project");
+        let real = root.join("real-components");
+        std::fs::create_dir_all(&real).unwrap();
+        let file = real.join("button.php");
+        std::fs::write(&file, "<?php\n").unwrap();
+
+        let link = root.join("linked-components");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        // The entry reached through the in-root symlink.
+        let entry = link.join("button.php");
+        assert!(
+            entry
+                .canonicalize()
+                .unwrap()
+                .starts_with(root.canonicalize().unwrap()),
+            "precondition: the entry resolves through an in-root symlink, staying \
+             inside the root"
+        );
+        assert!(
+            path_within_root_walk_entry(&entry, &root),
+            "an entry reached through an in-root symlink (target inside the root) \
+             must be admitted — the gate does not over-refuse"
+        );
+    }
+
+    #[test]
+    fn walk_entry_refuses_sibling_root_entry() {
+        // A real entry under a *sibling* root must not be reported as contained.
+        let parent = TempDir::new().unwrap();
+        let root = parent.path().join("project");
+        let sibling = parent.path().join("other");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&sibling).unwrap();
+        let escapee = sibling.join("secret.php");
+        std::fs::write(&escapee, "<?php\n").unwrap();
+
+        assert!(!path_within_root_walk_entry(&escapee, &root));
     }
 }

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -35,6 +35,7 @@ mod rename_integration;
 mod route_binding_resolution;
 mod route_diagnostics;
 mod routes_dir_gate;
+mod scan_dir_containment;
 mod slot_navigation_containment;
 mod slot_variable_resolution;
 mod translation_namespace_check;

--- a/laravel-lsp/src/tests/scan_dir_containment.rs
+++ b/laravel-lsp/src/tests/scan_dir_containment.rs
@@ -1,0 +1,218 @@
+//! Discovered-path containment for the component-completion directory walk,
+//! extending the `path_within_root` containment lineage
+//! (#130 → #143 → #148 → #194 → #199 → #201 → #214 → #218 → #222 → #226) to its
+//! discovered-path leg (issue #228).
+//!
+//! PR #227 (issue #226) gated the *walk root* of `scan_dir`
+//! (`ComposerAutoload::resolve_namespace_dirs` → `scan_class_dir`) with the
+//! fail-closed `path_within_root` guard, so the directory a walk starts from can
+//! no longer be out-of-root. It explicitly deferred the *discovered-path* leg:
+//! `scan_dir` walks with `WalkDir::new(dir).follow_links(true)`, so a symlink
+//! encountered *inside* an in-root `dir` whose target escapes the project root
+//! was still followed and its files emitted as `<x-...>` completion candidates.
+//!
+//! `scan_dir` (via the public `scan_anonymous_dir` / `scan_class_dir`) now runs
+//! every discovered entry through `path_within_root_walk_entry` — the same
+//! canonicalize-based, fail-closed semantics — before emitting it, dropping any
+//! entry whose real, symlink-resolved path escapes the root.
+//!
+//! Each negative case is *discriminating*: the escaping file is written to disk
+//! OUTSIDE the root and reached through an under-root symlink, so without the
+//! gate `follow_links(true)` would surface it and emit its candidate. Its absence
+//! from the result can therefore only come from the containment gate, never from
+//! the file not existing — the precondition assertions make that explicit. The
+//! positive controls prove the gate does not over-refuse: an in-root symlink
+//! (target inside the root) and an ordinary subdirectory still yield candidates.
+
+use laravel_lsp::component_completion::{scan_anonymous_dir, scan_class_dir, ComponentCandidate};
+use tempfile::TempDir;
+
+fn names(candidates: &[ComponentCandidate]) -> Vec<String> {
+    candidates.iter().map(|c| c.name.clone()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Negative (unix): a class-dir entry reached through an under-root symlink
+// whose target escapes the root is NOT emitted
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn scan_class_dir_drops_entry_through_under_root_symlink_escaping_root() {
+    // The walk root `<root>/app/View/Components` is in-root, but it contains a
+    // symlink `Escape` -> `<tmp>/outside`. `follow_links(true)` descends it and
+    // would surface `<root>/app/View/Components/Escape/Secret.php`, whose real
+    // path is `<tmp>/outside/Secret.php` — outside the project root. The gate
+    // must drop it. A legitimate in-root `Alert.php` is included so the walk is
+    // proven to run and emit: only the escaping candidate must be missing.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    let components = root.join("app").join("View").join("Components");
+    std::fs::create_dir_all(&components).unwrap();
+    std::fs::write(components.join("Alert.php"), "<?php class Alert {}").unwrap();
+
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let secret = outside.join("Secret.php");
+    std::fs::write(&secret, "<?php class Secret {}").unwrap();
+
+    let escape_link = components.join("Escape");
+    std::os::unix::fs::symlink(&outside, &escape_link).unwrap();
+
+    // Precondition: the escaping entry exists through the symlink and resolves
+    // OUTSIDE the root, so its absence can only be the gate refusing it.
+    let escaping_entry = components.join("Escape").join("Secret.php");
+    assert_eq!(
+        escaping_entry.canonicalize().unwrap(),
+        secret.canonicalize().unwrap(),
+        "precondition: the discovered entry resolves through the symlink to the \
+         out-of-root file"
+    );
+    assert!(
+        !escaping_entry
+            .canonicalize()
+            .unwrap()
+            .starts_with(root.canonicalize().unwrap()),
+        "precondition: the resolved entry escapes the project root"
+    );
+
+    let got = names(&scan_class_dir(&components, "", &root, &root));
+
+    assert!(
+        got.contains(&"alert".to_string()),
+        "the in-root class must still be discovered — the walk ran; got {got:?}"
+    );
+    assert!(
+        !got.contains(&"escape.secret".to_string()),
+        "a class-dir entry reached through an under-root symlink resolving outside \
+         the root must NOT be emitted as a candidate; got {got:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative (unix): an anonymous (blade) entry reached through an under-root
+// symlink whose target escapes the root is NOT emitted
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn scan_anonymous_dir_drops_entry_through_under_root_symlink_escaping_root() {
+    // Same escape, exercised through the anonymous-blade branch of `scan_dir`.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    let views = root.join("resources").join("views").join("components");
+    std::fs::create_dir_all(&views).unwrap();
+    std::fs::write(views.join("alert.blade.php"), "x").unwrap();
+
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let secret = outside.join("secret.blade.php");
+    std::fs::write(&secret, "x").unwrap();
+
+    let escape_link = views.join("escape");
+    std::os::unix::fs::symlink(&outside, &escape_link).unwrap();
+
+    // Precondition: the escaping entry exists through the symlink and resolves
+    // OUTSIDE the root.
+    let escaping_entry = views.join("escape").join("secret.blade.php");
+    assert_eq!(
+        escaping_entry.canonicalize().unwrap(),
+        secret.canonicalize().unwrap(),
+        "precondition: the discovered entry resolves through the symlink to the \
+         out-of-root file"
+    );
+    assert!(
+        !escaping_entry
+            .canonicalize()
+            .unwrap()
+            .starts_with(root.canonicalize().unwrap()),
+        "precondition: the resolved entry escapes the project root"
+    );
+
+    let got = names(&scan_anonymous_dir(&views, "", &root, &root));
+
+    assert!(
+        got.contains(&"alert".to_string()),
+        "the in-root blade component must still be discovered; got {got:?}"
+    );
+    assert!(
+        !got.contains(&"escape.secret".to_string()),
+        "an anonymous entry reached through an under-root symlink resolving outside \
+         the root must NOT be emitted as a candidate; got {got:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive control (unix): an entry reached through an IN-root symlink (target
+// inside the root) is still emitted — the gate does not over-refuse
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn scan_class_dir_still_emits_entry_through_in_root_symlink() {
+    // A symlink `<root>/app/View/Components/Linked` -> `<root>/real-components`
+    // (inside the root). `follow_links(true)` surfaces
+    // `.../Linked/Button.php`, which canonicalizes to
+    // `<root>/real-components/Button.php` — inside the root — so it must still be
+    // emitted. This pins that the canonicalize-based gate refuses *escapes*, not
+    // every symlink.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    let components = root.join("app").join("View").join("Components");
+    std::fs::create_dir_all(&components).unwrap();
+
+    let real = root.join("real-components");
+    std::fs::create_dir_all(&real).unwrap();
+    std::fs::write(real.join("Button.php"), "<?php class Button {}").unwrap();
+
+    let link = components.join("Linked");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    // Precondition: the entry resolves through the symlink to a path INSIDE the
+    // root, so its presence proves the gate admitted an in-root symlink.
+    let entry = components.join("Linked").join("Button.php");
+    assert!(
+        entry
+            .canonicalize()
+            .unwrap()
+            .starts_with(root.canonicalize().unwrap()),
+        "precondition: the entry resolves through the in-root symlink, staying \
+         inside the root"
+    );
+
+    let got = names(&scan_class_dir(&components, "", &root, &root));
+    assert!(
+        got.contains(&"linked.button".to_string()),
+        "an entry reached through an in-root symlink (target inside the root) must \
+         still be emitted — the gate must not over-refuse; got {got:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive control: ordinary in-root subdirectory entries are still emitted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scan_class_dir_still_emits_ordinary_in_root_subdir() {
+    // No symlinks at all: a plain nested subdirectory must still yield its
+    // candidate after the gate is wired in (the common case must not regress).
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let components = root.join("app").join("View").join("Components");
+    std::fs::create_dir_all(components.join("Forms")).unwrap();
+    std::fs::write(components.join("Alert.php"), "<?php class Alert {}").unwrap();
+    std::fs::write(
+        components.join("Forms").join("InputText.php"),
+        "<?php class InputText {}",
+    )
+    .unwrap();
+
+    let mut got = names(&scan_class_dir(&components, "", &root, &root));
+    got.sort();
+    assert_eq!(
+        got,
+        vec!["alert".to_string(), "forms.input-text".to_string()],
+        "ordinary in-root class entries (including a nested subdir) must still be \
+         emitted after the containment gate is applied"
+    );
+}


### PR DESCRIPTION
## Summary
Implements #228 — closes the **discovered-path leg** of the `path_within_root` containment lineage (#130 → … → #226). PR #227 gated the *walk root* of `scan_dir` but deferred gating the paths *discovered* under `WalkDir::follow_links(true)`: a symlink encountered **inside** an in-root directory whose target escapes the project root was still followed and its files emitted as candidates / read.

## Changes
- **New gate** `path_within_root_walk_entry(path, root)` in `path_containment.rs` — fail-closed, delegates to `path_within_root` (canonicalize-both semantics); takes `&Path` so the module keeps no `walkdir` coupling. Documented as a fourth named entry point alongside the existing three.
- **`scan_dir`** (`component_completion.rs`) gains a distinct `root: &Path` containment param (separate from `display_root`) and filters every discovered entry through the gate after the cheap type/extension filters, before emitting it. Callers updated: `scan_anonymous_dir`, `scan_class_dir`, `collect_flux_components`, the six `get_all_blade_components` call sites in `main.rs`, and the existing unit tests.
- **Deferred-scope comment removed** and replaced with the now-applied gate rationale.
- **`main.rs` `follow_links(true)` audit (per-site):**
  - `controllers_dir` — **gated**: it `read_to_string`s each discovered path (an out-of-root read primitive).
  - `view_path`, `package_path`, `livewire_path`, `base_dir` — **documented, gate not needed**: discovered paths become display/relative completion strings only, never read/opened or resolved to an FS primitive at the site (navigation resolves by *name* through independently containment-gated resolvers).

## Acceptance Criteria
- [x] Shared walk-entry gate added to `path_containment.rs` (`path_within_root_walk_entry`), fail-closed, mirroring `path_within_root`.
- [x] `scan_dir` accepts the project root and filters each discovered entry through the gate; all callers updated to supply the root.
- [x] The deferred-scope comment in `component_completion.rs` is removed once the gate is applied.
- [x] Each `follow_links(true)` walk site in `main.rs` audited per-site — gated where discovered paths are read primitives (`controllers_dir`), documented where they don't reach an FS primitive (the four completion walks).
- [x] `#[cfg(unix)]` negative-case test: an under-root symlink whose target exists outside the root → escaping file NOT emitted, with a precondition assertion the target resolves outside the root.
- [x] Positive-control test: an in-root symlink and an ordinary subdirectory still yield candidates (no over-refusal).
- [x] New tests live under `laravel-lsp/src/tests/scan_dir_containment.rs` per the lineage convention; gate logic also unit-tested directly in `path_containment.rs`.

## Test Plan
- [x] `cargo test` — lib (1898) and binary/`src/tests` (437) suites green, incl. 4 new `scan_dir_containment` integration tests + 4 new `walk_entry` gate unit tests.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean (matches CI).
- [x] The 8 `tests/integration_tests.rs` failures seen locally are environmental only (gitignored `test-project/.env` and `vendor/`); CI bootstraps both (`cp .env.example`, `composer update`) before testing.

Fixes #228