### PR TITLE
feat: ✨ Container-aware reference resolution for app('key')/resolve('key') receivers

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3068,6 +3068,9 @@ async fn build_magic_member_entries(
     if class_files.is_empty() {
         return Default::default();
     }
+    // Container-binding snapshot, paired with `class_files` in a `SnapshotResolver`
+    // so `app('key')->member` accesses resolve to the bound model during the build.
+    let bindings = salsa.snapshot_bindings().await.unwrap_or_default();
     let root = root.to_path_buf();
 
     // ── Pass 1: build the view-variable index ────────────────────────────
@@ -3153,6 +3156,7 @@ async fn build_magic_member_entries(
     for (path, data) in targets {
         let permit_owner = magic_sem.clone();
         let class_files = class_files.clone();
+        let bindings = bindings.clone();
         let root = root.clone();
         magic_handles.push(tokio::spawn(async move {
             let _permit = permit_owner.acquire_owned().await.ok()?;
@@ -3160,10 +3164,14 @@ async fn build_magic_member_entries(
                 let source = std::fs::read_to_string(&path).ok()?;
                 let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
                 let mut deps = HashSet::new();
+                let resolver = laravel_lsp::member_resolver::SnapshotResolver {
+                    class_files,
+                    bindings,
+                };
                 let mut entries = laravel_lsp::member_resolver::resolve_member_access_entries(
                     &source,
                     &data.member_access_refs,
-                    &*class_files,
+                    &resolver,
                     &mut classviews,
                     &root,
                     Some(&mut deps),
@@ -6140,10 +6148,18 @@ impl LaravelLanguageServer {
                 None => Vec::new(),
             }
         } else {
+            // Plain PHP: pair the class-file snapshot with the binding registry
+            // so `app('key')->member` resolves to the bound model. Safe to await
+            // here — unlike the Blade branch above, no read guard is held.
+            let bindings = self.salsa.snapshot_bindings().await.unwrap_or_default();
+            let resolver = laravel_lsp::member_resolver::SnapshotResolver {
+                class_files: class_files.clone(),
+                bindings,
+            };
             laravel_lsp::member_resolver::resolve_member_access_entries(
                 content,
                 &patterns.member_access_refs,
-                &*class_files,
+                &resolver,
                 &mut classviews,
                 &root,
                 Some(&mut deps),

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3236,6 +3236,7 @@ async fn build_magic_member_entries(
         for (path, data) in blade_targets {
             let permit_owner = blade_sem.clone();
             let class_files = class_files.clone();
+            let bindings = bindings.clone();
             let view_var_index = view_var_index.clone();
             let view_paths = view_paths.clone();
             let root = root.clone();
@@ -3243,6 +3244,12 @@ async fn build_magic_member_entries(
                 let _permit = permit_owner.acquire_owned().await.ok()?;
                 tokio::task::spawn_blocking(move || {
                     let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
+                    // Container-aware resolver so `app('key')->member` accesses in
+                    // Blade/Volt resolve to the bound model during indexing.
+                    let resolver = laravel_lsp::member_resolver::SnapshotResolver {
+                        class_files,
+                        bindings,
+                    };
                     // A Volt component (own front-matter, or an MFC template
                     // referencing `$this->`) needs the file source — for property
                     // typing AND for keying `$this->member` component references.
@@ -3266,7 +3273,7 @@ async fn build_magic_member_entries(
                         source.as_deref().map(|src| {
                             laravel_lsp::view_var_index::volt_property_types(
                                 src,
-                                &*class_files,
+                                &resolver,
                                 &mut classviews,
                                 &root,
                             )
@@ -3274,7 +3281,7 @@ async fn build_magic_member_entries(
                     } else if uses_this {
                         laravel_lsp::view_var_index::mfc_volt_property_types(
                             &path,
-                            &*class_files,
+                            &resolver,
                             &mut classviews,
                             &root,
                         )
@@ -3288,7 +3295,7 @@ async fn build_magic_member_entries(
                             &data.member_access_refs,
                             &prop_types,
                             &data.blade_loops,
-                            &*class_files,
+                            &resolver,
                             &mut classviews,
                             &root,
                             Some(&mut deps),
@@ -3301,7 +3308,7 @@ async fn build_magic_member_entries(
                             &view_name,
                             &view_var_index,
                             &data.blade_loops,
-                            &*class_files,
+                            &resolver,
                             &mut classviews,
                             &root,
                             Some(&mut deps),
@@ -6104,10 +6111,19 @@ impl LaravelLanguageServer {
 
         let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
         let mut deps: HashSet<String> = HashSet::new();
+        // Container-aware resolver shared by all three resolution paths so
+        // `app('key')->member` resolves to the bound model. Fetched here — after
+        // the early returns and before any view-var read guard — so the await is
+        // safe.
+        let bindings = self.salsa.snapshot_bindings().await.unwrap_or_default();
+        let resolver = laravel_lsp::member_resolver::SnapshotResolver {
+            class_files: class_files.clone(),
+            bindings,
+        };
         let mut entries = if is_volt {
             let prop_types = laravel_lsp::view_var_index::volt_property_types(
                 content,
-                &*class_files,
+                &resolver,
                 &mut classviews,
                 &root,
             );
@@ -6115,7 +6131,7 @@ impl LaravelLanguageServer {
                 &patterns.member_access_refs,
                 &prop_types,
                 &patterns.blade_loops,
-                &*class_files,
+                &resolver,
                 &mut classviews,
                 &root,
                 Some(&mut deps),
@@ -6138,7 +6154,7 @@ impl LaravelLanguageServer {
                         &view_name,
                         &vv,
                         &patterns.blade_loops,
-                        &*class_files,
+                        &resolver,
                         &mut classviews,
                         &root,
                         Some(&mut deps),
@@ -6148,14 +6164,6 @@ impl LaravelLanguageServer {
                 None => Vec::new(),
             }
         } else {
-            // Plain PHP: pair the class-file snapshot with the binding registry
-            // so `app('key')->member` resolves to the bound model. Safe to await
-            // here — unlike the Blade branch above, no read guard is held.
-            let bindings = self.salsa.snapshot_bindings().await.unwrap_or_default();
-            let resolver = laravel_lsp::member_resolver::SnapshotResolver {
-                class_files: class_files.clone(),
-                bindings,
-            };
             laravel_lsp::member_resolver::resolve_member_access_entries(
                 content,
                 &patterns.member_access_refs,

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -64,6 +64,26 @@ impl ClassFileResolver for HashMap<String, PathBuf> {
     }
 }
 
+/// A [`ClassFileResolver`] backed by owned snapshots — the resolver the
+/// out-of-actor magic-member build passes use. The `fqcn → file` snapshot
+/// answers `class_file`; the `binding key → concrete FQCN` snapshot answers
+/// `binding_concrete`, so `app('key')->member` resolves during indexing exactly
+/// as it does for the live, in-actor query path. Both maps are `Arc`-shared, so
+/// the per-file build tasks clone the resolver cheaply.
+pub struct SnapshotResolver {
+    pub class_files: Arc<HashMap<String, PathBuf>>,
+    pub bindings: Arc<HashMap<String, String>>,
+}
+
+impl ClassFileResolver for SnapshotResolver {
+    fn class_file(&self, fqcn: &str) -> Option<PathBuf> {
+        self.class_files.get(fqcn).cloned()
+    }
+    fn binding_concrete(&self, key: &str) -> Option<String> {
+        self.bindings.get(key).cloned()
+    }
+}
+
 // `AccessForm` moved to `salsa_impl` (it now travels inside
 // `MemberAccessReferenceData` through the pattern cache); re-exported here so
 // the engine's callers keep their `member_resolver::AccessForm` paths.

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -37,6 +37,19 @@ use tree_sitter::Node;
 /// works the same on either.
 pub trait ClassFileResolver {
     fn class_file(&self, fqcn: &str) -> Option<PathBuf>;
+
+    /// Resolve a container-binding key — the string in `app('key')` /
+    /// `resolve('key')` — to the concrete class FQCN it was bound to, if any.
+    ///
+    /// Defaulted to `None` so implementors that don't model container bindings
+    /// (the bare class index, the `HashMap<String, PathBuf>` test stub) need no
+    /// changes; the binding-aware resolvers on the salsa and main sides override
+    /// it with the parsed binding registry. This is the seam that lets the
+    /// receiver resolver type `app('key')->member` without threading a second
+    /// resolver argument through the whole call graph.
+    fn binding_concrete(&self, _key: &str) -> Option<String> {
+        None
+    }
 }
 
 impl ClassFileResolver for ClassHierarchyIndex {
@@ -645,6 +658,14 @@ fn resolve_receiver(
         return Some(resolved);
     }
 
+    // Container-resolution receivers (`app('key')`, `resolve('key')`) resolve
+    // the binding key to its registered concrete class. Checked before the
+    // generic match because these are `function_call_expression`s the arms
+    // below don't model, and the binding lookup rides in on `resolver`.
+    if let Some(resolved) = resolve_container_receiver(receiver, bytes, resolver) {
+        return Some(resolved);
+    }
+
     match receiver.kind() {
         "variable_name" => {
             let raw = receiver.utf8_text(bytes).ok()?;
@@ -702,6 +723,73 @@ fn resolve_receiver(
         }
         _ => None,
     }
+}
+
+/// Resolve a container-resolution receiver — `app('key')` / `resolve('key')` —
+/// to the concrete class its binding key was registered with.
+///
+/// The binding registry (reached through [`ClassFileResolver::binding_concrete`])
+/// maps the key to the concrete class the developer bound
+/// (`$this->app->singleton('currentTenant', Tenant::class)`), so a hit resolves
+/// at HIGH confidence — the registration is explicit, not inferred. A key with
+/// no registered binding, or one bound to a closure, returns a concrete the
+/// class index won't know, so it drops to `None` downstream rather than guessing.
+///
+/// Only the string-keyed helper forms are handled here; the `::class` argument
+/// form, `app()->make(…)`, and `App::make(…)` are separate receiver shapes.
+fn resolve_container_receiver(
+    receiver: Node,
+    bytes: &[u8],
+    resolver: &impl ClassFileResolver,
+) -> Option<(String, Confidence)> {
+    if receiver.kind() != "function_call_expression" {
+        return None;
+    }
+    let func = receiver
+        .child_by_field_name("function")?
+        .utf8_text(bytes)
+        .ok()?
+        .trim_start_matches('\\');
+    if !matches!(func, "app" | "resolve") {
+        return None;
+    }
+    let key = single_string_argument(receiver, bytes)?;
+    let concrete = resolver.binding_concrete(&key)?;
+    Some((concrete, Confidence::High))
+}
+
+/// The sole string-literal argument of a call — `'currentTenant'` in
+/// `app('currentTenant')`. Returns `None` when the call has zero or more than
+/// one argument, or the lone argument isn't a plain string literal (a variable,
+/// a `::class` const, a concatenation — none of which name a binding key here).
+fn single_string_argument(call: Node, bytes: &[u8]) -> Option<String> {
+    let args = call.child_by_field_name("arguments")?;
+    let mut cursor = args.walk();
+    let mut named = args.named_children(&mut cursor);
+    let first = named.next()?;
+    if named.next().is_some() {
+        return None;
+    }
+    // tree-sitter-php wraps each actual argument in an `argument` node.
+    let expr = if first.kind() == "argument" {
+        first.named_child(0)?
+    } else {
+        first
+    };
+    string_literal_value(expr, bytes)
+}
+
+/// The content of a single/double-quoted string literal node, or `None`.
+fn string_literal_value(node: Node, bytes: &[u8]) -> Option<String> {
+    if !matches!(node.kind(), "string" | "encapsed_string") {
+        return None;
+    }
+    Some(
+        node.utf8_text(bytes)
+            .ok()?
+            .trim_matches(['\'', '"'])
+            .to_string(),
+    )
 }
 
 /// Resolve a `$user`-style receiver that is the first parameter of a Gate

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -482,6 +482,57 @@ fn class_const_argument_is_not_a_string_key() {
     assert!(resolve_with(&resolver, &p.root, caller, "logo").is_none());
 }
 
+// ─── SnapshotResolver: the build-pass resolver over owned snapshots ────────
+
+#[test]
+fn snapshot_resolver_answers_class_file_and_binding() {
+    let class_files = Arc::new(HashMap::from([(
+        "App\\Models\\Tenant".to_string(),
+        PathBuf::from("/x/Tenant.php"),
+    )]));
+    let bindings = Arc::new(HashMap::from([(
+        "currentTenant".to_string(),
+        "App\\Models\\Tenant".to_string(),
+    )]));
+    let r = SnapshotResolver {
+        class_files,
+        bindings,
+    };
+    assert_eq!(
+        r.class_file("App\\Models\\Tenant"),
+        Some(PathBuf::from("/x/Tenant.php"))
+    );
+    assert_eq!(
+        r.binding_concrete("currentTenant"),
+        Some("App\\Models\\Tenant".to_string())
+    );
+    assert_eq!(r.binding_concrete("missing"), None);
+}
+
+#[test]
+fn snapshot_resolver_resolves_app_binding_through_engine() {
+    // The production resolver type, driven through the real resolution path
+    // (not just the `WithBindings` stub) — proves the build pass will resolve
+    // `app('currentTenant')->logo` to the bound model's accessor.
+    let p = project("app/Models/Tenant.php", TENANT_MODEL);
+    let class_files = Arc::new(HashMap::from([(
+        "App\\Models\\Tenant".to_string(),
+        p.index.class_file("App\\Models\\Tenant").expect("indexed"),
+    )]));
+    let bindings = Arc::new(HashMap::from([(
+        "currentTenant".to_string(),
+        "App\\Models\\Tenant".to_string(),
+    )]));
+    let resolver = SnapshotResolver {
+        class_files,
+        bindings,
+    };
+    let caller = "<?php $x = app('currentTenant')->logo;";
+    let r = resolve_with(&resolver, &p.root, caller, "logo").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::Accessor);
+    assert_eq!(r.declaring_fqcn, "App\\Models\\Tenant");
+}
+
 #[test]
 fn resolves_typed_param_property_to_column_high() {
     let p = project("app/Models/User.php", USER_MODEL);

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -351,6 +351,137 @@ fn resolve_in(p: &Project, caller: &str, member: &str) -> Option<ResolvedMemberA
     )
 }
 
+// ─── Container-resolution receivers: app('key')->member ───────────────────
+//
+// `app('currentTenant')->logo` types its receiver through the binding registry
+// (key → concrete FQCN) instead of variable flow. `WithBindings` is the test
+// analogue of the salsa/main `ContainerAwareResolver`: a class index that also
+// answers `binding_concrete`.
+
+use std::collections::HashMap;
+
+const TENANT_MODEL: &str = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Tenant extends Model {
+    protected $fillable = ['name'];
+    public function getLogoAttribute(): string { return ''; }
+}
+"#;
+
+/// A resolver that pairs a class index with a container-binding map, so a test
+/// can exercise `app('key')` receivers without standing up the salsa actor.
+struct WithBindings<'a> {
+    index: &'a ClassHierarchyIndex,
+    bindings: HashMap<String, String>,
+}
+
+impl ClassFileResolver for WithBindings<'_> {
+    fn class_file(&self, fqcn: &str) -> Option<PathBuf> {
+        self.index.class_file(fqcn)
+    }
+    fn binding_concrete(&self, key: &str) -> Option<String> {
+        self.bindings.get(key).cloned()
+    }
+}
+
+/// Resolve `$x->{member}` in `caller` against an arbitrary resolver.
+fn resolve_with(
+    resolver: &impl ClassFileResolver,
+    root: &std::path::Path,
+    caller: &str,
+    member: &str,
+) -> Option<ResolvedMemberAccess> {
+    let tree = parse_php(caller).expect("parse caller");
+    let bytes = caller.as_bytes();
+    let aliases = extract_use_aliases(&tree, caller);
+    let receiver = receiver_of(&tree, bytes, member)?;
+    let mut cache = ClassViewCache::new();
+    resolve_and_classify(
+        receiver,
+        member,
+        AccessForm::Property,
+        bytes,
+        &aliases,
+        resolver,
+        &mut cache,
+        root,
+        None,
+    )
+}
+
+/// Build a `WithBindings` resolver mapping `currentTenant` → the given concrete.
+fn tenant_bound_to<'a>(p: &'a Project, concrete: &str) -> WithBindings<'a> {
+    WithBindings {
+        index: &p.index,
+        bindings: HashMap::from([("currentTenant".to_string(), concrete.to_string())]),
+    }
+}
+
+#[test]
+fn resolves_app_string_binding_to_accessor() {
+    let p = project("app/Models/Tenant.php", TENANT_MODEL);
+    let resolver = tenant_bound_to(&p, "App\\Models\\Tenant");
+    let caller = "<?php $x = app('currentTenant')->logo;";
+    let r = resolve_with(&resolver, &p.root, caller, "logo").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::Accessor);
+    assert_eq!(r.confidence, Confidence::High);
+    assert_eq!(r.declaring_fqcn, "App\\Models\\Tenant");
+}
+
+#[test]
+fn resolves_resolve_helper_string_binding() {
+    let p = project("app/Models/Tenant.php", TENANT_MODEL);
+    let resolver = tenant_bound_to(&p, "App\\Models\\Tenant");
+    let caller = r#"<?php $x = resolve("currentTenant")->logo;"#;
+    let r = resolve_with(&resolver, &p.root, caller, "logo").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::Accessor);
+    assert_eq!(r.declaring_fqcn, "App\\Models\\Tenant");
+}
+
+#[test]
+fn resolves_app_string_binding_to_column() {
+    // The bridge feeds the whole classifier, not just accessors: a fillable
+    // column on the bound model resolves too.
+    let p = project("app/Models/Tenant.php", TENANT_MODEL);
+    let resolver = tenant_bound_to(&p, "App\\Models\\Tenant");
+    let caller = "<?php $x = app('currentTenant')->name;";
+    let r = resolve_with(&resolver, &p.root, caller, "name").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::Column);
+    assert_eq!(r.declaring_fqcn, "App\\Models\\Tenant");
+}
+
+#[test]
+fn unbound_container_key_does_not_resolve() {
+    let p = project("app/Models/Tenant.php", TENANT_MODEL);
+    let resolver = WithBindings {
+        index: &p.index,
+        bindings: HashMap::new(),
+    };
+    let caller = "<?php $x = app('currentTenant')->logo;";
+    assert!(resolve_with(&resolver, &p.root, caller, "logo").is_none());
+}
+
+#[test]
+fn closure_bound_key_does_not_resolve() {
+    // A binding registered with a closure has no concrete class the index knows;
+    // the receiver stays unresolved rather than resolving to a phantom "Closure".
+    let p = project("app/Models/Tenant.php", TENANT_MODEL);
+    let resolver = tenant_bound_to(&p, "Closure");
+    let caller = "<?php $x = app('currentTenant')->logo;";
+    assert!(resolve_with(&resolver, &p.root, caller, "logo").is_none());
+}
+
+#[test]
+fn class_const_argument_is_not_a_string_key() {
+    // `app(Tenant::class)` is a separate (later) receiver shape — the string-key
+    // path must not misfire on it.
+    let p = project("app/Models/Tenant.php", TENANT_MODEL);
+    let resolver = tenant_bound_to(&p, "App\\Models\\Tenant");
+    let caller = "<?php $x = app(Tenant::class)->logo;";
+    assert!(resolve_with(&resolver, &p.root, caller, "logo").is_none());
+}
+
 #[test]
 fn resolves_typed_param_property_to_column_high() {
     let p = project("app/Models/User.php", USER_MODEL);

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -3985,6 +3985,12 @@ pub enum SalsaRequest {
     SnapshotClassFiles {
         reply: oneshot::Sender<Arc<std::collections::HashMap<String, PathBuf>>>,
     },
+    /// Snapshot the `binding key → concrete FQCN` map for the same out-of-actor
+    /// build, so `app('key')` / `resolve('key')` receivers resolve to their
+    /// bound class while indexing.
+    SnapshotBindings {
+        reply: oneshot::Sender<Arc<std::collections::HashMap<String, String>>>,
+    },
     /// Snapshot every indexed class grouped by file, so warming can persist
     /// the hierarchy to the disk cache.
     SnapshotHierarchyNodes {
@@ -4631,6 +4637,23 @@ impl SalsaHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(SalsaRequest::SnapshotClassFiles { reply: reply_tx })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Snapshot the container-binding registry as a `binding key → concrete
+    /// FQCN` map for the out-of-actor magic-member build. Mirrors
+    /// [`Self::snapshot_class_files`]: the build pass resolves `app('key')`
+    /// receivers against this owned copy without borrowing the actor.
+    pub async fn snapshot_bindings(
+        &self,
+    ) -> Result<Arc<std::collections::HashMap<String, String>>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::SnapshotBindings { reply: reply_tx })
             .await
             .map_err(|_| "Salsa actor disconnected")?;
         reply_rx
@@ -5815,6 +5838,24 @@ impl SalsaActor {
                     }
                     let snapshot = self.class_files_snapshot.clone().unwrap_or_default();
                     let _ = reply.send(snapshot);
+                }
+                SalsaRequest::SnapshotBindings { reply } => {
+                    // Bindings number in the dozens, not thousands, so build
+                    // fresh each call — no cache to invalidate on service-
+                    // provider edits. Singletons first, then plain binds, so a
+                    // plain bind wins on key collision (mirrors the precedence
+                    // in `handle_get_binding_by_name`). Concrete FQCNs are
+                    // normalized to the leading-backslash-free form the class
+                    // index keys on.
+                    let mut map: std::collections::HashMap<String, String> =
+                        std::collections::HashMap::new();
+                    for (key, reg) in self.sp_singletons.iter().chain(self.sp_bindings.iter()) {
+                        map.insert(
+                            key.clone(),
+                            reg.concrete_class.trim_start_matches('\\').to_string(),
+                        );
+                    }
+                    let _ = reply.send(Arc::new(map));
                 }
                 SalsaRequest::SnapshotHierarchyNodes { reply } => {
                     let _ = reply.send(self.class_hierarchy_index.nodes_by_file());

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -3389,6 +3389,33 @@ pub struct BindingRegistrationData {
     pub priority: u8,
 }
 
+/// Pairs the class-hierarchy index (FQCN → file) with the in-actor container
+/// binding registry (binding key → concrete FQCN) behind the
+/// [`crate::member_resolver::ClassFileResolver`] seam, so the live query path
+/// (find-references fallback, hover, rename) types `app('key')` / `resolve('key')`
+/// receivers the same way the build pass does — without materializing the full
+/// class-file map a `SnapshotResolver` would need.
+struct ContainerAwareResolver<'a> {
+    index: &'a crate::class_hierarchy_index::ClassHierarchyIndex,
+    bindings: &'a HashMap<String, BindingRegistrationData>,
+    singletons: &'a HashMap<String, BindingRegistrationData>,
+}
+
+impl crate::member_resolver::ClassFileResolver for ContainerAwareResolver<'_> {
+    fn class_file(&self, fqcn: &str) -> Option<PathBuf> {
+        crate::member_resolver::ClassFileResolver::class_file(self.index, fqcn)
+    }
+    fn binding_concrete(&self, key: &str) -> Option<String> {
+        // Bindings win over singletons on key collision (mirrors
+        // `handle_get_binding_by_name`); the concrete is normalized to the
+        // leading-backslash-free form the class index keys on.
+        self.bindings
+            .get(key)
+            .or_else(|| self.singletons.get(key))
+            .map(|b| b.concrete_class.trim_start_matches('\\').to_string())
+    }
+}
+
 /// Environment variable data for transfer across async boundaries
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct EnvVariableData {
@@ -7482,6 +7509,7 @@ impl SalsaActor {
         // Blade-embedded refs may not locate, which is fine — the component
         // fallback below is text-based).
         let mut classviews = crate::member_resolver::ClassViewCache::new();
+        let resolver = self.container_aware_resolver();
         if let Some(receiver) = tree
             .root_node()
             .descendant_for_byte_range(member_ref.receiver_byte_start, member_ref.receiver_byte_end)
@@ -7492,7 +7520,7 @@ impl SalsaActor {
                 member_ref.form,
                 bytes,
                 &aliases,
-                &self.class_hierarchy_index,
+                &resolver,
                 &mut classviews,
                 &project_root,
                 None, // query-time path — no dependency recording
@@ -7551,6 +7579,7 @@ impl SalsaActor {
         let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, &text);
 
         let mut classviews = crate::member_resolver::ClassViewCache::new();
+        let resolver = self.container_aware_resolver();
         let receiver = tree.root_node().descendant_for_byte_range(
             member_ref.receiver_byte_start,
             member_ref.receiver_byte_end,
@@ -7567,7 +7596,7 @@ impl SalsaActor {
                 member_ref.form,
                 bytes,
                 &aliases,
-                &self.class_hierarchy_index,
+                &resolver,
                 &mut classviews,
                 &project_root,
                 None, // query-time path — no dependency recording
@@ -7584,7 +7613,7 @@ impl SalsaActor {
                         receiver,
                         bytes,
                         &aliases,
-                        &self.class_hierarchy_index,
+                        &resolver,
                         &mut classviews,
                         &project_root,
                     )?;
@@ -7661,6 +7690,7 @@ impl SalsaActor {
         let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, &text);
 
         let mut classviews = crate::member_resolver::ClassViewCache::new();
+        let resolver = self.container_aware_resolver();
         let receiver = tree.root_node().descendant_for_byte_range(
             member_ref.receiver_byte_start,
             member_ref.receiver_byte_end,
@@ -7671,7 +7701,7 @@ impl SalsaActor {
             member_ref.form,
             bytes,
             &aliases,
-            &self.class_hierarchy_index,
+            &resolver,
             &mut classviews,
             &project_root,
             None, // query-time path — no dependency recording
@@ -7826,6 +7856,17 @@ impl SalsaActor {
             .get(name)
             .cloned()
             .or_else(|| self.sp_singletons.get(name).cloned())
+    }
+
+    /// A container-aware [`ClassFileResolver`](crate::member_resolver::ClassFileResolver)
+    /// over the actor's class index + binding registry, for the live query path
+    /// (find-references fallback, hover, rename).
+    fn container_aware_resolver(&self) -> ContainerAwareResolver<'_> {
+        ContainerAwareResolver {
+            index: &self.class_hierarchy_index,
+            bindings: &self.sp_bindings,
+            singletons: &self.sp_singletons,
+        }
     }
 
     /// Handle get view namespace by name (queries Salsa-parsed service providers)

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -967,6 +967,61 @@ async fn snapshot_bindings_maps_keys_to_concrete() {
     );
 }
 
+#[test]
+fn container_aware_resolver_prefers_bindings_and_normalizes() {
+    // The live-query-path resolver: bindings win over singletons on collision,
+    // concrete FQCNs are backslash-normalized, and class_file delegates to the
+    // class index.
+    use crate::member_resolver::ClassFileResolver;
+
+    let reg = |concrete: &str, bt: BindingTypeData| BindingRegistrationData {
+        abstract_name: "x".to_string(),
+        concrete_class: concrete.to_string(),
+        file_path: None,
+        binding_type: bt,
+        source_file: None,
+        source_line: None,
+        priority: 2,
+    };
+
+    let mut bindings = HashMap::new();
+    bindings.insert(
+        "dup".to_string(),
+        reg("App\\FromBind", BindingTypeData::Bind),
+    );
+    let mut singletons = HashMap::new();
+    singletons.insert(
+        "dup".to_string(),
+        reg("App\\FromSingleton", BindingTypeData::Singleton),
+    );
+    singletons.insert(
+        "tenant".to_string(),
+        reg("\\App\\Models\\Tenant", BindingTypeData::Singleton),
+    );
+
+    let index = crate::class_hierarchy_index::ClassHierarchyIndex::default();
+    let resolver = ContainerAwareResolver {
+        index: &index,
+        bindings: &bindings,
+        singletons: &singletons,
+    };
+
+    // Singleton-only key resolves; leading backslash normalized.
+    assert_eq!(
+        resolver.binding_concrete("tenant").as_deref(),
+        Some("App\\Models\\Tenant"),
+    );
+    // Bindings win over singletons on key collision.
+    assert_eq!(
+        resolver.binding_concrete("dup").as_deref(),
+        Some("App\\FromBind"),
+    );
+    // Unknown key → None.
+    assert_eq!(resolver.binding_concrete("nope"), None);
+    // class_file delegates to the (here empty) class index.
+    assert_eq!(resolver.class_file("App\\Models\\Tenant"), None);
+}
+
 // ─── collect_matches_for_symbol (find-references engine) ───────────────
 
 use std::path::PathBuf;

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -915,6 +915,58 @@ async fn salsa_config_refreshes_when_provider_registered_after_first_build() {
     );
 }
 
+#[tokio::test]
+async fn snapshot_bindings_maps_keys_to_concrete() {
+    // The build-pass snapshot must expose `app('key') → concrete FQCN` so
+    // `app('currentTenant')->member` resolves while indexing. It merges both
+    // registries (singletons + plain binds) and normalizes the concrete to the
+    // leading-backslash-free form the class index keys on.
+    let handle = SalsaActor::spawn();
+
+    let reg = |abstract_name: &str, concrete: &str, bt: BindingTypeData| BindingRegistrationData {
+        abstract_name: abstract_name.to_string(),
+        concrete_class: concrete.to_string(),
+        file_path: None,
+        binding_type: bt,
+        source_file: None,
+        source_line: None,
+        priority: 2,
+    };
+
+    let mut singletons = HashMap::new();
+    // Leading backslash on purpose — the snapshot must strip it.
+    singletons.insert(
+        "currentTenant".to_string(),
+        reg(
+            "currentTenant",
+            "\\App\\Models\\Tenant",
+            BindingTypeData::Singleton,
+        ),
+    );
+    let mut bindings = HashMap::new();
+    bindings.insert(
+        "reporter".to_string(),
+        reg("reporter", "App\\Services\\Reporter", BindingTypeData::Bind),
+    );
+
+    handle
+        .register_service_provider_registry(HashMap::new(), bindings, singletons)
+        .await
+        .unwrap();
+
+    let snapshot = handle.snapshot_bindings().await.unwrap();
+    assert_eq!(
+        snapshot.get("currentTenant").map(String::as_str),
+        Some("App\\Models\\Tenant"),
+        "singleton key maps to concrete, leading backslash normalized",
+    );
+    assert_eq!(
+        snapshot.get("reporter").map(String::as_str),
+        Some("App\\Services\\Reporter"),
+        "plain bind key maps to concrete",
+    );
+}
+
 // ─── collect_matches_for_symbol (find-references engine) ───────────────
 
 use std::path::PathBuf;

--- a/laravel-lsp/src/view_var_index/tests.rs
+++ b/laravel-lsp/src/view_var_index/tests.rs
@@ -358,6 +358,69 @@ fn blade_var_with_no_inferred_type_is_dropped() {
     assert!(entries.is_empty(), "got {entries:?}");
 }
 
+/// A `SnapshotResolver` binding `currentUser` → the indexed `User` model.
+fn user_bound_resolver(p: &BladeProject, key: &str) -> crate::member_resolver::SnapshotResolver {
+    crate::member_resolver::SnapshotResolver {
+        class_files: Arc::new(std::collections::HashMap::from([(
+            "App\\Models\\User".to_string(),
+            p.root.join("app/Models/User.php"),
+        )])),
+        bindings: Arc::new(std::collections::HashMap::from([(
+            key.to_string(),
+            "App\\Models\\User".to_string(),
+        )])),
+    }
+}
+
+#[test]
+fn blade_container_binding_receiver_resolves() {
+    // `{{ app('currentUser')->email }}` — the receiver is a container
+    // resolution, not a view variable, so it has no entry in the view-var index.
+    // A binding-aware resolver types it to the bound model and the column
+    // classifies. This is the path that lights up `app('currentTenant')->logo`.
+    let p = blade_project();
+    let idx = ViewVarIndex::new(); // no controller render — type comes from the binding
+    let resolver = user_bound_resolver(&p, "currentUser");
+    let refs = vec![member_ref("app('currentUser')", "email", 5, 12)];
+    let mut cache = ClassViewCache::new();
+    let entries = resolve_blade_member_accesses(
+        &refs,
+        "users.show",
+        &idx,
+        &[],
+        &resolver,
+        &mut cache,
+        &p.root,
+        None,
+    );
+    assert_eq!(entries.len(), 1, "got {entries:?}");
+    assert_eq!(entries[0].fqcn, "App\\Models\\User");
+    assert_eq!(entries[0].member, "email");
+    assert_eq!(entries[0].line, 5);
+}
+
+#[test]
+fn blade_container_binding_unknown_key_is_dropped() {
+    // No binding registered for the accessed key → receiver unresolved → no
+    // entry (the resolver is binding-aware but the registry is empty for it).
+    let p = blade_project();
+    let idx = ViewVarIndex::new();
+    let resolver = user_bound_resolver(&p, "someOtherKey");
+    let refs = vec![member_ref("app('currentUser')", "email", 1, 0)];
+    let mut cache = ClassViewCache::new();
+    let entries = resolve_blade_member_accesses(
+        &refs,
+        "users.show",
+        &idx,
+        &[],
+        &resolver,
+        &mut cache,
+        &p.root,
+        None,
+    );
+    assert!(entries.is_empty(), "got {entries:?}");
+}
+
 #[test]
 fn blade_relationship_resolves() {
     let p = blade_project();


### PR DESCRIPTION
## Summary

Container-aware reference resolution: `app('key')->member` and `resolve('key')->member` now resolve through the service-container binding registry to the bound model, so the magic-member reference graph — find-references, CodeLens counts, hover, and rename — recognizes container-resolved receivers, not just `$variable` / `$this` / facade receivers.

For a binding like `$this->app->singleton('currentTenant', \App\Models\Tenant::class)`, a usage `app('currentTenant')->logo` resolves to `Tenant::getLogoAttribute()` (and columns / relationships / scopes) across PHP, Blade, and Volt.

## How it works

A defaulted `ClassFileResolver::binding_concrete(key) -> Option<String>` seam maps a binding key to its concrete FQCN. A new `resolve_container_receiver` branch in the magic-member receiver resolver types `app('key')` / `resolve('key')` receivers via that seam; the existing classifier then handles the member as usual. Binding data reaches the out-of-actor build through a new `SnapshotBindings` actor request + `SnapshotResolver`; the in-actor query path uses a borrowing `ContainerAwareResolver`.

## Commits

- `f9fcbed` — receiver resolver capability (`binding_concrete`, `resolve_container_receiver`)
- `1cbfa56` — PHP build path (`SnapshotBindings` actor request + `SnapshotResolver`)
- `915b000` — Blade/Volt build path
- `be13de8` — live query path (find-references fallback, hover, rename)

## Scope & limitations

- **Class-concrete bindings only** — `singleton('k', Tenant::class)` / `bind('k', Tenant::class)`.
- **Closure bindings** (`singleton('k', fn () => …)`) record `"Closure"` and stay unresolved by design — never a wrong target.
- The binding parser is still regex-based, so it matches `$this->app->bind(` / `singleton(` with a `::class` concrete; other registration syntaxes (`app()->singleton`, `App::singleton`, `scoped`, `instance`) and closure-body return inference are out of scope here.
- String-keyed `app`/`resolve` forms only; `app(Class::class)`, `app()->make()`, `App::make()` not yet handled.

## Test plan

- `cargo test` — **1910 passing** (added coverage: container receiver → accessor/column, `resolve` helper form, unbound-key drop, closure-concrete drop, `::class`-arg non-match, `SnapshotResolver`, `snapshot_bindings` actor request, Blade container receiver, `ContainerAwareResolver`).
- `cargo clippy --all-targets` clean; `cargo fmt` clean.
- Release binary builds; loaded in Zed for live testing.

## Follow-ups

- #234 — closure-bound bindings + replacing the regex binding parser with tree-sitter (enables closure-body return inference and the broader registration syntaxes above; tracks the hard cases — relationship-hop / conditional / union return types).
