### PR TITLE
feat: add alpine based images support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,10 @@ jobs:
 
       - name: cargo check
         run: cargo check --target wasm32-wasip2
+
+      # The unit tests in src/lib.rs live in this (root) crate, so they only run
+      # here — the laravel-lsp job's `cargo test` is a different crate. Run on the
+      # host target: the tests are pure (no wasm runtime needed), so no wasm test
+      # runner is required despite the crate being a cdylib.
+      - name: cargo test
+        run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,12 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             binary_name: laravel-lsp-linux-arm64
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            binary_name: laravel-lsp-linux-x64-musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            binary_name: laravel-lsp-linux-arm64-musl
           - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: laravel-lsp-macos-x64
@@ -197,6 +203,36 @@ jobs:
           [target.aarch64-unknown-linux-gnu]
           linker = "aarch64-linux-gnu-gcc"
           EOF
+
+      - name: Install musl cross-compilation tools (Linux x64 musl)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          # The cc crate (build.rs compiles the tree-sitter C grammar) and the
+          # Rust linker both need to target musl, not the host glibc.
+          mkdir -p ~/.cargo
+          cat >> ~/.cargo/config.toml << EOF
+          [target.x86_64-unknown-linux-musl]
+          linker = "musl-gcc"
+          EOF
+          echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> $GITHUB_ENV
+
+      - name: Install musl cross-compilation tools (Linux ARM64 musl)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: |
+          # musl.cc ships a complete aarch64 musl cross toolchain; the cc crate
+          # and the Rust linker both pick it up from PATH / the env below.
+          curl -fL --retry 3 --retry-delay 5 \
+            https://musl.cc/aarch64-linux-musl-cross.tgz -o /tmp/aarch64-musl-cross.tgz
+          sudo tar -xzf /tmp/aarch64-musl-cross.tgz -C /opt
+          echo "/opt/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
+          mkdir -p ~/.cargo
+          cat >> ~/.cargo/config.toml << EOF
+          [target.aarch64-unknown-linux-musl]
+          linker = "aarch64-linux-musl-gcc"
+          EOF
+          echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc" >> $GITHUB_ENV
 
       - name: Build LSP Server
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,6 +225,14 @@ jobs:
           # and the Rust linker both pick it up from PATH / the env below.
           curl -fL --retry 3 --retry-delay 5 \
             https://musl.cc/aarch64-linux-musl-cross.tgz -o /tmp/aarch64-musl-cross.tgz
+          # Pin the tarball: musl.cc is an unsigned single-maintainer mirror and
+          # this toolchain compiles a published release binary, so verify a
+          # known-good sha256 before extracting. A MITM'd, compromised, or
+          # silently-rebuilt tarball then fails the build loudly instead of
+          # backdooring the shipped arm64-musl binary. Update this hash if the
+          # upstream toolchain is intentionally rebuilt.
+          echo "c909817856d6ceda86aa510894fa3527eac7989f0ef6e87b5721c58737a06c38  /tmp/aarch64-musl-cross.tgz" \
+            | sha256sum -c -
           sudo tar -xzf /tmp/aarch64-musl-cross.tgz -C /opt
           echo "/opt/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
           mkdir -p ~/.cargo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,9 @@ impl LaravelExtension {
             }
             (zed::Os::Linux, zed::Architecture::X8664) => "laravel-lsp-linux-x64".to_string(),
             (zed::Os::Linux, zed::Architecture::Aarch64) => "laravel-lsp-linux-arm64".to_string(),
+            // Defensive fallback for any future Linux arch the SDK adds: still
+            // honor musl so we never serve a glibc binary to a musl host.
+            (zed::Os::Linux, _) if is_musl => "laravel-lsp-musl".to_string(),
             (zed::Os::Linux, _) => "laravel-lsp".to_string(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,15 @@ impl LaravelExtension {
     /// Get platform-specific binary name
     fn get_platform_binary_name() -> String {
         let (os, arch) = zed::current_platform();
+        Self::platform_binary_name(os, arch, Self::is_musl_libc())
+    }
+
+    /// Map a platform triple to the published release-asset binary name.
+    ///
+    /// `is_musl` only changes the Linux variants: musl-based distros (Alpine,
+    /// etc.) need the `-musl` binary because the glibc-linked build fails to
+    /// spawn against musl's loader.
+    fn platform_binary_name(os: zed::Os, arch: zed::Architecture, is_musl: bool) -> String {
         match (os, arch) {
             (zed::Os::Windows, zed::Architecture::X8664) => {
                 "laravel-lsp-windows-x64.exe".to_string()
@@ -169,10 +178,106 @@ impl LaravelExtension {
             (zed::Os::Mac, zed::Architecture::Aarch64) => "laravel-lsp-macos-arm64".to_string(),
             (zed::Os::Mac, zed::Architecture::X8664) => "laravel-lsp-macos-x64".to_string(),
             (zed::Os::Mac, _) => "laravel-lsp".to_string(),
+            (zed::Os::Linux, zed::Architecture::X8664) if is_musl => {
+                "laravel-lsp-linux-x64-musl".to_string()
+            }
+            (zed::Os::Linux, zed::Architecture::Aarch64) if is_musl => {
+                "laravel-lsp-linux-arm64-musl".to_string()
+            }
             (zed::Os::Linux, zed::Architecture::X8664) => "laravel-lsp-linux-x64".to_string(),
             (zed::Os::Linux, zed::Architecture::Aarch64) => "laravel-lsp-linux-arm64".to_string(),
             (zed::Os::Linux, _) => "laravel-lsp".to_string(),
         }
+    }
+
+    /// Detect a musl-based Linux host (Alpine and friends).
+    ///
+    /// Extensions run as WASM but `std::fs` reads resolve against the host the
+    /// LSP will run on — including a remote/devcontainer — so we probe for
+    /// musl's dynamic loaders and Alpine's release marker.
+    fn is_musl_libc() -> bool {
+        Self::detect_musl(|path| fs::metadata(path).is_ok())
+    }
+
+    /// Pure musl probe: returns true if any musl/Alpine marker path exists,
+    /// per the injected existence check. Split out so it is unit-testable
+    /// without touching the real filesystem.
+    fn detect_musl(path_exists: impl Fn(&str) -> bool) -> bool {
+        [
+            "/lib/ld-musl-x86_64.so.1",
+            "/lib/ld-musl-aarch64.so.1",
+            "/etc/alpine-release",
+        ]
+        .iter()
+        .any(|path| path_exists(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zed::{Architecture, Os};
+
+    #[test]
+    fn linux_gnu_names_unchanged() {
+        assert_eq!(
+            LaravelExtension::platform_binary_name(Os::Linux, Architecture::X8664, false),
+            "laravel-lsp-linux-x64"
+        );
+        assert_eq!(
+            LaravelExtension::platform_binary_name(Os::Linux, Architecture::Aarch64, false),
+            "laravel-lsp-linux-arm64"
+        );
+    }
+
+    #[test]
+    fn linux_musl_names_get_suffix() {
+        assert_eq!(
+            LaravelExtension::platform_binary_name(Os::Linux, Architecture::X8664, true),
+            "laravel-lsp-linux-x64-musl"
+        );
+        assert_eq!(
+            LaravelExtension::platform_binary_name(Os::Linux, Architecture::Aarch64, true),
+            "laravel-lsp-linux-arm64-musl"
+        );
+    }
+
+    #[test]
+    fn non_linux_ignores_musl_flag() {
+        for is_musl in [true, false] {
+            assert_eq!(
+                LaravelExtension::platform_binary_name(Os::Mac, Architecture::Aarch64, is_musl),
+                "laravel-lsp-macos-arm64"
+            );
+            assert_eq!(
+                LaravelExtension::platform_binary_name(Os::Mac, Architecture::X8664, is_musl),
+                "laravel-lsp-macos-x64"
+            );
+            assert_eq!(
+                LaravelExtension::platform_binary_name(Os::Windows, Architecture::X8664, is_musl),
+                "laravel-lsp-windows-x64.exe"
+            );
+            assert_eq!(
+                LaravelExtension::platform_binary_name(Os::Windows, Architecture::Aarch64, is_musl),
+                "laravel-lsp-windows-arm64.exe"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_musl_true_when_any_marker_present() {
+        assert!(LaravelExtension::detect_musl(|p| p == "/etc/alpine-release"));
+        assert!(LaravelExtension::detect_musl(
+            |p| p == "/lib/ld-musl-x86_64.so.1"
+        ));
+        assert!(LaravelExtension::detect_musl(
+            |p| p == "/lib/ld-musl-aarch64.so.1"
+        ));
+    }
+
+    #[test]
+    fn detect_musl_false_when_no_marker_present() {
+        assert!(!LaravelExtension::detect_musl(|_| false));
     }
 }
 


### PR DESCRIPTION
## Summary
Implements #236 — adds Alpine/musl support so the Laravel LSP runs inside musl-based containers (e.g. `dunglas/frankenphp:php8.5-alpine` devcontainers), where the glibc binary fails with `No such file or directory (os error 2)`.

## Changes
- **`release.yml`** — add build-matrix entries for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`, producing `laravel-lsp-linux-x64-musl` / `laravel-lsp-linux-arm64-musl`. Each musl target installs its cross toolchain (`musl-tools` for x64; `aarch64-linux-musl-cross` from musl.cc for arm64) and exports `CC_<target>` + a cargo `linker` so the `cc`-crate tree-sitter grammar build cross-compiles to musl too. The existing archive/upload steps then publish the `*.tar.gz` assets alongside the gnu ones.
- **`src/lib.rs`** — `get_platform_binary_name()` now probes for musl at runtime (`/lib/ld-musl-x86_64.so.1`, `/lib/ld-musl-aarch64.so.1`, `/etc/alpine-release`) and returns the `-musl` asset name on musl Linux. Non-musl Linux is unchanged. The binary-name mapping and musl probe are split into pure helpers (`platform_binary_name`, `detect_musl`) for unit testing.
- `download_binary()` needs no change: it derives the archive name and download URL from the binary name, so the `-musl` suffix flows through to extraction + `make_file_executable` automatically.

## Acceptance Criteria
- [x] Two new musl binary variants built/published (`laravel-lsp-linux-x64-musl`, `laravel-lsp-linux-arm64-musl`) via the `*-unknown-linux-musl` targets
- [x] `release.yml` adds both musl matrix entries, installs the musl cross toolchain, and uploads the `*.tar.gz` archives alongside the gnu assets
- [x] `get_platform_binary_name()` detects musl Linux at runtime and returns the `-musl` name
- [x] Non-musl Linux uses the existing gnu binaries unchanged — no behaviour change for existing users
- [x] `download_binary()` constructs the correct URL/archive name for musl variants and extracts + makes them executable (transitive via binary name)
- [ ] **Manual:** extension starts without error inside an Alpine devcontainer — no `os error 2` in the LSP log
- [ ] **Manual:** go-to-definition / hover works end-to-end inside the Alpine container

## Test Plan
- [x] `cargo test` — 5 new unit tests for the platform→binary mapping (gnu unchanged, musl suffixed, non-Linux ignores the flag) and musl detection
- [x] `cargo fmt --check`, `cargo clippy --target wasm32-wasip2 -- -D warnings`, `cargo check --target wasm32-wasip2` all clean
- [ ] **Manual (CI cannot cover):** trigger a release and confirm both `-musl` assets build + upload; then load the extension inside an Alpine devcontainer and confirm the LSP starts and go-to-definition works

## Notes for review
- The `release.yml` build is exercised **only on a real release**, not by PR CI — the workflow changes can't be validated by this PR's checks.
- Runtime musl detection relies on `std::fs` reads of absolute host paths from the WASM extension. The existing code only reads *relative* paths under the extension work dir; if Zed's WASI sandbox doesn't preopen `/`, the absolute-path probe may need an alternate vector. This is the detection approach the issue's AC prescribes, and is covered by the two manual AC items above.

Fixes #236