### PR TITLE
Add mutator (setXAttribute) reference-count code lens for property write sites

### DIFF
--- a/laravel-lsp/src/code_lens.rs
+++ b/laravel-lsp/src/code_lens.rs
@@ -12,6 +12,7 @@
 //! class references aren't indexed, so they get no lens (a generic PHP LSP
 //! covers those). Laravel literal definitions (routes/views/…) are a follow-up.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use tree_sitter::Node;
@@ -229,8 +230,9 @@ fn component_targets(source: &str, key: &str, base_line: u32) -> Vec<CodeLensTar
     out
 }
 
-/// Model magic members: relationships, scopes, and public properties (column /
-/// attribute reads). Keyed by the file's class FQCN + the *usage* name.
+/// Model magic members: relationships, scopes, accessors, mutators, and public
+/// properties (column / attribute reads). Keyed by the file's class FQCN + the
+/// *usage* name.
 fn model_targets(source: &str) -> Vec<CodeLensTarget> {
     let Ok(tree) = parse_php(source) else {
         return Vec::new();
@@ -239,6 +241,13 @@ fn model_targets(source: &str) -> Vec<CodeLensTarget> {
     let Some(fqcn) = first_class_fqcn(tree.root_node(), bytes) else {
         return Vec::new();
     };
+
+    // Every member that already carries an accessor lens. Reads and writes share
+    // a single reference count today, so a mutator gets its own lens only when no
+    // accessor covers the same member (#232, option b — fallback-only): that
+    // closes the setter-only gap without showing the same number twice on a model
+    // that has both a getter and a setter.
+    let accessor_members = accessor_member_names(tree.root_node(), bytes);
 
     let mut out = Vec::new();
     let mut stack = vec![tree.root_node()];
@@ -249,6 +258,10 @@ fn model_targets(source: &str) -> Vec<CodeLensTarget> {
                     if let Some(usage) = scope_usage_name(&name) {
                         out.push(target(&fqcn, &usage, line, col, end));
                     } else if let Some(usage) = accessor_usage_name(n, &name, bytes) {
+                        out.push(target(&fqcn, &usage, line, col, end));
+                    } else if let Some(usage) =
+                        mutator_usage_name(&name).filter(|m| !accessor_members.contains(m))
+                    {
                         out.push(target(&fqcn, &usage, line, col, end));
                     } else if method_is_relationship(n, bytes) {
                         out.push(target(&fqcn, &name, line, col, end));
@@ -322,6 +335,46 @@ fn accessor_usage_name(method: Node, name: &str, bytes: &[u8]) -> Option<String>
         })
         .unwrap_or(false);
     returns_attribute.then(|| pascal_to_snake(name))
+}
+
+/// The attribute name an old-style mutator writes, matching the accessor's
+/// keying (`setLogoAttribute` → `logo`), or `None` if the method isn't an
+/// old-style mutator. Mirrors `accessor_usage_name`'s old-style branch; an empty
+/// middle (`setAttribute`, Eloquent's own setter) returns `None`. New-style
+/// `Attribute`-returning methods cover get+set in one declaration and are
+/// already anchored by `accessor_usage_name`, so they aren't matched here.
+fn mutator_usage_name(name: &str) -> Option<String> {
+    use crate::laravel_introspector::model_metadata::pascal_to_snake;
+    let middle = name
+        .strip_prefix("set")
+        .and_then(|s| s.strip_suffix("Attribute"))?;
+    (!middle.is_empty()).then(|| pascal_to_snake(middle))
+}
+
+/// Every member name that already carries an accessor lens in this class —
+/// old-style `get{X}Attribute` or a new-style `Attribute`-returning method.
+/// Lets `model_targets` add a mutator lens only as a fallback, when no accessor
+/// covers the same member (#232, option b).
+fn accessor_member_names(root: Node, bytes: &[u8]) -> HashSet<String> {
+    let mut members = HashSet::new();
+    let mut stack = vec![root];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "method_declaration" {
+            if let Some(name) = n
+                .child_by_field_name("name")
+                .and_then(|nm| nm.utf8_text(bytes).ok())
+            {
+                if let Some(usage) = accessor_usage_name(n, name, bytes) {
+                    members.insert(usage);
+                }
+            }
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    members
 }
 
 /// True if a method body calls an Eloquent relationship factory

--- a/laravel-lsp/src/code_lens/tests.rs
+++ b/laravel-lsp/src/code_lens/tests.rs
@@ -145,6 +145,104 @@ class User extends \Illuminate\Database\Eloquent\Model {
     );
 }
 
+#[test]
+fn mutator_usage_name_maps_setter_to_snake_member() {
+    // `set{Name}Attribute` → snake-cased member; the empty middle
+    // (`setAttribute`, Eloquent's own setter) and non-mutators are `None`.
+    assert_eq!(
+        mutator_usage_name("setLogoAttribute").as_deref(),
+        Some("logo")
+    );
+    assert_eq!(
+        mutator_usage_name("setFullNameAttribute").as_deref(),
+        Some("full_name")
+    );
+    assert_eq!(mutator_usage_name("setAttribute"), None);
+    assert_eq!(mutator_usage_name("getLogoAttribute"), None);
+    assert_eq!(mutator_usage_name("save"), None);
+}
+
+#[test]
+fn model_mutator_only_gets_a_lens() {
+    // A model with only a setter (no matching getter) exposes a lens for the
+    // magic member — closes the setter-only gap (#232).
+    let src = r#"<?php
+namespace App\Models;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public function setLogoAttribute($value) { $this->attributes['logo'] = $value; }
+}
+"#;
+    let targets = code_lens_targets(Path::new("/proj/app/Models/User.php"), src);
+    let k = keys(&targets);
+    assert!(
+        k.contains(&("App\\Models\\User", "logo")),
+        "setter-only mutator lens, got {k:?}"
+    );
+    // The lens anchors on the method name, not the derived attribute.
+    let m = targets
+        .iter()
+        .find(
+            |t| matches!(&t.symbol, SymbolRefData::MagicMember { member, .. } if member == "logo"),
+        )
+        .unwrap();
+    let line = src.lines().nth(m.line as usize).unwrap();
+    assert_eq!(m.column, line.find("setLogoAttribute").unwrap() as u32);
+}
+
+#[test]
+fn model_getter_and_setter_shows_a_single_lens_on_the_getter() {
+    // Reads and writes share one reference count, so a model with both accessor
+    // and mutator must show exactly one lens — on the getter, not the setter
+    // (#232, option b).
+    let src = r#"<?php
+namespace App\Models;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public function getLogoAttribute() { return $this->attributes['logo']; }
+    public function setLogoAttribute($value) { $this->attributes['logo'] = $value; }
+}
+"#;
+    let targets = code_lens_targets(Path::new("/proj/app/Models/User.php"), src);
+    let logo: Vec<_> = targets
+        .iter()
+        .filter(
+            |t| matches!(&t.symbol, SymbolRefData::MagicMember { member, .. } if member == "logo"),
+        )
+        .collect();
+    assert_eq!(logo.len(), 1, "exactly one lens for `logo`, got {logo:?}");
+    // The single lens sits on the getter.
+    let line = src.lines().nth(logo[0].line as usize).unwrap();
+    assert_eq!(
+        logo[0].column,
+        line.find("getLogoAttribute").unwrap() as u32
+    );
+}
+
+#[test]
+fn model_new_style_attribute_is_not_double_counted_as_a_mutator() {
+    // A new-style `Attribute`-returning method covers get+set in one
+    // declaration — it must produce exactly one lens, never a second one for the
+    // write side (#232).
+    let src = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public function logo(): Attribute { return Attribute::make(get: fn () => $this->x, set: fn ($v) => $v); }
+}
+"#;
+    let targets = code_lens_targets(Path::new("/proj/app/Models/User.php"), src);
+    let logo: Vec<_> = targets
+        .iter()
+        .filter(
+            |t| matches!(&t.symbol, SymbolRefData::MagicMember { member, .. } if member == "logo"),
+        )
+        .collect();
+    assert_eq!(
+        logo.len(),
+        1,
+        "new-style attribute single lens, got {logo:?}"
+    );
+}
+
 // ── Route-name declaration lenses ─────────────────────────────────────────
 
 use crate::route_name_locator::RouteNameDeclaration;


### PR DESCRIPTION
## Summary

Implements #232. Anchors a reference-count code lens on **mutator** attribute methods so a setter surfaces a lens for its magic property — closing the setter-only gap where an indexed symbol had no surface.

Per the issue's design decision and @mikebronner's confirmation, this is **option (b) — fallback-only**: a mutator gets its own lens only when no accessor covers the same member. Because reads and writes share a single reference count today, this closes the gap with a `code_lens.rs`-only change and never shows the same number twice.

## Changes
- Add `mutator_usage_name` — old-style `set{Name}Attribute` → `pascal_to_snake(Name)`, mirroring `accessor_usage_name`; empty middle (`setAttribute`) returns `None`.
- Add `accessor_member_names` — collects every member already carrying an accessor lens (old-style getter or new-style `Attribute`-returning method).
- `model_targets` anchors a mutator lens only when `mutator_usage_name` is `Some` **and** no accessor covers that member (option b).
- Tests for setter-only, getter+setter, and new-style `Attribute` cases, plus a unit test of `mutator_usage_name`.

## Acceptance Criteria
- [x] `mutator_usage_name` recognises old-style `set{Name}Attribute` → `pascal_to_snake(Name)`; empty middle returns `None`
- [x] `model_targets` anchors a mutator lens only when `mutator_usage_name` is `Some` **and** no accessor for that member exists in the class (option b)
- [x] New-style `Attribute`-returning methods unaffected — `returns_attribute` path unchanged, no second lens
- [x] Model with only `setLogoAttribute` exposes a `MagicMember { fqcn, member: "logo" }` lens at the method-name position
- [x] Model with both `getLogoAttribute` and `setLogoAttribute` shows exactly one lens (on the getter)
- [x] Tests cover setter-only, getter+setter, and new-style attribute

## Test Plan
- [x] `cargo test` — lib unit tests pass (1914), including 4 new `code_lens` tests
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt` applied
- [ ] 8 pre-existing `integration_tests.rs` failures are environment-dependent (gitignored `.env` / `test-project` fixtures) and fail identically on a clean `main` checkout — unrelated to this change

Fixes #232