### PR TITLE
fix: harden release.yml against GitHub Actions expression injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,9 @@ jobs:
           echo "Extracted version: ${VERSION}"
 
       - name: Update versions and lock files
+        env:
+          VERSION: ${{ steps.extract_version.outputs.version }}
         run: |
-          VERSION="${{ steps.extract_version.outputs.version }}"
-
           # Update root Cargo.toml
           sed -i 's/^version = "[^"]*"/version = "'"$VERSION"'"/' Cargo.toml
           echo "Updated root Cargo.toml version to $VERSION"
@@ -82,6 +82,7 @@ jobs:
         env:
           GH_TOKEN: ${{ env.GITHUB_TOKEN }}
           SIGNING_KEY: ${{ secrets.COMMIT_SIGNING_SSH_KEY }}
+          VERSION: ${{ steps.extract_version.outputs.version }}
         run: |
           # Commit as the token owner (not github-actions[bot]) and SSH-sign so the
           # version-bump commit is "Verified" and satisfies the signed-commits rule
@@ -110,7 +111,7 @@ jobs:
             echo "new_commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           else
             git add -A
-            git commit -m "chore: update version to ${{ steps.extract_version.outputs.version }}"
+            git commit -m "chore: update version to ${VERSION}"
             git push origin main
             NEW_COMMIT_SHA=$(git rev-parse HEAD)
             echo "new_commit_sha=${NEW_COMMIT_SHA}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,15 @@ jobs:
 
       - name: Extract version from release tag
         id: extract_version
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           # Get tag from release event or workflow dispatch input
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+            TAG="$INPUT_TAG"
           else
-            TAG="${{ github.event.release.tag_name }}"
+            TAG="$RELEASE_TAG"
           fi
           # Remove 'v' prefix if present (e.g., v1.2.3 -> 1.2.3)
           VERSION="${TAG#v}"
@@ -117,8 +120,9 @@ jobs:
 
       - name: Update tag and release
         if: github.event_name == 'release' && steps.commit_changes.outputs.new_commit_sha != ''
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          TAG_NAME="${{ github.event.release.tag_name }}"
           RELEASE_ID="${{ github.event.release.id }}"
           FINAL_COMMIT_SHA="${{ steps.commit_changes.outputs.new_commit_sha }}"
 


### PR DESCRIPTION
## Summary
Implements #240 — hardens `.github/workflows/release.yml` against GitHub Actions expression injection by routing GitHub event data (and tag-derived step output) through step-level `env:` variables instead of interpolating `${{ ... }}` directly into `run:` shell bodies. This brings `release.yml` in line with the invariant already used in `dependabot-auto-merge.yml` (`PR_URL:` env mappings).

Defense-in-depth: exploitation requires a privileged actor (write access to trigger `workflow_dispatch` or publish a release), so this was correctly **not** a merge blocker for #237 — but a crafted tag name or compromised maintainer token should not be able to inject shell into the release/publish pipeline.

## Changes
- **"Extract version from release tag" step:** `env:` block maps `INPUT_TAG: ${{ github.event.inputs.tag }}` and `RELEASE_TAG: ${{ github.event.release.tag_name }}`; the `run:` script selects between `$INPUT_TAG` / `$RELEASE_TAG`.
- **"Update versions and lock files" step:** `env:` block maps `VERSION: ${{ steps.extract_version.outputs.version }}`; removed the in-script `VERSION="${{ ... }}"` assignment — the script already uses `$VERSION`.
- **"Commit and push changes" step:** added `VERSION: ${{ steps.extract_version.outputs.version }}` to the existing `env:` block; the commit message now references `${VERSION}` instead of the raw `${{ ... }}`.
- **"Update tag and release" step:** `env:` block maps `TAG_NAME: ${{ github.event.release.tag_name }}`; removed the in-script `TAG_NAME="${{ ... }}"` assignment.
- **Naming note:** the AC literally suggested `TAG:` as the env key for both event sources, which is invalid YAML (duplicate key). Each source is routed through a distinctly-named var (`INPUT_TAG`/`RELEASE_TAG`) selected by the existing `if/else`.

### Round 2 — laundered-output blockers (Holmes's review)
The first round moved the `github.event.*` sources out of `run:` bodies, but the `version` output is derived from that same tag with no sanitization, and was still re-interpolated raw at two downstream sites — re-opening the injection surface for a tag like `v$(whoami)`. Both are now routed through `env: VERSION` (the "Update versions" and "Commit and push" steps above), closing the laundered-output hole.

## Acceptance Criteria
- [x] `release.yml` "Extract version" — `github.event.inputs.tag` routed through `env:` (`INPUT_TAG`)
- [x] `release.yml` "Extract version" — `github.event.release.tag_name` routed through `env:` (`RELEASE_TAG`)
- [x] `release.yml` "Update tag and release" — `github.event.release.tag_name` routed through `env: TAG_NAME`
- [x] Audit `github.event_name` (enum), `github.event.release.id` (numeric), and the `tag_name:` action `with:` input — none require `env:` routing
- [x] Widened invariant: zero `${{ }}` interpolations of tag-derived data (`github.event.*tag*`, `steps.extract_version.outputs.version`) inside any `run:` body. Safe residuals: job `outputs:` declaration, `release.id` (numeric), `new_commit_sha` (git SHA)
- [ ] Workflow integration test (`workflow_dispatch` with a benign tag) — maintainer manual; cannot be run from a PR branch without publishing a real release

## Test Plan
- [x] Widened grep invariant holds (env mappings + safe residuals only; zero raw tag-derived interpolation in `run:` bodies)
- [x] YAML parses cleanly
- [x] `actionlint 1.7.7` — diffed against base `main`: identical (8 pre-existing info-level SC2086 notes, unchanged); no expression-injection warnings
- [x] CI (CodeQL Analyze) green
- [ ] **Maintainer manual:** trigger a `workflow_dispatch` run with a benign tag and confirm it completes without errors. Not runnable from this PR branch — the workflow updates version files, commits to `main`, builds binaries, and publishes the Zed extension.

Fixes #240