### PR TITLE
code_lens: model_targets dedups lens member-names against accessors only — scopes/properties can still double-anchor

### DIFF
--- a/laravel-lsp/src/code_lens.rs
+++ b/laravel-lsp/src/code_lens.rs
@@ -242,13 +242,6 @@ fn model_targets(source: &str) -> Vec<CodeLensTarget> {
         return Vec::new();
     };
 
-    // Every member that already carries an accessor lens. Reads and writes share
-    // a single reference count today, so a mutator gets its own lens only when no
-    // accessor covers the same member (#232, option b — fallback-only): that
-    // closes the setter-only gap without showing the same number twice on a model
-    // that has both a getter and a setter.
-    let accessor_members = accessor_member_names(tree.root_node(), bytes);
-
     let mut out = Vec::new();
     let mut stack = vec![tree.root_node()];
     while let Some(n) = stack.pop() {
@@ -259,9 +252,7 @@ fn model_targets(source: &str) -> Vec<CodeLensTarget> {
                         out.push(target(&fqcn, &usage, line, col, end));
                     } else if let Some(usage) = accessor_usage_name(n, &name, bytes) {
                         out.push(target(&fqcn, &usage, line, col, end));
-                    } else if let Some(usage) =
-                        mutator_usage_name(&name).filter(|m| !accessor_members.contains(m))
-                    {
+                    } else if let Some(usage) = mutator_usage_name(&name) {
                         out.push(target(&fqcn, &usage, line, col, end));
                     } else if method_is_relationship(n, bytes) {
                         out.push(target(&fqcn, &name, line, col, end));
@@ -280,6 +271,19 @@ fn model_targets(source: &str) -> Vec<CodeLensTarget> {
             stack.push(ch);
         }
     }
+
+    // Collapse to one lens per `(fqcn, member)`. Scopes (`scopeActive`),
+    // accessors (`getActiveAttribute` / `active(): Attribute`), mutators
+    // (`setActiveAttribute`), and public properties (`public $active`) each
+    // snake-case a member name independently, so several declaration kinds can
+    // resolve to the same member — e.g. `scopeActive` + `public $active`, or a
+    // getter + setter. Reads and writes share a single reference count, so
+    // emitting more than one lens for a member would display the same number
+    // twice (#239). Sort by source position and keep the first occurrence, so
+    // the surviving lens anchors on the member's topmost declaration.
+    out.sort_by_key(|t| (t.line, t.column));
+    let mut seen = HashSet::new();
+    out.retain(|t| seen.insert(t.symbol.clone()));
     out
 }
 
@@ -349,32 +353,6 @@ fn mutator_usage_name(name: &str) -> Option<String> {
         .strip_prefix("set")
         .and_then(|s| s.strip_suffix("Attribute"))?;
     (!middle.is_empty()).then(|| pascal_to_snake(middle))
-}
-
-/// Every member name that already carries an accessor lens in this class —
-/// old-style `get{X}Attribute` or a new-style `Attribute`-returning method.
-/// Lets `model_targets` add a mutator lens only as a fallback, when no accessor
-/// covers the same member (#232, option b).
-fn accessor_member_names(root: Node, bytes: &[u8]) -> HashSet<String> {
-    let mut members = HashSet::new();
-    let mut stack = vec![root];
-    while let Some(n) = stack.pop() {
-        if n.kind() == "method_declaration" {
-            if let Some(name) = n
-                .child_by_field_name("name")
-                .and_then(|nm| nm.utf8_text(bytes).ok())
-            {
-                if let Some(usage) = accessor_usage_name(n, name, bytes) {
-                    members.insert(usage);
-                }
-            }
-        }
-        let mut c = n.walk();
-        for ch in n.children(&mut c) {
-            stack.push(ch);
-        }
-    }
-    members
 }
 
 /// True if a method body calls an Eloquent relationship factory

--- a/laravel-lsp/src/code_lens/tests.rs
+++ b/laravel-lsp/src/code_lens/tests.rs
@@ -243,6 +243,164 @@ class User extends \Illuminate\Database\Eloquent\Model {
     );
 }
 
+/// How many magic-member lenses resolve to `member` — used by the cross-kind
+/// dedup tests (#239), where two declarations snake-case to the same name.
+fn member_lens_count(targets: &[CodeLensTarget], member: &str) -> usize {
+    targets
+        .iter()
+        .filter(
+            |t| matches!(&t.symbol, SymbolRefData::MagicMember { member: m, .. } if m == member),
+        )
+        .count()
+}
+
+#[test]
+fn scope_and_accessor_collision_yields_one_lens() {
+    // `scopeActive` and `getActiveAttribute` both resolve to member `active`;
+    // they share one reference count, so exactly one lens (#239).
+    let src = r#"<?php
+namespace App\Models;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public function scopeActive($q) { return $q->where('active', true); }
+    public function getActiveAttribute() { return true; }
+}
+"#;
+    let targets = code_lens_targets(Path::new("/proj/app/Models/User.php"), src);
+    assert_eq!(
+        member_lens_count(&targets, "active"),
+        1,
+        "scope + accessor, got {:?}",
+        keys(&targets)
+    );
+}
+
+#[test]
+fn scope_and_public_property_collision_yields_one_lens() {
+    // `scopeActive` and `public $active` both resolve to member `active` — a
+    // collision possible since before #238 (#239).
+    let src = r#"<?php
+namespace App\Models;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public bool $active = true;
+    public function scopeActive($q) { return $q->where('active', true); }
+}
+"#;
+    let targets = code_lens_targets(Path::new("/proj/app/Models/User.php"), src);
+    assert_eq!(
+        member_lens_count(&targets, "active"),
+        1,
+        "scope + public property, got {:?}",
+        keys(&targets)
+    );
+}
+
+#[test]
+fn accessor_and_public_property_collision_yields_one_lens() {
+    // `getActiveAttribute` and `public $active` both resolve to `active` (#239).
+    let src = r#"<?php
+namespace App\Models;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public bool $active = true;
+    public function getActiveAttribute() { return true; }
+}
+"#;
+    let targets = code_lens_targets(Path::new("/proj/app/Models/User.php"), src);
+    assert_eq!(
+        member_lens_count(&targets, "active"),
+        1,
+        "accessor + public property, got {:?}",
+        keys(&targets)
+    );
+}
+
+#[test]
+fn scope_and_mutator_collision_yields_one_lens() {
+    // `scopeActive` and `setActiveAttribute` both resolve to `active`; the
+    // mutator branch (#238) must not double-anchor against a scope (#239).
+    let src = r#"<?php
+namespace App\Models;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public function scopeActive($q) { return $q->where('active', true); }
+    public function setActiveAttribute($v) { $this->attributes['active'] = $v; }
+}
+"#;
+    let targets = code_lens_targets(Path::new("/proj/app/Models/User.php"), src);
+    assert_eq!(
+        member_lens_count(&targets, "active"),
+        1,
+        "scope + mutator, got {:?}",
+        keys(&targets)
+    );
+}
+
+#[test]
+fn mutator_and_public_property_collision_yields_one_lens() {
+    // `setActiveAttribute` and `public $active` both resolve to `active` (#239).
+    let src = r#"<?php
+namespace App\Models;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public bool $active = true;
+    public function setActiveAttribute($v) { $this->attributes['active'] = $v; }
+}
+"#;
+    let targets = code_lens_targets(Path::new("/proj/app/Models/User.php"), src);
+    assert_eq!(
+        member_lens_count(&targets, "active"),
+        1,
+        "mutator + public property, got {:?}",
+        keys(&targets)
+    );
+}
+
+#[test]
+fn new_style_accessor_and_old_style_mutator_collision_yields_one_lens() {
+    // Regression for #238's `accessor_member_names`: a new-style accessor
+    // (`logo(): Attribute`) and an old-style mutator (`setLogoAttribute`) both
+    // resolve to `logo` — exactly one lens, no double-anchor (#239).
+    let src = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public function logo(): Attribute { return Attribute::make(fn () => $this->x); }
+    public function setLogoAttribute($v) { $this->attributes['logo'] = $v; }
+}
+"#;
+    let targets = code_lens_targets(Path::new("/proj/app/Models/User.php"), src);
+    assert_eq!(
+        member_lens_count(&targets, "logo"),
+        1,
+        "new-style accessor + old-style mutator, got {:?}",
+        keys(&targets)
+    );
+}
+
+#[test]
+fn distinct_members_across_all_kinds_each_get_one_lens() {
+    // Dedup must not collapse genuinely distinct members: a scope, accessor,
+    // mutator, and public property that resolve to four different names still
+    // emit one lens each (#239).
+    let src = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+class User extends \Illuminate\Database\Eloquent\Model {
+    public string $nickname = '';
+    public function scopeRecent($q) { return $q->latest(); }
+    public function getFullNameAttribute() { return $this->first.' '.$this->last; }
+    public function setAvatarAttribute($v) { $this->attributes['avatar'] = $v; }
+}
+"#;
+    let targets = code_lens_targets(Path::new("/proj/app/Models/User.php"), src);
+    let k = keys(&targets);
+    for member in ["nickname", "recent", "full_name", "avatar"] {
+        assert_eq!(
+            member_lens_count(&targets, member),
+            1,
+            "{member} should have one lens, got {k:?}"
+        );
+    }
+    assert_eq!(k.len(), 4, "four distinct members, no extras, got {k:?}");
+}
+
 // ── Route-name declaration lenses ─────────────────────────────────────────
 
 use crate::route_name_locator::RouteNameDeclaration;


### PR DESCRIPTION
## Summary
Implements #239 — `model_targets` deduplicates lens member-names against accessors only, so cross-kind collisions (scope/accessor/mutator/public-property) could still anchor **two** lenses for the same `(fqcn, member)`, displaying the same shared reference count twice.

## Changes
- Replaced the accessor-only suppression set (`accessor_member_names` + the `mutator_usage_name(...).filter(...)`) with a single **post-assembly dedup** over the assembled targets, keyed by the `(fqcn, member)` symbol.
- The dedup sorts by source position and keeps the first occurrence, so the surviving lens anchors on the member's **topmost declaration** (preserves the existing "getter wins over setter" behaviour, since the getter is declared first).
- Removed the now-redundant `accessor_member_names` helper — the dedup subsumes it and closes the whole collision class in one place.

> **One cosmetic judgment call:** when two declarations share a member + count, *which* one keeps the gutter lens is arbitrary (same count, same references). I chose **topmost-declaration-wins** as the intuitive, deterministic default. Easy to swap for a per-kind precedence if preferred.

## Acceptance Criteria
- [x] A dedup mechanism ensures `model_targets` emits at most one `CodeLensTarget` per `(fqcn, member)`, regardless of how many declaration kinds resolve to the same member name
- [x] `scope + accessor` collision yields exactly one lens for `active`
- [x] `scope + public property` collision yields exactly one lens for `active`
- [x] `accessor + public property` collision yields exactly one lens for `active`
- [x] `scope + mutator` collision yields exactly one lens for `active`
- [x] `mutator + public property` collision yields exactly one lens for `active`
- [x] Regression test: new-style accessor (`logo(): Attribute`) + old-style mutator (`setLogoAttribute`) yields exactly one lens for `logo` — locks in #238's untested `accessor_member_names` suppression path
- [x] Non-colliding declarations unaffected: a scope, accessor, mutator, and property resolving to distinct names still emit one lens per member

## Test Plan
- [x] 7 new tests in `code_lens/tests.rs` cover every collision pair + the regression + the non-colliding case
- [x] `cargo test` — code_lens suite 36/36 green; full unit suites 1921 + 440 green
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [ ] Pre-existing integration-test failures (8) depend on a gitignored `test-project/.env` fixture absent in a fresh clone — unrelated to this change; CI provisions the fixture

Fixes #239