### PR TITLE
Respect loadTranslationsFrom registrations in app and vendor service providers

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -14753,6 +14753,42 @@ return [
         let root_guard = self.root_path.read().await;
         let root = root_guard.as_ref()?;
 
+        // Namespaced keys (`namespace::file.key`) resolve through the merged
+        // vendor/app registration map — the package's real lang dir when the
+        // namespace was registered (e.g. via an app service provider), else the
+        // published `lang/vendor/<ns>/` path. Mirrors the diagnostic's
+        // "Expected at:" and hover so goto can't disagree with them (issue #248).
+        if let Some((namespace, rest)) = trans.key.split_once("::") {
+            let file_segment = rest.split('.').next().unwrap_or(rest);
+            let vendor_map = self.vendor_translation_namespaces_for(root).await;
+            let lang_dir = vendor_map
+                .as_deref()
+                .and_then(|m| m.get(namespace).cloned())
+                .unwrap_or_else(|| root.join("lang/vendor").join(namespace));
+            let target = lang_dir.join("en").join(format!("{}.php", file_segment));
+            if self.file_exists_cached(&target).await {
+                if let Ok(target_uri) = Url::from_file_path(&target) {
+                    let origin_selection_range = Range {
+                        start: Position {
+                            line: trans.line,
+                            character: trans.column,
+                        },
+                        end: Position {
+                            line: trans.line,
+                            character: trans.end_column,
+                        },
+                    };
+                    return Some(GotoDefinitionResponse::Link(vec![LocationLink {
+                        origin_selection_range: Some(origin_selection_range),
+                        target_uri,
+                        target_range: Range::default(),
+                        target_selection_range: Range::default(),
+                    }]));
+                }
+            }
+            return None;
+        }
+
         // Determine if this is a dotted key (PHP file) or text key (JSON file)
         let is_dotted_key = trans.key.contains('.') && !trans.key.contains(' ');
 
@@ -19003,10 +19039,11 @@ return [
         }
     }
 
-    /// Return the cached vendor translation-namespace map, building it on
-    /// first call. The scan walks `vendor/` for service providers calling
-    /// `loadTranslationsFrom(...)` — see [`laravel_lsp::vendor_translations`].
-    /// Subsequent hover calls reuse the cached Arc without re-scanning.
+    /// Return the cached translation-namespace map, building it on first call.
+    /// The map merges two scans (see [`laravel_lsp::vendor_translations`]):
+    /// `vendor/` service providers calling `loadTranslationsFrom(...)`, and the
+    /// app's own `app/Providers/` service providers. Subsequent hover calls
+    /// reuse the cached Arc without re-scanning.
     async fn vendor_translation_namespaces_for(
         &self,
         root: &Path,
@@ -19021,7 +19058,15 @@ return [
         // walkdir traversal doesn't block the LSP event loop.
         let root_clone = root.to_path_buf();
         let scanned = tokio::task::spawn_blocking(move || {
-            laravel_lsp::vendor_translations::scan_vendor_translation_namespaces(&root_clone)
+            let mut merged =
+                laravel_lsp::vendor_translations::scan_vendor_translation_namespaces(&root_clone);
+            // App service-provider registrations override vendor ones on a
+            // namespace clash — App (2) outranks Package (1) in the project's
+            // priority convention.
+            let app_map =
+                laravel_lsp::vendor_translations::scan_app_translation_namespaces(&root_clone);
+            merged.extend(app_map);
+            merged
         })
         .await
         .ok()?;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -14766,6 +14766,16 @@ return [
                 .and_then(|m| m.get(namespace).cloned())
                 .unwrap_or_else(|| root.join("lang/vendor").join(namespace));
             let target = lang_dir.join("en").join(format!("{}.php", file_segment));
+            // Containment guard (issue #248), fail-closed and uniform with every
+            // sibling goto handler (e.g. `:14108`, `:14158`, `:14235`, `:14290`):
+            // both the fallback `lang_dir` (the raw `namespace` from the key) and
+            // the appended `file_segment` are user-controlled text after `::`, so a
+            // `..` sequence could otherwise resolve `target` outside the project
+            // root and hand the client an out-of-root navigation target. Refuse
+            // before the existence probe so no out-of-root path is even stat'd.
+            if !path_within_root(&target, root) {
+                return None;
+            }
             if self.file_exists_cached(&target).await {
                 if let Ok(target_uri) = Url::from_file_path(&target) {
                     let origin_selection_range = Range {

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -40,6 +40,7 @@ mod scan_dir_containment;
 mod slot_navigation_containment;
 mod slot_variable_resolution;
 mod translation_namespace_check;
+mod translation_namespaced_goto_containment;
 mod view_diagnostic_containment;
 mod view_navigation_containment;
 mod vite_completion_context;

--- a/laravel-lsp/src/tests/translation_namespaced_goto_containment.rs
+++ b/laravel-lsp/src/tests/translation_namespaced_goto_containment.rs
@@ -1,0 +1,111 @@
+//! Tests for the fail-closed root-containment guard in
+//! `LaravelLanguageServer::create_translation_location_from_salsa` (issue #248) —
+//! the namespaced-key goto branch, a sibling of the #130 → #143 → #148 → #199
+//! containment-guard chain.
+//!
+//! Goto-definition on a namespaced translation key (`namespace::file.key`)
+//! resolves the namespace to a lang directory — the merged vendor/app
+//! registration map when present, else the published `lang/vendor/<namespace>/`
+//! fallback — then probes `<lang_dir>/en/<file>.php` and hands the client a
+//! navigation target. Both the fallback `lang_dir` (the raw `namespace` from the
+//! key) and the appended file segment are user-controlled text after `::`, so a
+//! `..` sequence could resolve the target outside the project root. The guard
+//! refuses such a target with the fail-closed `path_within_root` — the same check
+//! every sibling goto handler applies — so the containment invariant holds
+//! uniformly on the translation goto path too.
+//!
+//! These tests drive the private async method directly via
+//! `tower_lsp::LspService` / `inner()`, mirroring the component-navigation
+//! containment tests.
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::salsa_impl::TranslationReferenceData;
+use std::fs;
+use std::path::Path;
+use tower_lsp::LspService;
+
+/// Build a server instance for testing. `LspService::new` wires up a real
+/// `Client`; `inner()` hands back the `LaravelLanguageServer` so we can call its
+/// private methods directly.
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// Set the server root so `create_translation_location_from_salsa` resolves the
+/// project root. No `app/Providers/` or `vendor/` is seeded, so the namespace
+/// map is empty and resolution takes the `lang/vendor/<namespace>/` fallback —
+/// the branch where a `..`-laden namespace escapes the root.
+async fn set_root(server: &LaravelLanguageServer, root: &Path) {
+    *server.root_path.write().await = Some(root.to_path_buf());
+}
+
+/// A translation reference for `key`; the cursor coordinates are irrelevant to
+/// containment, only the key drives namespace/file resolution.
+fn trans_ref(key: &str) -> TranslationReferenceData {
+    TranslationReferenceData {
+        key: key.to_string(),
+        line: 0,
+        column: 0,
+        end_column: 0,
+    }
+}
+
+#[tokio::test]
+async fn out_of_root_namespaced_target_returns_none() {
+    // The namespace climbs out of the project root via `..`, and the target file
+    // genuinely exists at the escaped location — so a `None` result can only come
+    // from the containment guard, never a missing file. `lang/vendor/../../../evil`
+    // resolves to `<tmp>/evil`, a sibling of the project root.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    fs::create_dir_all(&root).unwrap();
+
+    // Materialize the escaped target on disk: <tmp>/evil/en/messages.php.
+    let evil = tmp.path().join("evil/en");
+    fs::create_dir_all(&evil).unwrap();
+    fs::write(evil.join("messages.php"), "<?php return ['x' => 'pwned'];").unwrap();
+
+    let server = test_server();
+    set_root(&server, &root).await;
+
+    let result = server
+        .create_translation_location_from_salsa(&trans_ref("../../../evil::messages.x"))
+        .await;
+
+    assert!(
+        result.is_none(),
+        "a namespaced goto target that escapes the project root must never resolve, \
+         even though the file exists on disk — the fail-closed containment guard \
+         refuses it"
+    );
+}
+
+#[tokio::test]
+async fn in_root_namespaced_target_still_resolves() {
+    // Positive control: a published namespaced key resolves through the
+    // `lang/vendor/<namespace>/` fallback to a real in-root file, passing the
+    // guard's allow branch — proving the new check doesn't regress in-root goto.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    let published = root.join("lang/vendor/shop/en");
+    fs::create_dir_all(&published).unwrap();
+    fs::write(
+        published.join("messages.php"),
+        "<?php return ['greeting' => 'hi'];",
+    )
+    .unwrap();
+
+    let server = test_server();
+    set_root(&server, &root).await;
+
+    let result = server
+        .create_translation_location_from_salsa(&trans_ref("shop::messages.greeting"))
+        .await;
+
+    assert!(
+        result.is_some(),
+        "an in-root published namespaced key must resolve through the guard's allow \
+         branch to its lang/vendor file"
+    );
+}

--- a/laravel-lsp/src/translation_lookup.rs
+++ b/laravel-lsp/src/translation_lookup.rs
@@ -58,7 +58,7 @@ pub fn resolve_translation_detailed(
         // Published path missed — try the unpublished vendor directory.
         if let Some(map) = vendor_map {
             if let Some(dir) = map.get(namespace) {
-                return resolve_namespaced_in_dir(dir, rest, locale);
+                return resolve_namespaced_in_dir(root, dir, rest, locale);
             }
         }
         return None;
@@ -128,6 +128,7 @@ fn resolve_namespaced(
 /// fallback used when the published path missed and the namespace was
 /// discovered via [`crate::vendor_translations`].
 fn resolve_namespaced_in_dir(
+    root: &Path,
     lang_dir: &Path,
     rest: &str,
     locale: &str,
@@ -139,6 +140,13 @@ fn resolve_namespaced_in_dir(
         return None;
     }
     let path = lang_dir.join(locale).join(format!("{}.php", file));
+    // Defense-in-depth: never read a file outside the project root, even if a
+    // malicious `loadTranslationsFrom` argument seeded `lang_dir` with an
+    // out-of-root path. The same fail-closed guard every other read site in this
+    // codebase applies before `read_to_string` (issue #248).
+    if !crate::path_containment::path_within_root(&path, root) {
+        return None;
+    }
     read_php_value(&path, &key_path)
 }
 

--- a/laravel-lsp/src/vendor_translations.rs
+++ b/laravel-lsp/src/vendor_translations.rs
@@ -26,10 +26,35 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 lazy_static! {
-    /// Matches `$this->loadTranslationsFrom(__DIR__.'/relative/path', 'namespace')`.
-    /// Captures the relative path and the namespace.
+    /// Matches `$this->loadTranslationsFrom(<first-arg>, 'namespace')`, capturing
+    /// the raw first-argument expression and the namespace. The first argument is
+    /// resolved to an absolute lang directory by [`resolve_load_translations_arg`],
+    /// which understands the `__DIR__`, `dirname(__DIR__)`, `lang_path()` and
+    /// `base_path()` forms Laravel app and package providers use in practice.
     static ref LOAD_TRANSLATIONS_RE: Regex = Regex::new(
-        r#"\$this->loadTranslationsFrom\s*\(\s*__DIR__\s*\.\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]+)['"]\s*\)"#
+        r#"\$this->loadTranslationsFrom\s*\(\s*([^,]+?)\s*,\s*['"]([^'"]+)['"]\s*\)"#
+    ).unwrap();
+
+    /// `lang_path('app')` — the argument resolves to `<root>/lang/<arg>`.
+    static ref LANG_PATH_ARG_RE: Regex = Regex::new(
+        r#"^lang_path\s*\(\s*['"]([^'"]*)['"]\s*\)$"#
+    ).unwrap();
+
+    /// `base_path('lang/custom')` — the argument resolves to `<root>/<arg>`.
+    static ref BASE_PATH_ARG_RE: Regex = Regex::new(
+        r#"^base_path\s*\(\s*['"]([^'"]*)['"]\s*\)$"#
+    ).unwrap();
+
+    /// `dirname(__DIR__).'/lang'` — `__DIR__` is the provider directory, so
+    /// `dirname()` climbs one level and the literal is joined onto that parent.
+    static ref DIRNAME_DIR_ARG_RE: Regex = Regex::new(
+        r#"^dirname\s*\(\s*__DIR__\s*\)\s*\.\s*['"]([^'"]+)['"]$"#
+    ).unwrap();
+
+    /// `__DIR__.'/../resources/lang'` — the literal is joined onto the provider
+    /// directory.
+    static ref DIR_ARG_RE: Regex = Regex::new(
+        r#"^__DIR__\s*\.\s*['"]([^'"]+)['"]$"#
     ).unwrap();
 
     /// Matches a fluent package-builder name declaration: `->name('package')`.
@@ -98,16 +123,97 @@ pub fn scan_vendor_translation_namespaces(root: &Path) -> HashMap<String, PathBu
             continue;
         }
 
-        extract_translations_from(&source, path, &mut namespaces);
+        extract_translations_from(&source, path, root, &mut namespaces);
         extract_builder_translations_from(&source, path, &mut namespaces);
     }
 
     namespaces
 }
 
+/// Walk `app/Providers/` for application service providers that register
+/// translation namespaces via `loadTranslationsFrom`. Returns a map of
+/// `namespace → absolute lang directory`, resolved exactly as the vendor scan
+/// resolves its registrations (see [`resolve_load_translations_arg`]).
+///
+/// App providers are the usual home for registrations the vendor scan never
+/// sees — e.g. `loadTranslationsFrom(lang_path('app'), 'app')` in
+/// `AppServiceProvider`. Unlike the vendor scan, there is no `ServiceProvider`
+/// filename gate: any `*.php` under `app/Providers/` is eligible, gated only on
+/// containing a `loadTranslationsFrom` call.
+pub fn scan_app_translation_namespaces(root: &Path) -> HashMap<String, PathBuf> {
+    let providers = root.join("app").join("Providers");
+    if !providers.is_dir() {
+        return HashMap::new();
+    }
+
+    let mut namespaces: HashMap<String, PathBuf> = HashMap::new();
+
+    for entry in walkdir::WalkDir::new(&providers)
+        .max_depth(10)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("php") {
+            continue;
+        }
+        let Ok(source) = fs::read_to_string(path) else {
+            continue;
+        };
+        if !source.contains("loadTranslationsFrom") {
+            continue;
+        }
+
+        extract_translations_from(&source, path, root, &mut namespaces);
+    }
+
+    namespaces
+}
+
+/// Resolve a `loadTranslationsFrom` first-argument expression to an absolute
+/// lang directory. `provider_dir` is the directory holding the service-provider
+/// file (PHP's `__DIR__`); `root` is the project root (the base for the
+/// `lang_path`/`base_path` helpers). Returns `None` for argument forms this
+/// scanner doesn't model, so an unrecognized call contributes no entry rather
+/// than a wrong one.
+fn resolve_load_translations_arg(arg: &str, provider_dir: &Path, root: &Path) -> Option<PathBuf> {
+    if let Some(cap) = LANG_PATH_ARG_RE.captures(arg) {
+        return Some(
+            root.join("lang")
+                .join(strip_path_prefix(cap.get(1)?.as_str())),
+        );
+    }
+    if let Some(cap) = BASE_PATH_ARG_RE.captures(arg) {
+        return Some(root.join(strip_path_prefix(cap.get(1)?.as_str())));
+    }
+    if let Some(cap) = DIRNAME_DIR_ARG_RE.captures(arg) {
+        return Some(
+            provider_dir
+                .parent()?
+                .join(strip_path_prefix(cap.get(1)?.as_str())),
+        );
+    }
+    if let Some(cap) = DIR_ARG_RE.captures(arg) {
+        return Some(provider_dir.join(strip_path_prefix(cap.get(1)?.as_str())));
+    }
+    None
+}
+
+/// Strip a leading `/` or `./` so the fragment joins onto the receiver instead
+/// of being treated as absolute (Rust's `Path::join` discards the receiver when
+/// the argument starts with `/`).
+fn strip_path_prefix(fragment: &str) -> &str {
+    fragment.trim_start_matches('/').trim_start_matches("./")
+}
+
 /// Apply [`LOAD_TRANSLATIONS_RE`] to the given source. Each match contributes
-/// a `namespace → absolute_lang_dir` entry. The relative path is resolved
-/// against the provider file's directory (the `__DIR__` reference).
+/// a `namespace → absolute_lang_dir` entry. The first argument is resolved by
+/// [`resolve_load_translations_arg`], which covers the `__DIR__`,
+/// `dirname(__DIR__)`, `lang_path()` and `base_path()` forms; `root` is the
+/// project root the path helpers are relative to.
 ///
 /// First-match-wins on namespace conflict — service-provider boot order is
 /// non-deterministic and we have no good way to rank packages without a full
@@ -115,26 +221,21 @@ pub fn scan_vendor_translation_namespaces(root: &Path) -> HashMap<String, PathBu
 fn extract_translations_from(
     source: &str,
     provider_path: &Path,
+    root: &Path,
     namespaces: &mut HashMap<String, PathBuf>,
 ) {
-    let provider_dir = match provider_path.parent() {
-        Some(d) => d,
-        None => return,
+    let Some(provider_dir) = provider_path.parent() else {
+        return;
     };
 
     for cap in LOAD_TRANSLATIONS_RE.captures_iter(source) {
-        let (Some(rel), Some(ns)) = (cap.get(1), cap.get(2)) else {
+        let (Some(arg), Some(ns)) = (cap.get(1), cap.get(2)) else {
             continue;
         };
-        // PHP source: `__DIR__.'/../resources/lang'` — the captured fragment
-        // starts with `/`. Rust's `Path::join` treats any path starting with
-        // `/` as absolute and discards the receiver, so we strip leading `/`
-        // and `./` before joining onto the provider directory.
-        let rel_str = rel
-            .as_str()
-            .trim_start_matches('/')
-            .trim_start_matches("./");
-        let lang_dir = provider_dir.join(rel_str);
+        let Some(lang_dir) = resolve_load_translations_arg(arg.as_str().trim(), provider_dir, root)
+        else {
+            continue;
+        };
         let resolved = lang_dir.canonicalize().unwrap_or(lang_dir);
         namespaces
             .entry(ns.as_str().to_string())

--- a/laravel-lsp/src/vendor_translations.rs
+++ b/laravel-lsp/src/vendor_translations.rs
@@ -236,7 +236,21 @@ fn extract_translations_from(
         else {
             continue;
         };
-        let resolved = lang_dir.canonicalize().unwrap_or(lang_dir);
+        // Resolve to the real on-disk path and refuse anything that escapes the
+        // project root. The four argument forms all capture an arbitrary string,
+        // so a crafted `loadTranslationsFrom('../../etc/passwd', 'ns')` could
+        // otherwise seed the map with an out-of-root directory the resolver would
+        // later read from — the same fail-closed path-traversal guard every other
+        // read site in this codebase applies (issue #248). `canonicalize()`
+        // failing (the target dir doesn't exist yet) drops the entry rather than
+        // storing an unresolved `..`-laden path; it re-enters the map on a later
+        // scan once the directory exists.
+        let Ok(resolved) = lang_dir.canonicalize() else {
+            continue;
+        };
+        if !crate::path_containment::path_within_root(&resolved, root) {
+            continue;
+        }
         namespaces
             .entry(ns.as_str().to_string())
             .or_insert(resolved);

--- a/laravel-lsp/src/vendor_translations.rs
+++ b/laravel-lsp/src/vendor_translations.rs
@@ -124,7 +124,7 @@ pub fn scan_vendor_translation_namespaces(root: &Path) -> HashMap<String, PathBu
         }
 
         extract_translations_from(&source, path, root, &mut namespaces);
-        extract_builder_translations_from(&source, path, &mut namespaces);
+        extract_builder_translations_from(&source, path, root, &mut namespaces);
     }
 
     namespaces
@@ -236,24 +236,28 @@ fn extract_translations_from(
         else {
             continue;
         };
-        // Resolve to the real on-disk path and refuse anything that escapes the
-        // project root. The four argument forms all capture an arbitrary string,
-        // so a crafted `loadTranslationsFrom('../../etc/passwd', 'ns')` could
-        // otherwise seed the map with an out-of-root directory the resolver would
-        // later read from — the same fail-closed path-traversal guard every other
-        // read site in this codebase applies (issue #248). `canonicalize()`
-        // failing (the target dir doesn't exist yet) drops the entry rather than
-        // storing an unresolved `..`-laden path; it re-enters the map on a later
-        // scan once the directory exists.
-        let Ok(resolved) = lang_dir.canonicalize() else {
-            continue;
-        };
-        if !crate::path_containment::path_within_root(&resolved, root) {
+        // Refuse anything that escapes the project root, but keep a not-yet-
+        // published in-root lang dir. The four argument forms all capture an
+        // arbitrary string, so a crafted `loadTranslationsFrom('../../etc', 'ns')`
+        // could otherwise seed the map with an out-of-root directory the resolver
+        // would later read from (issue #248). `path_within_root_lexical` refuses
+        // that escape — it collapses interior `..`/`.` and rejects an out-of-root
+        // candidate *before* any disk probe — while admitting a speculative in-root
+        // dir that doesn't exist yet. That admission matters: this map is built
+        // once and cached for the LSP's lifetime (`vendor_translation_namespaces_for`
+        // never re-scans it), so a fail-closed `canonicalize()` here would
+        // permanently drop every registration whose dir is absent at first scan —
+        // a fresh clone, pre-`vendor:publish`, or a mid-`composer install` package —
+        // the exact unpublished case this module exists to serve. The real read-time
+        // security is the fail-closed `path_within_root` at the read site
+        // (`translation_lookup::resolve_namespaced_in_dir`); this is the codebase's
+        // standard lexical-at-candidate / fail-closed-at-read split.
+        if !crate::path_containment::path_within_root_lexical(&lang_dir, root) {
             continue;
         }
         namespaces
             .entry(ns.as_str().to_string())
-            .or_insert(resolved);
+            .or_insert_with(|| crate::route_discovery::normalize_path(&lang_dir));
     }
 }
 
@@ -267,6 +271,7 @@ fn extract_translations_from(
 fn extract_builder_translations_from(
     source: &str,
     provider_path: &Path,
+    root: &Path,
     namespaces: &mut HashMap<String, PathBuf>,
 ) {
     if !BUILDER_HAS_TRANSLATIONS_RE.is_match(source) {
@@ -287,8 +292,19 @@ fn extract_builder_translations_from(
         return;
     };
     let lang_dir = provider_dir.join("../resources/lang");
-    let resolved = lang_dir.canonicalize().unwrap_or(lang_dir);
-    namespaces.entry(namespace).or_insert(resolved);
+    // Apply the same containment guard as `extract_translations_from` so the
+    // "every read site is guarded" invariant holds uniformly — this builder
+    // registration feeds the same merged map the goto/hover/diagnostic paths
+    // read. The builder dir is derived from the provider path so it is normally
+    // in-root, but the lexical guard refuses a `..` escape before any disk probe
+    // while preserving a not-yet-published in-root dir; the read site is
+    // fail-closed (issue #248).
+    if !crate::path_containment::path_within_root_lexical(&lang_dir, root) {
+        return;
+    }
+    namespaces
+        .entry(namespace)
+        .or_insert_with(|| crate::route_discovery::normalize_path(&lang_dir));
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/vendor_translations/tests.rs
+++ b/laravel-lsp/src/vendor_translations/tests.rs
@@ -239,3 +239,118 @@ class UiServiceProvider extends PackageServiceProvider
         "no ->hasTranslations() means no translation namespace, got {map:?}"
     );
 }
+
+// ─── App service-provider registrations (app/Providers/**/*.php) ─────────
+
+/// Write a service provider under `app/Providers/<name>.php` with the given
+/// body and return its path.
+fn write_app_provider(project: &Path, name: &str, body: &str) -> PathBuf {
+    let dir = project.join("app").join("Providers");
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{name}.php"));
+    fs::write(&path, body).unwrap();
+    path
+}
+
+#[test]
+fn scans_app_provider_with_lang_path_argument() {
+    let project = TempDir::new().unwrap();
+    fs::create_dir_all(project.path().join("lang/app")).unwrap();
+    write_app_provider(
+        project.path(),
+        "AppServiceProvider",
+        r#"<?php
+namespace App\Providers;
+class AppServiceProvider {
+    public function boot(): void {
+        $this->loadTranslationsFrom(lang_path('app'), 'app');
+    }
+}
+"#,
+    );
+
+    let map = scan_app_translation_namespaces(project.path());
+    let resolved = map.get("app").expect("should find app namespace");
+    assert!(
+        resolved.ends_with("lang/app"),
+        "lang_path('app') must resolve to <root>/lang/app, got: {resolved:?}"
+    );
+}
+
+#[test]
+fn scans_app_provider_with_base_path_argument() {
+    let project = TempDir::new().unwrap();
+    fs::create_dir_all(project.path().join("lang/custom")).unwrap();
+    write_app_provider(
+        project.path(),
+        "TranslationServiceProvider",
+        r#"<?php
+class TranslationServiceProvider {
+    public function boot(): void {
+        $this->loadTranslationsFrom(base_path('lang/custom'), 'custom');
+    }
+}
+"#,
+    );
+
+    let map = scan_app_translation_namespaces(project.path());
+    let resolved = map.get("custom").expect("should find custom namespace");
+    assert!(
+        resolved.ends_with("lang/custom"),
+        "base_path('lang/custom') must resolve to <root>/lang/custom, got: {resolved:?}"
+    );
+}
+
+#[test]
+fn scans_app_provider_with_dir_concat_argument() {
+    // The existing `__DIR__.'...'` form must keep working for app providers.
+    let project = TempDir::new().unwrap();
+    // app/Providers/AppServiceProvider.php + __DIR__.'/../../lang/app' → <root>/lang/app
+    fs::create_dir_all(project.path().join("lang/app")).unwrap();
+    write_app_provider(
+        project.path(),
+        "AppServiceProvider",
+        r#"<?php
+class AppServiceProvider {
+    public function boot(): void {
+        $this->loadTranslationsFrom(__DIR__.'/../../lang/app', 'app');
+    }
+}
+"#,
+    );
+
+    let map = scan_app_translation_namespaces(project.path());
+    let resolved = map.get("app").expect("should find app namespace");
+    assert!(
+        resolved.ends_with("lang/app"),
+        "__DIR__.'/../../lang/app' must resolve to <root>/lang/app, got: {resolved:?}"
+    );
+}
+
+#[test]
+fn vendor_scan_resolves_dirname_dir_argument() {
+    // `dirname(__DIR__).'/lang'` climbs one level from the provider directory.
+    let project = TempDir::new().unwrap();
+    let provider = fake_vendor_package(project.path(), "acme", "billing", "BillingServiceProvider");
+    // provider lives in vendor/acme/billing/src — dirname(__DIR__) is .../billing
+    fs::create_dir_all(provider.parent().unwrap().join("../lang")).unwrap();
+    fs::write(
+        &provider,
+        "<?php\nclass X { public function boot() { $this->loadTranslationsFrom(dirname(__DIR__).'/lang', 'billing'); } }\n",
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    let resolved = map.get("billing").expect("should find billing namespace");
+    assert!(
+        resolved.ends_with("billing/lang"),
+        "dirname(__DIR__).'/lang' must resolve to the package root's lang dir, got: {resolved:?}"
+    );
+}
+
+#[test]
+fn app_scan_returns_empty_without_providers_dir() {
+    let project = TempDir::new().unwrap();
+    let map = scan_app_translation_namespaces(project.path());
+    assert!(map.is_empty(), "no app/Providers means no namespaces");
+}

--- a/laravel-lsp/src/vendor_translations/tests.rs
+++ b/laravel-lsp/src/vendor_translations/tests.rs
@@ -41,6 +41,39 @@ class BillingServiceProvider {
 }
 
 #[test]
+fn preserves_registration_for_not_yet_published_in_root_dir() {
+    // Regression (issue #248, second-review blocker): the namespace map is built
+    // once and cached for the LSP's lifetime, so a registration whose lang dir is
+    // absent at scan time — a fresh clone, a package pre-`vendor:publish`, or one
+    // mid-`composer install` — must NOT be dropped. It has to survive so the
+    // namespaced key resolves once the directory appears, without an editor
+    // restart. The lexical containment guard admits the speculative in-root dir
+    // while still refusing `..` escapes; the fail-closed read-site guard in
+    // `translation_lookup` provides the actual read-time security.
+    let project = TempDir::new().unwrap();
+    let provider = fake_vendor_package(project.path(), "acme", "billing", "BillingServiceProvider");
+    // Deliberately do NOT create the lang dir on disk — this is the unpublished case.
+    fs::write(
+        &provider,
+        "<?php\nclass X { public function boot() { $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'billing'); } }\n",
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    let resolved = map
+        .get("billing")
+        .expect("a not-yet-published in-root registration must be preserved, not dropped");
+    assert!(
+        resolved.ends_with("resources/lang"),
+        "must store the registered in-root dir, got: {resolved:?}"
+    );
+    assert!(
+        !resolved.exists(),
+        "precondition: the registered dir must not exist on disk yet"
+    );
+}
+
+#[test]
 fn ignores_non_provider_php_files() {
     // A non-provider file with `loadTranslationsFrom` in a docblock should
     // be skipped by the filename gate.
@@ -89,10 +122,6 @@ fn captures_multiple_namespaces_across_packages() {
     let project = TempDir::new().unwrap();
     let p1 = fake_vendor_package(project.path(), "acme", "billing", "BillingServiceProvider");
     let p2 = fake_vendor_package(project.path(), "acme", "auth", "AuthServiceProvider");
-    // The registered lang dirs must exist on disk — the scan refuses any
-    // registration whose directory can't be canonicalized (issue #248).
-    fs::create_dir_all(p1.parent().unwrap().join("../lang")).unwrap();
-    fs::create_dir_all(p2.parent().unwrap().join("../lang")).unwrap();
     fs::write(
         &p1,
         "<?php\nclass X { public function boot() { $this->loadTranslationsFrom(__DIR__.'/../lang', 'billing'); } }\n",
@@ -123,10 +152,6 @@ fn first_registration_wins_on_namespace_conflict() {
     let project = TempDir::new().unwrap();
     let p1 = fake_vendor_package(project.path(), "first", "pkg", "FirstServiceProvider");
     let p2 = fake_vendor_package(project.path(), "second", "pkg", "SecondServiceProvider");
-    // Both registered lang dirs must exist — the scan refuses a registration
-    // whose directory can't be canonicalized (issue #248).
-    fs::create_dir_all(p1.parent().unwrap().join("../lang")).unwrap();
-    fs::create_dir_all(p2.parent().unwrap().join("../lang")).unwrap();
     fs::write(
         &p1,
         "<?php\nclass A { public function boot() { $this->loadTranslationsFrom(__DIR__.'/../lang', 'shared'); } }\n",
@@ -218,6 +243,41 @@ class ToolsServiceProvider extends PackageServiceProvider
     assert!(
         map.contains_key("tools"),
         "->name('laravel-tools') must register namespace 'tools', got {map:?}"
+    );
+}
+
+#[test]
+fn builder_preserves_registration_for_not_yet_published_in_root_dir() {
+    // The builder path (`->name()->hasTranslations()`) now carries the same
+    // lexical containment guard as the literal-call path (issue #248 follow-up).
+    // Its derived `../resources/lang` dir is always in-root, so the guard must
+    // admit it even when the directory doesn't exist yet — the registration is
+    // preserved exactly as the old `canonicalize().unwrap_or(lang_dir)` did,
+    // without weakening containment.
+    let project = TempDir::new().unwrap();
+    let provider = fake_vendor_package(project.path(), "acme", "tools", "ToolsServiceProvider");
+    // Deliberately do NOT create resources/lang — the unpublished builder case.
+    fs::write(
+        &provider,
+        r#"<?php
+class ToolsServiceProvider extends PackageServiceProvider
+{
+    public function configurePackage(Package $package): void
+    {
+        $package->name('acme-tools')->hasTranslations();
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    let resolved = map
+        .get("acme-tools")
+        .expect("a not-yet-published builder registration must be preserved");
+    assert!(
+        resolved.ends_with("resources/lang"),
+        "must store the builder's in-root lang dir, got: {resolved:?}"
     );
 }
 
@@ -442,9 +502,10 @@ fn refuses_registration_escaping_project_root() {
     // A crafted `loadTranslationsFrom` argument that climbs out of the project
     // root must never enter the namespace map — the resolver would otherwise read
     // translation files from outside the project tree (issue #248, path
-    // traversal). The escape target is created on disk so it canonicalizes
-    // successfully, proving the entry is rejected by the containment guard and
-    // not merely dropped because the directory is missing.
+    // traversal). The escape target is created on disk, so its rejection cannot be
+    // attributed to a missing directory: the lexical containment guard refuses it
+    // on root grounds alone (it collapses the interior `..` and sees the path land
+    // outside the root) even though the directory exists.
     let tmp = TempDir::new().unwrap();
     let root = tmp.path().join("project");
     fs::create_dir_all(&root).unwrap();

--- a/laravel-lsp/src/vendor_translations/tests.rs
+++ b/laravel-lsp/src/vendor_translations/tests.rs
@@ -89,6 +89,10 @@ fn captures_multiple_namespaces_across_packages() {
     let project = TempDir::new().unwrap();
     let p1 = fake_vendor_package(project.path(), "acme", "billing", "BillingServiceProvider");
     let p2 = fake_vendor_package(project.path(), "acme", "auth", "AuthServiceProvider");
+    // The registered lang dirs must exist on disk — the scan refuses any
+    // registration whose directory can't be canonicalized (issue #248).
+    fs::create_dir_all(p1.parent().unwrap().join("../lang")).unwrap();
+    fs::create_dir_all(p2.parent().unwrap().join("../lang")).unwrap();
     fs::write(
         &p1,
         "<?php\nclass X { public function boot() { $this->loadTranslationsFrom(__DIR__.'/../lang', 'billing'); } }\n",
@@ -119,6 +123,10 @@ fn first_registration_wins_on_namespace_conflict() {
     let project = TempDir::new().unwrap();
     let p1 = fake_vendor_package(project.path(), "first", "pkg", "FirstServiceProvider");
     let p2 = fake_vendor_package(project.path(), "second", "pkg", "SecondServiceProvider");
+    // Both registered lang dirs must exist — the scan refuses a registration
+    // whose directory can't be canonicalized (issue #248).
+    fs::create_dir_all(p1.parent().unwrap().join("../lang")).unwrap();
+    fs::create_dir_all(p2.parent().unwrap().join("../lang")).unwrap();
     fs::write(
         &p1,
         "<?php\nclass A { public function boot() { $this->loadTranslationsFrom(__DIR__.'/../lang', 'shared'); } }\n",
@@ -345,6 +353,120 @@ fn vendor_scan_resolves_dirname_dir_argument() {
     assert!(
         resolved.ends_with("billing/lang"),
         "dirname(__DIR__).'/lang' must resolve to the package root's lang dir, got: {resolved:?}"
+    );
+}
+
+#[test]
+fn scans_app_provider_with_dirname_dir_argument() {
+    // `dirname(__DIR__).'/lang'` climbs one level from the provider directory
+    // (app/Providers → app) for an app service provider, mirroring the vendor
+    // scan's handling of the same form (AC: dirname(__DIR__) coverage for the
+    // app scanner specifically).
+    let project = TempDir::new().unwrap();
+    // app/Providers/AppServiceProvider.php → dirname(__DIR__) is app, /lang → app/lang
+    fs::create_dir_all(project.path().join("app/lang")).unwrap();
+    write_app_provider(
+        project.path(),
+        "AppServiceProvider",
+        r#"<?php
+class AppServiceProvider {
+    public function boot(): void {
+        $this->loadTranslationsFrom(dirname(__DIR__).'/lang', 'app');
+    }
+}
+"#,
+    );
+
+    let map = scan_app_translation_namespaces(project.path());
+    let resolved = map.get("app").expect("should find app namespace");
+    assert!(
+        resolved.ends_with("app/lang"),
+        "dirname(__DIR__).'/lang' must resolve to <root>/app/lang, got: {resolved:?}"
+    );
+}
+
+#[test]
+fn app_provider_wins_over_vendor_on_namespace_conflict() {
+    // When a vendor package and an app service provider both register the same
+    // namespace, the merge in `main.rs::vendor_translation_namespaces_for`
+    // (`vendor.extend(app)`) makes the app entry win — App (2) outranks
+    // Package (1) in the project's priority convention. This exercises that
+    // documented `extend()` / app-wins semantics rather than assuming it.
+    let project = TempDir::new().unwrap();
+
+    // Vendor provider registers `shared` → vendor/acme/shared-pkg/lang.
+    let vendor_provider = fake_vendor_package(
+        project.path(),
+        "acme",
+        "shared-pkg",
+        "SharedServiceProvider",
+    );
+    fs::create_dir_all(vendor_provider.parent().unwrap().join("../lang")).unwrap();
+    fs::write(
+        &vendor_provider,
+        "<?php\nclass V { public function boot() { $this->loadTranslationsFrom(__DIR__.'/../lang', 'shared'); } }\n",
+    )
+    .unwrap();
+
+    // App provider registers the same `shared` namespace → <root>/lang/app.
+    fs::create_dir_all(project.path().join("lang/app")).unwrap();
+    write_app_provider(
+        project.path(),
+        "AppServiceProvider",
+        r#"<?php
+class AppServiceProvider {
+    public function boot(): void {
+        $this->loadTranslationsFrom(lang_path('app'), 'shared');
+    }
+}
+"#,
+    );
+
+    // Mirror the merge order in `vendor_translation_namespaces_for`.
+    let mut merged = scan_vendor_translation_namespaces(project.path());
+    merged.extend(scan_app_translation_namespaces(project.path()));
+
+    let resolved = merged.get("shared").expect("conflict must still resolve");
+    assert!(
+        resolved.ends_with("lang/app"),
+        "app registration must win the namespace clash, got: {resolved:?}"
+    );
+    assert!(
+        !resolved.to_string_lossy().contains("shared-pkg"),
+        "app registration must override the vendor entry, got: {resolved:?}"
+    );
+}
+
+#[test]
+fn refuses_registration_escaping_project_root() {
+    // A crafted `loadTranslationsFrom` argument that climbs out of the project
+    // root must never enter the namespace map — the resolver would otherwise read
+    // translation files from outside the project tree (issue #248, path
+    // traversal). The escape target is created on disk so it canonicalizes
+    // successfully, proving the entry is rejected by the containment guard and
+    // not merely dropped because the directory is missing.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    fs::create_dir_all(&root).unwrap();
+    // A sibling of the project root — inside the tempdir, but outside `root`.
+    fs::create_dir_all(tmp.path().join("escape/lang")).unwrap();
+
+    write_app_provider(
+        &root,
+        "AppServiceProvider",
+        r#"<?php
+class AppServiceProvider {
+    public function boot(): void {
+        $this->loadTranslationsFrom(base_path('../escape/lang'), 'evil');
+    }
+}
+"#,
+    );
+
+    let map = scan_app_translation_namespaces(&root);
+    assert!(
+        !map.contains_key("evil"),
+        "a registration resolving outside the project root must be refused, got: {map:?}"
     );
 }
 

--- a/laravel-lsp/tests/integration_tests.rs
+++ b/laravel-lsp/tests/integration_tests.rs
@@ -1527,3 +1527,93 @@ mod command_resolution {
         fs::remove_dir_all(&dir).ok();
     }
 }
+
+// ============================================================================
+// App service-provider translation registrations (issue #248)
+// ============================================================================
+
+mod app_provider_translations {
+    use laravel_lsp::translation_lookup::resolve_translation_detailed;
+    use laravel_lsp::vendor_translations::{
+        scan_app_translation_namespaces, scan_vendor_translation_namespaces,
+    };
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// Merge the vendor and app provider scans the same way the LSP does in
+    /// `vendor_translation_namespaces_for` (app registrations win on a clash).
+    fn merged_namespace_map(root: &std::path::Path) -> HashMap<String, PathBuf> {
+        let mut merged = scan_vendor_translation_namespaces(root);
+        merged.extend(scan_app_translation_namespaces(root));
+        merged
+    }
+
+    #[test]
+    fn app_provider_lang_path_registration_resolves_namespaced_key() {
+        let project = TempDir::new().unwrap();
+        let root = project.path();
+
+        // AppServiceProvider registers `app` translations at lang_path('app').
+        let providers = root.join("app/Providers");
+        fs::create_dir_all(&providers).unwrap();
+        fs::write(
+            providers.join("AppServiceProvider.php"),
+            r#"<?php
+namespace App\Providers;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        $this->loadTranslationsFrom(lang_path('app'), 'app');
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        // The translation file lives at lang/app/en/notification.php.
+        let lang_en = root.join("lang/app/en");
+        fs::create_dir_all(&lang_en).unwrap();
+        fs::write(
+            lang_en.join("notification.php"),
+            r#"<?php
+return [
+    'task_group_status_change' => [
+        'title' => 'Status changed',
+    ],
+];
+"#,
+        )
+        .unwrap();
+
+        let map = merged_namespace_map(root);
+        assert!(
+            map.contains_key("app"),
+            "merged map must carry the app-provider namespace, got {map:?}"
+        );
+
+        // No false "translation not found": the key resolves through the map to
+        // the real lang/app file, not the published lang/vendor/app/ fallback.
+        let resolved = resolve_translation_detailed(
+            root,
+            "app::notification.task_group_status_change.title",
+            "en",
+            Some(&map),
+        )
+        .expect("app::notification.task_group_status_change.title must resolve");
+
+        assert!(
+            resolved
+                .source_file
+                .ends_with("lang/app/en/notification.php"),
+            "must resolve to lang/app/en/notification.php, got {:?}",
+            resolved.source_file
+        );
+        assert!(
+            resolved.value.contains("Status changed"),
+            "resolved value should be the translated string, got {:?}",
+            resolved.value
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Implements #248. The translation namespace map is now built from **app**
service providers (`app/Providers/**/*.php`) in addition to vendor packages,
and the `loadTranslationsFrom` first-argument resolver understands the path
forms Laravel projects actually use — so go-to-definition, hover and
diagnostics for namespaced keys (`namespace::file.key`) stay consistent and
stop emitting false "translation not found" warnings.

## Changes
- **`vendor_translations.rs`**
  - Generalised `LOAD_TRANSLATIONS_RE` to capture any first-argument
    expression + namespace, and added `resolve_load_translations_arg` which
    resolves the four argument forms:
    - `__DIR__.'/../resources/lang'` → relative to the provider directory (unchanged behaviour)
    - `dirname(__DIR__).'/lang'` → relative to the provider directory's parent
    - `lang_path('app')` → `<root>/lang/app`
    - `base_path('lang/custom')` → `<root>/lang/custom`
  - Added `scan_app_translation_namespaces(root)` — scans `app/Providers/**/*.php`
    for `loadTranslationsFrom` registrations and returns `namespace → absolute lang dir`.
- **`main.rs`**
  - `vendor_translation_namespaces_for` now merges the vendor scan with the
    app-provider scan into one unified map (app wins on a namespace clash —
    App=2 > Package=1).
  - `create_translation_location_from_salsa` (go-to-definition) now handles
    namespaced keys via the merged map instead of mis-splitting the namespace
    on `.`, matching hover and the diagnostic.
- Diagnostics (`check_translation_file`) and hover already consumed the map,
  so they pick up app registrations with no further change.

## Acceptance Criteria
- [x] A new function (`scan_app_translation_namespaces`) scans `app/Providers/**/*.php` for `loadTranslationsFrom` calls and returns `namespace → absolute lang directory` entries
- [x] `vendor_translation_namespaces_for` in `main.rs` merges the app-provider scan with the existing vendor scan into a single unified namespace map
- [x] `lang_path('...')` arguments resolved as `<root>/lang/<arg>`
- [x] `base_path('...')` arguments resolved as `<root>/<arg>`
- [x] `dirname(__DIR__).'...'` arguments resolved relative to the provider file's directory
- [x] The existing `__DIR__.'...'` pattern continues to work for both vendor and app service providers
- [x] `check_translation_file` uses the discovered map path (not the `lang/vendor/{namespace}/` fallback) when the namespace is present in the merged map, for both diagnostics and the "Expected at:" hint
- [x] Go-to-definition and hover for a namespaced key route to the path from the merged map when registered via an app service provider
- [x] Unit tests added in `vendor_translations/tests.rs` covering app-provider scanning, `lang_path`, `base_path`, and `dirname(__DIR__)` forms
- [x] Integration test: `AppServiceProvider` with `loadTranslationsFrom(lang_path('app'), 'app')` causes `app::notification...title` to resolve to `lang/app/en/notification.php` (no false "translation not found" diagnostic)

## Test Plan
- [x] `cargo test` — 1942 lib tests pass; new `vendor_translations` unit tests and the new `app_provider_translations` integration test pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] All existing translation tests unchanged and green (no regressions)

Fixes #248