### PR TITLE
feat: ✨ Resolve app and vendor loadTranslationsFrom translation registrations

### DIFF
--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -44,6 +44,11 @@ use std::path::Path;
 /// re-typing the literal.
 pub const FILE_NOT_FOUND_TRAILER: &str = "*(file not found)*";
 
+/// The italic trailer [`translation_card`] renders when a key resolves to no
+/// value in the default locale. Single source of truth so tests assert against
+/// the production string.
+pub const TRANSLATION_NOT_FOUND_TRAILER: &str = "*(translation not found for default locale)*";
+
 /// Anything the cursor might be hovering. Pattern variants come straight from
 /// the Salsa position index; the Blade-variable variant is extracted by line
 /// scanning, and only matters in `.blade.php` files.
@@ -162,6 +167,53 @@ pub fn render(content: &HoverContent<'_>) -> String {
     }
 
     sections.join("\n\n")
+}
+
+/// Build the hover card for a translation key. The detail line carries just
+/// the key's leaf segment (inline code) and the locale it resolved against —
+/// the full key is already under the cursor, so repeating it is noise. The
+/// value follows on its own line wrapped in typographic quotes, which mark it
+/// unmistakably as the resolved string. `value` is the already-unquoted,
+/// length-capped string, or `None` when the key resolves to nothing — in which
+/// case the not-found trailer renders instead. `source_link` is a pre-built
+/// markdown link to the lang file, or `None`.
+///
+/// ```text
+/// `title` · en
+///
+/// “Status changed”
+///
+/// [lang/app/en/notification.php](file://…)
+/// ```
+pub fn translation_card(
+    key: &str,
+    locale: &str,
+    value: Option<&str>,
+    source_link: Option<&str>,
+) -> String {
+    let detail = format!("`{}` · {locale}", leaf_segment(key));
+    // Curly quotes delimit the value so it can't be mistaken for the key or a
+    // path, and won't clash with any straight quotes inside the string itself.
+    let quoted = value.map(|v| format!("“{v}”"));
+    let trailer = value.is_none().then_some(TRANSLATION_NOT_FOUND_TRAILER);
+    render(&HoverContent {
+        detail: Some(&detail),
+        description: quoted.as_deref(),
+        source_link,
+        trailer,
+        ..Default::default()
+    })
+}
+
+/// The leaf of a translation key: the last `.`-segment, after dropping any
+/// `namespace::` prefix. `app::notification.task.title` → `title`,
+/// `messages.welcome` → `welcome`, a spaced JSON text key → unchanged.
+fn leaf_segment(key: &str) -> &str {
+    let after_namespace = key.split_once("::").map(|(_, rest)| rest).unwrap_or(key);
+    after_namespace
+        .rsplit('.')
+        .next()
+        .unwrap_or(after_namespace)
 }
 
 /// Build a semantic hover card for a resolved magic member (M6) — the

--- a/laravel-lsp/src/hover/tests.rs
+++ b/laravel-lsp/src/hover/tests.rs
@@ -445,3 +445,37 @@ fn helper_identifier_card_is_none_for_non_curated_helper() {
         "non-curated helpers render no card"
     );
 }
+
+// ============================================================================
+// translation_card — leaf key + locale detail, quoted value, not-found trailer
+// ============================================================================
+
+#[test]
+fn translation_card_shows_leaf_key_locale_quoted_value_and_link() {
+    let link = "[lang/app/en/notification.php](file:///p/lang/app/en/notification.php)";
+    let out = translation_card(
+        "app::notification.task_group_status_change.title",
+        "en",
+        Some("Status changed"),
+        Some(link),
+    );
+    // Only the leaf (`title`) — not the full namespaced key — and the value in
+    // typographic quotes on its own line.
+    assert_eq!(out, format!("`title` · en\n\n“Status changed”\n\n{link}"));
+}
+
+#[test]
+fn translation_card_leaf_strips_namespace_and_parent_segments() {
+    // A non-namespaced dotted key reduces to its last segment too.
+    let out = translation_card("messages.nav.home", "fr", Some("Accueil"), None);
+    assert_eq!(out, "`home` · fr\n\n“Accueil”");
+}
+
+#[test]
+fn translation_card_without_value_shows_not_found_trailer() {
+    let out = translation_card("app::missing.key", "en", None, None);
+    assert_eq!(
+        out,
+        format!("`key` · en\n\n{TRANSLATION_NOT_FOUND_TRAILER}")
+    );
+}

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -14753,22 +14753,44 @@ return [
         let root_guard = self.root_path.read().await;
         let root = root_guard.as_ref()?;
 
-        // Determine if this is a dotted key (PHP file) or text key (JSON file)
-        let is_dotted_key = trans.key.contains('.') && !trans.key.contains(' ');
-
-        let translation_path = if is_dotted_key {
-            // Dotted key: "validation.required" -> lang/en/validation.php
-            let parts: Vec<&str> = trans.key.split('.').collect();
-            if parts.is_empty() {
-                return None;
-            }
-            root.join("lang")
-                .join("en")
-                .join(format!("{}.php", parts[0]))
-        } else {
-            // Text key: "Welcome to our app" -> lang/en.json
-            root.join("lang").join("en.json")
-        };
+        // Resolve the target lang file. Three shapes, mirroring
+        // `check_translation_file` / `hover_for_translation` so navigation,
+        // diagnostics, and hover all agree on where a key lives:
+        //  - namespaced (`app::file.key`) → <dir>/en/<file>.php, where <dir>
+        //    comes from the merged vendor/app-provider map (falling back to
+        //    the published `lang/vendor/<namespace>` path)
+        //  - dotted (`validation.required`) → lang/en/<file>.php
+        //  - text (`Welcome to our app`) → lang/en.json
+        // For PHP files, `php_key_path` is the nested array path to the key
+        // *within* the file (the segments after the file name), used to jump to
+        // the key's exact line. `None` marks a JSON text key.
+        let (translation_path, php_key_path) =
+            if let Some((namespace, rest)) = trans.key.split_once("::") {
+                let mut segments = rest.split('.');
+                let file_segment = segments.next().unwrap_or(rest);
+                let key_path: Vec<&str> = segments.collect();
+                let vendor_map = self.vendor_translation_namespaces_for(root).await;
+                let lang_dir = vendor_map
+                    .as_ref()
+                    .and_then(|m| m.get(namespace).cloned())
+                    .unwrap_or_else(|| root.join("lang/vendor").join(namespace));
+                (
+                    lang_dir.join("en").join(format!("{file_segment}.php")),
+                    Some(key_path),
+                )
+            } else if trans.key.contains('.') && !trans.key.contains(' ') {
+                // Dotted key: "validation.required" -> lang/en/validation.php
+                let mut segments = trans.key.split('.');
+                let file = segments.next().unwrap_or(&trans.key);
+                let key_path: Vec<&str> = segments.collect();
+                (
+                    root.join("lang").join("en").join(format!("{file}.php")),
+                    Some(key_path),
+                )
+            } else {
+                // Text key: "Welcome to our app" -> lang/en.json
+                (root.join("lang").join("en.json"), None)
+            };
 
         if self.file_exists_cached(&translation_path).await {
             if let Ok(target_uri) = Url::from_file_path(&translation_path) {
@@ -14783,13 +14805,17 @@ return [
                     },
                 };
 
-                // Find the line number of the key in the file
-                let target_range = if !is_dotted_key {
-                    // For JSON files, find the line where the key is defined
-                    Self::find_json_key_location(&translation_path, &trans.key).unwrap_or_default()
-                } else {
-                    // For PHP files, default to start (could be enhanced later)
-                    Range::default()
+                // Jump to the key's own line where we can locate it, else the
+                // top of the file (the file resolved, only the key didn't).
+                let target_range = match php_key_path.as_deref() {
+                    // JSON text key: line of the `"key":` property.
+                    None => Self::find_json_key_location(&translation_path, &trans.key)
+                        .unwrap_or_default(),
+                    // PHP nested array key: walk the array to the leaf's line.
+                    Some(key_path) if !key_path.is_empty() => {
+                        Self::locate_php_key_range(&translation_path, key_path).unwrap_or_default()
+                    }
+                    Some(_) => Range::default(),
                 };
 
                 return Some(GotoDefinitionResponse::Link(vec![LocationLink {
@@ -14801,6 +14827,27 @@ return [
             }
         }
         None
+    }
+
+    /// Find the line/columns of a nested array key in a PHP lang file via the
+    /// tree-sitter array walker [`config_key_locator`] (translation files are
+    /// the same nested-array shape as config files). `key_path` is the segments
+    /// *inside* the file — e.g. `["task_group_status_change", "title"]` for
+    /// `app::notification.task_group_status_change.title`. `None` when the file
+    /// can't be read or the key path isn't present.
+    fn locate_php_key_range(php_path: &Path, key_path: &[&str]) -> Option<Range> {
+        let content = std::fs::read_to_string(php_path).ok()?;
+        let pos = laravel_lsp::config_key_locator::locate_in_source(&content, key_path)?;
+        Some(Range {
+            start: Position {
+                line: pos.line,
+                character: pos.start_column,
+            },
+            end: Position {
+                line: pos.line,
+                character: pos.end_column,
+            },
+        })
     }
 
     /// Find the line and column of a key in a JSON translation file
@@ -18548,15 +18595,18 @@ return [
         }
     }
 
-    /// Translation — resolved value (with outer quotes stripped) as a plain
-    /// code block, link to the lang file.
+    /// Translation — the key and locale on a detail line, the resolved value
+    /// (outer quotes stripped) in a plain code block, link to the lang file.
     async fn hover_for_translation(&self, key: &str, root: Option<&Path>) -> String {
         use laravel_lsp::hover;
+        let locale = "en";
         let resolution = match root {
             Some(r) => {
                 let vendor_map = self.vendor_translation_namespaces_for(r).await;
                 let map_ref = vendor_map.as_ref().map(|m| m.as_ref());
-                laravel_lsp::translation_lookup::resolve_translation_detailed(r, key, "en", map_ref)
+                laravel_lsp::translation_lookup::resolve_translation_detailed(
+                    r, key, locale, map_ref,
+                )
             }
             None => None,
         };
@@ -18565,32 +18615,17 @@ return [
             None => None,
         };
         // Translation values are PHP literals (`'foo'`) — strip the outer
-        // quotes for nicer in-block display.
-        let unquoted = resolution.as_ref().map(|r| {
+        // quotes and cap the length for in-block display.
+        let value = resolution.as_ref().map(|r| {
             let v = r.value.trim();
-            v.strip_prefix('\'')
+            let unquoted = v
+                .strip_prefix('\'')
                 .and_then(|s| s.strip_suffix('\''))
                 .or_else(|| v.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
-                .unwrap_or(v)
-                .to_string()
+                .unwrap_or(v);
+            hover::truncate_for_display(unquoted, 200)
         });
-        let truncated = unquoted
-            .as_deref()
-            .map(|s| laravel_lsp::hover::truncate_for_display(s, 200));
-        let trailer = if resolution.is_none() {
-            Some("*(translation not found for default locale)*")
-        } else {
-            None
-        };
-        hover::render(&hover::HoverContent {
-            code: truncated.as_deref().map(|s| hover::CodeBlock {
-                language: hover::CodeLanguage::Plain,
-                content: s,
-            }),
-            source_link: link.as_deref(),
-            trailer,
-            ..Default::default()
-        })
+        hover::translation_card(key, locale, value.as_deref(), link.as_deref())
     }
 
     /// Middleware — header is the alias's class FQN (the new info beyond
@@ -19019,9 +19054,21 @@ return [
         }
         // Cache miss — scan and store. Done under spawn_blocking so the
         // walkdir traversal doesn't block the LSP event loop.
+        //
+        // Two passes merge into one map: the vendor scan first, then the
+        // app-provider scan, which overrides vendor on namespace conflict —
+        // the app boots last, so an app `loadTranslationsFrom` for a namespace
+        // a package also registers is the one that wins at runtime.
         let root_clone = root.to_path_buf();
         let scanned = tokio::task::spawn_blocking(move || {
-            laravel_lsp::vendor_translations::scan_vendor_translation_namespaces(&root_clone)
+            let mut map =
+                laravel_lsp::vendor_translations::scan_vendor_translation_namespaces(&root_clone);
+            for (namespace, dir) in
+                laravel_lsp::vendor_translations::scan_app_translation_namespaces(&root_clone)
+            {
+                map.insert(namespace, dir);
+            }
+            map
         })
         .await
         .ok()?;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -40,6 +40,7 @@ mod scan_dir_containment;
 mod slot_navigation_containment;
 mod slot_variable_resolution;
 mod translation_namespace_check;
+mod translation_namespace_navigation;
 mod view_diagnostic_containment;
 mod view_navigation_containment;
 mod vite_completion_context;

--- a/laravel-lsp/src/tests/translation_namespace_check.rs
+++ b/laravel-lsp/src/tests/translation_namespace_check.rs
@@ -67,6 +67,66 @@ fn missing_namespaced_key_still_flags_with_vendor_path() {
 }
 
 #[test]
+fn app_provider_load_translations_from_resolves_namespaced_key() {
+    // Issue #248: an `AppServiceProvider` registering
+    // `loadTranslationsFrom(lang_path('app'), 'app')` must make
+    // `app::notification.title` resolve to `lang/app/en/notification.php` —
+    // no false "translation not found" diagnostic.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // The registered lang files.
+    let lang_en = root.join("lang/app/en");
+    fs::create_dir_all(&lang_en).unwrap();
+    fs::write(
+        lang_en.join("notification.php"),
+        "<?php return ['task_group_status_change' => ['title' => 'Status changed']];",
+    )
+    .unwrap();
+
+    // The provider that registers them.
+    let providers = root.join("app/Providers");
+    fs::create_dir_all(&providers).unwrap();
+    fs::write(
+        providers.join("AppServiceProvider.php"),
+        r#"<?php
+namespace App\Providers;
+class AppServiceProvider {
+    public function boot(): void {
+        $this->loadTranslationsFrom(lang_path('app'), 'app');
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    // The merged map the LSP builds — here just the app-provider scan.
+    let map = laravel_lsp::vendor_translations::scan_app_translation_namespaces(&root);
+    // The dir exists, so the scan canonicalizes it (resolving macOS's
+    // /var → /private/var symlink) — compare against the canonical form.
+    assert_eq!(
+        map.get("app"),
+        Some(&root.join("lang/app").canonicalize().unwrap()),
+        "app scan must register the 'app' namespace at lang/app"
+    );
+
+    let check = LaravelLanguageServer::check_translation_file(
+        &root,
+        "app::notification.task_group_status_change.title",
+        Some(&map),
+    );
+    assert!(
+        check.exists,
+        "the app-registered translation must resolve via the merged map"
+    );
+    let expected = check.expected_path.expect("expected path set");
+    assert!(
+        expected.ends_with("lang/app/en/notification.php"),
+        "expected path must target the app-registered lang file: {expected:?}"
+    );
+}
+
+#[test]
 fn namespaced_key_without_vendor_map_expects_published_path() {
     let (_dir, root, _vendor_map) = project_with_vendor_translations();
 

--- a/laravel-lsp/src/tests/translation_namespace_navigation.rs
+++ b/laravel-lsp/src/tests/translation_namespace_navigation.rs
@@ -1,0 +1,128 @@
+//! Handler-level coverage for go-to-definition on a namespaced translation
+//! key (`app::file.key`) — issue #248 follow-up.
+//!
+//! `create_translation_location_from_salsa` (`main.rs`) used to split every key
+//! on `.` and build `lang/en/<first-segment>.php`. For a namespaced key that
+//! produced a bogus `lang/en/app::notification.php`, the file never existed, and
+//! the handler returned `None` — so cmd-hover showed no underline and the click
+//! did nothing. The fix resolves the namespace through the merged vendor/app
+//! provider map (the same map hover and diagnostics use) to the real lang file.
+//!
+//! These tests drive the real async handler on a server built through the
+//! `tower_lsp::LspService` harness the other handler tests use, priming the two
+//! pieces of state the chain reads — the project root and the vendor/app
+//! namespace cache — so it runs purely against a tempdir.
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::salsa_impl::TranslationReferenceData;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Url};
+use tower_lsp::LspService;
+
+/// Build a backend with the project root and the namespace map primed, so
+/// `vendor_translation_namespaces_for` returns the cache without scanning disk
+/// and the Salsa actor the harness spawns stays inert.
+async fn backend_with_namespaces(
+    root: &Path,
+    namespaces: HashMap<String, PathBuf>,
+) -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    let backend = service.inner().clone();
+    *backend.root_path.write().await = Some(root.to_path_buf());
+    *backend.vendor_translation_namespaces.write().await = Some(Arc::new(namespaces));
+    backend
+}
+
+/// A `TranslationReferenceData` for `key`. `column`/`end_column` are the string
+/// content span — exactly what becomes the link's `origin_selection_range`
+/// (the underline).
+fn trans_ref(key: &str, column: u32, end_column: u32) -> TranslationReferenceData {
+    TranslationReferenceData {
+        key: key.to_string(),
+        line: 3,
+        column,
+        end_column,
+    }
+}
+
+fn single_link(resp: GotoDefinitionResponse) -> tower_lsp::lsp_types::LocationLink {
+    match resp {
+        GotoDefinitionResponse::Link(mut links) => {
+            assert_eq!(links.len(), 1, "expected exactly one LocationLink");
+            links.remove(0)
+        }
+        other => panic!("expected GotoDefinitionResponse::Link, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn namespaced_key_navigates_to_app_provider_lang_file() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+
+    // The app-registered lang file the namespace points at — a nested array so
+    // the leaf key sits on its own line (line 3, 0-based).
+    let lang_file = root.join("lang/app/en/notification.php");
+    fs::create_dir_all(lang_file.parent().unwrap()).unwrap();
+    fs::write(
+        &lang_file,
+        "<?php\nreturn [\n    'task_group_status_change' => [\n        'title' => 'Status changed',\n    ],\n];\n",
+    )
+    .unwrap();
+
+    // The merged map the LSP would have built from AppServiceProvider's
+    // loadTranslationsFrom(lang_path('app'), 'app').
+    let mut namespaces = HashMap::new();
+    namespaces.insert("app".to_string(), root.join("lang/app"));
+    let backend = backend_with_namespaces(root, namespaces).await;
+
+    let resp = backend
+        .create_translation_location_from_salsa(&trans_ref(
+            "app::notification.task_group_status_change.title",
+            9,
+            57,
+        ))
+        .await
+        .expect("a namespaced key with an existing lang file must resolve to a link");
+
+    let link = single_link(resp);
+    assert_eq!(
+        link.target_uri,
+        Url::from_file_path(&lang_file).unwrap(),
+        "target must be the app-registered lang file, not lang/en/app::… or lang/vendor/app/…"
+    );
+    // The underline covers exactly the key's string content.
+    let origin = link
+        .origin_selection_range
+        .expect("origin selection range drives the cmd-hover underline");
+    assert_eq!(origin.start.character, 9);
+    assert_eq!(origin.end.character, 57);
+    assert_eq!(origin.start.line, 3);
+    // The jump lands on the leaf key's line (`'title'` on line 3), not line 0.
+    assert_eq!(
+        link.target_range.start.line, 3,
+        "navigation must land on the key's line, not the top of the file"
+    );
+}
+
+#[tokio::test]
+async fn namespaced_key_without_file_yields_no_link() {
+    // No lang file on disk → no navigation target (and so no phantom underline).
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+
+    let mut namespaces = HashMap::new();
+    namespaces.insert("app".to_string(), root.join("lang/app"));
+    let backend = backend_with_namespaces(root, namespaces).await;
+
+    let resp = backend
+        .create_translation_location_from_salsa(&trans_ref("app::missing.title", 9, 27))
+        .await;
+    assert!(
+        resp.is_none(),
+        "a namespaced key whose file doesn't exist must not produce a link"
+    );
+}

--- a/laravel-lsp/src/vendor_translations.rs
+++ b/laravel-lsp/src/vendor_translations.rs
@@ -1,7 +1,7 @@
-//! Discover translation-namespace registrations across vendor packages.
+//! Discover translation-namespace registrations across service providers.
 //!
-//! Laravel packages register their translations in a `ServiceProvider::boot()`
-//! method via:
+//! Laravel packages and apps register their translations in a
+//! `ServiceProvider::boot()` method via:
 //!
 //! ```php
 //! $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'package-namespace');
@@ -9,16 +9,35 @@
 //!
 //! The published location for those translations is `lang/vendor/<namespace>/`
 //! in the host project, which [`crate::translation_lookup`] already handles.
-//! This module fills the gap for translations that **haven't been published** —
-//! it walks `vendor/` for service providers that call `loadTranslationsFrom`,
-//! extracts each `(namespace, directory)` pair, and returns a map the
-//! resolver can fall back to when the published path doesn't exist.
+//! This module fills the gap for translations that **haven't been published**,
+//! and for **app-level** registrations that never go through `lang/vendor/`:
+//! it walks `vendor/` (and `app/Providers/`) for service providers that call
+//! `loadTranslationsFrom`, extracts each `(namespace, directory)` pair, and
+//! returns a map the resolver can fall back to when the published path doesn't
+//! exist.
+//!
+//! The first-argument expression is parsed from the PHP AST (tree-sitter)
+//! rather than a single literal regex, so the common path-helper forms all
+//! resolve:
+//!
+//! | Form                              | Resolves to                                  |
+//! | --------------------------------- | -------------------------------------------- |
+//! | `__DIR__.'/rel'`                  | provider dir + `rel`                          |
+//! | `dirname(__DIR__).'/rel'`         | provider dir's parent + `rel` (nests)         |
+//! | `lang_path('app')`               | `<root>/lang/app`                             |
+//! | `base_path('lang/custom')`       | `<root>/lang/custom`                          |
+//!
+//! The fluent package-builder convention (`->name('pkg')->hasTranslations()`)
+//! is still matched by regex — its real `loadTranslationsFrom($computedDir,
+//! $name)` call runs in a base class with runtime-computed arguments that no
+//! AST walk of the provider file can see.
 //!
 //! No on-disk cache yet — the scan runs once at LSP startup and the result
 //! lives in memory. A composer.lock-keyed cache (like
 //! [`crate::config::scan_vendor_for_component_aliases`]) is a worthwhile
 //! follow-up once the scan time becomes a noticeable cost on first hover.
 
+use crate::parser::parse_php;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::collections::HashMap;
@@ -26,12 +45,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 lazy_static! {
-    /// Matches `$this->loadTranslationsFrom(__DIR__.'/relative/path', 'namespace')`.
-    /// Captures the relative path and the namespace.
-    static ref LOAD_TRANSLATIONS_RE: Regex = Regex::new(
-        r#"\$this->loadTranslationsFrom\s*\(\s*__DIR__\s*\.\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]+)['"]\s*\)"#
-    ).unwrap();
-
     /// Matches a fluent package-builder name declaration: `->name('package')`.
     /// Builder-convention providers (e.g. Filament via laravel-package-tools)
     /// never call `loadTranslationsFrom` with literal arguments — the real call
@@ -57,7 +70,8 @@ lazy_static! {
 ///
 /// The scan applies two cheap gates before parsing any file:
 /// - **Filename**: must contain `ServiceProvider`
-/// - **Content substring**: must contain `loadTranslationsFrom`
+/// - **Content substring**: must contain `loadTranslationsFrom` or
+///   `hasTranslations`
 ///
 /// Roughly the same shape as
 /// [`crate::config::scan_vendor_for_component_aliases`] — these two scans
@@ -98,54 +112,277 @@ pub fn scan_vendor_translation_namespaces(root: &Path) -> HashMap<String, PathBu
             continue;
         }
 
-        extract_translations_from(&source, path, &mut namespaces);
-        extract_builder_translations_from(&source, path, &mut namespaces);
+        process_provider_file(&source, path, root, &mut namespaces);
     }
 
     namespaces
 }
 
-/// Apply [`LOAD_TRANSLATIONS_RE`] to the given source. Each match contributes
-/// a `namespace → absolute_lang_dir` entry. The relative path is resolved
-/// against the provider file's directory (the `__DIR__` reference).
+/// Walk `app/Providers/` for app service providers that register translation
+/// namespaces. Returns a map of `namespace → absolute lang directory`.
+///
+/// App providers (e.g. `AppServiceProvider`) commonly register translations
+/// with `loadTranslationsFrom(lang_path('app'), 'app')` — a path the vendor
+/// scan never sees because it lives outside `vendor/` and never publishes to
+/// `lang/vendor/`. The directory itself is the gate here (everything under
+/// `app/Providers/` is a provider), so only the content substring is checked.
+pub fn scan_app_translation_namespaces(root: &Path) -> HashMap<String, PathBuf> {
+    let providers = root.join("app").join("Providers");
+    if !providers.is_dir() {
+        return HashMap::new();
+    }
+
+    let mut namespaces: HashMap<String, PathBuf> = HashMap::new();
+
+    for entry in walkdir::WalkDir::new(&providers)
+        .max_depth(10)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("php") {
+            continue;
+        }
+
+        let Ok(source) = fs::read_to_string(path) else {
+            continue;
+        };
+        if !source.contains("loadTranslationsFrom") && !source.contains("hasTranslations") {
+            continue;
+        }
+
+        process_provider_file(&source, path, root, &mut namespaces);
+    }
+
+    namespaces
+}
+
+/// Run both extraction passes over a single provider file: the AST-based
+/// `loadTranslationsFrom(...)` walk and the regex-based builder convention.
+fn process_provider_file(
+    source: &str,
+    provider_path: &Path,
+    root: &Path,
+    namespaces: &mut HashMap<String, PathBuf>,
+) {
+    extract_load_translations_calls(source, provider_path, root, namespaces);
+    extract_builder_translations_from(source, provider_path, namespaces);
+}
+
+/// Walk the PHP AST for `$this->loadTranslationsFrom(<path>, '<namespace>')`
+/// calls and contribute a `namespace → absolute_lang_dir` entry for each one
+/// whose path argument resolves to a directory.
 ///
 /// First-match-wins on namespace conflict — service-provider boot order is
 /// non-deterministic and we have no good way to rank packages without a full
 /// composer dependency graph.
-fn extract_translations_from(
+fn extract_load_translations_calls(
     source: &str,
     provider_path: &Path,
+    root: &Path,
     namespaces: &mut HashMap<String, PathBuf>,
 ) {
-    let provider_dir = match provider_path.parent() {
-        Some(d) => d,
-        None => return,
+    let Some(provider_dir) = provider_path.parent() else {
+        return;
     };
+    let Ok(tree) = parse_php(source) else {
+        return;
+    };
+    let bytes = source.as_bytes();
+    walk_load_translations(tree.root_node(), bytes, provider_dir, root, namespaces);
+}
 
-    for cap in LOAD_TRANSLATIONS_RE.captures_iter(source) {
-        let (Some(rel), Some(ns)) = (cap.get(1), cap.get(2)) else {
-            continue;
-        };
-        // PHP source: `__DIR__.'/../resources/lang'` — the captured fragment
-        // starts with `/`. Rust's `Path::join` treats any path starting with
-        // `/` as absolute and discards the receiver, so we strip leading `/`
-        // and `./` before joining onto the provider directory.
-        let rel_str = rel
-            .as_str()
-            .trim_start_matches('/')
-            .trim_start_matches("./");
-        let lang_dir = provider_dir.join(rel_str);
-        let resolved = lang_dir.canonicalize().unwrap_or(lang_dir);
-        namespaces
-            .entry(ns.as_str().to_string())
-            .or_insert(resolved);
+/// Recursive AST descent collecting every `loadTranslationsFrom` registration.
+fn walk_load_translations(
+    node: tree_sitter::Node,
+    bytes: &[u8],
+    provider_dir: &Path,
+    root: &Path,
+    namespaces: &mut HashMap<String, PathBuf>,
+) {
+    if node.kind() == "member_call_expression" {
+        if let Some((ns, dir)) = classify_load_translations_call(node, bytes, provider_dir, root) {
+            namespaces.entry(ns).or_insert(dir);
+        }
     }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        walk_load_translations(child, bytes, provider_dir, root, namespaces);
+    }
+}
+
+/// Classify one `$this->loadTranslationsFrom(<path>, '<namespace>')` call.
+/// Returns `None` for any call that isn't such a registration, or whose path
+/// argument can't be resolved to a directory (e.g. a bare variable).
+fn classify_load_translations_call(
+    node: tree_sitter::Node,
+    bytes: &[u8],
+    provider_dir: &Path,
+    root: &Path,
+) -> Option<(String, PathBuf)> {
+    if !is_this_receiver(node.child_by_field_name("object")?, bytes) {
+        return None;
+    }
+    if node.child_by_field_name("name")?.utf8_text(bytes).ok()? != "loadTranslationsFrom" {
+        return None;
+    }
+
+    let args = node.child_by_field_name("arguments")?;
+    let mut cursor = args.walk();
+    let mut arg_exprs = args.named_children(&mut cursor).map(argument_value);
+
+    let path_arg = arg_exprs.next()??;
+    let ns_arg = arg_exprs.next()??;
+    let namespace = string_literal_text(ns_arg, bytes)?;
+
+    let lang_dir = resolve_path_arg(path_arg, bytes, provider_dir, root)?;
+    let resolved = lang_dir.canonicalize().unwrap_or(lang_dir);
+    Some((namespace, resolved))
+}
+
+/// Resolve a `loadTranslationsFrom` path argument to an absolute directory.
+///
+/// Handles the four common forms (see the module docs): `__DIR__.'/rel'`,
+/// `dirname(__DIR__).'/rel'`, `lang_path('…')`, and `base_path('…')`, plus a
+/// bare `__DIR__`. Anything else (a variable, an unrecognized helper) yields
+/// `None` and the registration is skipped.
+fn resolve_path_arg(
+    node: tree_sitter::Node,
+    bytes: &[u8],
+    provider_dir: &Path,
+    root: &Path,
+) -> Option<PathBuf> {
+    match node.kind() {
+        // `__DIR__.'/rel'` or `dirname(__DIR__).'/rel'`: a `.` concatenation
+        // of a directory base and a string literal.
+        "binary_expression" => {
+            let left = node.child_by_field_name("left")?;
+            let right = node.child_by_field_name("right")?;
+            let rel = string_literal_text(right, bytes)?;
+            let base = resolve_dir_base(left, bytes, provider_dir)?;
+            Some(join_relative(&base, &rel))
+        }
+        // `lang_path('app')` / `base_path('lang/custom')` / a bare
+        // `dirname(__DIR__)` used directly without concatenation.
+        "function_call_expression" => {
+            let fname = node
+                .child_by_field_name("function")?
+                .utf8_text(bytes)
+                .ok()?;
+            match fname {
+                "lang_path" => {
+                    let base = root.join("lang");
+                    Some(match first_string_arg(node, bytes) {
+                        Some(arg) => join_relative(&base, &arg),
+                        None => base,
+                    })
+                }
+                "base_path" => Some(match first_string_arg(node, bytes) {
+                    Some(arg) => join_relative(root, &arg),
+                    None => root.to_path_buf(),
+                }),
+                "dirname" => resolve_dir_base(node, bytes, provider_dir),
+                _ => None,
+            }
+        }
+        // Bare `__DIR__` with no relative suffix.
+        "name" if node.utf8_text(bytes).ok()? == "__DIR__" => Some(provider_dir.to_path_buf()),
+        _ => None,
+    }
+}
+
+/// Resolve the directory-base side of a concatenation: `__DIR__` (the provider
+/// dir) or `dirname(...)` (one level up, nesting for `dirname(dirname(...))`).
+fn resolve_dir_base(node: tree_sitter::Node, bytes: &[u8], provider_dir: &Path) -> Option<PathBuf> {
+    match node.kind() {
+        "name" if node.utf8_text(bytes).ok()? == "__DIR__" => Some(provider_dir.to_path_buf()),
+        "function_call_expression" => {
+            if node
+                .child_by_field_name("function")?
+                .utf8_text(bytes)
+                .ok()?
+                != "dirname"
+            {
+                return None;
+            }
+            let inner = first_argument(node)?;
+            let base = resolve_dir_base(inner, bytes, provider_dir)?;
+            base.parent().map(|p| p.to_path_buf())
+        }
+        _ => None,
+    }
+}
+
+/// Join a captured relative fragment onto a base directory. PHP source like
+/// `__DIR__.'/../resources/lang'` yields a fragment starting with `/`; Rust's
+/// `Path::join` treats a leading `/` as absolute and discards the receiver, so
+/// strip leading `/` and `./` before joining.
+fn join_relative(base: &Path, rel: &str) -> PathBuf {
+    let rel = rel.trim_start_matches('/').trim_start_matches("./");
+    base.join(rel)
+}
+
+/// The first string-literal argument of a function call, or `None`.
+fn first_string_arg(call: tree_sitter::Node, bytes: &[u8]) -> Option<String> {
+    string_literal_text(first_argument(call)?, bytes)
+}
+
+/// The value expression of a function call's first argument.
+fn first_argument(call: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    let args = call.child_by_field_name("arguments")?;
+    let mut cursor = args.walk();
+    let first = args.named_children(&mut cursor).next();
+    first.and_then(argument_value)
+}
+
+/// The value expression of a call argument. tree-sitter-php wraps each argument
+/// in an `argument` node; for a named argument the parameter label is the
+/// `name` field, so the value is the other child.
+fn argument_value(arg: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    if arg.kind() != "argument" {
+        return Some(arg);
+    }
+    let label = arg.child_by_field_name("name");
+    (0..arg.named_child_count() as u32)
+        .filter_map(|i| arg.named_child(i))
+        .find(|&ch| Some(ch) != label)
+}
+
+/// Whether `object` is the `$this` receiver of a `$this->method(...)` call.
+fn is_this_receiver(object: tree_sitter::Node, bytes: &[u8]) -> bool {
+    object.utf8_text(bytes).ok() == Some("$this")
+}
+
+/// The content of a single/double-quoted string literal node, or `None`.
+/// Descends to the `string_content` child, matching the rest of the LSP; an
+/// empty literal has no such child, so fall back to stripping a surrounding
+/// quote pair.
+fn string_literal_text(node: tree_sitter::Node, bytes: &[u8]) -> Option<String> {
+    if !matches!(node.kind(), "string" | "encapsed_string") {
+        return None;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "string_content" {
+            return Some(child.utf8_text(bytes).ok()?.to_string());
+        }
+    }
+    Some(
+        node.utf8_text(bytes)
+            .ok()?
+            .trim_start_matches(['\'', '"'])
+            .trim_end_matches(['\'', '"'])
+            .to_string(),
+    )
 }
 
 /// Reconstruct the fluent package-builder translation registration:
 /// `$package->name('filament-tables')->hasTranslations()`. The builder's base
 /// class registers `loadTranslationsFrom(<pkg>/resources/lang, shortName())`
-/// at runtime — both arguments computed, invisible to [`LOAD_TRANSLATIONS_RE`].
+/// at runtime — both arguments computed, invisible to the AST walk above.
 /// The namespace is the package short-name (leading `laravel-` stripped) and
 /// the directory follows the builder's `basePath('/../resources/lang')`
 /// convention: one level up from the provider's `src/` dir.

--- a/laravel-lsp/src/vendor_translations/tests.rs
+++ b/laravel-lsp/src/vendor_translations/tests.rs
@@ -138,6 +138,149 @@ fn first_registration_wins_on_namespace_conflict() {
     assert!(s.contains("first") || s.contains("second"), "got: {}", s);
 }
 
+// ─── Path-helper argument forms (lang_path / base_path / dirname) ────────
+
+#[test]
+fn extracts_lang_path_argument_form() {
+    // A vendor provider could conceivably use lang_path(); more importantly
+    // this exercises the helper independent of where the file lives.
+    let project = TempDir::new().unwrap();
+    let provider = fake_vendor_package(project.path(), "acme", "billing", "BillingServiceProvider");
+    fs::write(
+        &provider,
+        r#"<?php
+class BillingServiceProvider {
+    public function boot() {
+        $this->loadTranslationsFrom(lang_path('app'), 'app');
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    let resolved = map
+        .get("app")
+        .expect("lang_path('app') must register 'app'");
+    assert_eq!(
+        resolved,
+        &project.path().join("lang").join("app"),
+        "lang_path('app') resolves to <root>/lang/app"
+    );
+}
+
+#[test]
+fn extracts_base_path_argument_form() {
+    let project = TempDir::new().unwrap();
+    let provider = fake_vendor_package(project.path(), "acme", "billing", "BillingServiceProvider");
+    fs::write(
+        &provider,
+        r#"<?php
+class BillingServiceProvider {
+    public function boot() {
+        $this->loadTranslationsFrom(base_path('lang/custom'), 'custom');
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    let resolved = map
+        .get("custom")
+        .expect("base_path('lang/custom') must register 'custom'");
+    assert_eq!(
+        resolved,
+        &project.path().join("lang").join("custom"),
+        "base_path('lang/custom') resolves to <root>/lang/custom"
+    );
+}
+
+#[test]
+fn extracts_dirname_dir_argument_form() {
+    // `dirname(__DIR__).'/lang'` resolves relative to the provider's parent
+    // directory: provider lives in <pkg>/src, so dirname(__DIR__) is <pkg>.
+    let project = TempDir::new().unwrap();
+    let provider = fake_vendor_package(project.path(), "acme", "billing", "BillingServiceProvider");
+    let lang_dir = provider.parent().unwrap().join("../lang");
+    fs::create_dir_all(&lang_dir).unwrap();
+    fs::write(
+        &provider,
+        r#"<?php
+class BillingServiceProvider {
+    public function boot() {
+        $this->loadTranslationsFrom(dirname(__DIR__).'/lang', 'billing');
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let map = scan_vendor_translation_namespaces(project.path());
+    let resolved = map
+        .get("billing")
+        .expect("dirname(__DIR__).'/lang' must register 'billing'");
+    // <pkg>/src is the provider dir; dirname(__DIR__) is <pkg>; + /lang.
+    assert_eq!(
+        resolved.canonicalize().unwrap(),
+        lang_dir.canonicalize().unwrap(),
+        "dirname(__DIR__).'/lang' resolves to the package's lang dir"
+    );
+}
+
+// ─── App service provider scanning (app/Providers/**/*.php) ──────────────
+
+/// Write an app service provider at `app/Providers/<name>.php`.
+fn fake_app_provider(project: &Path, name: &str, body: &str) -> PathBuf {
+    let dir = project.join("app").join("Providers");
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{name}.php"));
+    fs::write(&path, body).unwrap();
+    path
+}
+
+#[test]
+fn scans_app_provider_load_translations_from() {
+    let project = TempDir::new().unwrap();
+    fake_app_provider(
+        project.path(),
+        "AppServiceProvider",
+        r#"<?php
+namespace App\Providers;
+class AppServiceProvider {
+    public function boot(): void {
+        $this->loadTranslationsFrom(lang_path('app'), 'app');
+    }
+}
+"#,
+    );
+
+    let map = scan_app_translation_namespaces(project.path());
+    let resolved = map
+        .get("app")
+        .expect("app provider registration must yield the 'app' namespace");
+    assert_eq!(resolved, &project.path().join("lang").join("app"));
+}
+
+#[test]
+fn app_scan_returns_empty_when_providers_dir_missing() {
+    let project = TempDir::new().unwrap();
+    let map = scan_app_translation_namespaces(project.path());
+    assert!(map.is_empty());
+}
+
+#[test]
+fn app_scan_ignores_providers_without_load_translations() {
+    let project = TempDir::new().unwrap();
+    fake_app_provider(
+        project.path(),
+        "AppServiceProvider",
+        "<?php\nclass AppServiceProvider { public function boot(): void {} }\n",
+    );
+    let map = scan_app_translation_namespaces(project.path());
+    assert!(map.is_empty());
+}
+
 // ─── Fluent package-builder registrations (->name()->hasTranslations()) ──
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #248.

Namespaced translation keys (`namespace::file.key`) only resolved against Laravel's default published path (`lang/vendor/<namespace>/`) plus a narrow literal `__DIR__` regex, so **app-level** and many **vendor** `loadTranslationsFrom` registrations were missed — go-to-definition, hover, and diagnostics pointed at the wrong path or false-flagged translations that work at runtime.

### What changed

- **Tree-sitter argument parsing** (`vendor_translations.rs`) — the `loadTranslationsFrom` path argument is now parsed from the PHP AST instead of one literal regex, resolving all four common forms:
  - `__DIR__.'/rel'` → provider dir + rel
  - `dirname(__DIR__).'/rel'` → provider parent + rel (nests)
  - `lang_path('app')` → `<root>/lang/app`
  - `base_path('lang/custom')` → `<root>/lang/custom`
- **App-provider scan** — new `scan_app_translation_namespaces` walks `app/Providers/**`, merged with the vendor scan into one namespace map in `vendor_translation_namespaces_for` (app overrides vendor on conflict, matching runtime boot order).
- **Go-to-definition** — namespaced keys now route through the merged map (previously built a bogus `lang/en/app::file.php` and returned no link), underline the key string, and land on the **key's own line** via the existing tree-sitter array walker instead of the top of the file. Plain dotted keys gain the jump-to-line too.
- **Hover card** — redesigned to a leaf-key · locale line with the resolved value in typographic quotes and the source link.

The builder convention (`->name('pkg')->hasTranslations()`) stays regex-based — its real call runs in a base class with runtime-computed arguments no AST walk of the provider file can see.

## Acceptance criteria

- [x] App-provider scan over `app/Providers/**` returning `namespace → absolute lang directory`
- [x] `vendor_translation_namespaces_for` merges app-provider + vendor scans into one map
- [x] `lang_path('...')` resolved as `<root>/lang/<arg>`
- [x] `base_path('...')` resolved as `<root>/<arg>`
- [x] `dirname(__DIR__).'...'` resolved relative to the provider directory
- [x] Existing `__DIR__.'...'` form still works (vendor and app)
- [x] `check_translation_file` uses the merged-map path (not the `lang/vendor/<ns>/` fallback) for diagnostics and the "Expected at:" hint
- [x] Go-to-definition and hover for a namespaced key route to the merged-map path
- [x] Unit tests for app-provider scanning, `lang_path`, `base_path`, `dirname(__DIR__)`
- [x] Integration test: `AppServiceProvider` + `loadTranslationsFrom(lang_path('app'), 'app')` → `app::notification.title` resolves to `lang/app/en/notification.php`

## Test plan

- `cargo test` — 1949 lib + 443 integration + 80 doc tests green
- `cargo clippy` clean, `cargo fmt --check` clean
- New coverage: `vendor_translations/tests.rs` (lang_path/base_path/dirname/app-scan + negatives), `translation_namespace_check.rs` (app-provider integration), `translation_namespace_navigation.rs` (handler-level go-to-definition incl. jump-to-line), `hover/tests.rs` (`translation_card`)
- Manually verified in a Laravel 13 project (Vapor): namespaced key resolves to the app-registered lang file, underlines, lands on the key's line, and the hover card renders correctly.
