### PR TITLE
feat: ✨ Resolve facades, macros & mixins to concrete implementations

### DIFF
--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -517,6 +517,65 @@ fn parse_component_aliases(source: &str, aliases: &mut HashMap<String, String>) 
 }
 
 // ============================================================================
+// Facade aliases (config/app.php 'aliases')
+// ============================================================================
+
+/// Parse the `'aliases'` array from a `config/app.php` source into a
+/// token → facade-FQCN map (`'Auth' => 'Illuminate\Support\Facades\Auth'`).
+///
+/// This is the legacy facade-alias registration: a `Facade::defaultAliases()`
+/// override returned from `config/app.php`, each entry an `'Alias' =>
+/// Class::class` pair. It is the **opposite** of [`parse_component_aliases`],
+/// which *skips* `::class` values (those are Blade component classes); here a
+/// `::class` value is exactly what we want — it names the facade class the
+/// alias resolves to.
+///
+/// Values are read as written: a `::class` constant (`Auth::class`,
+/// `Illuminate\Support\Facades\Auth::class`, or a leading-`\` form). We strip
+/// the `::class` suffix and any leading `\`, taking the remaining FQCN
+/// verbatim. config/app.php's `aliases` are written fully-qualified by Laravel
+/// convention, so no `use`-import resolution is needed for this source (the
+/// `bootstrap/app.php` `withAliases` source, parsed via tree-sitter, does
+/// resolve imports). A non-`::class` value (a bare string, a computed
+/// expression) is skipped — it can't name a facade class statically.
+pub fn parse_facade_aliases(source: &str) -> HashMap<String, String> {
+    let mut aliases = HashMap::new();
+    let Some(block) = php_array_block(source, "aliases") else {
+        return aliases;
+    };
+
+    for raw_line in block.lines() {
+        let line = raw_line.trim();
+        if line.is_empty()
+            || line.starts_with("//")
+            || line.starts_with('#')
+            || line.starts_with("/*")
+        {
+            continue;
+        }
+
+        let Some((alias, value)) = split_arrow_pair(line) else {
+            continue;
+        };
+        let Some(alias_name) = unquote(alias) else {
+            continue;
+        };
+        // Only `Class::class` values name a facade class; anything else is not
+        // a static class reference.
+        let Some(class_ref) = value.strip_suffix("::class") else {
+            continue;
+        };
+        let fqcn = class_ref.trim().trim_start_matches('\\');
+        if fqcn.is_empty() {
+            continue;
+        }
+        aliases.insert(alias_name.to_string(), fqcn.to_string());
+    }
+
+    aliases
+}
+
+// ============================================================================
 // Livewire component namespaces (Livewire v4)
 // ============================================================================
 

--- a/laravel-lsp/src/config/tests.rs
+++ b/laravel-lsp/src/config/tests.rs
@@ -636,3 +636,73 @@ fn resolve_config_string_app_override_wins_over_package_default() {
 
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ============================================================================
+// Facade aliases (config/app.php 'aliases')
+// ============================================================================
+
+#[test]
+fn parse_facade_aliases_reads_fully_qualified_class_consts() {
+    // The canonical config/app.php form: fully-qualified `::class` values.
+    let source = r#"<?php
+return [
+    'name' => env('APP_NAME', 'Laravel'),
+    'aliases' => [
+        'App' => Illuminate\Support\Facades\App::class,
+        'Auth' => Illuminate\Support\Facades\Auth::class,
+    ],
+];
+"#;
+    let aliases = parse_facade_aliases(source);
+    assert_eq!(
+        aliases.get("App").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\App")
+    );
+    assert_eq!(
+        aliases.get("Auth").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+}
+
+#[test]
+fn parse_facade_aliases_strips_leading_backslash() {
+    let source = r#"<?php
+return [
+    'aliases' => [
+        'Cache' => \Illuminate\Support\Facades\Cache::class,
+    ],
+];
+"#;
+    let aliases = parse_facade_aliases(source);
+    assert_eq!(
+        aliases.get("Cache").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\Cache")
+    );
+}
+
+#[test]
+fn parse_facade_aliases_skips_non_class_values() {
+    // A non-`::class` value can't name a facade class statically — skip it,
+    // but keep the valid sibling. (Contrast `parse_component_aliases`, which
+    // skips `::class` and keeps the string.)
+    let source = r#"<?php
+return [
+    'aliases' => [
+        'Legacy' => 'some.string.binding',
+        'Auth' => Illuminate\Support\Facades\Auth::class,
+    ],
+];
+"#;
+    let aliases = parse_facade_aliases(source);
+    assert!(!aliases.contains_key("Legacy"));
+    assert_eq!(
+        aliases.get("Auth").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+}
+
+#[test]
+fn parse_facade_aliases_absent_key_yields_empty() {
+    let source = "<?php return ['name' => 'Laravel'];";
+    assert!(parse_facade_aliases(source).is_empty());
+}

--- a/laravel-lsp/src/facade_resolver.rs
+++ b/laravel-lsp/src/facade_resolver.rs
@@ -1,0 +1,361 @@
+//! Facade receiver resolution — every facade call form, to the real impl.
+//!
+//! laravel-lsp resolves a facade static call to the **real implementation** the
+//! call forwards to, for all three forms:
+//!
+//! 1. **Imported / inline fully-qualified** — `use
+//!    Illuminate\Support\Facades\Auth; Auth::check();` or
+//!    `\Illuminate\Support\Facades\Auth::check()`. Intelephense also resolves
+//!    this form, but only as well as the framework's committed `@method static`
+//!    docblocks (e.g. `Auth` ships 59 `@method` tags, zero `@property`, no
+//!    macros), and its goto lands on the *docblock*, not the implementation. We
+//!    resolve to the concrete impl, accepting that Zed shows a 2-entry goto
+//!    multibuffer (Intelephense's docblock + our real impl) for the documented
+//!    methods (zed#24100, an accepted trade).
+//! 2. **Root-namespace alias** — `\Auth::check()`, `\DB::beginTransaction()`.
+//!    The global aliases registered by `Facade::defaultAliases()` make the
+//!    leading-`\` token resolve at runtime, but there is no `use` import for
+//!    Intelephense to follow, so the call resolves nowhere without us.
+//! 3. **Facade-returning helper** — `auth()->check()`, `app('db')->…`. Handled
+//!    by the container / helper receiver paths in `member_resolver`; this
+//!    module supplies the accessor → binding bridge they share.
+//!
+//! ## Resolution model (walk the chain, not the `@see` shortcut)
+//!
+//! A facade is a thin static proxy: `getFacadeAccessor()` returns a container
+//! binding key, and the bound concrete is the real implementation the calls
+//! forward to. We resolve the same way Laravel does at runtime:
+//!
+//! ```text
+//! token (Auth)
+//!   → facade FQCN (Illuminate\Support\Facades\Auth)   [alias map]
+//!   → accessor key ('auth')                            [getFacadeAccessor()]
+//!   → concrete FQCN (Illuminate\Auth\AuthManager)      [binding registry]
+//! ```
+//!
+//! This module owns the first two hops. The third — accessor key → concrete
+//! class — is the existing
+//! [`ClassFileResolver::binding_concrete`](crate::member_resolver::ClassFileResolver::binding_concrete)
+//! seam, fed by the provider-binding registry (`extract_provider_bindings`),
+//! which already sees vendor framework providers at priority 0. The
+//! `@see` docblock tag is intentionally **not** the primary path: it is only a
+//! last-resort fallback when both the parsed accessor and the binding lookup
+//! come up empty.
+
+use crate::query_chain::use_aliases::resolve_class_name;
+use crate::query_chain::use_aliases::UseAliases;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// The `Illuminate\Support\Facades` namespace every built-in facade lives in.
+/// Used both to seed the default alias map and as the marker that identifies a
+/// facade FQCN: a receiver that resolves into this namespace (via a `use` import
+/// or written inline fully-qualified) IS a facade, and we resolve it to the real
+/// implementation.
+pub const FACADE_NAMESPACE: &str = "Illuminate\\Support\\Facades";
+
+/// Laravel's built-in facade tokens — the local aliases `Facade::defaultAliases()`
+/// registers globally. Maps the bare token (`Auth`) to the facade short class
+/// name; the FQCN is `FACADE_NAMESPACE\<short>`. This is the seed for the
+/// root-namespace alias form, merged at the Salsa layer with any user aliases
+/// from `config/app.php` / `bootstrap/app.php`.
+///
+/// The list mirrors `Illuminate\Foundation\Application::registerCoreContainerAliases`
+/// /`Facade::defaultAliases()` for the facades that proxy a container binding.
+const DEFAULT_FACADES: &[&str] = &[
+    "App",
+    "Artisan",
+    "Auth",
+    "Blade",
+    "Broadcast",
+    "Bus",
+    "Cache",
+    "Config",
+    "Context",
+    "Cookie",
+    "Crypt",
+    "Date",
+    "DB",
+    "Event",
+    "File",
+    "Gate",
+    "Hash",
+    "Http",
+    "Lang",
+    "Log",
+    "Mail",
+    "Notification",
+    "Password",
+    "Pipeline",
+    "Process",
+    "Queue",
+    "RateLimiter",
+    "Redirect",
+    "Redis",
+    "Request",
+    "Response",
+    "Route",
+    "Schema",
+    "Session",
+    "Storage",
+    "URL",
+    "Validator",
+    "View",
+    "Vite",
+];
+
+/// Default `getFacadeAccessor()` keys for the built-in facades whose accessor is
+/// a bare string binding key — the fast path that avoids parsing the facade
+/// source, and the fallback when the source can't be read (vendor absent). Only
+/// facades that proxy a *string-keyed* container binding are listed; facades
+/// whose accessor returns a `::class` constant (e.g. `Date`, `Pipeline`) are
+/// omitted and fall through to source parsing.
+const DEFAULT_ACCESSORS: &[(&str, &str)] = &[
+    ("App", "app"),
+    ("Artisan", "artisan"),
+    ("Auth", "auth"),
+    ("Blade", "blade.compiler"),
+    ("Broadcast", "Illuminate\\Contracts\\Broadcasting\\Factory"),
+    ("Cache", "cache"),
+    ("Config", "config"),
+    ("Cookie", "cookie"),
+    ("Crypt", "encrypter"),
+    ("DB", "db"),
+    ("Event", "events"),
+    ("File", "files"),
+    ("Gate", "Illuminate\\Contracts\\Auth\\Access\\Gate"),
+    ("Hash", "hash"),
+    ("Lang", "translator"),
+    ("Log", "log"),
+    ("Mail", "mailer"),
+    ("Password", "auth.password"),
+    ("Queue", "queue"),
+    ("Redirect", "redirect"),
+    ("Redis", "redis"),
+    ("Request", "request"),
+    ("Route", "router"),
+    ("Schema", "db.schema"),
+    ("Session", "session"),
+    ("Storage", "filesystem"),
+    ("URL", "url"),
+    ("View", "view"),
+];
+
+/// Seed the default facade alias map: token → facade FQCN. The Salsa layer
+/// merges user-defined aliases (`config/app.php` `aliases`, `bootstrap/app.php`)
+/// on top — a user alias for an existing token overrides the default, and a new
+/// token is added.
+pub fn default_facade_aliases() -> HashMap<String, String> {
+    DEFAULT_FACADES
+        .iter()
+        .map(|short| ((*short).to_string(), format!("{FACADE_NAMESPACE}\\{short}")))
+        .collect()
+}
+
+/// Resolve a static-call receiver token to its facade FQCN, covering all three
+/// facade forms and honoring PHP's namespace-resolution rule for class names.
+///
+/// `receiver` is the scope text exactly as written (`\Auth`, `Auth`,
+/// `\Illuminate\Support\Facades\Auth`). `aliases` is the file's `use`-import
+/// map; `facade_aliases` is the seeded-plus-merged token → facade-FQCN map.
+/// `is_namespaced` is whether the *calling file* has a `namespace` declaration —
+/// determined at the call site from a `namespace_definition` node.
+///
+/// ## Resolution order
+///
+/// 1. **Facades-namespace form first** — if the receiver resolves into
+///    `Illuminate\Support\Facades\*` (through a `use` import, or written inline
+///    fully-qualified `\Illuminate\Support\Facades\Auth`), that IS the facade
+///    FQCN — return it. This is checked *before* the bare-namespaced rule so an
+///    imported bare `Auth` resolves even inside a namespaced file (the import
+///    wins). We own this form now, resolving to the real impl rather than staying
+///    silent — see the module docs for the Intelephense rationale.
+/// 2. **Global alias form** — a leading-`\` token (`\Auth`), or a bare token
+///    (`Auth`) in a **non-namespaced** file: PHP resolves these in the global
+///    namespace where `Facade::defaultAliases()` lives, so the facade alias
+///    applies — match it against `facade_aliases` and return its FQCN.
+///
+/// ## PHP namespace-resolution rule (why `is_namespaced` matters)
+///
+/// For a **class** name, an unqualified token with no matching `use` import
+/// resolves against the *current* namespace — it does **not** fall back to the
+/// global namespace (that fallback exists for functions and constants only). So
+/// bare `Auth::check()` inside `namespace App\Http;` means `App\Http\Auth`, not
+/// the global `\Auth` facade alias.
+///
+/// Returns `None` when:
+/// - it's a **bare token in a namespaced file** with no facade import (PHP
+///   resolves it against the current namespace, not the global alias — we must
+///   not emit a wrong goto; Intelephense's "undefined `CurrentNs\Auth`" squiggle
+///   correctly stands), or
+/// - the token contains a `\` separator but is not in the Facades namespace
+///   (`App\Services\Auth` — a real class reference, not a facade alias), or
+/// - the token isn't a known facade at all.
+pub fn resolve_facade_fqcn(
+    receiver: &str,
+    aliases: &UseAliases,
+    facade_aliases: &HashMap<String, String>,
+    is_namespaced: bool,
+) -> Option<String> {
+    // Distinguish a root-`\` receiver from a bare one BEFORE `resolve_class_name`
+    // strips the leading `\` and collapses the two cases. A leading `\` forces
+    // global resolution regardless of the file's namespace.
+    let is_root_qualified = receiver.starts_with('\\');
+
+    // A receiver that resolves into `Illuminate\Support\Facades\*` IS a facade —
+    // whether through a `use` import (`use …\Facades\Auth; Auth::…`) or written
+    // inline fully-qualified (`\Illuminate\Support\Facades\Auth::…`). Return it as
+    // the facade FQCN so it flows on to accessor → binding → real impl. We now own
+    // this form too: Intelephense only resolves it via the framework's committed
+    // `@method` docblocks (and goto lands on the docblock, not the impl), so we
+    // resolve to the real implementation and accept Zed's 2-entry goto multibuffer
+    // for documented methods (zed#24100). `resolve_class_name` expands the file's
+    // `use` aliases and strips a leading `\`, so an imported `Auth` becomes the
+    // facade FQCN here. This check is FIRST so an imported bare token resolves even
+    // in a namespaced file (the import wins over the bare-namespaced rule below).
+    let via_use = resolve_class_name(receiver, aliases);
+    if via_use.starts_with(FACADE_NAMESPACE) {
+        return Some(via_use);
+    }
+
+    // Otherwise it's a bare / root-`\` token relying on the global alias. Match
+    // it (case-insensitively, like the rest of the alias machinery) against our
+    // facade map — the leading `\` is already stripped by `resolve_class_name`,
+    // and `via_use` is the unresolved token when no import matched.
+    let token = via_use.as_str();
+    // A token that itself contains a namespace separator is a real class
+    // reference, not a facade alias (`App\Foo::bar()`), so it can't be a
+    // root-namespace facade alias — bail.
+    if token.contains('\\') {
+        return None;
+    }
+
+    // PHP class-name rule: a bare (non-`\`-qualified) token in a namespaced file
+    // with no matching `use` import resolves against the current namespace, NOT
+    // the global alias. Only honor the global alias for a leading-`\` token or a
+    // file with no namespace declaration.
+    if !is_root_qualified && is_namespaced {
+        return None;
+    }
+
+    facade_aliases
+        .iter()
+        .find(|(alias, _)| alias.eq_ignore_ascii_case(token))
+        .map(|(_, fqcn)| fqcn.clone())
+}
+
+/// The container binding key a facade proxies — its `getFacadeAccessor()`
+/// return value.
+///
+/// Fast path: the [`DEFAULT_ACCESSORS`] table for the built-in facades.
+/// Otherwise parse the facade source (located via `class_locator`) and read the
+/// string returned by `getFacadeAccessor()`. Returns `None` when the facade
+/// isn't built-in and its source can't be read or its accessor isn't a plain
+/// string (e.g. it returns a `::class` constant — the caller's binding lookup
+/// keys on the string form only).
+pub fn facade_accessor(facade_fqcn: &str, root: &Path) -> Option<String> {
+    let short = facade_fqcn.rsplit('\\').next().unwrap_or(facade_fqcn);
+    if let Some((_, accessor)) = DEFAULT_ACCESSORS
+        .iter()
+        .find(|(token, _)| token.eq_ignore_ascii_case(short))
+    {
+        return Some((*accessor).to_string());
+    }
+
+    let file = crate::class_locator::find_php_class_file_in_app_or_vendor(facade_fqcn, root)?;
+    let source = std::fs::read_to_string(&file).ok()?;
+    parse_facade_accessor(&source)
+}
+
+/// Read the string a facade's `getFacadeAccessor()` returns from source.
+///
+/// Handles the canonical forms:
+/// - `protected static function getFacadeAccessor() { return 'auth'; }`
+/// - `protected static function getFacadeAccessor(): string { return 'db'; }`
+/// - an arrow-style single-return body.
+///
+/// Returns `None` when the method is absent, returns a non-string (a `::class`
+/// constant — the binding lookup keys on string accessors), or returns a
+/// computed expression we can't statically read.
+pub fn parse_facade_accessor(source: &str) -> Option<String> {
+    let tree = crate::parser::parse_php(source).ok()?;
+    let bytes = source.as_bytes();
+    let method = find_facade_accessor_method(tree.root_node(), bytes)?;
+    let body = method.child_by_field_name("body")?;
+    let ret = single_return_expr(body)?;
+    string_literal_value(ret, bytes)
+}
+
+/// Locate the `getFacadeAccessor` `method_declaration` node anywhere in the
+/// subtree (it's nested under `class_declaration` → `declaration_list`).
+fn find_facade_accessor_method<'t>(
+    root: tree_sitter::Node<'t>,
+    bytes: &[u8],
+) -> Option<tree_sitter::Node<'t>> {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "method_declaration" {
+            let is_accessor = node
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(bytes).ok())
+                == Some("getFacadeAccessor");
+            if is_accessor {
+                return Some(node);
+            }
+        }
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+    None
+}
+
+/// The expression of a body's sole `return <expr>;`, or `None` for zero /
+/// multiple returns. Mirrors `salsa_impl::single_return_expr`; kept local so
+/// this module stays self-contained.
+fn single_return_expr(body: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    let mut found: Option<tree_sitter::Node> = None;
+    let mut stack = vec![body];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "return_statement" {
+            if found.is_some() {
+                return None;
+            }
+            found = node.named_child(0);
+        }
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            // A nested closure's returns belong to it, not this body.
+            if matches!(child.kind(), "arrow_function" | "anonymous_function") {
+                continue;
+            }
+            stack.push(child);
+        }
+    }
+    found
+}
+
+/// The content of a single/double-quoted string literal, descending to the
+/// `string_content` child (matching the rest of the LSP); `None` for a
+/// non-string node.
+fn string_literal_value(node: tree_sitter::Node, bytes: &[u8]) -> Option<String> {
+    if !matches!(node.kind(), "string" | "encapsed_string") {
+        return None;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "string_content" {
+            return Some(child.utf8_text(bytes).ok()?.to_string());
+        }
+    }
+    Some(
+        node.utf8_text(bytes)
+            .ok()?
+            .trim_matches(['\'', '"'])
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/facade_resolver.rs
+++ b/laravel-lsp/src/facade_resolver.rs
@@ -45,7 +45,7 @@
 use crate::query_chain::use_aliases::resolve_class_name;
 use crate::query_chain::use_aliases::UseAliases;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// The `Illuminate\Support\Facades` namespace every built-in facade lives in.
 /// Used both to seed the default alias map and as the marker that identifies a
@@ -265,6 +265,240 @@ pub fn facade_accessor(facade_fqcn: &str, root: &Path) -> Option<String> {
     let file = crate::class_locator::find_php_class_file_in_app_or_vendor(facade_fqcn, root)?;
     let source = std::fs::read_to_string(&file).ok()?;
     parse_facade_accessor(&source)
+}
+
+/// Follow a facade method the bound concrete doesn't declare directly to its
+/// real declaration site, the way Laravel surfaces manager methods.
+///
+/// `Auth::check()` resolves the receiver to `Illuminate\Auth\AuthManager`, but
+/// `check` isn't declared there — `AuthManager` forwards unknown calls via
+/// `__call` and documents the surface with
+/// `@mixin \Illuminate\Contracts\Auth\Guard`. We chase that statically: a method
+/// declared on the concrete wins; otherwise each `@mixin` type (resolved through
+/// the concrete file's `use` aliases) is searched recursively; otherwise a
+/// matching `@method` tag's own line in the concrete's class docblock. Returns
+/// `(file, 0-based decl line)`, or `None` to let the caller fall back to the
+/// concrete class line.
+pub fn facade_method_decl(
+    concrete_fqcn: &str,
+    member: &str,
+    root: &Path,
+) -> Option<(PathBuf, u32)> {
+    let (file, line, on_interface) = facade_method_decl_inner(concrete_fqcn, member, root, 0)?;
+    if !on_interface {
+        return Some((file, line));
+    }
+    // The chase landed on an *interface* method (`AuthManager` forwards `check`
+    // to the `Guard` contract). Go to the implementation: a manager instantiates
+    // its concrete drivers (`new SessionGuard(...)`), so chase the member into
+    // those to land on the real body (`GuardHelpers::check`). Fall back to the
+    // interface declaration when no implementation turns up.
+    manager_concrete_impl(concrete_fqcn, member, root).or(Some((file, line)))
+}
+
+/// Bound on chase recursion — guards documentation/inheritance cycles and keeps
+/// an interactive goto cheap.
+const MAX_FACADE_MIXIN_DEPTH: u32 = 4;
+
+/// Returns `(file, 0-based decl line, on_interface)` — `on_interface` is `true`
+/// when the declaration was found on an `interface` (a signature, not a body),
+/// the signal the public wrapper uses to switch to implementation lookup.
+fn facade_method_decl_inner(
+    concrete_fqcn: &str,
+    member: &str,
+    root: &Path,
+    depth: u32,
+) -> Option<(PathBuf, u32, bool)> {
+    if depth > MAX_FACADE_MIXIN_DEPTH {
+        return None;
+    }
+    let file = crate::class_locator::find_php_class_file_in_app_or_vendor(concrete_fqcn, root)?;
+    let source = std::fs::read_to_string(&file).ok()?;
+    let tree = crate::parser::parse_php(&source).ok()?;
+    let structure = crate::laravel_introspector::walker::extract_php_structure_from_tree(
+        &tree,
+        source.as_bytes(),
+    );
+    let short = concrete_fqcn.rsplit('\\').next().unwrap_or(concrete_fqcn);
+    let class = structure.structures.iter().find(|s| s.name == short)?;
+
+    // 1. Declared directly on this class (the concrete, a trait/parent we
+    //    recursed into, or an interface) — its own declaration line.
+    if let Some(m) = class.methods.iter().find(|m| m.name == member) {
+        let on_interface =
+            class.kind == crate::laravel_introspector::walker::PhpStructureKind::Interface;
+        return Some((file, m.start_line, on_interface));
+    }
+
+    let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, &source);
+    let namespace = structure.namespace.as_deref();
+    let qualify = |raw: &str| qualify_doc_type(raw, &aliases, namespace);
+
+    // 2. Composed traits — the implementation frequently lives in a trait
+    //    (`Connection::beginTransaction` is declared in the `ManagesTransactions`
+    //    trait, not on `Connection` itself).
+    for raw in &class.trait_uses {
+        if let Some(hit) = facade_method_decl_inner(&qualify(raw), member, root, depth + 1) {
+            return Some(hit);
+        }
+    }
+
+    // 3. Parent class.
+    if let Some(parent) = &class.extends_raw {
+        if let Some(hit) = facade_method_decl_inner(&qualify(parent), member, root, depth + 1) {
+            return Some(hit);
+        }
+    }
+
+    // 4. `@mixin` types — how a manager documents the surface it forwards to via
+    //    `__call`: `AuthManager`'s `@mixin \…\Guard` is where `check` lives, and
+    //    `DatabaseManager`'s `@mixin \…\Connection` leads to `beginTransaction`.
+    let docblock = class_docblock(&source, class.start_line);
+    if let Some((_, doc_text)) = &docblock {
+        for raw in doc_tag_values(doc_text, "@mixin") {
+            if let Some(hit) = facade_method_decl_inner(&qualify(&raw), member, root, depth + 1) {
+                return Some(hit);
+            }
+        }
+    }
+
+    // 5. Implemented interfaces — the signature declaration, when no concrete
+    //    impl turned up above.
+    for raw in &class.implements_raw {
+        if let Some(hit) = facade_method_decl_inner(&qualify(raw), member, root, depth + 1) {
+            return Some(hit);
+        }
+    }
+
+    // 6. `@method` tag on this class's own docblock — a virtual method with no
+    //    body; land on the tag's line (still a declaration, not the class line).
+    if let Some((doc_start_line, doc_text)) = &docblock {
+        if let Some(rel) = method_tag_offset(doc_text, member) {
+            return Some((file, *doc_start_line + rel, false));
+        }
+    }
+
+    None
+}
+
+/// Find a concrete implementation of `member` by way of the driver classes the
+/// manager instantiates. A Laravel manager builds its drivers with `new …` in
+/// `create*Driver()` methods (`AuthManager` → `new SessionGuard(...)`), so the
+/// `new`-expressions in its source name the concrete types behind the contract.
+/// We chase `member` into each and return the first that resolves to a real
+/// (non-interface) declaration — for `check`, every guard reaches the shared
+/// `GuardHelpers::check`, so the targets collapse to that one body.
+fn manager_concrete_impl(manager_fqcn: &str, member: &str, root: &Path) -> Option<(PathBuf, u32)> {
+    let file = crate::class_locator::find_php_class_file_in_app_or_vendor(manager_fqcn, root)?;
+    let source = std::fs::read_to_string(&file).ok()?;
+    let tree = crate::parser::parse_php(&source).ok()?;
+    let structure = crate::laravel_introspector::walker::extract_php_structure_from_tree(
+        &tree,
+        source.as_bytes(),
+    );
+    let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, &source);
+    let namespace = structure.namespace.as_deref();
+    let bytes = source.as_bytes();
+
+    let mut seen: HashMap<String, ()> = HashMap::new();
+    let mut stack = vec![tree.root_node()];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "object_creation_expression" {
+            if let Some(raw) = new_class_name(node, bytes) {
+                let fqcn = qualify_doc_type(&raw, &aliases, namespace);
+                if seen.insert(fqcn.clone(), ()).is_none() {
+                    // Only accept a real (non-interface) declaration.
+                    if let Some((f, l, false)) = facade_method_decl_inner(&fqcn, member, root, 0) {
+                        return Some((f, l));
+                    }
+                }
+            }
+        }
+        // Push children reversed so the LIFO stack yields document (pre-)order —
+        // a deterministic goto that prefers the first-declared driver.
+        let mut cursor = node.walk();
+        let children: Vec<_> = node.named_children(&mut cursor).collect();
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
+    }
+    None
+}
+
+/// The class-name text of a `new X(...)` (`object_creation_expression`) — its
+/// `name` / `qualified_name` / `relative_name` child. `None` for anonymous
+/// classes (`new class {…}`).
+fn new_class_name(node: tree_sitter::Node, bytes: &[u8]) -> Option<String> {
+    let mut cursor = node.walk();
+    let name = node
+        .named_children(&mut cursor)
+        .find(|c| matches!(c.kind(), "name" | "qualified_name" | "relative_name"))?;
+    name.utf8_text(bytes).ok().map(str::to_string)
+}
+
+/// The `/** … */` block immediately preceding the class declaration starting at
+/// `class_start_line` (0-based). Returns `(first-line index, raw text)`.
+/// Line-based to dodge fragile tree-sitter comment-sibling navigation; skips
+/// blank and `#[attribute]` lines between the docblock and the class.
+fn class_docblock(source: &str, class_start_line: u32) -> Option<(u32, String)> {
+    let lines: Vec<&str> = source.lines().collect();
+    if class_start_line == 0 || class_start_line as usize > lines.len() {
+        return None;
+    }
+    let mut end = class_start_line as i64 - 1;
+    while end >= 0 {
+        let t = lines[end as usize].trim();
+        if t.is_empty() || t.starts_with("#[") {
+            end -= 1;
+        } else {
+            break;
+        }
+    }
+    if end < 0 || !lines[end as usize].trim_end().ends_with("*/") {
+        return None;
+    }
+    let mut start = end;
+    while start >= 0 && !lines[start as usize].trim_start().starts_with("/**") {
+        start -= 1;
+    }
+    if start < 0 {
+        return None;
+    }
+    let text = lines[start as usize..=end as usize].join("\n");
+    Some((start as u32, text))
+}
+
+/// Values of a docblock tag across all lines, e.g. `@mixin \Foo\Bar` →
+/// `["\Foo\Bar"]`.
+fn doc_tag_values(doc: &str, tag: &str) -> Vec<String> {
+    doc.lines()
+        .filter_map(|line| {
+            let line = line.trim_start().trim_start_matches('*').trim_start();
+            let rest = line.strip_prefix(tag)?;
+            rest.split_whitespace().next().map(str::to_string)
+        })
+        .collect()
+}
+
+/// 0-based line offset within `doc` of the `@method … name(` tag for `member`.
+fn method_tag_offset(doc: &str, member: &str) -> Option<u32> {
+    let needle = format!("{member}(");
+    doc.lines().enumerate().find_map(|(i, line)| {
+        let line = line.trim_start().trim_start_matches('*').trim_start();
+        let rest = line.strip_prefix("@method")?;
+        rest.contains(&needle).then_some(i as u32)
+    })
+}
+
+/// Resolve a docblock type reference to an FQCN: a leading-`\` or imported type
+/// resolves via the file's `use` aliases (which strip the `\`); a still-bare
+/// name is qualified against the file namespace.
+fn qualify_doc_type(raw: &str, aliases: &UseAliases, namespace: Option<&str>) -> String {
+    let resolved = resolve_class_name(raw, aliases);
+    match namespace {
+        Some(ns) if !resolved.contains('\\') => format!("{ns}\\{resolved}"),
+        _ => resolved,
+    }
 }
 
 /// Read the string a facade's `getFacadeAccessor()` returns from source.

--- a/laravel-lsp/src/facade_resolver/tests.rs
+++ b/laravel-lsp/src/facade_resolver/tests.rs
@@ -1,0 +1,238 @@
+//! Tests for facade resolution: token → facade FQCN (imported, inline
+//! fully-qualified, and global-alias forms, plus the bare-namespaced `None`
+//! case) and facade FQCN → `getFacadeAccessor()` binding key.
+
+use super::*;
+use crate::query_chain::use_aliases::{extract_use_aliases, UseAliases};
+use std::collections::HashMap;
+
+/// Parse a PHP file's `use` imports into the alias map the resolver consumes.
+fn aliases(source: &str) -> UseAliases {
+    let tree = crate::parser::parse_php(source).expect("parse");
+    extract_use_aliases(&tree, source)
+}
+
+// ---- alias map seed ----
+
+#[test]
+fn default_aliases_map_token_to_facade_fqcn() {
+    let map = default_facade_aliases();
+    assert_eq!(
+        map.get("Auth").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+    assert_eq!(
+        map.get("DB").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\DB")
+    );
+    assert_eq!(
+        map.get("Storage").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\Storage")
+    );
+}
+
+// ---- root-namespace alias form (we respond) ----
+
+#[test]
+fn root_namespace_alias_resolves() {
+    // A leading-`\` token hits the global alias regardless of the file's
+    // namespace — pass `is_namespaced = true` to prove `\` wins over the
+    // current-namespace rule.
+    let map = default_facade_aliases();
+    let no_imports = HashMap::new();
+    assert_eq!(
+        resolve_facade_fqcn("\\Auth", &no_imports, &map, true).as_deref(),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+    assert_eq!(
+        resolve_facade_fqcn("\\DB", &no_imports, &map, true).as_deref(),
+        Some("Illuminate\\Support\\Facades\\DB")
+    );
+}
+
+#[test]
+fn bare_token_in_non_namespaced_file_resolves() {
+    // `Auth::check()` in a file with NO `namespace` declaration and no `use`
+    // import: PHP resolves the bare class name in the global namespace, where
+    // the alias lives — so the global facade alias applies and we respond.
+    let map = default_facade_aliases();
+    let no_imports = HashMap::new();
+    assert_eq!(
+        resolve_facade_fqcn("Auth", &no_imports, &map, false).as_deref(),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+}
+
+#[test]
+fn bare_token_in_namespaced_file_is_none() {
+    // `Auth::check()` inside `namespace App\Http;` with no `use` import: PHP's
+    // class-name rule resolves this against the CURRENT namespace
+    // (`App\Http\Auth`), NOT the global `\Auth` alias. We must stay silent — a
+    // goto to the facade would be wrong, and Intelephense's "undefined
+    // App\Http\Auth" squiggle correctly stands.
+    let map = default_facade_aliases();
+    let no_imports = HashMap::new();
+    assert_eq!(resolve_facade_fqcn("Auth", &no_imports, &map, true), None);
+}
+
+#[test]
+fn alias_match_is_case_insensitive() {
+    let map = default_facade_aliases();
+    let no_imports = HashMap::new();
+    // The alias machinery is case-insensitive; `\db` should still resolve.
+    assert_eq!(
+        resolve_facade_fqcn("\\db", &no_imports, &map, true).as_deref(),
+        Some("Illuminate\\Support\\Facades\\DB")
+    );
+}
+
+#[test]
+fn user_alias_merged_over_defaults() {
+    // A package facade aliased in config/app.php: `'Flux' => Flux\Flux::class`.
+    let mut map = default_facade_aliases();
+    map.insert("Flux".to_string(), "Flux\\Flux".to_string());
+    let no_imports = HashMap::new();
+    assert_eq!(
+        resolve_facade_fqcn("\\Flux", &no_imports, &map, true).as_deref(),
+        Some("Flux\\Flux")
+    );
+}
+
+// ---- imported / fully-qualified form (we resolve to the real impl) ----
+
+#[test]
+fn imported_facade_resolves() {
+    // `use Illuminate\Support\Facades\Auth; Auth::check();` — the import resolves
+    // into the Facades namespace, so this IS the facade FQCN. We own this form
+    // and resolve to the real impl; Zed shows a 2-entry goto multibuffer
+    // (Intelephense's @method docblock + our impl) for documented methods,
+    // accepted (zed#24100).
+    let imports = aliases("<?php\nuse Illuminate\\Support\\Facades\\Auth;\n");
+    let map = default_facade_aliases();
+    assert_eq!(
+        resolve_facade_fqcn("Auth", &imports, &map, false).as_deref(),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+}
+
+#[test]
+fn imported_facade_in_namespaced_file_resolves() {
+    // The import wins over the bare-namespaced rule: `use …\Facades\Auth;` inside
+    // a namespaced file still resolves to the facade FQCN, because the Facades-
+    // namespace check runs before the bare-namespaced `None` rule.
+    let imports = aliases("<?php\nnamespace App\\Http;\nuse Illuminate\\Support\\Facades\\Auth;\n");
+    let map = default_facade_aliases();
+    assert_eq!(
+        resolve_facade_fqcn("Auth", &imports, &map, true).as_deref(),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+}
+
+#[test]
+fn imported_aliased_facade_resolves() {
+    // `use Illuminate\Support\Facades\Auth as Authentication;` — the alias still
+    // resolves into the Facades namespace, so it IS the facade FQCN.
+    let imports = aliases("<?php\nuse Illuminate\\Support\\Facades\\Auth as Authentication;\n");
+    let map = default_facade_aliases();
+    assert_eq!(
+        resolve_facade_fqcn("Authentication", &imports, &map, false).as_deref(),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+}
+
+#[test]
+fn fully_qualified_facade_resolves() {
+    // `\Illuminate\Support\Facades\Auth::check()` written inline — resolves into
+    // the Facades namespace with no import needed, so it IS the facade FQCN.
+    let map = default_facade_aliases();
+    let no_imports = HashMap::new();
+    assert_eq!(
+        resolve_facade_fqcn(
+            "\\Illuminate\\Support\\Facades\\Auth",
+            &no_imports,
+            &map,
+            false
+        )
+        .as_deref(),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+}
+
+// ---- non-facades ----
+
+#[test]
+fn unknown_token_is_none() {
+    let map = default_facade_aliases();
+    let no_imports = HashMap::new();
+    assert_eq!(
+        resolve_facade_fqcn("\\SomeRandomClass", &no_imports, &map, false),
+        None
+    );
+}
+
+#[test]
+fn namespaced_class_reference_is_none() {
+    // `App\Services\Auth::run()` — a real class that happens to end in `Auth`
+    // is not a root-namespace facade alias.
+    let map = default_facade_aliases();
+    let no_imports = HashMap::new();
+    assert_eq!(
+        resolve_facade_fqcn("App\\Services\\Auth", &no_imports, &map, false),
+        None
+    );
+}
+
+// ---- getFacadeAccessor parsing ----
+
+#[test]
+fn parses_block_body_accessor() {
+    let src = r#"<?php
+namespace Illuminate\Support\Facades;
+class Auth extends Facade {
+    protected static function getFacadeAccessor()
+    {
+        return 'auth';
+    }
+}
+"#;
+    assert_eq!(parse_facade_accessor(src).as_deref(), Some("auth"));
+}
+
+#[test]
+fn parses_typed_return_accessor() {
+    let src = r#"<?php
+namespace Illuminate\Support\Facades;
+class DB extends Facade {
+    protected static function getFacadeAccessor(): string
+    {
+        return 'db';
+    }
+}
+"#;
+    assert_eq!(parse_facade_accessor(src).as_deref(), Some("db"));
+}
+
+#[test]
+fn non_string_accessor_is_none() {
+    // A facade whose accessor returns a `::class` constant isn't a string
+    // binding key — the binding lookup keys on strings.
+    let src = r#"<?php
+namespace Illuminate\Support\Facades;
+class Date extends Facade {
+    protected static function getFacadeAccessor()
+    {
+        return DateFactory::class;
+    }
+}
+"#;
+    assert_eq!(parse_facade_accessor(src), None);
+}
+
+#[test]
+fn missing_accessor_method_is_none() {
+    let src = r#"<?php
+namespace Illuminate\Support\Facades;
+class Weird extends Facade {}
+"#;
+    assert_eq!(parse_facade_accessor(src), None);
+}

--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -241,6 +241,11 @@ pub fn magic_member_card(
         MagicMemberKind::Relationship => "Eloquent relationship",
         MagicMemberKind::Column => "Database column",
         MagicMemberKind::DynamicFinder => "Dynamic finder",
+        MagicMemberKind::Macro => "Macro",
+        // A method reached through a facade proxy — `declaring_fqcn` is the bound
+        // concrete the facade forwards to. Worth a card precisely because
+        // Intelephense can't see through the proxy.
+        MagicMemberKind::FacadeMethod => "Facade method",
         // Generic property — Intelephense already covers it. Don't duplicate.
         MagicMemberKind::PlainMember => return String::new(),
     };

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -36,6 +36,7 @@ pub mod config_lookup;
 pub mod database;
 pub mod document_symbols;
 pub mod env_key_locator;
+pub mod facade_resolver;
 pub mod file_watcher;
 pub mod folio_discovery;
 pub mod hover;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3075,6 +3075,10 @@ async fn build_magic_member_entries(
     // receivers (`Auth::check()`) resolve to their bound implementation during
     // the build exactly as they do on the live query path.
     let facade_aliases = salsa.snapshot_facade_aliases().await.unwrap_or_default();
+    // Macro registry snapshot, fed into the `SnapshotResolver` so a runtime-
+    // registered macro/mixin member (`Str::uuid7()`) classifies during the build
+    // exactly as it does on the live query path.
+    let macros = salsa.snapshot_macros().await.unwrap_or_default();
     let root = root.to_path_buf();
 
     // ── Pass 1: build the view-variable index ────────────────────────────
@@ -3162,6 +3166,7 @@ async fn build_magic_member_entries(
         let class_files = class_files.clone();
         let bindings = bindings.clone();
         let facade_aliases = facade_aliases.clone();
+        let macros = macros.clone();
         let root = root.clone();
         magic_handles.push(tokio::spawn(async move {
             let _permit = permit_owner.acquire_owned().await.ok()?;
@@ -3173,6 +3178,7 @@ async fn build_magic_member_entries(
                     class_files,
                     bindings,
                     facade_aliases,
+                    macros,
                 };
                 let mut entries = laravel_lsp::member_resolver::resolve_member_access_entries(
                     &source,
@@ -3244,6 +3250,7 @@ async fn build_magic_member_entries(
             let class_files = class_files.clone();
             let bindings = bindings.clone();
             let facade_aliases = facade_aliases.clone();
+            let macros = macros.clone();
             let view_var_index = view_var_index.clone();
             let view_paths = view_paths.clone();
             let root = root.clone();
@@ -3257,6 +3264,7 @@ async fn build_magic_member_entries(
                         class_files,
                         bindings,
                         facade_aliases,
+                        macros,
                     };
                     // A Volt component (own front-matter, or an MFC template
                     // referencing `$this->`) needs the file source — for property
@@ -6145,10 +6153,12 @@ impl LaravelLanguageServer {
             .snapshot_facade_aliases()
             .await
             .unwrap_or_default();
+        let macros = self.salsa.snapshot_macros().await.unwrap_or_default();
         let resolver = laravel_lsp::member_resolver::SnapshotResolver {
             class_files: class_files.clone(),
             bindings,
             facade_aliases,
+            macros,
         };
         let mut entries = if is_volt {
             let prop_types = laravel_lsp::view_var_index::volt_property_types(
@@ -17757,10 +17767,15 @@ return [
     ///   to its declaration site on the model.
     /// - **Dynamic finder** → the underlying column's migration line
     ///   (`whereEmail` → `email`); a finder has no declaring method.
-    /// - **Relationship / scope / accessor** → the declaring method's name
-    ///   token in the declaring class (inheritance/trait-resolved), located
-    ///   the same way the rename path rewrites it; falls back to the
-    ///   declaration's start line when the token can't be located.
+    /// - **Relationship / scope / accessor / facade method** → the declaring
+    ///   method's name token in the declaring class (inheritance/trait-resolved),
+    ///   located the same way the rename path rewrites it; falls back to the
+    ///   declaration's start line when the token can't be located. For a facade
+    ///   method (`Auth::check()`) the declaring class is the bound concrete
+    ///   (`AuthManager`); when the concrete only FORWARDS the call via
+    ///   `__call`/a guard (the `@method`-documented case) no token exists, so the
+    ///   fallback lands on the concrete class line — still a useful target,
+    ///   never `None`. This is exactly the case Intelephense can't see through.
     /// - **Plain member** → `None` — Intelephense already handles those (the
     ///   multi-LSP dedup policy: suppress at the source).
     async fn create_magic_member_location(
@@ -17792,6 +17807,16 @@ return [
             }
             // `$casts`-declared column with no migration: the Salsa side
             // already located its declaration site (property / class line).
+            let decl_file = data.decl_file?;
+            return Self::goto_link(&decl_file, data.decl_line.unwrap_or(0), 0, 0);
+        }
+
+        // A macro/mixin member resolves straight to its registered definition
+        // site (the closure, or the mixin method) — the Salsa side already read
+        // it from the macro registry into `decl_file`/`decl_line`. There is no
+        // method-name token to narrow to on the Macroable host (it's vendor), so
+        // jump to the definition's start with a zero-width caret.
+        if matches!(data.kind, MagicMemberKind::Macro) {
             let decl_file = data.decl_file?;
             return Self::goto_link(&decl_file, data.decl_line.unwrap_or(0), 0, 0);
         }
@@ -21386,6 +21411,24 @@ impl LanguageServer for LaravelLanguageServer {
                     return Ok(Some(loc));
                 }
 
+                // Facade-receiver fallback: cmd-click on the receiver token of a
+                // facade static call (`\Auth` in `\Auth::check()`) jumps to the
+                // bound concrete class (`AuthManager`). The position index only
+                // marks the method-name token, so the receiver lands here.
+                if let Ok(Some(target)) = self
+                    .salsa
+                    .resolve_facade_receiver_at(
+                        file_path.clone(),
+                        position.line,
+                        position.character,
+                    )
+                    .await
+                {
+                    if let Some(loc) = Self::goto_link(&target.file, target.decl_line, 0, 0) {
+                        return Ok(Some(loc));
+                    }
+                }
+
                 // Debug: show what middleware patterns exist on this line
                 let mw_on_line: Vec<_> = patterns
                     .middleware_refs
@@ -21571,7 +21614,7 @@ impl LanguageServer for LaravelLanguageServer {
         // Salsa pattern lookup. The target dispatch in `find_hover_target`
         // tries patterns first and only falls back to Blade variables when
         // nothing matched at the cursor.
-        let patterns = match self.salsa.get_patterns(file_path).await {
+        let patterns = match self.salsa.get_patterns(file_path.clone()).await {
             Ok(Some(p)) => p,
             _ => {
                 // No cached patterns — Blade-variable hover can still fire on
@@ -21605,9 +21648,51 @@ impl LanguageServer for LaravelLanguageServer {
             is_blade,
         ) {
             Some(t) => t,
-            // No Salsa-indexed hover target — try the Artisan command-string
-            // fallback (call sites aren't position-indexed) before giving up.
-            None => return Ok(self.command_hover_response(uri, position).await),
+            // No Salsa-indexed hover target. Before giving up, try the facade
+            // receiver (`\Auth`) — its token isn't position-indexed — rendering a
+            // class-definition card for the bound concrete; then the Artisan
+            // command-string fallback.
+            None => {
+                if is_php {
+                    if let Ok(Some(target)) = self
+                        .salsa
+                        .resolve_facade_receiver_at(
+                            file_path.clone(),
+                            position.line,
+                            position.character,
+                        )
+                        .await
+                    {
+                        // Render the bound concrete as a class-definition card —
+                        // FQCN header + class signature snippet + source link —
+                        // the same shape the Livewire/class hover uses.
+                        use laravel_lsp::hover;
+                        let snippet = laravel_lsp::php_class::extract_class_signature(&target.file);
+                        let header = laravel_lsp::php_class::extract_class_fqn(&target.file)
+                            .unwrap_or(target.fqcn);
+                        let link = self
+                            .source_link(&target.file, Some(target.decl_line + 1))
+                            .await;
+                        let card = hover::render(&hover::HoverContent {
+                            header: Some(&header),
+                            code: snippet.as_deref().map(|s| hover::CodeBlock {
+                                language: hover::CodeLanguage::Php,
+                                content: s,
+                            }),
+                            source_link: Some(&link),
+                            ..Default::default()
+                        });
+                        return Ok(Some(Hover {
+                            contents: HoverContents::Markup(MarkupContent {
+                                kind: MarkupKind::Markdown,
+                                value: card,
+                            }),
+                            range: None,
+                        }));
+                    }
+                }
+                return Ok(self.command_hover_response(uri, position).await);
+            }
         };
 
         let value = match self.build_hover_markdown(target, uri).await {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3071,6 +3071,10 @@ async fn build_magic_member_entries(
     // Container-binding snapshot, paired with `class_files` in a `SnapshotResolver`
     // so `app('key')->member` accesses resolve to the bound model during the build.
     let bindings = salsa.snapshot_bindings().await.unwrap_or_default();
+    // Facade alias snapshot, also fed into the `SnapshotResolver` so facade
+    // receivers (`Auth::check()`) resolve to their bound implementation during
+    // the build exactly as they do on the live query path.
+    let facade_aliases = salsa.snapshot_facade_aliases().await.unwrap_or_default();
     let root = root.to_path_buf();
 
     // ── Pass 1: build the view-variable index ────────────────────────────
@@ -3157,6 +3161,7 @@ async fn build_magic_member_entries(
         let permit_owner = magic_sem.clone();
         let class_files = class_files.clone();
         let bindings = bindings.clone();
+        let facade_aliases = facade_aliases.clone();
         let root = root.clone();
         magic_handles.push(tokio::spawn(async move {
             let _permit = permit_owner.acquire_owned().await.ok()?;
@@ -3167,6 +3172,7 @@ async fn build_magic_member_entries(
                 let resolver = laravel_lsp::member_resolver::SnapshotResolver {
                     class_files,
                     bindings,
+                    facade_aliases,
                 };
                 let mut entries = laravel_lsp::member_resolver::resolve_member_access_entries(
                     &source,
@@ -3237,6 +3243,7 @@ async fn build_magic_member_entries(
             let permit_owner = blade_sem.clone();
             let class_files = class_files.clone();
             let bindings = bindings.clone();
+            let facade_aliases = facade_aliases.clone();
             let view_var_index = view_var_index.clone();
             let view_paths = view_paths.clone();
             let root = root.clone();
@@ -3249,6 +3256,7 @@ async fn build_magic_member_entries(
                     let resolver = laravel_lsp::member_resolver::SnapshotResolver {
                         class_files,
                         bindings,
+                        facade_aliases,
                     };
                     // A Volt component (own front-matter, or an MFC template
                     // referencing `$this->`) needs the file source — for property
@@ -6132,9 +6140,15 @@ impl LaravelLanguageServer {
         // the early returns and before any view-var read guard — so the await is
         // safe.
         let bindings = self.salsa.snapshot_bindings().await.unwrap_or_default();
+        let facade_aliases = self
+            .salsa
+            .snapshot_facade_aliases()
+            .await
+            .unwrap_or_default();
         let resolver = laravel_lsp::member_resolver::SnapshotResolver {
             class_files: class_files.clone(),
             bindings,
+            facade_aliases,
         };
         let mut entries = if is_volt {
             let prop_types = laravel_lsp::view_var_index::volt_property_types(

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4294,6 +4294,22 @@ impl LaravelLanguageServer {
         } else {
             info!("Laravel: Config files registered with Salsa for incremental caching");
         }
+
+        // config/app.php — registered as a ConfigFile so the facade-alias
+        // snapshot can read its legacy `aliases` array. Not part of the
+        // `register_config_files` triple (which models view/livewire discovery);
+        // `did_change` of any `config/*.php` already routes through
+        // `update_config_file`, so this only seeds it at boot.
+        let app_config_path = root_path.join("config/app.php");
+        if let Ok(app_config) = fs::read_to_string(&app_config_path) {
+            if let Err(e) = self
+                .salsa
+                .update_config_file(app_config_path, app_config)
+                .await
+            {
+                debug!("Failed to register config/app.php with Salsa: {}", e);
+            }
+        }
     }
 
     /// Register project files with Salsa for reference finding

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -70,6 +70,38 @@ pub trait ClassFileResolver {
     fn facade_aliases(&self) -> std::borrow::Cow<'_, HashMap<String, String>> {
         std::borrow::Cow::Owned(crate::facade_resolver::default_facade_aliases())
     }
+
+    /// Resolve a runtime-registered macro/mixin member — the
+    /// `(receiver_fqcn, name)` pair where `receiver_fqcn` is the resolved
+    /// Macroable host (`Illuminate\Support\Str`) and `name` is the called member
+    /// (`uuid7`) — to its definition site `(file, 0-based line)`, if the
+    /// project-wide macro registry has one.
+    ///
+    /// Defaulted to `None` so implementors that don't model macros (the bare
+    /// class index, the `HashMap<String, PathBuf>` test stub) need no changes;
+    /// the registry-aware resolvers on the salsa and main sides override it with
+    /// the parsed macro registry. This is the classification surface that lets
+    /// `Str::uuid7()` resolve when `uuid7` is registered in a provider — it rides
+    /// the resolver exactly as [`binding_concrete`](Self::binding_concrete) does.
+    fn macro_target(&self, _receiver_fqcn: &str, _name: &str) -> Option<(PathBuf, u32)> {
+        None
+    }
+
+    /// Whether the macro registry holds *any* macro for `receiver_fqcn` — i.e.
+    /// `receiver_fqcn` is a known Macroable host.
+    ///
+    /// The static-receiver arm uses this to yield an FQCN for a host the class
+    /// index doesn't carry: the dominant Macroable hosts (`Illuminate\Support\Str`,
+    /// `Arr`, `Request`) are vendor classes absent from the project index, so the
+    /// plain `class_file`-gated resolution drops them and no macro on them would
+    /// ever classify. A host with a registered macro is resolvable even without an
+    /// indexed file; the per-member [`macro_target`](Self::macro_target) lookup in
+    /// classification still gates which members actually resolve.
+    ///
+    /// Defaulted to `false` so non-registry implementors are unaffected.
+    fn has_macro_host(&self, _receiver_fqcn: &str) -> bool {
+        false
+    }
 }
 
 impl ClassFileResolver for ClassHierarchyIndex {
@@ -97,6 +129,11 @@ pub struct SnapshotResolver {
     /// actor alongside `bindings` so the build pass resolves facade receivers
     /// (`Auth::check()`) the same way the live query path does.
     pub facade_aliases: Arc<HashMap<String, String>>,
+    /// The macro registry — `(receiver_fqcn, macro_name)` → `(decl_file,
+    /// decl_line)` — snapshotted from the actor so the build pass classifies
+    /// runtime-registered macro/mixin members the same way the live query path
+    /// does.
+    pub macros: Arc<HashMap<(String, String), (PathBuf, u32)>>,
 }
 
 impl ClassFileResolver for SnapshotResolver {
@@ -108,6 +145,14 @@ impl ClassFileResolver for SnapshotResolver {
     }
     fn facade_aliases(&self) -> std::borrow::Cow<'_, HashMap<String, String>> {
         std::borrow::Cow::Borrowed(&self.facade_aliases)
+    }
+    fn macro_target(&self, receiver_fqcn: &str, name: &str) -> Option<(PathBuf, u32)> {
+        self.macros
+            .get(&(receiver_fqcn.to_string(), name.to_string()))
+            .cloned()
+    }
+    fn has_macro_host(&self, receiver_fqcn: &str) -> bool {
+        self.macros.keys().any(|(host, _)| host == receiver_fqcn)
     }
 }
 
@@ -317,8 +362,15 @@ pub fn resolve_member_access_entries(
         // codebase — Intelephense's territory and pure index bloat. Only the
         // magic kinds (scope / finder / relationship) index from calls.
         // Property-form plain members stay (bounded: declared properties on
-        // resolved classes).
-        if m.form.is_call() && resolved.kind == MagicMemberKind::PlainMember {
+        // resolved classes). Facade methods (`Auth::check()`) are likewise
+        // unbounded across a codebase; they're a goto/hover surface, not a
+        // find-references one, so they don't index here either.
+        if m.form.is_call()
+            && matches!(
+                resolved.kind,
+                MagicMemberKind::PlainMember | MagicMemberKind::FacadeMethod
+            )
+        {
             continue;
         }
         out.push(MagicMemberEntry {
@@ -359,26 +411,55 @@ pub fn resolve_and_classify(
     project_root: &Path,
     mut deps: Option<&mut HashSet<String>>,
 ) -> Option<ResolvedMemberAccess> {
-    let (fqcn, confidence) =
-        match resolve_receiver(receiver, bytes, aliases, resolver, classviews, project_root) {
-            Some(r) => r,
-            // Call-form receivers are frequently builder CHAINS
-            // (`User::query()->active()`, `User::where(…)->active()`) whose
-            // links the direct resolver can't type. The chain's subject is its
-            // root — resolve that instead (#77 review). Property-form chains
-            // (`User::first()->full_name`) deliberately stay chain-blind: the
-            // column surface makes property terminals a far bigger
-            // false-positive net than the call surfaces gated below.
-            None if form.is_call() => resolve_call_chain_receiver(
+    // Facade interception, checked first for a static-call name receiver —
+    // `Auth::check()` — so the "resolved via facade" signal threads cleanly into
+    // classification. A `Some` here means the concrete came through the facade
+    // proxy (facade FQCN → accessor → bound concrete), so the member is a FACADE
+    // method (tag `FacadeMethod`, goto the concrete's decl site) rather than a
+    // plain method Intelephense owns. `resolve_receiver` runs the same
+    // interception internally for any other caller; doing it explicitly here is
+    // what carries the boolean to `classify_against`.
+    let via_facade = matches!(receiver.kind(), "name" | "qualified_name");
+    let facade_concrete = if via_facade {
+        receiver.utf8_text(bytes).ok().and_then(|raw| {
+            resolve_facade_receiver(receiver, raw, bytes, aliases, resolver, project_root)
+        })
+    } else {
+        None
+    };
+
+    let (fqcn, confidence, via_facade) = match facade_concrete {
+        Some((fqcn, confidence)) => (fqcn, confidence, true),
+        None => {
+            let (fqcn, confidence) = match resolve_receiver(
                 receiver,
                 bytes,
                 aliases,
                 resolver,
                 classviews,
                 project_root,
-            )?,
-            None => return None,
-        };
+            ) {
+                Some(r) => r,
+                // Call-form receivers are frequently builder CHAINS
+                // (`User::query()->active()`, `User::where(…)->active()`) whose
+                // links the direct resolver can't type. The chain's subject is its
+                // root — resolve that instead (#77 review). Property-form chains
+                // (`User::first()->full_name`) deliberately stay chain-blind: the
+                // column surface makes property terminals a far bigger
+                // false-positive net than the call surfaces gated below.
+                None if form.is_call() => resolve_call_chain_receiver(
+                    receiver,
+                    bytes,
+                    aliases,
+                    resolver,
+                    classviews,
+                    project_root,
+                )?,
+                None => return None,
+            };
+            (fqcn, confidence, false)
+        }
+    };
 
     if let Some(d) = deps.as_deref_mut() {
         d.insert(fqcn.clone());
@@ -389,6 +470,7 @@ pub fn resolve_and_classify(
         member,
         form,
         confidence,
+        via_facade,
         resolver,
         classviews,
         project_root,
@@ -417,6 +499,7 @@ pub fn resolve_and_classify(
             member,
             form,
             Confidence::Medium,
+            false, // a builder retry never comes through a facade
             resolver,
             classviews,
             project_root,
@@ -428,23 +511,81 @@ pub fn resolve_and_classify(
 
 /// Classify `member` against `fqcn`'s resolved surfaces — the shared tail of
 /// [`resolve_and_classify`]'s direct path and its builder retry.
+///
+/// `via_facade` is the "receiver resolved through the facade proxy" signal: when
+/// set, a member that would otherwise classify as a plain method is tagged
+/// [`MagicMemberKind::FacadeMethod`] instead — a facade call's target IS the
+/// concrete's decl site (goto-able / hoverable), NOT Intelephense's territory
+/// the way a plain `$obj->method()` is. (Magic kinds — scope / accessor /
+/// relationship / finder — still win over the facade tag: those are the
+/// concrete's own Eloquent surfaces and resolve more precisely.)
+#[allow(clippy::too_many_arguments)]
 fn classify_against(
     fqcn: &str,
     member: &str,
     form: AccessForm,
     confidence: Confidence,
+    via_facade: bool,
     resolver: &impl ClassFileResolver,
     classviews: &mut ClassViewCache,
     project_root: &Path,
 ) -> Option<ResolvedMemberAccess> {
-    let file_path = resolver.class_file(fqcn)?;
-    let view = classviews.get_or_build(fqcn, &file_path, project_root)?;
-    let classified = classify_member(&view, member, form)?;
-    Some(ResolvedMemberAccess {
-        declaring_fqcn: classified.declaring_fqcn,
-        kind: classified.kind,
-        confidence,
-    })
+    // A class the index knows: classify against its real surfaces first.
+    if let Some(file_path) = resolver.class_file(fqcn) {
+        if let Some(view) = classviews.get_or_build(fqcn, &file_path, project_root) {
+            if let Some(classified) = classify_member(&view, member, form) {
+                // A facade call whose member is just a plain method on the
+                // concrete (`Auth::check()` → `AuthManager::check()`) is a real
+                // goto target — tag it `FacadeMethod` so the consumers don't drop
+                // it as Intelephense's. A magic kind keeps its own classification
+                // (it's already a precise, goto-able surface).
+                if via_facade && classified.kind == MagicMemberKind::PlainMember {
+                    return Some(ResolvedMemberAccess {
+                        declaring_fqcn: classified.declaring_fqcn,
+                        kind: MagicMemberKind::FacadeMethod,
+                        confidence,
+                    });
+                }
+                return Some(ResolvedMemberAccess {
+                    declaring_fqcn: classified.declaring_fqcn,
+                    kind: classified.kind,
+                    confidence,
+                });
+            }
+        }
+        // A facade call whose member is NOT declared on the concrete — the
+        // `__call`/`@method` forwarding case (`Auth::guard()`,
+        // `DB::beginTransaction()` are forwarded, not declared). The exact method
+        // can't be located (chasing `__call`/guard chains is out of scope), so
+        // DEGRADE to the concrete CLASS as the target — still useful — rather
+        // than dropping to None. The declaring FQCN is the concrete itself; the
+        // consumer falls back to the class's start line.
+        if via_facade && form.is_call() {
+            return Some(ResolvedMemberAccess {
+                declaring_fqcn: fqcn.to_string(),
+                kind: MagicMemberKind::FacadeMethod,
+                confidence,
+            });
+        }
+    }
+    // Macro / mixin fallback: a call-form member that matches none of the class's
+    // own surfaces may be a runtime-registered macro (`Str::macro('foo', …)`) or
+    // a mixin method. Consulted last — after the real surfaces, before giving up
+    // — and crucially OUTSIDE the `class_file` guard above: the dominant
+    // Macroable hosts (`Str`, `Arr`, `Request`) are vendor classes the project
+    // index doesn't carry, so requiring a buildable ClassView would drop every
+    // framework-host macro. The registry is keyed on the resolved receiver FQCN
+    // (exactly `fqcn`); the declaring class is that Macroable host. Only
+    // call-form: a macro is reached via `__callStatic` / `__call`, never a
+    // property read. The registry carries the true definition site for goto/hover.
+    if form.is_call() && resolver.macro_target(fqcn, member).is_some() {
+        return Some(ResolvedMemberAccess {
+            declaring_fqcn: fqcn.to_string(),
+            kind: MagicMemberKind::Macro,
+            confidence,
+        });
+    }
+    None
 }
 
 /// Resolve a call-chain receiver by its ROOT (#77 review). The chain's
@@ -757,23 +898,18 @@ fn resolve_receiver(
             // the plain class-index lookup below: the facade class itself may be
             // indexed (vendor), and resolving to it would classify against the
             // empty proxy instead of the implementation.
-            let is_namespaced = file_namespace(receiver, bytes).is_some();
-            if let Some(facade_fqcn) = crate::facade_resolver::resolve_facade_fqcn(
-                raw,
-                aliases,
-                &resolver.facade_aliases(),
-                is_namespaced,
-            ) {
-                if let Some(concrete) =
-                    crate::facade_resolver::facade_accessor(&facade_fqcn, project_root)
-                        .and_then(|accessor| resolver.binding_concrete(&accessor))
-                {
-                    return Some((concrete, Confidence::High));
-                }
+            if let Some(concrete) =
+                resolve_facade_receiver(receiver, raw, bytes, aliases, resolver, project_root)
+            {
+                return Some(concrete);
             }
 
             let fqcn = qualify_fqcn(resolve_class_name(raw, aliases), receiver, bytes);
-            if resolver.class_file(&fqcn).is_some() {
+            if resolver.class_file(&fqcn).is_some() || resolver.has_macro_host(&fqcn) {
+                // The class is indexed, OR it's a known Macroable host the index
+                // doesn't carry (vendor `Str`/`Arr`/…) but the macro registry
+                // does — either way the receiver resolves at HIGH (explicit
+                // class name). Per-member classification still gates the result.
                 Some((fqcn, Confidence::High))
             } else {
                 None
@@ -797,6 +933,42 @@ fn resolve_receiver(
         }
         _ => None,
     }
+}
+
+/// Resolve a static-call receiver THROUGH a facade to its concrete
+/// implementation: `Auth::check()`, `\Auth::check()`,
+/// `\Illuminate\Support\Facades\Auth::check()` → `Illuminate\Auth\AuthManager`.
+///
+/// A facade is a thin static proxy whose own class carries only `@method`
+/// docblocks, never the real members — so when the receiver token resolves to a
+/// facade we walk facade FQCN → accessor key → bound concrete and return THAT,
+/// so the member classifies against the real class. Returns `None` when the
+/// token isn't a facade (or its accessor has no bound concrete), letting the
+/// plain class-index lookup take over.
+///
+/// Extracted from [`resolve_receiver`]'s `name`/`qualified_name` arm so
+/// [`resolve_and_classify`] can call it directly: a `Some` here is the
+/// "resolved via the facade interception" signal that classification keys on to
+/// tag [`MagicMemberKind::FacadeMethod`] instead of a plain method (a facade
+/// call's target is the concrete's decl site, NOT Intelephense's territory).
+pub(crate) fn resolve_facade_receiver(
+    receiver: Node,
+    raw: &str,
+    bytes: &[u8],
+    aliases: &UseAliases,
+    resolver: &impl ClassFileResolver,
+    project_root: &Path,
+) -> Option<(String, Confidence)> {
+    let is_namespaced = file_namespace(receiver, bytes).is_some();
+    let facade_fqcn = crate::facade_resolver::resolve_facade_fqcn(
+        raw,
+        aliases,
+        &resolver.facade_aliases(),
+        is_namespaced,
+    )?;
+    let concrete = crate::facade_resolver::facade_accessor(&facade_fqcn, project_root)
+        .and_then(|accessor| resolver.binding_concrete(&accessor))?;
+    Some((concrete, Confidence::High))
 }
 
 /// Resolve a container-resolution receiver — `app('key')` / `resolve('key')` —
@@ -1108,7 +1280,15 @@ fn resolve_typed_property(
 /// `namespace App;`) is treated as already-qualified and won't resolve to
 /// `App\Models\User` — a false negative both the static-receiver arm and the
 /// chain-root arm inherit.
-fn qualify_fqcn(name: String, node: Node, bytes: &[u8]) -> String {
+///
+/// `pub` so the provider-binding closure resolver
+/// ([`crate::salsa_impl::resolve_closure_concrete`]) reuses the SAME
+/// namespace-qualification the static-receiver arm uses: a binding bound to a
+/// bare same-namespace `new X` (e.g. `singleton('auth', fn ($app) => new
+/// AuthManager($app))` in a provider that lives in `AuthManager`'s namespace)
+/// must qualify `AuthManager` → `Illuminate\Auth\AuthManager` before the
+/// on-disk gate, or the binding degrades to `"Closure"`.
+pub fn qualify_fqcn(name: String, node: Node, bytes: &[u8]) -> String {
     let trimmed = name.trim_start_matches('\\').to_string();
     if trimmed.contains('\\') {
         // Already namespaced (alias-resolved or absolute).

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -50,6 +50,26 @@ pub trait ClassFileResolver {
     fn binding_concrete(&self, _key: &str) -> Option<String> {
         None
     }
+
+    /// The facade alias map — token (`Auth`) → facade FQCN
+    /// (`Illuminate\Support\Facades\Auth`) — for resolving a facade static-call
+    /// receiver to its real implementation.
+    ///
+    /// Defaulted to the built-in [`default_facade_aliases`] seed so implementors
+    /// that don't model user aliases (the bare class index, test stubs) resolve
+    /// the framework facades with no changes. The binding-aware resolvers on the
+    /// salsa and main sides override it with the merged map (seed +
+    /// `config/app.php` `aliases` + `bootstrap/app.php` `withAliases`), so a user
+    /// alias for an existing token wins and new tokens are seen. Rides the
+    /// resolver exactly as [`binding_concrete`](Self::binding_concrete) does — no
+    /// extra argument threaded through the receiver-resolution call graph.
+    ///
+    /// Returns a [`Cow`] so the default yields an owned seed while overrides
+    /// borrow their cached `Arc`-shared map without cloning the dozens of entries
+    /// on every receiver resolution.
+    fn facade_aliases(&self) -> std::borrow::Cow<'_, HashMap<String, String>> {
+        std::borrow::Cow::Owned(crate::facade_resolver::default_facade_aliases())
+    }
 }
 
 impl ClassFileResolver for ClassHierarchyIndex {
@@ -73,6 +93,10 @@ impl ClassFileResolver for HashMap<String, PathBuf> {
 pub struct SnapshotResolver {
     pub class_files: Arc<HashMap<String, PathBuf>>,
     pub bindings: Arc<HashMap<String, String>>,
+    /// The merged facade alias map (token → facade FQCN), snapshotted from the
+    /// actor alongside `bindings` so the build pass resolves facade receivers
+    /// (`Auth::check()`) the same way the live query path does.
+    pub facade_aliases: Arc<HashMap<String, String>>,
 }
 
 impl ClassFileResolver for SnapshotResolver {
@@ -81,6 +105,9 @@ impl ClassFileResolver for SnapshotResolver {
     }
     fn binding_concrete(&self, key: &str) -> Option<String> {
         self.bindings.get(key).cloned()
+    }
+    fn facade_aliases(&self) -> std::borrow::Cow<'_, HashMap<String, String>> {
+        std::borrow::Cow::Borrowed(&self.facade_aliases)
     }
 }
 
@@ -718,6 +745,33 @@ fn resolve_receiver(
         // unresolved rather than guessed.
         "name" | "qualified_name" => {
             let raw = receiver.utf8_text(bytes).ok()?;
+
+            // Facade interception, checked first: `Auth::check()`,
+            // `\Auth::check()`, `\Illuminate\Support\Facades\Auth::check()`. A
+            // facade is a thin static proxy — its own class only carries
+            // `@method` docblocks, not the real members — so when the receiver
+            // resolves to a facade we walk to the concrete implementation the
+            // calls forward to (facade FQCN → accessor key → bound concrete) and
+            // return THAT as the receiver type, so the member classifies against
+            // the real class (`Auth::check` → `AuthManager`). This runs before
+            // the plain class-index lookup below: the facade class itself may be
+            // indexed (vendor), and resolving to it would classify against the
+            // empty proxy instead of the implementation.
+            let is_namespaced = file_namespace(receiver, bytes).is_some();
+            if let Some(facade_fqcn) = crate::facade_resolver::resolve_facade_fqcn(
+                raw,
+                aliases,
+                &resolver.facade_aliases(),
+                is_namespaced,
+            ) {
+                if let Some(concrete) =
+                    crate::facade_resolver::facade_accessor(&facade_fqcn, project_root)
+                        .and_then(|accessor| resolver.binding_concrete(&accessor))
+                {
+                    return Some((concrete, Confidence::High));
+                }
+            }
+
             let fqcn = qualify_fqcn(resolve_class_name(raw, aliases), receiver, bytes);
             if resolver.class_file(&fqcn).is_some() {
                 Some((fqcn, Confidence::High))

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -497,6 +497,7 @@ fn snapshot_resolver_answers_class_file_and_binding() {
     let r = SnapshotResolver {
         class_files,
         bindings,
+        facade_aliases: Arc::new(crate::facade_resolver::default_facade_aliases()),
     };
     assert_eq!(
         r.class_file("App\\Models\\Tenant"),
@@ -526,11 +527,160 @@ fn snapshot_resolver_resolves_app_binding_through_engine() {
     let resolver = SnapshotResolver {
         class_files,
         bindings,
+        facade_aliases: Arc::new(crate::facade_resolver::default_facade_aliases()),
     };
     let caller = "<?php $x = app('currentTenant')->logo;";
     let r = resolve_with(&resolver, &p.root, caller, "logo").expect("resolves");
     assert_eq!(r.kind, MagicMemberKind::Accessor);
     assert_eq!(r.declaring_fqcn, "App\\Models\\Tenant");
+}
+
+// ─── Facade receivers: Auth::check() → AuthManager (all three forms) ───────
+//
+// A facade is a thin static proxy whose own class carries only `@method`
+// docblocks. The interception in the `name`/`qualified_name` arm walks the
+// facade to its real implementation — facade FQCN → accessor key → bound
+// concrete — and returns that concrete as the receiver type so the member
+// classifies against the real class. These tests prove the whole chain
+// end-to-end (token → FQCN → accessor → priority-0 vendor binding → concrete →
+// member classification), not merely the seam, for each facade-call form.
+
+/// Laravel's `AuthManager` as it lives in vendor — the concrete the framework's
+/// `auth` container binding resolves to, with a `check()` the facade forwards.
+const AUTH_MANAGER: &str = r#"<?php
+namespace Illuminate\Auth;
+class AuthManager {
+    public function check() { return true; }
+    public function user() { return null; }
+}
+"#;
+
+/// Project with the vendor `AuthManager` indexed, plus a `SnapshotResolver`
+/// binding the framework's `auth` key to it (the priority-0 vendor binding the
+/// `AuthServiceProvider` registers at runtime). `facade_aliases` is the built-in
+/// seed — `Auth` is a default facade, no user config needed.
+fn auth_facade_project() -> (Project, SnapshotResolver) {
+    let p = project(
+        "vendor/laravel/framework/src/Illuminate/Auth/AuthManager.php",
+        AUTH_MANAGER,
+    );
+    let class_files = Arc::new(HashMap::from([(
+        "Illuminate\\Auth\\AuthManager".to_string(),
+        p.index
+            .class_file("Illuminate\\Auth\\AuthManager")
+            .expect("AuthManager indexed"),
+    )]));
+    let bindings = Arc::new(HashMap::from([(
+        "auth".to_string(),
+        "Illuminate\\Auth\\AuthManager".to_string(),
+    )]));
+    let resolver = SnapshotResolver {
+        class_files,
+        bindings,
+        facade_aliases: Arc::new(crate::facade_resolver::default_facade_aliases()),
+    };
+    (p, resolver)
+}
+
+/// Resolve a static call `<scope>::{member}()` in `caller` against `resolver`,
+/// classifying as a `StaticCall`. Mirrors [`resolve_with`] but targets the
+/// `scope` of a `scoped_call_expression` (the facade token) rather than a
+/// `->`-access object.
+fn resolve_static_call(
+    resolver: &impl ClassFileResolver,
+    root: &std::path::Path,
+    caller: &str,
+    member: &str,
+) -> Option<ResolvedMemberAccess> {
+    let tree = parse_php(caller).expect("parse caller");
+    let bytes = caller.as_bytes();
+    let aliases = extract_use_aliases(&tree, caller);
+    // Find the `scoped_call_expression` whose name is `member`, return its scope.
+    let mut stack = vec![tree.root_node()];
+    let mut scope = None;
+    while let Some(n) = stack.pop() {
+        if n.kind() == "scoped_call_expression"
+            && n.child_by_field_name("name")
+                .and_then(|nm| nm.utf8_text(bytes).ok())
+                == Some(member)
+        {
+            scope = n.child_by_field_name("scope");
+            break;
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    let mut cache = ClassViewCache::new();
+    resolve_and_classify(
+        scope?,
+        member,
+        AccessForm::StaticCall,
+        bytes,
+        &aliases,
+        resolver,
+        &mut cache,
+        root,
+        None,
+    )
+}
+
+#[test]
+fn facade_imported_resolves_to_concrete_through_binding() {
+    // Imported / inline form: `use …\Facades\Auth; Auth::check();`. The receiver
+    // resolves into the Facades namespace via the `use`, so it's a facade — we
+    // walk to `AuthManager` (the `auth` binding's concrete) and classify
+    // `check()` against IT, not the empty proxy.
+    let (p, resolver) = auth_facade_project();
+    let caller = r#"<?php
+use Illuminate\Support\Facades\Auth;
+Auth::check();
+"#;
+    let r = resolve_static_call(&resolver, &p.root, caller, "check").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::PlainMember);
+    assert_eq!(r.confidence, Confidence::High);
+    assert_eq!(r.declaring_fqcn, "Illuminate\\Auth\\AuthManager");
+}
+
+#[test]
+fn facade_global_alias_resolves_to_concrete() {
+    // Root-namespace alias form: `\Auth::check()`. No `use` import — PHP's
+    // global `Facade::defaultAliases()` registration makes the leading-`\` token
+    // resolve, and our seed alias maps it to the facade FQCN, then on to the
+    // concrete. Intelephense resolves this nowhere; we own it.
+    let (p, resolver) = auth_facade_project();
+    let caller = "<?php \\Auth::check();";
+    let r = resolve_static_call(&resolver, &p.root, caller, "check").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::PlainMember);
+    assert_eq!(r.declaring_fqcn, "Illuminate\\Auth\\AuthManager");
+}
+
+#[test]
+fn facade_inline_fully_qualified_resolves_to_concrete() {
+    // Inline fully-qualified form: `\Illuminate\Support\Facades\Auth::check()`
+    // with no `use`. The written-out path lands directly in the Facades
+    // namespace, so it's recognized as a facade and walked to the concrete.
+    let (p, resolver) = auth_facade_project();
+    let caller = "<?php \\Illuminate\\Support\\Facades\\Auth::check();";
+    let r = resolve_static_call(&resolver, &p.root, caller, "check").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::PlainMember);
+    assert_eq!(r.declaring_fqcn, "Illuminate\\Auth\\AuthManager");
+}
+
+#[test]
+fn facade_bare_token_in_namespaced_file_without_import_does_not_resolve() {
+    // Bare `Auth::check()` inside a namespaced file with NO facade import: PHP's
+    // class-name rule resolves `Auth` against the CURRENT namespace
+    // (`App\Http\Auth`), not the global facade alias. We must not emit a wrong
+    // goto — resolution drops to None (the would-be `App\Http\Auth` isn't a
+    // facade and isn't indexed).
+    let (p, resolver) = auth_facade_project();
+    let caller = r#"<?php
+namespace App\Http;
+Auth::check();
+"#;
+    assert!(resolve_static_call(&resolver, &p.root, caller, "check").is_none());
 }
 
 #[test]

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -498,6 +498,7 @@ fn snapshot_resolver_answers_class_file_and_binding() {
         class_files,
         bindings,
         facade_aliases: Arc::new(crate::facade_resolver::default_facade_aliases()),
+        macros: Default::default(),
     };
     assert_eq!(
         r.class_file("App\\Models\\Tenant"),
@@ -528,6 +529,7 @@ fn snapshot_resolver_resolves_app_binding_through_engine() {
         class_files,
         bindings,
         facade_aliases: Arc::new(crate::facade_resolver::default_facade_aliases()),
+        macros: Default::default(),
     };
     let caller = "<?php $x = app('currentTenant')->logo;";
     let r = resolve_with(&resolver, &p.root, caller, "logo").expect("resolves");
@@ -578,6 +580,7 @@ fn auth_facade_project() -> (Project, SnapshotResolver) {
         class_files,
         bindings,
         facade_aliases: Arc::new(crate::facade_resolver::default_facade_aliases()),
+        macros: Default::default(),
     };
     (p, resolver)
 }
@@ -638,7 +641,9 @@ use Illuminate\Support\Facades\Auth;
 Auth::check();
 "#;
     let r = resolve_static_call(&resolver, &p.root, caller, "check").expect("resolves");
-    assert_eq!(r.kind, MagicMemberKind::PlainMember);
+    // `check()` IS declared on `AuthManager` here, so it's a facade method
+    // pointing at that declaration (not a plain method the consumers drop).
+    assert_eq!(r.kind, MagicMemberKind::FacadeMethod);
     assert_eq!(r.confidence, Confidence::High);
     assert_eq!(r.declaring_fqcn, "Illuminate\\Auth\\AuthManager");
 }
@@ -652,7 +657,7 @@ fn facade_global_alias_resolves_to_concrete() {
     let (p, resolver) = auth_facade_project();
     let caller = "<?php \\Auth::check();";
     let r = resolve_static_call(&resolver, &p.root, caller, "check").expect("resolves");
-    assert_eq!(r.kind, MagicMemberKind::PlainMember);
+    assert_eq!(r.kind, MagicMemberKind::FacadeMethod);
     assert_eq!(r.declaring_fqcn, "Illuminate\\Auth\\AuthManager");
 }
 
@@ -664,7 +669,7 @@ fn facade_inline_fully_qualified_resolves_to_concrete() {
     let (p, resolver) = auth_facade_project();
     let caller = "<?php \\Illuminate\\Support\\Facades\\Auth::check();";
     let r = resolve_static_call(&resolver, &p.root, caller, "check").expect("resolves");
-    assert_eq!(r.kind, MagicMemberKind::PlainMember);
+    assert_eq!(r.kind, MagicMemberKind::FacadeMethod);
     assert_eq!(r.declaring_fqcn, "Illuminate\\Auth\\AuthManager");
 }
 
@@ -681,6 +686,130 @@ namespace App\Http;
 Auth::check();
 "#;
     assert!(resolve_static_call(&resolver, &p.root, caller, "check").is_none());
+}
+
+#[test]
+fn facade_method_not_declared_on_concrete_degrades_to_class() {
+    // `Auth::guard()` — `guard` is NOT declared on this `AuthManager` stub (it's
+    // forwarded via `__call`/`@method` in real Laravel). We must NOT drop to None
+    // and we must NOT chase the forwarding chain: DEGRADE to the concrete CLASS
+    // (`AuthManager`) as the goto target. Still a useful jump — and exactly the
+    // case Intelephense can't resolve.
+    let (p, resolver) = auth_facade_project();
+    let caller = r#"<?php
+use Illuminate\Support\Facades\Auth;
+Auth::guard();
+"#;
+    let r = resolve_static_call(&resolver, &p.root, caller, "guard").expect("degrades, not None");
+    assert_eq!(r.kind, MagicMemberKind::FacadeMethod);
+    // The declaring FQCN is the concrete itself — the consumer falls back to its
+    // class line since there's no `guard` method token to narrow to.
+    assert_eq!(r.declaring_fqcn, "Illuminate\\Auth\\AuthManager");
+    assert_eq!(r.confidence, Confidence::High);
+}
+
+// ─── Macro receivers: Str::macro('foo', …) classification (commit 1) ──────
+//
+// A runtime-registered macro on a Macroable host (the dominant host being the
+// vendor `Illuminate\Support\Str`, which the project class index does NOT carry)
+// classifies a static call as `MagicMemberKind::Macro` via the macro registry,
+// keyed on the resolved receiver FQCN. `macros_resolver` is the test analogue of
+// the `ContainerAwareResolver`/`SnapshotResolver` macro path: a `SnapshotResolver`
+// whose `macros` map holds one `(host, name) → (decl_file, line)` entry, with no
+// indexed class file for the host (proving the host need not be indexed).
+
+/// A `SnapshotResolver` with a single macro `(host, name)` registered at a
+/// definition site — and crucially no class file for `host`, so it exercises the
+/// "Macroable host the index doesn't carry" path.
+fn macros_resolver(host: &str, name: &str, decl: (PathBuf, u32)) -> SnapshotResolver {
+    SnapshotResolver {
+        class_files: Default::default(),
+        bindings: Default::default(),
+        facade_aliases: Arc::new(crate::facade_resolver::default_facade_aliases()),
+        macros: Arc::new(HashMap::from([(
+            (host.to_string(), name.to_string()),
+            decl,
+        )])),
+    }
+}
+
+#[test]
+fn registered_macro_on_imported_host_classifies_as_macro() {
+    // `use Illuminate\Support\Str; Str::uuid7();` with `uuid7` registered as a
+    // macro on `Illuminate\Support\Str`. The receiver resolves to the host FQCN
+    // through the `use` import even though the host isn't indexed (the macro
+    // registry vouches for it), and the member classifies as a Macro.
+    let dir = TempDir::new().unwrap();
+    let provider = dir.path().join("app/Providers/AppServiceProvider.php");
+    let resolver = macros_resolver("Illuminate\\Support\\Str", "uuid7", (provider.clone(), 17));
+    let caller = r#"<?php
+use Illuminate\Support\Str;
+Str::uuid7();
+"#;
+    let r = resolve_static_call(&resolver, dir.path(), caller, "uuid7").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::Macro);
+    assert_eq!(r.confidence, Confidence::High);
+    assert_eq!(r.declaring_fqcn, "Illuminate\\Support\\Str");
+    // The registry carries the true definition site (the closure) for goto/hover.
+    assert_eq!(
+        resolver.macro_target("Illuminate\\Support\\Str", "uuid7"),
+        Some((provider, 17))
+    );
+}
+
+#[test]
+fn unregistered_member_on_macro_host_does_not_resolve() {
+    // The host has *a* macro (`uuid7`), so it's a known Macroable host the static
+    // arm will yield — but a different, unregistered member (`notAMacro`) matches
+    // no real surface and no registry entry, so classification drops to None
+    // rather than guessing.
+    let dir = TempDir::new().unwrap();
+    let provider = dir.path().join("app/Providers/AppServiceProvider.php");
+    let resolver = macros_resolver("Illuminate\\Support\\Str", "uuid7", (provider, 17));
+    let caller = r#"<?php
+use Illuminate\Support\Str;
+Str::notAMacro();
+"#;
+    assert!(resolve_static_call(&resolver, dir.path(), caller, "notAMacro").is_none());
+}
+
+#[test]
+fn macro_lookup_keys_on_resolved_fqcn_not_token() {
+    // A bare `\Str::uuid7()` (root-qualified, no import) must resolve to the same
+    // `Illuminate\Support\Str` key the import form uses — proving registry keys
+    // and lookup keys agree on the resolved FQCN, not the raw token. Here `\Str`
+    // has no import and isn't in the Facades namespace, so it resolves to the
+    // global `Str` — which is NOT the registered host, so it must NOT resolve.
+    // (The faithful agreement case is the imported form above; this guards the
+    // negative: a token that resolves elsewhere doesn't collide.)
+    let dir = TempDir::new().unwrap();
+    let provider = dir.path().join("app/Providers/AppServiceProvider.php");
+    let resolver = macros_resolver("Illuminate\\Support\\Str", "uuid7", (provider, 17));
+    let caller = "<?php \\Str::uuid7();";
+    assert!(resolve_static_call(&resolver, dir.path(), caller, "uuid7").is_none());
+}
+
+#[test]
+fn mixin_method_classifies_as_macro_and_targets_mixin_file() {
+    // A mixin-expanded member behaves identically to a scalar macro at the
+    // classification surface — `(host, method)` is a registry entry whose
+    // definition site is the mixin method's own file/line. `Str::shout()` with
+    // `shout` registered (host = Str, target = the mixin file) classifies as a
+    // Macro and goto lands on the mixin method.
+    let dir = TempDir::new().unwrap();
+    let mixin = dir.path().join("app/Mixins/StrMixin.php");
+    let resolver = macros_resolver("Illuminate\\Support\\Str", "shout", (mixin.clone(), 4));
+    let caller = r#"<?php
+use Illuminate\Support\Str;
+Str::shout();
+"#;
+    let r = resolve_static_call(&resolver, dir.path(), caller, "shout").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::Macro);
+    assert_eq!(r.declaring_fqcn, "Illuminate\\Support\\Str");
+    assert_eq!(
+        resolver.macro_target("Illuminate\\Support\\Str", "shout"),
+        Some((mixin, 4))
+    );
 }
 
 #[test]

--- a/laravel-lsp/src/php_class.rs
+++ b/laravel-lsp/src/php_class.rs
@@ -483,23 +483,80 @@ pub fn extract_class_fqn(path: &std::path::Path) -> Option<String> {
 /// statements that precede the class declaration. Returns the single line
 /// containing the `class` keyword, trimmed.
 ///
-/// Used by the Livewire hover to show the component's class signature so
-/// the reader sees the type at a glance — same vibe as intelephense's
-/// hover showing a class signature line in a `php` code block.
+/// Used by the class/component/Livewire/facade hovers to show the class at a
+/// glance — same vibe as intelephense's hover showing a class signature in a
+/// `php` code block.
 ///
-/// Recognises `final class Foo`, `abstract class Foo`, `readonly class Foo`,
-/// and combinations. Anchored at start-of-line so `class` substrings inside
-/// string literals or comments don't trigger false matches.
+/// Returns the class declaration (`class Foo extends Bar implements Baz`,
+/// including `final`/`abstract`/`readonly` modifiers) and, when the class
+/// composes traits, the leading `use Trait1, Trait2, …;` block that follows it
+/// — wrapped in `{ … }` — so the card shows the traits the class pulls in:
+///
+/// ```text
+/// class User extends Authenticatable implements MustVerifyEmail
+/// {
+///     use HasApiTokens, HasFactory, Notifiable;
+/// }
+/// ```
+///
+/// A class with no in-body trait imports yields just the declaration line.
+/// Tree-sitter-driven so a `class` substring in a string/comment can't trigger
+/// a false match.
 pub fn extract_class_signature(path: &std::path::Path) -> Option<String> {
-    use lazy_static::lazy_static;
-    use regex::Regex;
-    lazy_static! {
-        static ref CLASS_RE: Regex =
-            Regex::new(r"(?m)^\s*(?:(?:final|abstract|readonly)\s+)*class\s+\w+[^{\n]*").unwrap();
-    }
     let content = std::fs::read_to_string(path).ok()?;
-    let m = CLASS_RE.find(&content)?;
-    Some(m.as_str().trim().to_string())
+    let tree = crate::parser::parse_php(&content).ok()?;
+    let class = first_class_node(tree.root_node())?;
+
+    let mut cursor = class.walk();
+    let body = class
+        .named_children(&mut cursor)
+        .find(|c| c.kind() == "declaration_list");
+
+    // Header: the declaration up to (but excluding) the body's opening `{`.
+    let header_end = body.map_or(class.end_byte(), |b| b.start_byte());
+    let header = content.get(class.start_byte()..header_end)?.trim();
+
+    // Append the leading trait-`use` block verbatim from source, when present.
+    if let Some(body) = body {
+        if let Some(last_use_end) = leading_trait_use_end(body) {
+            let block = content.get(class.start_byte()..last_use_end)?;
+            return Some(format!("{}\n}}", block.trim_end()));
+        }
+    }
+    Some(header.to_string())
+}
+
+/// First `class_declaration` node anywhere in the tree, in document order.
+fn first_class_node(root: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "class_declaration" {
+            return Some(node);
+        }
+        let mut cursor = node.walk();
+        let children: Vec<_> = node.named_children(&mut cursor).collect();
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
+    }
+    None
+}
+
+/// End byte of the last LEADING trait `use_declaration` in a class body, or
+/// `None` when the class imports no traits before its first member. Comments
+/// between trait imports don't end the run; the first real member (property /
+/// method / const) does.
+fn leading_trait_use_end(body: tree_sitter::Node) -> Option<usize> {
+    let mut cursor = body.walk();
+    let mut end = None;
+    for child in body.named_children(&mut cursor) {
+        match child.kind() {
+            "use_declaration" => end = Some(child.end_byte()),
+            "comment" => continue,
+            _ => break,
+        }
+    }
+    end
 }
 
 /// Rich information about a property/method declaration extracted from a

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -1448,6 +1448,32 @@ pub struct ParsedBindingReg<'db> {
     pub source_file: PathBuf,
 }
 
+/// A parsed macro/mixin registration (Salsa tracked).
+///
+/// Example: `Str::macro('uuid7', fn () => ...)` registers a `uuid7` macro on the
+/// `Macroable` host `Illuminate\Support\Str`; `Str::mixin(new MyMixin)` registers
+/// every public method of `MyMixin` as a macro on the same host. The
+/// `receiver_fqcn` is the resolved host FQCN (token resolved through the file's
+/// `use` imports + facade alias map, so it agrees with the call-site receiver
+/// resolution), `macro_name` is the registered member name, and the source
+/// file + line point at the **definition site** — the closure for a scalar macro,
+/// the mixin method for a mixin-expanded one.
+#[salsa::tracked]
+pub struct ParsedMacroReg<'db> {
+    /// Resolved Macroable host FQCN (e.g. "Illuminate\\Support\\Str").
+    pub receiver_fqcn: BindingName<'db>,
+    /// The registered macro/method name (e.g. "uuid7").
+    pub macro_name: BindingName<'db>,
+    /// Definition site file — the provider for a scalar macro (closure), or the
+    /// mixin class file for a mixin-expanded method.
+    #[returns(ref)]
+    pub decl_file: PathBuf,
+    /// 0-based definition line — the closure's line, or the mixin method's line.
+    pub decl_line: u32,
+    /// Priority (0=framework, 1=package, 2=app)
+    pub priority: u8,
+}
+
 /// A parsed view namespace registration from loadViewsFrom() (Salsa tracked)
 /// Example: $this->loadViewsFrom(__DIR__.'/../resources/views', 'courier')
 #[salsa::tracked]
@@ -1552,6 +1578,10 @@ pub struct ParsedServiceProvider<'db> {
     /// Container bindings found in this provider
     #[returns(ref)]
     pub bindings: Vec<ParsedBindingReg<'db>>,
+    /// Macro/mixin registrations found in this provider (`Str::macro(...)`,
+    /// `Str::mixin(...)`)
+    #[returns(ref)]
+    pub macros: Vec<ParsedMacroReg<'db>>,
     /// View namespace registrations from loadViewsFrom()
     #[returns(ref)]
     pub view_namespaces: Vec<ParsedViewNamespaceReg<'db>>,
@@ -1760,6 +1790,33 @@ pub fn parse_service_provider_source<'db>(
                 pb.source_line,
                 priority,
                 path.clone(),
+            ));
+        }
+    }
+
+    // Parse macro/mixin registrations (`Str::macro('foo', fn …)`,
+    // `Str::mixin(new MyMixin)`) via tree-sitter. The receiver token is resolved
+    // to its Macroable host FQCN the same way the call site resolves it (use
+    // imports + facade alias map), so registry keys agree with lookup keys. The
+    // first registration of a `(host, name)` pair in source order wins the dedup.
+    let mut macros = Vec::new();
+    if let Ok(macro_tree) = parse_php(text) {
+        let aliases = crate::query_chain::use_aliases::extract_use_aliases(&macro_tree, text);
+        let mut macros_seen: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        for pm in extract_provider_macros(&macro_tree, text, path, &root, &aliases) {
+            if !macros_seen.insert((pm.receiver_fqcn.clone(), pm.macro_name.clone())) {
+                continue;
+            }
+            let receiver = BindingName::new(db, pm.receiver_fqcn);
+            let name = BindingName::new(db, pm.macro_name);
+            macros.push(ParsedMacroReg::new(
+                db,
+                receiver,
+                name,
+                pm.decl_file,
+                pm.decl_line,
+                priority,
             ));
         }
     }
@@ -2020,6 +2077,7 @@ pub fn parse_service_provider_source<'db>(
         db,
         middleware,
         bindings,
+        macros,
         view_namespaces,
         blade_components,
         component_namespaces,
@@ -2214,6 +2272,242 @@ fn class_const_name(expr: tree_sitter::Node, bytes: &[u8]) -> Option<String> {
     )
 }
 
+/// A macro/mixin registration extracted from a provider's AST, ready to become
+/// a `ParsedMacroReg`. `receiver_fqcn` is the resolved Macroable host FQCN,
+/// `macro_name` the registered member, and `decl_file`/`decl_line` the
+/// definition site (the closure for a scalar macro, the mixin method otherwise).
+struct ProviderMacro {
+    receiver_fqcn: String,
+    macro_name: String,
+    decl_file: PathBuf,
+    decl_line: u32,
+}
+
+/// Walk a provider's PHP AST for `Receiver::macro('name', <closure>)` and
+/// `Receiver::mixin(new Mixin)` static calls, resolving each to a definition
+/// site. Mirrors [`extract_provider_bindings`]: a pre-order descent so the first
+/// registration of a `(host, name)` pair in source order wins the caller's dedup.
+///
+/// ## Coverage boundaries (be honest about the caps)
+///
+/// - **Which files**: every file registered as a [`ServiceProviderFile`] Salsa
+///   input — app providers (priority 2), framework providers (0), and package
+///   providers (1), the last two discovered by the vendor scan
+///   (`rescan_vendor_providers`). Priority merging happens in
+///   [`SalsaActor::build_macro_registry`], not here.
+/// - **Which calls**: only a STATIC `Receiver::macro(...)` / `Receiver::mixin(...)`
+///   (`scoped_call_expression`). The dominant registration site is a provider's
+///   `boot()`, but the walk is whole-file, not `boot()`-scoped — so a macro
+///   registered in any method of a registered provider is caught. An instance-form
+///   `$compiler->macro(...)` is intentionally NOT matched (it's a
+///   `member_call_expression`, and `macro` as an instance method is rarely a
+///   Macroable registration on a resolvable host).
+/// - **Known caps** (registrations we do NOT see): a macro registered OUTSIDE a
+///   registered provider (e.g. directly in `routes/`, a test bootstrap, or a
+///   package file that isn't a `*ServiceProvider.php`); a host token that doesn't
+///   resolve to an FQCN statically; a `macro` name that isn't a plain string
+///   literal (a variable / concatenation); and a `mixin` whose class can't be
+///   resolved to an on-disk file. These degrade silently to "no macro" rather
+///   than a wrong target.
+fn extract_provider_macros(
+    tree: &tree_sitter::Tree,
+    text: &str,
+    provider_path: &Path,
+    root: &Path,
+    aliases: &crate::query_chain::use_aliases::UseAliases,
+) -> Vec<ProviderMacro> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    walk_provider_macros(
+        tree.root_node(),
+        bytes,
+        provider_path,
+        root,
+        aliases,
+        &mut out,
+    );
+    out
+}
+
+fn walk_provider_macros(
+    node: tree_sitter::Node,
+    bytes: &[u8],
+    provider_path: &Path,
+    root: &Path,
+    aliases: &crate::query_chain::use_aliases::UseAliases,
+    out: &mut Vec<ProviderMacro>,
+) {
+    if node.kind() == "scoped_call_expression" {
+        classify_macro_call(node, bytes, provider_path, root, aliases, out);
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        walk_provider_macros(child, bytes, provider_path, root, aliases, out);
+    }
+}
+
+/// Classify one `Receiver::macro('name', <closure>)` / `Receiver::mixin(<expr>)`
+/// static call, pushing zero or more `ProviderMacro`s into `out`. A scalar macro
+/// yields one entry (definition site = the closure); a mixin yields one entry per
+/// public method of the resolved mixin class (definition site = each method).
+/// Returns silently for any call that isn't such a registration or whose receiver
+/// can't be resolved to a host FQCN.
+fn classify_macro_call(
+    node: tree_sitter::Node,
+    bytes: &[u8],
+    provider_path: &Path,
+    root: &Path,
+    aliases: &crate::query_chain::use_aliases::UseAliases,
+    out: &mut Vec<ProviderMacro>,
+) {
+    let Some(method) = node
+        .child_by_field_name("name")
+        .and_then(|n| n.utf8_text(bytes).ok())
+    else {
+        return;
+    };
+    if !matches!(method, "macro" | "mixin") {
+        return;
+    }
+    // Resolve the receiver token to its Macroable host FQCN the same way the
+    // call site does — through the file's `use` imports (and, for a facade
+    // token, the alias map fed via the seed; user aliases ride at the snapshot
+    // merge, not here). A token with a `\` separator is already qualified.
+    let Some(scope) = node
+        .child_by_field_name("scope")
+        .and_then(|s| s.utf8_text(bytes).ok())
+    else {
+        return;
+    };
+    let receiver_fqcn = resolve_macro_host_fqcn(scope, aliases);
+
+    let Some(args) = node.child_by_field_name("arguments") else {
+        return;
+    };
+    let mut cursor = args.walk();
+    let mut arg_exprs = args.named_children(&mut cursor).map(argument_value);
+
+    if method == "macro" {
+        // `macro('name', <closure>)` — the name is the first string argument and
+        // the definition site is the closure (second argument).
+        let Some(Some(name_node)) = arg_exprs.next() else {
+            return;
+        };
+        let Some(macro_name) = string_literal_text(name_node, bytes) else {
+            return;
+        };
+        let closure = arg_exprs.next().flatten();
+        // The definition line: the closure if present (where the body lives),
+        // otherwise the call itself. 0-based to match the rest of the stack. The
+        // definition file for a scalar macro is the provider source itself.
+        let decl_line = closure.unwrap_or(node).start_position().row as u32;
+        out.push(ProviderMacro {
+            receiver_fqcn,
+            macro_name,
+            decl_file: provider_path.to_path_buf(),
+            decl_line,
+        });
+        return;
+    }
+
+    // `mixin(new MyMixin)` / `mixin(MyMixin::class)` — expand each public OR
+    // protected method of the mixin class into a macro on the same host. The
+    // mixin's methods ARE the registered members (Laravel reflects them onto the
+    // host at runtime), so each one's definition site is its own declaration in
+    // the mixin file.
+    let Some(Some(arg)) = arg_exprs.next() else {
+        return;
+    };
+    let Some(mixin_fqcn) = mixin_class_fqcn(arg, bytes, aliases) else {
+        return;
+    };
+    let Some(mixin_file) = resolve_class_to_file_internal(&mixin_fqcn, root) else {
+        return;
+    };
+    // Analyze the mixin to enumerate its methods with their declaration lines —
+    // the same inheritance-resolved walk the model surfaces use (and the same
+    // `ReflectionClass::getMethods` inheritance scope Laravel reflects over). A
+    // mixin that can't be analyzed (unreadable, no class) yields nothing.
+    let Some(view) = crate::laravel_introspector::chain::analyze(&mixin_file, root) else {
+        return;
+    };
+    for m in &view.all_methods {
+        let method = &m.value;
+        // Laravel's `Macroable::mixin` reflects with
+        // `getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED)`
+        // and `setAccessible(true)` on each before registering it — so PUBLIC and
+        // PROTECTED methods alike become live macros; only PRIVATE methods are
+        // excluded. Laravel does NOT filter by `__` name (a real mixin never
+        // returns a closure from `__construct`/`__call`, so they don't surface as
+        // callable macros in practice), so we mirror that and exclude purely by
+        // visibility.
+        if method.visibility == crate::laravel_introspector::walker::PhpVisibility::Private {
+            continue;
+        }
+        // The method's own declaring file (a trait the mixin composes lives
+        // elsewhere); fall back to the mixin file when the source class isn't
+        // separately resolvable.
+        let decl_file = resolve_class_to_file_internal(&m.source_class, root)
+            .unwrap_or_else(|| mixin_file.clone());
+        out.push(ProviderMacro {
+            receiver_fqcn: receiver_fqcn.clone(),
+            macro_name: method.name.clone(),
+            decl_file,
+            decl_line: method.start_line,
+        });
+    }
+}
+
+/// Resolve the mixin class FQCN from a `mixin(...)` argument — either
+/// `new MyMixin` / `new MyMixin()` (an `object_creation_expression`) or
+/// `MyMixin::class` (a `class_constant_access_expression`) — through the file's
+/// `use` imports. Returns `None` for any other argument shape (a variable, a
+/// computed expression — none of which name a mixin class statically).
+fn mixin_class_fqcn(
+    arg: tree_sitter::Node,
+    bytes: &[u8],
+    aliases: &crate::query_chain::use_aliases::UseAliases,
+) -> Option<String> {
+    let class_ref = match arg.kind() {
+        "class_constant_access_expression" => class_const_name(arg, bytes)?,
+        "object_creation_expression" => {
+            // The class name is the first named child that is a name / qualified
+            // name / relative name (skipping the `new` keyword and any argument
+            // list). `relative_name` covers `new namespace\MyMixin`; this matches
+            // the sibling `new X` resolvers in `query_chain::extractor` and
+            // `query_chain::flow`, which feed the same raw text through
+            // `resolve_class_name`. Collect into a Vec so the walk cursor doesn't
+            // outlive the borrow.
+            let mut cursor = arg.walk();
+            let children: Vec<_> = arg.named_children(&mut cursor).collect();
+            let name_node = children
+                .into_iter()
+                .find(|c| matches!(c.kind(), "name" | "qualified_name" | "relative_name"))?;
+            name_node.utf8_text(bytes).ok()?.to_string()
+        }
+        _ => return None,
+    };
+    Some(
+        crate::query_chain::use_aliases::resolve_class_name(&class_ref, aliases)
+            .trim_start_matches('\\')
+            .to_string(),
+    )
+}
+
+/// Resolve a `Receiver::macro(...)` scope token to its Macroable host FQCN.
+/// Expands the file's `use` imports and strips a leading `\`; a bare token with
+/// no import stays as written (the framework Macroables — `Str`, `Arr`,
+/// `Request`, … — are referenced by their imported short name in practice, and
+/// the call-site resolver qualifies the same way).
+fn resolve_macro_host_fqcn(
+    scope: &str,
+    aliases: &crate::query_chain::use_aliases::UseAliases,
+) -> String {
+    crate::query_chain::use_aliases::resolve_class_name(scope, aliases)
+        .trim_start_matches('\\')
+        .to_string()
+}
+
 /// Extract `$app->withAliases([...])` facade-alias registrations from a
 /// `bootstrap/app.php` source into a token → facade-FQCN map (`'Auth' =>
 /// 'Illuminate\Support\Facades\Auth'`).
@@ -2360,6 +2654,16 @@ fn resolve_closure_concrete(
     if !matches!(confidence, Confidence::High | Confidence::Medium) {
         return None;
     }
+    // `resolve_expression_type` expands `use`-aliases and absolute names but
+    // leaves a bare SAME-NAMESPACE `new X` unqualified — the real Laravel shape
+    // `singleton('auth', fn ($app) => new AuthManager($app))` in a provider that
+    // lives in `AuthManager`'s own namespace returns the bare `AuthManager`,
+    // which then fails the on-disk gate below and degrades the binding to
+    // "Closure". Qualify it against the closure's FILE namespace with the SAME
+    // helper the static-receiver arm uses, so the bare name becomes
+    // `Illuminate\Auth\AuthManager` before the gate. (A name `resolve_class_name`
+    // already qualified — imported or absolute — is left untouched.)
+    let fqcn = crate::member_resolver::qualify_fqcn(fqcn, expr, bytes);
     // Only store a concrete that names a real class file — an inferred FQCN that
     // doesn't resolve to disk would be a guess, and the contract is to degrade
     // to "Closure" rather than point at a wrong or absent target.
@@ -2894,6 +3198,22 @@ pub enum MagicMemberKind {
     Column,
     /// Dynamic finder (`User::whereEmail(...)` → `where('email', ...)`).
     DynamicFinder,
+    /// Runtime-registered macro / mixin method (`Str::macro('foo', fn …)`,
+    /// `Str::mixin(new MyMixin)`). Resolved via the project-wide macro registry
+    /// rather than the receiver class's own surfaces — its definition site is the
+    /// registered closure (or the mixin method), carried in the registry entry.
+    Macro,
+    /// A method reached through a FACADE proxy (`Auth::check()`,
+    /// `Cache::get()`). The facade's own class carries only `@method` docblocks,
+    /// so resolution walked it to the bound concrete (facade FQCN → accessor →
+    /// container binding); `declaring_fqcn` is that concrete. The goto/hover
+    /// target is the member's declaration on the concrete when it declares one
+    /// (`AuthManager::check`), DEGRADING to the concrete CLASS when the concrete
+    /// only forwards the call via `__call`/a guard (`Auth::guard()` is
+    /// `@method`-documented, not declared). Distinct from `PlainMember` —
+    /// which the consumers drop as Intelephense's territory — because a facade
+    /// call is precisely what Intelephense CAN'T see through, so we own it.
+    FacadeMethod,
     /// Generic (non-magic) property on a resolved class.
     PlainMember,
 }
@@ -3672,6 +3992,24 @@ pub struct BindingRegistrationData {
     pub priority: u8,
 }
 
+/// A resolved macro/mixin registration for transfer across async boundaries and
+/// for the live query path. Keyed in the actor registry on
+/// `(receiver_fqcn, macro_name)`; the `decl_file`/`decl_line` point at the
+/// definition site (the registered closure, or the mixin method).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MacroRegistrationData {
+    /// Resolved Macroable host FQCN (e.g. "Illuminate\\Support\\Str").
+    pub receiver_fqcn: String,
+    /// The registered macro/method name (e.g. "uuid7").
+    pub macro_name: String,
+    /// Definition site file.
+    pub decl_file: PathBuf,
+    /// 0-based definition line.
+    pub decl_line: u32,
+    /// Priority: 0=framework, 1=package, 2=app (higher wins on key collision).
+    pub priority: u8,
+}
+
 /// Pairs the class-hierarchy index (FQCN → file) with the in-actor container
 /// binding registry (binding key → concrete FQCN) behind the
 /// [`crate::member_resolver::ClassFileResolver`] seam, so the live query path
@@ -3686,6 +4024,10 @@ struct ContainerAwareResolver<'a> {
     /// resolves facade receivers (`Auth::check()`) to their implementation the
     /// same way the build pass does.
     facade_aliases: Arc<HashMap<String, String>>,
+    /// The macro registry — `(receiver_fqcn, macro_name)` → definition site —
+    /// so the live query path classifies a runtime-registered macro/mixin member
+    /// the same way the build pass does.
+    macros: Arc<HashMap<(String, String), MacroRegistrationData>>,
 }
 
 impl crate::member_resolver::ClassFileResolver for ContainerAwareResolver<'_> {
@@ -3703,6 +4045,14 @@ impl crate::member_resolver::ClassFileResolver for ContainerAwareResolver<'_> {
     }
     fn facade_aliases(&self) -> std::borrow::Cow<'_, HashMap<String, String>> {
         std::borrow::Cow::Borrowed(&self.facade_aliases)
+    }
+    fn macro_target(&self, receiver_fqcn: &str, name: &str) -> Option<(PathBuf, u32)> {
+        self.macros
+            .get(&(receiver_fqcn.to_string(), name.to_string()))
+            .map(|m| (m.decl_file.clone(), m.decl_line))
+    }
+    fn has_macro_host(&self, receiver_fqcn: &str) -> bool {
+        self.macros.keys().any(|(host, _)| host == receiver_fqcn)
     }
 }
 
@@ -4158,6 +4508,17 @@ impl ParsedPatternsData {
 // Actor Pattern - For async integration
 // ============================================================================
 
+/// A facade receiver (`\Auth`) resolved to its bound concrete class — the
+/// goto/hover target shared by both handlers. Goto jumps to `file`/`decl_line`;
+/// hover renders a class-definition card from the file (FQCN header + class
+/// signature snippet), the same way the Livewire/class hover does.
+#[derive(Debug, Clone)]
+pub struct FacadeReceiverTarget {
+    pub fqcn: String,
+    pub file: PathBuf,
+    pub decl_line: u32,
+}
+
 /// Requests that can be sent to the Salsa actor
 pub enum SalsaRequest {
     /// Update or create a file in the database
@@ -4316,6 +4677,13 @@ pub enum SalsaRequest {
     SnapshotFacadeAliases {
         reply: oneshot::Sender<Arc<std::collections::HashMap<String, String>>>,
     },
+    /// Snapshot the macro registry — `(receiver_fqcn, macro_name)` → `(decl_file,
+    /// decl_line)` — for the same out-of-actor build, so a runtime-registered
+    /// macro/mixin member (`Str::uuid7()`) classifies while indexing exactly as
+    /// it does on the live query path. Mirrors [`Self::SnapshotBindings`].
+    SnapshotMacros {
+        reply: oneshot::Sender<Arc<std::collections::HashMap<(String, String), (PathBuf, u32)>>>,
+    },
     /// Snapshot every indexed class grouped by file, so warming can persist
     /// the hierarchy to the disk cache.
     SnapshotHierarchyNodes {
@@ -4377,6 +4745,15 @@ pub enum SalsaRequest {
         line: u32,
         column: u32,
         reply: oneshot::Sender<Option<MagicMemberHoverData>>,
+    },
+
+    /// Resolve a facade receiver token (`\Auth`) at a cursor to its bound
+    /// concrete class location (`AuthManager` file + decl line).
+    ResolveFacadeReceiverAt {
+        path: PathBuf,
+        line: u32,
+        column: u32,
+        reply: oneshot::Sender<Option<FacadeReceiverTarget>>,
     },
 
     /// Resolve the magic member at a cursor for rename (M7) — method-backed
@@ -5003,6 +5380,23 @@ impl SalsaHandle {
             .map_err(|_| "Salsa actor dropped reply channel")
     }
 
+    /// Snapshot the macro registry — `(receiver_fqcn, macro_name)` →
+    /// `(decl_file, decl_line)` — for the out-of-actor magic-member build.
+    /// Mirrors [`Self::snapshot_bindings`].
+    pub async fn snapshot_macros(
+        &self,
+    ) -> Result<Arc<std::collections::HashMap<(String, String), (PathBuf, u32)>>, &'static str>
+    {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::SnapshotMacros { reply: reply_tx })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
     /// Snapshot every indexed class grouped by declaring file, so warming can
     /// persist the hierarchy to the disk cache (it survives a warm restart
     /// only if persisted — fresh parses are the sole other populator).
@@ -5157,6 +5551,30 @@ impl SalsaHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(SalsaRequest::ResolveMagicMemberAt {
+                path,
+                line,
+                column,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Resolve a facade receiver token at `(line, column)` to its bound concrete
+    /// class location (`AuthManager` file + 0-based decl line), or `None` when
+    /// the cursor isn't on a resolvable facade receiver.
+    pub async fn resolve_facade_receiver_at(
+        &self,
+        path: PathBuf,
+        line: u32,
+        column: u32,
+    ) -> Result<Option<FacadeReceiverTarget>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::ResolveFacadeReceiverAt {
                 path,
                 line,
                 column,
@@ -6202,6 +6620,18 @@ impl SalsaActor {
                 SalsaRequest::SnapshotFacadeAliases { reply } => {
                     let _ = reply.send(self.build_facade_alias_snapshot());
                 }
+                SalsaRequest::SnapshotMacros { reply } => {
+                    // Reduce the registration data to the (decl_file, decl_line)
+                    // the build-pass resolver needs; priority merging already
+                    // happened in `build_macro_registry`.
+                    let registry = self.build_macro_registry();
+                    let mut map: std::collections::HashMap<(String, String), (PathBuf, u32)> =
+                        std::collections::HashMap::with_capacity(registry.len());
+                    for (key, data) in registry.iter() {
+                        map.insert(key.clone(), (data.decl_file.clone(), data.decl_line));
+                    }
+                    let _ = reply.send(Arc::new(map));
+                }
                 SalsaRequest::SnapshotHierarchyNodes { reply } => {
                     let _ = reply.send(self.class_hierarchy_index.nodes_by_file());
                 }
@@ -6259,6 +6689,15 @@ impl SalsaActor {
                     reply,
                 } => {
                     let result = self.handle_resolve_magic_member_at(&path, line, column);
+                    let _ = reply.send(result);
+                }
+                SalsaRequest::ResolveFacadeReceiverAt {
+                    path,
+                    line,
+                    column,
+                    reply,
+                } => {
+                    let result = self.handle_resolve_facade_receiver_at(&path, line, column);
                     let _ = reply.send(result);
                 }
                 SalsaRequest::ResolveMagicMemberRenameAt {
@@ -7942,6 +8381,29 @@ impl SalsaActor {
                 }
             };
 
+        // A macro/mixin member's definition site is the registered closure (or
+        // mixin method), carried in the macro registry — NOT a method on the
+        // declaring (Macroable host) class, which is typically a vendor class
+        // with no such method. Look it up directly; no end line (the registry
+        // stores only the definition's start).
+        if kind == MagicMemberKind::Macro {
+            let (decl_file, decl_line) = self
+                .build_macro_registry()
+                .get(&(declaring_fqcn.clone(), member_ref.member.clone()))
+                .map(|m| (Some(m.decl_file.clone()), Some(m.decl_line)))
+                .unwrap_or((None, None));
+            return Some(MagicMemberHoverData {
+                declaring_fqcn,
+                member: member_ref.member.clone(),
+                kind,
+                confidence,
+                decl_file,
+                decl_line,
+                decl_end_line: None,
+                tentative: false,
+            });
+        }
+
         // Locate the declaration in the declaring class. A method-backed member
         // (relationship / scope / accessor / finder) yields both start+end lines
         // so the hover can show its source; a property (column / plain) yields
@@ -7961,9 +8423,33 @@ impl SalsaActor {
                         node.properties.iter().find(|p| p.name == member_ref.member)
                     {
                         (Some(node.file_path.clone()), Some(p.start_line), None)
+                    } else if kind == MagicMemberKind::FacadeMethod {
+                        // The concrete doesn't declare this member — it forwards
+                        // via `__call`/`@mixin` (e.g. `AuthManager` → `Guard::check`).
+                        // Chase the real declaration from source; fall back to the
+                        // concrete class line only when the chase comes up empty.
+                        match crate::facade_resolver::facade_method_decl(
+                            &declaring_fqcn,
+                            &member_ref.member,
+                            &project_root,
+                        ) {
+                            Some((f, l)) => (Some(f), Some(l), None),
+                            None => (Some(node.file_path.clone()), Some(node.start_line), None),
+                        }
                     } else {
                         (Some(node.file_path.clone()), Some(node.start_line), None)
                     }
+                }
+                // A facade's concrete may be a vendor class absent from the
+                // hierarchy index — still chase its declaration from disk.
+                None if kind == MagicMemberKind::FacadeMethod => {
+                    crate::facade_resolver::facade_method_decl(
+                        &declaring_fqcn,
+                        &member_ref.member,
+                        &project_root,
+                    )
+                    .map(|(f, l)| (Some(f), Some(l), None))
+                    .unwrap_or((None, None, None))
                 }
                 None => (None, None, None),
             };
@@ -7977,6 +8463,77 @@ impl SalsaActor {
             decl_line,
             decl_end_line,
             tentative,
+        })
+    }
+
+    /// Resolve a facade *receiver* at a cursor (`\Auth` in `\Auth::check()`) to
+    /// its bound concrete class location. The position index only marks the
+    /// method-name token, so this is the goto/hover path when the cursor sits on
+    /// the receiver itself: find the enclosing `scoped_call_expression`, confirm
+    /// the cursor is on its `scope`, resolve the facade to the concrete it
+    /// proxies (`AuthManager`), and locate that class's declaration line.
+    fn handle_resolve_facade_receiver_at(
+        &mut self,
+        path: &PathBuf,
+        line: u32,
+        column: u32,
+    ) -> Option<FacadeReceiverTarget> {
+        let project_root = self.config_root.clone()?;
+        self.ensure_file_registered(path);
+        let file = self.files.get(path)?;
+        let text = file.text(&self.db).clone();
+        let tree = crate::parser::parse_php(&text).ok()?;
+        let bytes = text.as_bytes();
+
+        // The node under the cursor, then the static call it belongs to.
+        let point = tree_sitter::Point {
+            row: line as usize,
+            column: column as usize,
+        };
+        let node = tree.root_node().descendant_for_point_range(point, point)?;
+        let mut call = node;
+        while call.kind() != "scoped_call_expression" {
+            call = call.parent()?;
+        }
+        let scope = call.child_by_field_name("scope")?;
+        // Only fire on the receiver — when the cursor is on the method name the
+        // normal member-access goto handles it.
+        if node.start_byte() < scope.start_byte() || node.end_byte() > scope.end_byte() {
+            return None;
+        }
+
+        let raw = scope.utf8_text(bytes).ok()?;
+        let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, &text);
+        let resolver = self.container_aware_resolver();
+        let (concrete, _) = crate::member_resolver::resolve_facade_receiver(
+            scope,
+            raw,
+            bytes,
+            &aliases,
+            &resolver,
+            &project_root,
+        )?;
+
+        // Locate the concrete class's own declaration line.
+        let class_file =
+            crate::class_locator::find_php_class_file_in_app_or_vendor(&concrete, &project_root)?;
+        let class_src = std::fs::read_to_string(&class_file).ok()?;
+        let class_tree = crate::parser::parse_php(&class_src).ok()?;
+        let structure = crate::laravel_introspector::walker::extract_php_structure_from_tree(
+            &class_tree,
+            class_src.as_bytes(),
+        );
+        let short = concrete.rsplit('\\').next().unwrap_or(&concrete);
+        let decl_line = structure
+            .structures
+            .iter()
+            .find(|s| s.name == short)
+            .map(|s| s.start_line)
+            .unwrap_or(0);
+        Some(FacadeReceiverTarget {
+            fqcn: concrete,
+            file: class_file,
+            decl_line,
         })
     }
 
@@ -8182,6 +8739,42 @@ impl SalsaActor {
         Arc::new(map)
     }
 
+    /// Build the macro registry — `(receiver_fqcn, macro_name)` → registration —
+    /// by merging every Salsa-parsed service provider's `macros`, highest
+    /// priority winning on key collision (framework=0 < package=1 < app=2). Built
+    /// fresh each call from the tracked-query outputs (mirrors
+    /// [`Self::build_facade_alias_snapshot`]); macros number in the dozens-to-
+    /// hundreds, with no cache to invalidate on a provider edit.
+    fn build_macro_registry(&self) -> Arc<HashMap<(String, String), MacroRegistrationData>> {
+        let mut map: HashMap<(String, String), MacroRegistrationData> = HashMap::new();
+        let Some(root) = self.salsa_sp_root.as_ref() else {
+            return Arc::new(map);
+        };
+        for sp_file in self.salsa_sp_files.values() {
+            let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+            for m in parsed.macros(&self.db) {
+                let key = (
+                    m.receiver_fqcn(&self.db).name(&self.db).clone(),
+                    m.macro_name(&self.db).name(&self.db).clone(),
+                );
+                let data = MacroRegistrationData {
+                    receiver_fqcn: key.0.clone(),
+                    macro_name: key.1.clone(),
+                    decl_file: m.decl_file(&self.db).clone(),
+                    decl_line: m.decl_line(&self.db),
+                    priority: m.priority(&self.db),
+                };
+                match map.get(&key) {
+                    Some(existing) if existing.priority >= data.priority => {}
+                    _ => {
+                        map.insert(key, data);
+                    }
+                }
+            }
+        }
+        Arc::new(map)
+    }
+
     // === Service Provider Handlers ===
 
     /// Handle service provider registry registration
@@ -8221,6 +8814,7 @@ impl SalsaActor {
             bindings: &self.sp_bindings,
             singletons: &self.sp_singletons,
             facade_aliases: self.build_facade_alias_snapshot(),
+            macros: self.build_macro_registry(),
         }
     }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -3682,6 +3682,10 @@ struct ContainerAwareResolver<'a> {
     index: &'a crate::class_hierarchy_index::ClassHierarchyIndex,
     bindings: &'a HashMap<String, BindingRegistrationData>,
     singletons: &'a HashMap<String, BindingRegistrationData>,
+    /// The merged facade alias map (token → facade FQCN), so the live query path
+    /// resolves facade receivers (`Auth::check()`) to their implementation the
+    /// same way the build pass does.
+    facade_aliases: Arc<HashMap<String, String>>,
 }
 
 impl crate::member_resolver::ClassFileResolver for ContainerAwareResolver<'_> {
@@ -3696,6 +3700,9 @@ impl crate::member_resolver::ClassFileResolver for ContainerAwareResolver<'_> {
             .get(key)
             .or_else(|| self.singletons.get(key))
             .map(|b| b.concrete_class.trim_start_matches('\\').to_string())
+    }
+    fn facade_aliases(&self) -> std::borrow::Cow<'_, HashMap<String, String>> {
+        std::borrow::Cow::Borrowed(&self.facade_aliases)
     }
 }
 
@@ -8213,6 +8220,7 @@ impl SalsaActor {
             index: &self.class_hierarchy_index,
             bindings: &self.sp_bindings,
             singletons: &self.sp_singletons,
+            facade_aliases: self.build_facade_alias_snapshot(),
         }
     }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2214,6 +2214,104 @@ fn class_const_name(expr: tree_sitter::Node, bytes: &[u8]) -> Option<String> {
     )
 }
 
+/// Extract `$app->withAliases([...])` facade-alias registrations from a
+/// `bootstrap/app.php` source into a token → facade-FQCN map (`'Auth' =>
+/// 'Illuminate\Support\Facades\Auth'`).
+///
+/// `withAliases` is the Laravel 11+ way to override `Facade::defaultAliases()`,
+/// the modern counterpart to `config/app.php`'s `aliases` array (parsed by
+/// [`crate::config::parse_facade_aliases`]). It is a `member_call_expression`
+/// whose method is `withAliases` and whose single argument is an array literal
+/// of `'Alias' => Class::class` pairs. We walk the AST (mirroring
+/// [`extract_provider_bindings`]) so each `::class` value resolves through the
+/// file's `use` imports — `withAliases([…Auth::class])` under
+/// `use Illuminate\Support\Facades\Auth;` yields the full FQCN.
+///
+/// Only `Class::class` values are honored; a non-`::class` entry (a bare
+/// string, a computed expression) is skipped — it can't name a facade class
+/// statically.
+pub fn extract_with_aliases(tree: &tree_sitter::Tree, text: &str) -> HashMap<String, String> {
+    let bytes = text.as_bytes();
+    let aliases = crate::query_chain::use_aliases::extract_use_aliases(tree, text);
+    let mut out = HashMap::new();
+    walk_with_aliases(tree.root_node(), bytes, &aliases, &mut out);
+    out
+}
+
+/// Pre-order descent collecting `withAliases([...])` entries.
+fn walk_with_aliases(
+    node: tree_sitter::Node,
+    bytes: &[u8],
+    aliases: &crate::query_chain::use_aliases::UseAliases,
+    out: &mut HashMap<String, String>,
+) {
+    if node.kind() == "member_call_expression"
+        && node
+            .child_by_field_name("name")
+            .and_then(|n| n.utf8_text(bytes).ok())
+            == Some("withAliases")
+    {
+        collect_with_aliases_args(node, bytes, aliases, out);
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        walk_with_aliases(child, bytes, aliases, out);
+    }
+}
+
+/// Pull `'Alias' => Class::class` pairs from the array-literal argument of a
+/// `withAliases(...)` call, resolving each `::class` value through `aliases`.
+fn collect_with_aliases_args(
+    call: tree_sitter::Node,
+    bytes: &[u8],
+    aliases: &crate::query_chain::use_aliases::UseAliases,
+    out: &mut HashMap<String, String>,
+) {
+    let Some(args) = call.child_by_field_name("arguments") else {
+        return;
+    };
+    let mut cursor = args.walk();
+    for arg in args.named_children(&mut cursor) {
+        let Some(value) = argument_value(arg) else {
+            continue;
+        };
+        if value.kind() != "array_creation_expression" {
+            continue;
+        }
+        let mut el_cursor = value.walk();
+        for element in value.named_children(&mut el_cursor) {
+            if element.kind() != "array_element_initializer" {
+                continue;
+            }
+            let Some(key_node) = element
+                .child_by_field_name("key")
+                .or_else(|| element.named_child(0))
+            else {
+                continue;
+            };
+            let Some(value_node) = element
+                .child_by_field_name("value")
+                .or_else(|| element.named_child(1))
+            else {
+                continue;
+            };
+            let Some(alias) = string_literal_text(key_node, bytes) else {
+                continue;
+            };
+            // Only `Class::class` values name a facade class; resolve the bare
+            // class name through the file's `use` imports to its full FQCN.
+            if value_node.kind() != "class_constant_access_expression" {
+                continue;
+            }
+            let Some(class_ref) = class_const_name(value_node, bytes) else {
+                continue;
+            };
+            let fqcn = crate::query_chain::use_aliases::resolve_class_name(&class_ref, aliases);
+            out.insert(alias, fqcn.trim_start_matches('\\').to_string());
+        }
+    }
+}
+
 /// Resolve the concrete model a binding closure returns, or `None` to fall back
 /// to `"Closure"`. The contract is to degrade cleanly — only a single, concrete,
 /// on-disk class is ever returned; the hard tiers (relationship hops, multiple
@@ -4203,6 +4301,14 @@ pub enum SalsaRequest {
     SnapshotBindings {
         reply: oneshot::Sender<Arc<std::collections::HashMap<String, String>>>,
     },
+    /// Snapshot the facade alias map — token → facade FQCN (`Auth` →
+    /// `Illuminate\Support\Facades\Auth`) — merged from the built-in seed,
+    /// `config/app.php`'s `aliases`, and `bootstrap/app.php`'s `withAliases`.
+    /// Mirrors [`Self::SnapshotBindings`]: the facade receiver path resolves a
+    /// static-call token to its facade FQCN against this owned copy.
+    SnapshotFacadeAliases {
+        reply: oneshot::Sender<Arc<std::collections::HashMap<String, String>>>,
+    },
     /// Snapshot every indexed class grouped by file, so warming can persist
     /// the hierarchy to the disk cache.
     SnapshotHierarchyNodes {
@@ -4866,6 +4972,23 @@ impl SalsaHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(SalsaRequest::SnapshotBindings { reply: reply_tx })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Snapshot the facade alias map — token → facade FQCN — for the facade
+    /// receiver resolver. Mirrors [`Self::snapshot_bindings`]: the map merges
+    /// the built-in seed with any user aliases from `config/app.php`'s
+    /// `aliases` and `bootstrap/app.php`'s `withAliases`, user sources winning.
+    pub async fn snapshot_facade_aliases(
+        &self,
+    ) -> Result<Arc<std::collections::HashMap<String, String>>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::SnapshotFacadeAliases { reply: reply_tx })
             .await
             .map_err(|_| "Salsa actor disconnected")?;
         reply_rx
@@ -6068,6 +6191,9 @@ impl SalsaActor {
                         );
                     }
                     let _ = reply.send(Arc::new(map));
+                }
+                SalsaRequest::SnapshotFacadeAliases { reply } => {
+                    let _ = reply.send(self.build_facade_alias_snapshot());
                 }
                 SalsaRequest::SnapshotHierarchyNodes { reply } => {
                     let _ = reply.send(self.class_hierarchy_index.nodes_by_file());
@@ -8011,6 +8137,42 @@ impl SalsaActor {
             find_elapsed,
         );
         results
+    }
+
+    /// Build the facade alias snapshot — token → facade FQCN — merging three
+    /// sources in ascending precedence: the built-in seed
+    /// (`default_facade_aliases`), `config/app.php`'s `aliases` array, then
+    /// `bootstrap/app.php`'s `withAliases([...])`. A later source overrides an
+    /// earlier one's token (a user `'Auth' => Custom::class` wins over the
+    /// default) and adds new tokens. Built fresh each call — the sources number
+    /// in the dozens, with no cache to invalidate on a config/bootstrap edit
+    /// (mirrors the `SnapshotBindings` rationale).
+    fn build_facade_alias_snapshot(&self) -> Arc<HashMap<String, String>> {
+        let mut map = crate::facade_resolver::default_facade_aliases();
+
+        // config/app.php 'aliases' (legacy) — overrides the seed.
+        if let Some(root) = self.config_root.as_ref() {
+            if let Some(file) = self.config_files.get(&root.join("config/app.php")) {
+                for (token, fqcn) in crate::config::parse_facade_aliases(file.text(&self.db)) {
+                    map.insert(token, fqcn);
+                }
+            }
+        }
+
+        // bootstrap/app.php withAliases (Laravel 11+) — overrides both above.
+        if let Some(root) = self.salsa_sp_root.as_ref().or(self.config_root.as_ref()) {
+            let bootstrap = root.join("bootstrap/app.php");
+            if let Some(file) = self.salsa_sp_files.get(&bootstrap) {
+                let text = file.text(&self.db);
+                if let Ok(tree) = parse_php(text) {
+                    for (token, fqcn) in extract_with_aliases(&tree, text) {
+                        map.insert(token, fqcn);
+                    }
+                }
+            }
+        }
+
+        Arc::new(map)
     }
 
     // === Service Provider Handlers ===

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -1004,6 +1004,7 @@ fn container_aware_resolver_prefers_bindings_and_normalizes() {
         index: &index,
         bindings: &bindings,
         singletons: &singletons,
+        facade_aliases: std::sync::Arc::new(crate::facade_resolver::default_facade_aliases()),
     };
 
     // Singleton-only key resolves; leading backslash normalized.

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -3242,3 +3242,139 @@ fn quoted_key_content_is_read_without_greedy_trim() {
         concrete_for(&found, "'wrapped'").expect("key with embedded quotes registered verbatim");
     assert_eq!(concrete, "Tenant");
 }
+
+// ─── Facade aliases (bootstrap/app.php withAliases + merge precedence) ──────
+
+#[test]
+fn extract_with_aliases_resolves_imported_class_consts() {
+    // `use` import resolution: the bare `Auth::class` becomes the full FQCN.
+    let src = r#"<?php
+use Illuminate\Support\Facades\Auth;
+use App\Support\CustomCache;
+
+return Application::configure(basePath: __DIR__)
+    ->withAliases([
+        'Auth' => Auth::class,
+        'Cache' => CustomCache::class,
+    ])
+    ->create();
+"#;
+    let tree = parse_php(src).unwrap();
+    let aliases = extract_with_aliases(&tree, src);
+    assert_eq!(
+        aliases.get("Auth").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+    assert_eq!(
+        aliases.get("Cache").map(String::as_str),
+        Some("App\\Support\\CustomCache")
+    );
+}
+
+#[test]
+fn extract_with_aliases_skips_non_class_values() {
+    let src = r#"<?php
+return Application::configure(basePath: __DIR__)
+    ->withAliases([
+        'Legacy' => 'not.a.class',
+    ])
+    ->create();
+"#;
+    let tree = parse_php(src).unwrap();
+    assert!(extract_with_aliases(&tree, src).is_empty());
+}
+
+#[tokio::test]
+async fn facade_alias_snapshot_seeds_defaults() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+
+    let aliases = handle.snapshot_facade_aliases().await.unwrap();
+    // A built-in default is present even with no config/bootstrap sources.
+    assert_eq!(
+        aliases.get("Auth").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\Auth")
+    );
+}
+
+#[tokio::test]
+async fn facade_alias_snapshot_merges_sources_by_precedence() {
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // config/app.php: overrides the default `Auth` to a custom class and adds
+    // a new `LegacyAlias`.
+    let app_config = r#"<?php
+return [
+    'aliases' => [
+        'Auth' => App\Facades\LegacyAuth::class,
+        'LegacyAlias' => App\Facades\Legacy::class,
+    ],
+];
+"#;
+    let app_config_path = root.join("config/app.php");
+    std::fs::create_dir_all(app_config_path.parent().unwrap()).unwrap();
+    std::fs::write(&app_config_path, app_config).unwrap();
+
+    // bootstrap/app.php: withAliases overrides `Auth` again (highest source)
+    // and adds a brand-new `Modern` alias.
+    let bootstrap = r#"<?php
+use App\Facades\ModernAuth;
+use App\Facades\Modern;
+
+return Application::configure(basePath: __DIR__)
+    ->withAliases([
+        'Auth' => ModernAuth::class,
+        'Modern' => Modern::class,
+    ])
+    ->create();
+"#;
+    let bootstrap_path = root.join("bootstrap/app.php");
+    std::fs::create_dir_all(bootstrap_path.parent().unwrap()).unwrap();
+    std::fs::write(&bootstrap_path, bootstrap).unwrap();
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    handle
+        .update_config_file(app_config_path, app_config.to_string())
+        .await
+        .unwrap();
+    handle
+        .register_service_provider_source(bootstrap_path, bootstrap.to_string(), 2, root.clone())
+        .await
+        .unwrap();
+
+    let aliases = handle.snapshot_facade_aliases().await.unwrap();
+
+    // withAliases wins over config/app.php wins over the seed for `Auth`.
+    assert_eq!(
+        aliases.get("Auth").map(String::as_str),
+        Some("App\\Facades\\ModernAuth"),
+        "bootstrap withAliases has the highest precedence"
+    );
+    // config/app.php adds a new alias the seed lacks.
+    assert_eq!(
+        aliases.get("LegacyAlias").map(String::as_str),
+        Some("App\\Facades\\Legacy")
+    );
+    // withAliases adds a new alias.
+    assert_eq!(
+        aliases.get("Modern").map(String::as_str),
+        Some("App\\Facades\\Modern")
+    );
+    // An untouched default is still present.
+    assert_eq!(
+        aliases.get("DB").map(String::as_str),
+        Some("Illuminate\\Support\\Facades\\DB")
+    );
+}

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -1005,6 +1005,7 @@ fn container_aware_resolver_prefers_bindings_and_normalizes() {
         bindings: &bindings,
         singletons: &singletons,
         facade_aliases: std::sync::Arc::new(crate::facade_resolver::default_facade_aliases()),
+        macros: Default::default(),
     };
 
     // Singleton-only key resolves; leading backslash normalized.
@@ -3085,6 +3086,79 @@ fn closure_new_model_resolves_to_bound_model() {
     assert_eq!(concrete, "App\\Models\\Tenant");
 }
 
+// ─── FIX #1: bare same-namespace `new X` in a binding closure ──────────────
+//
+// The REAL Laravel `AuthServiceProvider` shape: a provider that lives in the
+// same namespace as the concrete it binds, registering
+// `singleton('auth', fn ($app) => new AuthManager($app))` with NO `use` import
+// — PHP resolves the bare `AuthManager` against the current namespace. Before
+// the fix `resolve_expression_type` returned the bare `AuthManager`, which
+// failed the on-disk gate (it looked up `AuthManager`, not
+// `Illuminate\Auth\AuthManager`) and degraded the binding to "Closure" — so
+// `binding_concrete("auth")` resolved nothing and EVERY `Auth::*` facade goto
+// died at the source. The fix qualifies the bare name against the closure's
+// file namespace before the gate.
+
+/// The vendor `AuthManager`, at the PSR-4-mapped `Illuminate\` path so
+/// `resolve_class_to_file_internal` finds it on disk.
+const AUTH_MANAGER_FILE: (&str, &str) = (
+    "vendor/laravel/framework/src/Illuminate/Auth/AuthManager.php",
+    "<?php namespace Illuminate\\Auth; class AuthManager { public function check() {} }",
+);
+
+/// A provider in `Illuminate\Auth` (the concrete's OWN namespace) whose
+/// `register()` body is `binding_line` — with NO import, so a bare `AuthManager`
+/// only resolves if qualified against this file namespace.
+fn same_namespace_auth_provider(binding_line: &str) -> String {
+    format!(
+        r#"<?php
+namespace Illuminate\Auth;
+
+use Illuminate\Support\ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{{
+    public function register(): void
+    {{
+        {binding_line}
+    }}
+}}
+"#
+    )
+}
+
+#[test]
+fn closure_bare_same_namespace_new_resolves_to_concrete() {
+    // FIX #1: `fn ($app) => new AuthManager($app)` in a provider that lives in
+    // `Illuminate\Auth` — the bare `AuthManager` (no import) must qualify to
+    // `Illuminate\Auth\AuthManager` and resolve to its file, NOT degrade to
+    // "Closure".
+    let (_dir, root) = project_with_files(&[AUTH_MANAGER_FILE]);
+    let src = same_namespace_auth_provider(
+        "$this->app->singleton('auth', fn ($app) => new AuthManager($app));",
+    );
+    let found = discovered_bindings(&src, root);
+    let (_, concrete, file) = concrete_for(&found, "auth").expect("binding registered");
+    assert_eq!(concrete, "Illuminate\\Auth\\AuthManager");
+    assert!(file
+        .as_ref()
+        .is_some_and(|f| f.ends_with("Illuminate/Auth/AuthManager.php")));
+}
+
+#[test]
+fn closure_fully_qualified_new_resolves_unchanged_control() {
+    // Control: the fully-qualified `new \Illuminate\Auth\AuthManager($app)` was
+    // already resolvable (absolute names don't need qualification) — the fix's
+    // qualify step must leave it byte-for-byte identical, never double-qualify.
+    let (_dir, root) = project_with_files(&[AUTH_MANAGER_FILE]);
+    let src = same_namespace_auth_provider(
+        "$this->app->singleton('auth', fn ($app) => new \\Illuminate\\Auth\\AuthManager($app));",
+    );
+    let found = discovered_bindings(&src, root);
+    let (_, concrete, _) = concrete_for(&found, "auth").expect("binding registered");
+    assert_eq!(concrete, "Illuminate\\Auth\\AuthManager");
+}
+
 #[test]
 fn closure_return_type_hint_resolves_to_bound_model() {
     // The body call is opaque; the explicit `: Tenant` return type is the signal.
@@ -3377,5 +3451,745 @@ return Application::configure(basePath: __DIR__)
     assert_eq!(
         aliases.get("DB").map(String::as_str),
         Some("Illuminate\\Support\\Facades\\DB")
+    );
+}
+
+// ─── Macro registry extraction (commit 1) ─────────────────────────────────
+
+#[test]
+fn extract_provider_macros_reads_scalar_macro() {
+    // `Str::macro('uuid7', fn () => …)` in a provider, with `Str` imported:
+    // the receiver token resolves to the Macroable host FQCN, the name is the
+    // first string argument, and the definition line is the closure's.
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let provider = dir.path().join("app/Providers/AppServiceProvider.php");
+    let src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('uuid7', fn () => 'x');
+    }
+}
+"#;
+    let tree = parse_php(src).unwrap();
+    let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, src);
+    let macros = extract_provider_macros(&tree, src, &provider, dir.path(), &aliases);
+    assert_eq!(macros.len(), 1);
+    assert_eq!(macros[0].receiver_fqcn, "Illuminate\\Support\\Str");
+    assert_eq!(macros[0].macro_name, "uuid7");
+    assert_eq!(macros[0].decl_file, provider);
+    // The closure is on the same line as the call (0-based line 6).
+    assert_eq!(macros[0].decl_line, 6);
+}
+
+#[test]
+fn extract_provider_macros_ignores_non_macro_static_calls() {
+    // A `Str::upper(...)` call (a real method, not a macro registration) and a
+    // `bind(...)` are not macro registrations — only `macro`/`mixin` count.
+    let src = r#"<?php
+use Illuminate\Support\Str;
+Str::upper('x');
+"#;
+    let tree = parse_php(src).unwrap();
+    let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, src);
+    let macros = extract_provider_macros(
+        &tree,
+        src,
+        std::path::Path::new("/x/Provider.php"),
+        std::path::Path::new("/x"),
+        &aliases,
+    );
+    assert!(macros.is_empty());
+}
+
+#[test]
+fn extract_provider_macros_expands_mixin_methods() {
+    // `Str::mixin(new StrMixin)` reflects every PUBLIC and PROTECTED method of
+    // `StrMixin` onto the host as a macro — mirroring Laravel's
+    // `getMethods(IS_PUBLIC | IS_PROTECTED)` + `setAccessible(true)`. Each one's
+    // definition site is its own declaration in the mixin file. PRIVATE methods
+    // are the only visibility excluded; Laravel does NOT filter by `__` name, so
+    // `__construct` reflects too (a real mixin never returns a closure from it,
+    // but the registry faithfully mirrors the reflection scope rather than
+    // second-guessing it).
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    // composer PSR-4 so `App\Mixins\StrMixin` resolves to its file.
+    std::fs::write(
+        root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#,
+    )
+    .unwrap();
+    let mixin_path = root.join("app/Mixins/StrMixin.php");
+    std::fs::create_dir_all(mixin_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &mixin_path,
+        r#"<?php
+namespace App\Mixins;
+class StrMixin {
+    public function __construct() {}
+    public function shout(): callable { return fn () => ''; }
+    protected function helper(): callable { return fn () => ''; }
+    private function secret(): void {}
+    public function whisper(): callable { return fn () => ''; }
+}
+"#,
+    )
+    .unwrap();
+
+    let provider_src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use App\Mixins\StrMixin;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::mixin(new StrMixin);
+    }
+}
+"#;
+    let tree = parse_php(provider_src).unwrap();
+    let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, provider_src);
+    let provider = root.join("app/Providers/AppServiceProvider.php");
+    let mut macros = extract_provider_macros(&tree, provider_src, &provider, root, &aliases);
+    macros.sort_by(|a, b| a.macro_name.cmp(&b.macro_name));
+
+    // Public + protected register on the `Str` host (4 of the 5 methods); the
+    // PRIVATE `secret` is the only one excluded. After sorting by name:
+    // `__construct`, `helper`, `shout`, `whisper`. Each points at its own
+    // declaration line in the mixin file.
+    let names: Vec<&str> = macros.iter().map(|m| m.macro_name.as_str()).collect();
+    assert_eq!(names, vec!["__construct", "helper", "shout", "whisper"]);
+    assert!(
+        !macros.iter().any(|m| m.macro_name == "secret"),
+        "the PRIVATE mixin method must NOT register as a macro"
+    );
+    for m in &macros {
+        assert_eq!(m.receiver_fqcn, "Illuminate\\Support\\Str");
+        assert_eq!(m.decl_file, mixin_path);
+    }
+    // The PROTECTED `helper` registers at its own 0-based declaration line (line
+    // 5: `<?php`=0, `namespace`=1, `class`=2, `__construct`=3, `shout`=4,
+    // `helper`=5) — protected mixin methods ARE live macros, with correct goto.
+    let helper = macros
+        .iter()
+        .find(|m| m.macro_name == "helper")
+        .expect("protected mixin method registers");
+    assert_eq!(helper.decl_line, 5);
+}
+
+#[test]
+fn extract_provider_macros_expands_relative_name_mixin() {
+    // `Str::mixin(new namespace\StrMixin)` — the `relative_name` argument shape
+    // (PHP's `namespace\…` keyword form, an `object_creation_expression` whose
+    // class node is `relative_name`, not `name`/`qualified_name`). The arm must
+    // reach it and resolve exactly as the sibling `new X` resolvers in
+    // `query_chain::extractor`/`flow` do: feed the raw `namespace\StrMixin` text
+    // through `resolve_class_name` (which leaves the literal `namespace\` prefix
+    // alone, since there is no `use namespace …` alias) and resolve THAT FQCN to
+    // a file. PSR-4 here maps the literal prefix so the mixin resolves and its
+    // public methods expand — proving the `relative_name` arm is wired without
+    // inventing a new resolution path.
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    // PSR-4 keyed on the literal `namespace\` prefix the sibling resolvers leave
+    // intact, so `namespace\StrMixin` → `mixins/StrMixin.php`.
+    std::fs::write(
+        root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "namespace\\": "mixins/" } } }"#,
+    )
+    .unwrap();
+    let mixin_path = root.join("mixins/StrMixin.php");
+    std::fs::create_dir_all(mixin_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &mixin_path,
+        r#"<?php
+namespace namespace;
+class StrMixin {
+    public function shout(): callable { return fn () => ''; }
+}
+"#,
+    )
+    .unwrap();
+
+    let provider_src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::mixin(new namespace\StrMixin);
+    }
+}
+"#;
+    let tree = parse_php(provider_src).unwrap();
+    let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, provider_src);
+    let provider = root.join("app/Providers/AppServiceProvider.php");
+    let macros = extract_provider_macros(&tree, provider_src, &provider, root, &aliases);
+
+    // The relative_name mixin resolved and its public method expanded — before
+    // the fix, the arm matched only `name`/`qualified_name` and yielded nothing.
+    assert_eq!(macros.len(), 1, "the relative_name mixin must resolve");
+    assert_eq!(macros[0].macro_name, "shout");
+    assert_eq!(macros[0].receiver_fqcn, "Illuminate\\Support\\Str");
+    assert_eq!(macros[0].decl_file, mixin_path);
+}
+
+#[tokio::test]
+async fn snapshot_macros_registers_provider_macro_at_definition_site() {
+    // End-to-end: register a provider source declaring `Str::macro('uuid7', …)`,
+    // then assert the macro registry snapshot keys it on the resolved host FQCN
+    // and points the definition site at the provider/closure line.
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let provider = root.join("app/Providers/AppServiceProvider.php");
+    let src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('uuid7', fn () => 'x');
+    }
+}
+"#;
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    handle
+        .register_service_provider_source(provider.clone(), src.to_string(), 2, root.clone())
+        .await
+        .unwrap();
+
+    let macros = handle.snapshot_macros().await.unwrap();
+    let target = macros.get(&("Illuminate\\Support\\Str".to_string(), "uuid7".to_string()));
+    assert_eq!(target, Some(&(provider, 6)));
+}
+
+#[tokio::test]
+async fn snapshot_macros_priority_merges_vendor_and_app() {
+    // A package provider (priority 1) and an app provider (priority 2) both
+    // register `Str::shared`; the app's site wins on key collision. The package
+    // also ships `Str::pkgOnly`, which is resolvable on its own. This is the
+    // framework=0 < package=1 < app=2 merge the binding registry uses, applied to
+    // macros — vendor providers are already `ServiceProviderFile` Salsa inputs,
+    // so the same plumbing covers them.
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // Package provider (priority 1): two macros.
+    let pkg = root.join("vendor/acme/pkg/src/PkgServiceProvider.php");
+    let pkg_src = r#"<?php
+namespace Acme\Pkg;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class PkgServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('shared', fn () => 'pkg');
+        Str::macro('pkgOnly', fn () => 'pkg');
+    }
+}
+"#;
+
+    // App provider (priority 2): overrides `shared`.
+    let app = root.join("app/Providers/AppServiceProvider.php");
+    let app_src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('shared', fn () => 'app');
+    }
+}
+"#;
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    handle
+        .register_service_provider_source(pkg.clone(), pkg_src.to_string(), 1, root.clone())
+        .await
+        .unwrap();
+    handle
+        .register_service_provider_source(app.clone(), app_src.to_string(), 2, root.clone())
+        .await
+        .unwrap();
+
+    let macros = handle.snapshot_macros().await.unwrap();
+
+    // App override wins for the colliding key — points at the app provider.
+    let shared = macros.get(&("Illuminate\\Support\\Str".to_string(), "shared".to_string()));
+    assert_eq!(shared, Some(&(app, 6)));
+
+    // The package-only macro still resolves to the package provider.
+    let pkg_only = macros.get(&(
+        "Illuminate\\Support\\Str".to_string(),
+        "pkgOnly".to_string(),
+    ));
+    assert_eq!(pkg_only, Some(&(pkg, 7)));
+}
+
+#[tokio::test]
+async fn resolve_magic_member_at_classifies_macro_call() {
+    // The headline feature, end-to-end through the actor: register a provider
+    // declaring `Str::macro('uuid7', fn () => …)`, then resolve a `Str::uuid7()`
+    // call site. The receiver `Str` is a VENDOR class the index doesn't carry —
+    // it resolves only because the macro registry knows it as a Macroable host
+    // (`has_macro_host`) — and the member classifies as `Macro`, with decl_file /
+    // decl_line read straight from the registry (the closure's location, NOT a
+    // method on the host class). Drives the `kind == Macro` arm of
+    // `handle_resolve_magic_member_at` (`salsa_impl.rs`).
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+
+    let provider = root.join("app/Providers/AppServiceProvider.php");
+    let provider_src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('uuid7', fn () => 'x');
+    }
+}
+"#;
+
+    // The call site. `Str` is imported so it qualifies to the framework host.
+    let caller_path = root.join("app/Support/Ids.php");
+    let caller_src = r#"<?php
+namespace App\Support;
+use Illuminate\Support\Str;
+class Ids {
+    public function make(): string { return Str::uuid7(); }
+}
+"#;
+    std::fs::create_dir_all(caller_path.parent().unwrap()).unwrap();
+    std::fs::write(&caller_path, caller_src).unwrap();
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    handle
+        .register_service_provider_source(
+            provider.clone(),
+            provider_src.to_string(),
+            2,
+            root.clone(),
+        )
+        .await
+        .unwrap();
+    handle
+        .update_file(caller_path.clone(), 1, caller_src.to_string())
+        .await
+        .unwrap();
+    handle.get_patterns(caller_path.clone()).await.unwrap();
+
+    // Cursor on the `uuid7` member token.
+    let (line, col) = position_of(caller_src, "uuid7");
+    let data = handle
+        .resolve_magic_member_at(caller_path, line, col)
+        .await
+        .unwrap()
+        .expect("a registered macro call should resolve");
+
+    assert_eq!(data.kind, MagicMemberKind::Macro);
+    assert_eq!(data.declaring_fqcn, "Illuminate\\Support\\Str");
+    assert_eq!(data.member, "uuid7");
+    // The definition site is the registered closure's location in the provider —
+    // line 6 (0-based) where `Str::macro('uuid7', …)` lives — not a method on the
+    // vendor host. No end line (the registry stores only the start).
+    assert_eq!(data.decl_file, Some(provider));
+    assert_eq!(data.decl_line, Some(6));
+    assert_eq!(data.decl_end_line, None);
+}
+
+// ─── Facade goto/hover end-to-end (the gap that hid both breaks) ───────────
+//
+// The PERMANENT regression test for the whole facade feature, driving the REAL
+// request path (`SalsaHandle::resolve_magic_member_at` — the exact call
+// goto_definition / hover make), not a direct resolver call. It models a real
+// Laravel 12 project:
+//
+//   - a vendor `Illuminate\Auth\AuthManager` declaring `check()` (but NOT
+//     `guard()`, which Laravel forwards via `__call`/a guard),
+//   - a vendor `Illuminate\Auth\AuthServiceProvider` registering the EXACT
+//     arrow-fn `singleton('auth', fn ($app) => new AuthManager($app))` — the
+//     bare same-namespace `new` that FIX #1 must namespace-qualify, and
+//   - a namespaced `AboutController` calling `Auth::check()` in each of the
+//     three facade forms.
+//
+// Without the two fixes this resolves NOTHING: FIX #1's break degrades the
+// `auth` binding to "Closure" so `binding_concrete("auth")` is empty and the
+// receiver never reaches the concrete; FIX #2's break classifies the method as
+// `PlainMember` which the consumer drops as Intelephense's. With both, the call
+// resolves to `FacadeMethod` on `AuthManager` with a non-None decl site.
+
+const VENDOR_AUTH_MANAGER_SRC: &str = r#"<?php
+namespace Illuminate\Auth;
+class AuthManager {
+    public function check() { return true; }
+}
+"#;
+
+/// The vendor `AuthServiceProvider`, in `AuthManager`'s OWN namespace, binding
+/// `auth` via the bare same-namespace arrow-fn `new` — the FIX #1 shape.
+const VENDOR_AUTH_PROVIDER_SRC: &str = r#"<?php
+namespace Illuminate\Auth;
+use Illuminate\Support\ServiceProvider;
+class AuthServiceProvider extends ServiceProvider {
+    public function register(): void {
+        $this->app->singleton('auth', fn ($app) => new AuthManager($app));
+    }
+}
+"#;
+
+/// Spawn an actor over a tempdir Laravel project with the vendor `AuthManager`
+/// plus `AuthServiceProvider` registered and a namespaced caller whose body is
+/// `caller_body` (the `Auth::…` call). Returns the caller path so the test can
+/// position on the member token.
+async fn auth_facade_e2e_project(caller_body: &str) -> (TempDir, SalsaHandle, PathBuf, String) {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+
+    // Vendor AuthManager on disk at its PSR-4-mapped path so the binding's
+    // concrete resolves to a real file.
+    let manager_path = root.join("vendor/laravel/framework/src/Illuminate/Auth/AuthManager.php");
+    std::fs::create_dir_all(manager_path.parent().unwrap()).unwrap();
+    std::fs::write(&manager_path, VENDOR_AUTH_MANAGER_SRC).unwrap();
+
+    let provider_path =
+        root.join("vendor/laravel/framework/src/Illuminate/Auth/AuthServiceProvider.php");
+    std::fs::write(&provider_path, VENDOR_AUTH_PROVIDER_SRC).unwrap();
+
+    let caller_src = format!(
+        r#"<?php
+namespace App\Http\Controllers;
+
+class AboutController {{
+    public function show() {{
+        {caller_body}
+    }}
+}}
+"#
+    );
+    let caller_path = root.join("app/Http/Controllers/AboutController.php");
+    std::fs::create_dir_all(caller_path.parent().unwrap()).unwrap();
+    std::fs::write(&caller_path, &caller_src).unwrap();
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    // Registering the provider source parses the `auth → AuthManager` binding
+    // (via FIX #1's qualification); `register_cached_binding_batch` below mirrors
+    // production's `populate_cache_from_salsa` to land it in the container
+    // registry the resolver reads. (FIX #1 is what makes the parsed concrete
+    // `AuthManager` instead of "Closure"; without it this binding is useless.)
+    handle
+        .register_service_provider_source(
+            provider_path,
+            VENDOR_AUTH_PROVIDER_SRC.to_string(),
+            0,
+            root.clone(),
+        )
+        .await
+        .unwrap();
+    register_parsed_bindings_into_registry(&handle).await;
+    handle
+        .update_file(caller_path.clone(), 1, caller_src.clone())
+        .await
+        .unwrap();
+    // Force the vendor AuthManager's parse so it lands in the class-hierarchy
+    // index (the on-demand population path) — the consumer needs its file/line.
+    handle.get_patterns(manager_path).await.unwrap();
+    handle.get_patterns(caller_path.clone()).await.unwrap();
+    (dir, handle, caller_path, caller_src)
+}
+
+/// Mirror production's `populate_cache_from_salsa` binding step: pull the bindings
+/// the actor parsed from registered provider SOURCES and feed them back through
+/// `register_cached_binding_batch`, which is what actually fills the `sp_bindings`
+/// registry the live-query resolver (`binding_concrete`) reads. The source path
+/// alone only fills the lazy `salsa_sp_files` Salsa input, not that registry — so
+/// without this round-trip a facade's accessor never reaches its concrete.
+async fn register_parsed_bindings_into_registry(handle: &SalsaHandle) {
+    let parsed = handle.get_all_parsed_bindings().await.unwrap();
+    let entries: Vec<_> = parsed
+        .into_iter()
+        .map(|b| {
+            (
+                b.abstract_name,
+                b.concrete_class,
+                format!("{:?}", b.binding_type).to_lowercase(),
+                b.file_path.map(|p| p.to_string_lossy().into_owned()),
+                Some(b.source_file.to_string_lossy().into_owned()),
+                b.source_line,
+            )
+        })
+        .collect();
+    handle.register_cached_binding_batch(entries).await.unwrap();
+}
+
+/// Resolve `member` at its position in `caller_body` through the real request
+/// path. Asserts it classifies as a `FacadeMethod` on `AuthManager` with a
+/// non-None decl site (NEVER None — the break this guards).
+async fn assert_facade_method_resolves(caller_body: &str, member: &str) -> MagicMemberHoverData {
+    let (_dir, handle, caller_path, caller_src) = auth_facade_e2e_project(caller_body).await;
+    let (line, col) = position_of(&caller_src, member);
+    let data = handle
+        .resolve_magic_member_at(caller_path, line, col)
+        .await
+        .unwrap()
+        .unwrap_or_else(|| {
+            panic!("`{caller_body}` must resolve to a facade method, got None (the break)")
+        });
+    assert_eq!(data.kind, MagicMemberKind::FacadeMethod);
+    assert_eq!(data.declaring_fqcn, "Illuminate\\Auth\\AuthManager");
+    assert_eq!(data.member, member);
+    // A non-None decl site is the whole point: goto/hover must have somewhere to
+    // jump. (For a declared method it's the method line; for the __call degrade
+    // it's the class line — either way, present.)
+    assert!(
+        data.decl_file.is_some() && data.decl_line.is_some(),
+        "facade goto must have a decl site, got {data:?}"
+    );
+    data
+}
+
+#[tokio::test]
+async fn facade_e2e_receiver_resolves_to_concrete_class() {
+    // Cursor on the RECEIVER token `\Auth` (not the method) navigates to the
+    // bound concrete class `AuthManager` — bullet #1. The position index only
+    // marks the method token, so this exercises the receiver fallback path.
+    let (_dir, handle, caller_path, caller_src) =
+        auth_facade_e2e_project(r#"\Auth::check();"#).await;
+
+    let (line, col) = position_of(&caller_src, "Auth");
+    let target = handle
+        .resolve_facade_receiver_at(caller_path.clone(), line, col)
+        .await
+        .unwrap()
+        .expect("receiver `\\Auth` must resolve to the concrete class");
+    assert!(
+        target.file.ends_with("Illuminate/Auth/AuthManager.php"),
+        "expected AuthManager file, got {:?}",
+        target.file
+    );
+    // `class AuthManager {` is line 2 (0-based) in VENDOR_AUTH_MANAGER_SRC.
+    assert_eq!(target.decl_line, 2);
+    assert_eq!(target.fqcn, "Illuminate\\Auth\\AuthManager");
+
+    // The METHOD token is NOT the receiver path — it must decline so the normal
+    // member-access goto (FacadeMethod) handles it.
+    let (mline, mcol) = position_of(&caller_src, "check");
+    assert!(
+        handle
+            .resolve_facade_receiver_at(caller_path, mline, mcol)
+            .await
+            .unwrap()
+            .is_none(),
+        "cursor on the method name must not resolve as a receiver"
+    );
+}
+
+#[tokio::test]
+async fn facade_e2e_global_alias_check_resolves_in_namespaced_file() {
+    // Global-alias form in a NAMESPACED controller: `\Auth::check();`. The
+    // leading `\` forces global resolution despite the file's namespace, so the
+    // seed alias `Auth → …\Facades\Auth` applies. This is the headline real-world
+    // shape (`\Auth::check()` in `App\Http\Controllers\AboutController`).
+    let data = assert_facade_method_resolves(r#"\Auth::check();"#, "check").await;
+    assert_eq!(data.decl_line, Some(3));
+}
+
+#[tokio::test]
+async fn facade_e2e_inline_fully_qualified_check_resolves() {
+    // Inline fully-qualified form: `\Illuminate\Support\Facades\Auth::check();`
+    // with no import — the path lands directly in the Facades namespace.
+    let data =
+        assert_facade_method_resolves(r#"\Illuminate\Support\Facades\Auth::check();"#, "check")
+            .await;
+    assert_eq!(data.decl_line, Some(3));
+}
+
+#[tokio::test]
+async fn facade_e2e_imported_alias_check_resolves() {
+    // The true imported form, with the `use` inside the file. Built bespoke (not
+    // via the shared helper) so the import sits above the class.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let manager_path = root.join("vendor/laravel/framework/src/Illuminate/Auth/AuthManager.php");
+    std::fs::create_dir_all(manager_path.parent().unwrap()).unwrap();
+    std::fs::write(&manager_path, VENDOR_AUTH_MANAGER_SRC).unwrap();
+    let provider_path =
+        root.join("vendor/laravel/framework/src/Illuminate/Auth/AuthServiceProvider.php");
+    std::fs::write(&provider_path, VENDOR_AUTH_PROVIDER_SRC).unwrap();
+
+    let caller_src = r#"<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Auth;
+
+class AboutController {
+    public function show() {
+        Auth::check();
+    }
+}
+"#;
+    let caller_path = root.join("app/Http/Controllers/AboutController.php");
+    std::fs::create_dir_all(caller_path.parent().unwrap()).unwrap();
+    std::fs::write(&caller_path, caller_src).unwrap();
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    handle
+        .register_service_provider_source(
+            provider_path,
+            VENDOR_AUTH_PROVIDER_SRC.to_string(),
+            0,
+            root.clone(),
+        )
+        .await
+        .unwrap();
+    register_parsed_bindings_into_registry(&handle).await;
+    handle
+        .update_file(caller_path.clone(), 1, caller_src.to_string())
+        .await
+        .unwrap();
+    handle.get_patterns(manager_path).await.unwrap();
+    handle.get_patterns(caller_path.clone()).await.unwrap();
+
+    // Position on the `check` member of `Auth::check()` (skip the `use` line's
+    // none — `check` appears only in the call).
+    let (line, col) = position_of(caller_src, "check");
+    let data = handle
+        .resolve_magic_member_at(caller_path, line, col)
+        .await
+        .unwrap()
+        .expect("imported `Auth::check()` must resolve, not None");
+    assert_eq!(data.kind, MagicMemberKind::FacadeMethod);
+    assert_eq!(data.declaring_fqcn, "Illuminate\\Auth\\AuthManager");
+    assert_eq!(data.decl_line, Some(3));
+}
+
+#[tokio::test]
+async fn facade_e2e_undeclared_method_degrades_to_class_never_none() {
+    // `\Auth::guard()` — `guard` is NOT declared on the AuthManager stub (real
+    // Laravel forwards it via `__call`/a guard). We must NOT chase the forwarding
+    // chain and must NOT return None: DEGRADE to the concrete CLASS line. This is
+    // the __call caveat, end-to-end.
+    let (_dir, handle, caller_path, caller_src) =
+        auth_facade_e2e_project(r#"\Auth::guard();"#).await;
+    let (line, col) = position_of(&caller_src, "guard");
+    let data = handle
+        .resolve_magic_member_at(caller_path, line, col)
+        .await
+        .unwrap()
+        .expect("undeclared facade method must degrade, not return None");
+    assert_eq!(data.kind, MagicMemberKind::FacadeMethod);
+    assert_eq!(data.declaring_fqcn, "Illuminate\\Auth\\AuthManager");
+    // No `guard` method token → decl line falls back to the class declaration
+    // line (2, 0-based: `class AuthManager {` — line 0 `<?php`, 1 `namespace`),
+    // still a real target.
+    assert!(data.decl_file.is_some());
+    assert_eq!(data.decl_line, Some(2));
+}
+
+#[tokio::test]
+async fn snapshot_macros_invalidates_when_provider_body_changes() {
+    // Salsa invalidation for macros: register a provider source, snapshot, then
+    // re-register the SAME path with a renamed macro and a removed one. The next
+    // snapshot must reflect the edit — the renamed key replaces the old, and the
+    // removed macro is gone. Mirrors
+    // `salsa_config_refreshes_when_provider_registered_after_first_build`: the
+    // provider is a `ServiceProviderFile` Salsa input, so re-registering the path
+    // bumps the input and recomputes `parse_service_provider_source`.
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let provider = root.join("app/Providers/AppServiceProvider.php");
+
+    let before_src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('oldName', fn () => 'x');
+        Str::macro('doomed', fn () => 'y');
+    }
+}
+"#;
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    handle
+        .register_service_provider_source(provider.clone(), before_src.to_string(), 2, root.clone())
+        .await
+        .unwrap();
+
+    let key = |name: &str| ("Illuminate\\Support\\Str".to_string(), name.to_string());
+
+    let before = handle.snapshot_macros().await.unwrap();
+    assert!(
+        before.contains_key(&key("oldName")),
+        "precondition: oldName registered"
+    );
+    assert!(
+        before.contains_key(&key("doomed")),
+        "precondition: doomed registered"
+    );
+
+    // Re-register the SAME path: `oldName` → `newName`, and `doomed` removed.
+    let after_src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('newName', fn () => 'x');
+    }
+}
+"#;
+    handle
+        .register_service_provider_source(provider.clone(), after_src.to_string(), 2, root.clone())
+        .await
+        .unwrap();
+
+    let after = handle.snapshot_macros().await.unwrap();
+    assert!(
+        after.contains_key(&key("newName")),
+        "the renamed macro must appear after re-registration (Salsa recomputed the input)"
+    );
+    assert!(
+        !after.contains_key(&key("oldName")),
+        "the old macro name must be GONE after the rename — stale registry entry would mean no invalidation"
+    );
+    assert!(
+        !after.contains_key(&key("doomed")),
+        "the removed macro must be GONE after re-registration"
     );
 }

--- a/laravel-lsp/src/tests/class_locator_and_properties.rs
+++ b/laravel-lsp/src/tests/class_locator_and_properties.rs
@@ -550,6 +550,24 @@ fn extract_class_signature_ignores_class_keyword_in_strings() {
 }
 
 #[test]
+fn extract_class_signature_includes_leading_trait_use_block() {
+    // A class that composes traits renders the declaration PLUS its leading
+    // `use …;` block, wrapped in braces — the rich class card.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("User.php");
+    fs::write(
+        &path,
+        "<?php\nnamespace App\\Models;\n\nuse Illuminate\\Foundation\\Auth\\User as Authenticatable;\n\nclass User extends Authenticatable implements MustVerifyEmail\n{\n    use HasApiTokens, HasFactory, Notifiable;\n\n    protected $fillable = ['name'];\n}\n",
+    )
+    .unwrap();
+    let got = extract_class_signature(&path).expect("should find class");
+    assert_eq!(
+        got,
+        "class User extends Authenticatable implements MustVerifyEmail\n{\n    use HasApiTokens, HasFactory, Notifiable;\n}"
+    );
+}
+
+#[test]
 fn extract_class_signature_returns_none_for_files_without_class() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("helpers.php");

--- a/laravel-lsp/src/tests/macro_goto_def_handler.rs
+++ b/laravel-lsp/src/tests/macro_goto_def_handler.rs
@@ -1,0 +1,238 @@
+//! End-to-end coverage for macro goto-definition through the real Backend
+//! handler `LaravelLanguageServer::create_magic_member_location` (the headline
+//! macro feature on `feat/facade-resolution`).
+//!
+//! The actor-side classification (`resolve_magic_member_at` → `kind == Macro`
+//! with decl_file/decl_line from the macro registry) is covered in
+//! `salsa_impl/tests.rs`. What was NOT covered is the goto-target *producer*:
+//! the `MagicMemberKind::Macro` arm of `create_magic_member_location` in
+//! `main.rs`, which turns the resolved `MagicMemberHoverData` into the actual
+//! `GotoDefinitionResponse::Link` the editor jumps to. A regression there — a
+//! dropped `Link` wrap, the wrong line, or a `None` for a macro that *does*
+//! resolve — would slip past every lower-level test.
+//!
+//! Unlike the Flux/view goto tests, the macro path has no `cached_config`
+//! short-circuit: `create_magic_member_location` always goes through the
+//! Backend's live Salsa actor. So these tests prime that actor directly
+//! (registering config + provider source + the caller file, exactly as the
+//! server does during indexing) and then drive the real handler.
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::salsa_impl::{AccessForm, Confidence, MemberAccessReferenceData};
+use std::path::Path;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::GotoDefinitionResponse;
+use tower_lsp::LspService;
+
+/// Build a server instance for testing. `LspService::new` wires up a real
+/// `Client`; `inner()` hands back the `LaravelLanguageServer` so we can prime
+/// its (live) Salsa actor and call its private `create_magic_member_location`.
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// A provider registering `Str::macro('uuid7', fn () => …)`. The closure sits on
+/// line 6 (0-based): `<?php`=0, `namespace`=1, `use Str`=2, `use SP`=3,
+/// `class`=4, `boot`=5, `Str::macro(...)`=6.
+const PROVIDER_SRC: &str = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('uuid7', fn () => 'x');
+    }
+}
+"#;
+
+/// A caller invoking the registered macro. `Str` is imported so it qualifies to
+/// the framework Macroable host.
+const CALLER_SRC: &str = r#"<?php
+namespace App\Support;
+use Illuminate\Support\Str;
+class Ids {
+    public function make(): string { return Str::uuid7(); }
+}
+"#;
+
+/// Find the (line, column) of `needle` in `src`, 0-based — repo convention.
+fn position_of(src: &str, needle: &str) -> (u32, u32) {
+    for (row, line) in src.lines().enumerate() {
+        if let Some(col) = line.find(needle) {
+            return (row as u32, col as u32);
+        }
+    }
+    panic!("{needle} not found in fixture");
+}
+
+/// Byte range of `needle` in `src` — for the receiver byte range the handler
+/// re-locates in the live tree.
+fn byte_range_of(src: &str, needle: &str) -> (usize, usize) {
+    let start = src.find(needle).expect("needle in fixture");
+    (start, start + needle.len())
+}
+
+/// A `MemberAccessReferenceData` for the `Str::uuid7()` call site. The handler
+/// re-resolves from the file's parsed patterns using `line`/`column`, so only
+/// the member position drives resolution; the receiver byte range is filled for
+/// completeness, mirroring what the parser emits.
+fn uuid7_ref() -> MemberAccessReferenceData {
+    let (line, column) = position_of(CALLER_SRC, "uuid7");
+    let (receiver_byte_start, receiver_byte_end) = byte_range_of(CALLER_SRC, "Str::uuid7");
+    MemberAccessReferenceData {
+        member: "uuid7".to_string(),
+        receiver: "Str".to_string(),
+        receiver_byte_start,
+        receiver_byte_end,
+        is_nullsafe: false,
+        form: AccessForm::StaticCall,
+        line,
+        column,
+        end_column: column + "uuid7".len() as u32,
+        declaring_fqcn: None,
+        kind: None,
+        confidence: Confidence::Unresolved,
+    }
+}
+
+/// Prime `server`'s live Salsa actor with the config, the provider source (so
+/// the macro registry knows `Str::uuid7`), and the caller file — exactly the
+/// registration the server performs while indexing. Returns the caller path.
+async fn prime_macro_project(server: &LaravelLanguageServer, root: &Path) -> std::path::PathBuf {
+    let provider = root.join("app/Providers/AppServiceProvider.php");
+    let caller = root.join("app/Support/Ids.php");
+    std::fs::create_dir_all(caller.parent().unwrap()).unwrap();
+    std::fs::write(&caller, CALLER_SRC).unwrap();
+
+    server
+        .salsa
+        .register_config_files(root.to_path_buf(), None, None, None)
+        .await
+        .unwrap();
+    server
+        .salsa
+        .register_service_provider_source(provider, PROVIDER_SRC.to_string(), 2, root.to_path_buf())
+        .await
+        .unwrap();
+    server
+        .salsa
+        .update_file(caller.clone(), 1, CALLER_SRC.to_string())
+        .await
+        .unwrap();
+    server.salsa.get_patterns(caller.clone()).await.unwrap();
+    caller
+}
+
+/// Pull the single `LocationLink` out of a goto-def response, asserting the
+/// `Link` shape the handler must return for a resolved macro.
+fn single_link(resp: GotoDefinitionResponse) -> tower_lsp::lsp_types::LocationLink {
+    let links = match resp {
+        GotoDefinitionResponse::Link(links) => links,
+        other => panic!("expected GotoDefinitionResponse::Link, got {other:?}"),
+    };
+    assert_eq!(
+        links.len(),
+        1,
+        "exactly one LocationLink for a resolved macro"
+    );
+    links.into_iter().next().unwrap()
+}
+
+#[tokio::test]
+async fn macro_call_goto_lands_on_closure_line() {
+    // `Str::uuid7()` → the registered closure in the provider. The handler must
+    // return a `Link` whose target is the provider file at the closure's line
+    // (6, 0-based), with a zero-width caret (no method token to narrow to on the
+    // vendor host).
+    let dir = TempDir::new().unwrap();
+    let server = test_server();
+    let _caller = prime_macro_project(&server, dir.path()).await;
+    let provider = dir.path().join("app/Providers/AppServiceProvider.php");
+
+    let resp = server
+        .create_magic_member_location(&_caller, &uuid7_ref())
+        .await
+        .expect("a registered macro call resolves to a goto Link");
+
+    let link = single_link(resp);
+    assert_eq!(
+        link.target_uri.to_file_path().expect("file:// target"),
+        provider,
+        "goto lands on the provider file declaring the macro"
+    );
+    assert_eq!(
+        link.target_range.start.line, 6,
+        "goto lands on the closure's 0-based declaration line"
+    );
+    assert_eq!(
+        link.target_range.start.character, 0,
+        "zero-width caret — no method token on the vendor host to narrow to"
+    );
+}
+
+#[tokio::test]
+async fn unregistered_macro_call_does_not_resolve() {
+    // A `Str::notAMacro()` call site, with `Str::uuid7` registered so `Str` IS a
+    // known Macroable host (`has_macro_host`) but THIS member is absent from the
+    // registry. The member fails to classify as a macro (the registry lookup
+    // misses), so the handler degrades to `None` gracefully — no panic, no bogus
+    // location. This is the negative side of the `Macro` arm: a macro that
+    // doesn't exist must not produce a goto target.
+    let dir = TempDir::new().unwrap();
+    let server = test_server();
+    let root = dir.path();
+
+    // Caller invokes an UNREGISTERED macro on the same host.
+    let caller_src = r#"<?php
+namespace App\Support;
+use Illuminate\Support\Str;
+class Ids {
+    public function make(): string { return Str::notAMacro(); }
+}
+"#;
+    let provider = root.join("app/Providers/AppServiceProvider.php");
+    let caller = root.join("app/Support/Ids.php");
+    std::fs::create_dir_all(caller.parent().unwrap()).unwrap();
+    std::fs::write(&caller, caller_src).unwrap();
+
+    server
+        .salsa
+        .register_config_files(root.to_path_buf(), None, None, None)
+        .await
+        .unwrap();
+    server
+        .salsa
+        .register_service_provider_source(provider, PROVIDER_SRC.to_string(), 2, root.to_path_buf())
+        .await
+        .unwrap();
+    server
+        .salsa
+        .update_file(caller.clone(), 1, caller_src.to_string())
+        .await
+        .unwrap();
+    server.salsa.get_patterns(caller.clone()).await.unwrap();
+
+    let (line, column) = position_of(caller_src, "notAMacro");
+    let (rs, re) = byte_range_of(caller_src, "Str::notAMacro");
+    let member = MemberAccessReferenceData {
+        member: "notAMacro".to_string(),
+        receiver: "Str".to_string(),
+        receiver_byte_start: rs,
+        receiver_byte_end: re,
+        is_nullsafe: false,
+        form: AccessForm::StaticCall,
+        line,
+        column,
+        end_column: column + "notAMacro".len() as u32,
+        declaring_fqcn: None,
+        kind: None,
+        confidence: Confidence::Unresolved,
+    };
+
+    let resp = server.create_magic_member_location(&caller, &member).await;
+    assert!(
+        resp.is_none(),
+        "an unregistered macro must not produce a goto target; got {resp:?}"
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -31,6 +31,7 @@ mod inertia_handler;
 mod livewire_component_resolution;
 mod livewire_tag_navigation_containment;
 mod loop_variable_resolution;
+mod macro_goto_def_handler;
 mod query_chain_completion_handler;
 mod rename_integration;
 mod route_binding_resolution;

--- a/laravel-lsp/src/view_var_index/tests.rs
+++ b/laravel-lsp/src/view_var_index/tests.rs
@@ -369,6 +369,7 @@ fn user_bound_resolver(p: &BladeProject, key: &str) -> crate::member_resolver::S
             key.to_string(),
             "App\\Models\\User".to_string(),
         )])),
+        facade_aliases: Arc::new(crate::facade_resolver::default_facade_aliases()),
     }
 }
 

--- a/laravel-lsp/src/view_var_index/tests.rs
+++ b/laravel-lsp/src/view_var_index/tests.rs
@@ -370,6 +370,7 @@ fn user_bound_resolver(p: &BladeProject, key: &str) -> crate::member_resolver::S
             "App\\Models\\User".to_string(),
         )])),
         facade_aliases: Arc::new(crate::facade_resolver::default_facade_aliases()),
+        macros: Default::default(),
     }
 }
 


### PR DESCRIPTION
Laravel-aware member navigation that resolves facades, macros, and mixins to their **concrete implementations**, with a rich class hover. Refs #30.

## What's included
- **Facade resolution engine** — `token → facade FQCN → getFacadeAccessor() key → bound concrete`, covering the imported, inline-FQ, and global-alias (`\Auth`) forms; aliases merged from `config/app.php` + bootstrap `withAliases`.
- **Facade methods → real implementation** — classified as `MagicMemberKind::FacadeMethod`; the target is chased through composed traits → parent → `@mixin` → interfaces → `@method`, with go-to-implementation via the manager's instantiated drivers. `Auth::check()` → `GuardHelpers::check`, `DB::beginTransaction()` → `ManagesTransactions::beginTransaction`.
- **Binding extraction fix** — qualify a bare same-namespace `new X` inside a binding closure before the on-disk gate, so the real arrow-fn provider binding (`auth → AuthManager`) resolves instead of degrading to `"Closure"`.
- **Facade receiver** — goto + hover on the receiver token (`\Auth`, `\DB`) resolve to the bound concrete class.
- **Macros & mixins** — a project-wide macro registry (priority-merged framework/package/app) resolving `Str::macro` / `mixin`-expanded members to their definition site.
- **Rich class hover** — the shared class card now renders the declaration plus its leading trait `use …;` block (facade, Livewire, and component hovers alike).

## Verification
- Full suite green: **2524 tests** (1998 lib + 446 bin + 80 integration), clippy + fmt clean.
- End-to-end tests through the real request handler (`resolve_magic_member_at` / `resolve_facade_receiver_at`), plus the chase verified against a real Laravel 12 vendor tree.
- Adversarial multi-agent review of the macro/mixin change; findings resolved, inherited registry follow-ups filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)