### PR TITLE
Ship static musl binaries as the only Linux assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,18 +163,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            binary_name: laravel-lsp-linux-x64
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            binary_name: laravel-lsp-linux-arm64
+          # The Linux assets are statically-linked musl builds: one binary per
+          # arch runs on glibc distros, Alpine, and NixOS alike (the same
+          # approach Zed uses for its own remote server). No separate gnu builds.
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            binary_name: laravel-lsp-linux-x64-musl
+            binary_name: laravel-lsp-linux-x64
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            binary_name: laravel-lsp-linux-arm64-musl
+            binary_name: laravel-lsp-linux-arm64
           - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: laravel-lsp-macos-x64
@@ -198,7 +195,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      # All four Linux targets (gnu/musl × x64/arm64) cross-compile through
+      # Both Linux targets (musl x64/arm64) cross-compile through
       # cargo-zigbuild. Zig bundles the cross-linker and a C compiler — the cc
       # crate (build.rs compiles the tree-sitter C grammar) and the Rust linker
       # both use it — so no apt cross-toolchains, no ~/.cargo linker hacks, and

--- a/laravel-lsp/Cargo.toml
+++ b/laravel-lsp/Cargo.toml
@@ -68,6 +68,16 @@ arc-swap = "1.9"
 # SalsaActor::pattern_cache for context.
 dashmap = "6"
 
+# The release binaries for Linux are statically-linked musl builds (one
+# binary runs on glibc distros, Alpine, and NixOS alike), but musl's
+# default allocator serializes multithreaded allocation behind a global
+# lock — documented 7-20x regressions for parse-heavy tokio workloads
+# like ours. mimalloc restores glibc-parity allocation performance.
+# Gated to musl so glibc/macOS/Windows builds keep their known-good
+# system allocators (ripgrep's model).
+[target.'cfg(target_env = "musl")'.dependencies]
+mimalloc = "0.1"
+
 [build-dependencies]
 # For downloading grammar from GitHub
 ureq = "3"

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -45,6 +45,15 @@ use laravel_lsp::salsa_impl::{
     UrlReferenceData, ViewReferenceData,
 };
 
+// The Linux release binaries are static musl builds; musl's default
+// allocator collapses under multithreaded allocation load (global-lock
+// contention), which is exactly this server's profile — tokio workers +
+// Salsa parsing tens of thousands of files. See laravel-lsp/Cargo.toml
+// for the dependency rationale.
+#[cfg(target_env = "musl")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 // ============================================================================
 // PART 1: Core Language Server Implementation
 // ============================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,15 +158,15 @@ impl LaravelExtension {
     /// Get platform-specific binary name
     fn get_platform_binary_name() -> String {
         let (os, arch) = zed::current_platform();
-        Self::platform_binary_name(os, arch, Self::is_musl_libc())
+        Self::platform_binary_name(os, arch)
     }
 
     /// Map a platform triple to the published release-asset binary name.
     ///
-    /// `is_musl` only changes the Linux variants: musl-based distros (Alpine,
-    /// etc.) need the `-musl` binary because the glibc-linked build fails to
-    /// spawn against musl's loader.
-    fn platform_binary_name(os: zed::Os, arch: zed::Architecture, is_musl: bool) -> String {
+    /// The Linux assets are statically-linked musl builds, so a single
+    /// binary per arch runs on glibc distros, musl distros (Alpine), and
+    /// loader-less setups (NixOS) alike — no libc detection needed.
+    fn platform_binary_name(os: zed::Os, arch: zed::Architecture) -> String {
         match (os, arch) {
             (zed::Os::Windows, zed::Architecture::X8664) => {
                 "laravel-lsp-windows-x64.exe".to_string()
@@ -178,41 +178,10 @@ impl LaravelExtension {
             (zed::Os::Mac, zed::Architecture::Aarch64) => "laravel-lsp-macos-arm64".to_string(),
             (zed::Os::Mac, zed::Architecture::X8664) => "laravel-lsp-macos-x64".to_string(),
             (zed::Os::Mac, _) => "laravel-lsp".to_string(),
-            (zed::Os::Linux, zed::Architecture::X8664) if is_musl => {
-                "laravel-lsp-linux-x64-musl".to_string()
-            }
-            (zed::Os::Linux, zed::Architecture::Aarch64) if is_musl => {
-                "laravel-lsp-linux-arm64-musl".to_string()
-            }
             (zed::Os::Linux, zed::Architecture::X8664) => "laravel-lsp-linux-x64".to_string(),
             (zed::Os::Linux, zed::Architecture::Aarch64) => "laravel-lsp-linux-arm64".to_string(),
-            // Defensive fallback for any future Linux arch the SDK adds: still
-            // honor musl so we never serve a glibc binary to a musl host.
-            (zed::Os::Linux, _) if is_musl => "laravel-lsp-musl".to_string(),
             (zed::Os::Linux, _) => "laravel-lsp".to_string(),
         }
-    }
-
-    /// Detect a musl-based Linux host (Alpine and friends).
-    ///
-    /// Extensions run as WASM but `std::fs` reads resolve against the host the
-    /// LSP will run on — including a remote/devcontainer — so we probe for
-    /// musl's dynamic loaders and Alpine's release marker.
-    fn is_musl_libc() -> bool {
-        Self::detect_musl(|path| fs::metadata(path).is_ok())
-    }
-
-    /// Pure musl probe: returns true if any musl/Alpine marker path exists,
-    /// per the injected existence check. Split out so it is unit-testable
-    /// without touching the real filesystem.
-    fn detect_musl(path_exists: impl Fn(&str) -> bool) -> bool {
-        [
-            "/lib/ld-musl-x86_64.so.1",
-            "/lib/ld-musl-aarch64.so.1",
-            "/etc/alpine-release",
-        ]
-        .iter()
-        .any(|path| path_exists(path))
     }
 }
 
@@ -222,65 +191,35 @@ mod tests {
     use zed::{Architecture, Os};
 
     #[test]
-    fn linux_gnu_names_unchanged() {
+    fn linux_names() {
         assert_eq!(
-            LaravelExtension::platform_binary_name(Os::Linux, Architecture::X8664, false),
+            LaravelExtension::platform_binary_name(Os::Linux, Architecture::X8664),
             "laravel-lsp-linux-x64"
         );
         assert_eq!(
-            LaravelExtension::platform_binary_name(Os::Linux, Architecture::Aarch64, false),
+            LaravelExtension::platform_binary_name(Os::Linux, Architecture::Aarch64),
             "laravel-lsp-linux-arm64"
         );
     }
 
     #[test]
-    fn linux_musl_names_get_suffix() {
+    fn mac_and_windows_names() {
         assert_eq!(
-            LaravelExtension::platform_binary_name(Os::Linux, Architecture::X8664, true),
-            "laravel-lsp-linux-x64-musl"
+            LaravelExtension::platform_binary_name(Os::Mac, Architecture::Aarch64),
+            "laravel-lsp-macos-arm64"
         );
         assert_eq!(
-            LaravelExtension::platform_binary_name(Os::Linux, Architecture::Aarch64, true),
-            "laravel-lsp-linux-arm64-musl"
+            LaravelExtension::platform_binary_name(Os::Mac, Architecture::X8664),
+            "laravel-lsp-macos-x64"
         );
-    }
-
-    #[test]
-    fn non_linux_ignores_musl_flag() {
-        for is_musl in [true, false] {
-            assert_eq!(
-                LaravelExtension::platform_binary_name(Os::Mac, Architecture::Aarch64, is_musl),
-                "laravel-lsp-macos-arm64"
-            );
-            assert_eq!(
-                LaravelExtension::platform_binary_name(Os::Mac, Architecture::X8664, is_musl),
-                "laravel-lsp-macos-x64"
-            );
-            assert_eq!(
-                LaravelExtension::platform_binary_name(Os::Windows, Architecture::X8664, is_musl),
-                "laravel-lsp-windows-x64.exe"
-            );
-            assert_eq!(
-                LaravelExtension::platform_binary_name(Os::Windows, Architecture::Aarch64, is_musl),
-                "laravel-lsp-windows-arm64.exe"
-            );
-        }
-    }
-
-    #[test]
-    fn detect_musl_true_when_any_marker_present() {
-        assert!(LaravelExtension::detect_musl(|p| p == "/etc/alpine-release"));
-        assert!(LaravelExtension::detect_musl(
-            |p| p == "/lib/ld-musl-x86_64.so.1"
-        ));
-        assert!(LaravelExtension::detect_musl(
-            |p| p == "/lib/ld-musl-aarch64.so.1"
-        ));
-    }
-
-    #[test]
-    fn detect_musl_false_when_no_marker_present() {
-        assert!(!LaravelExtension::detect_musl(|_| false));
+        assert_eq!(
+            LaravelExtension::platform_binary_name(Os::Windows, Architecture::X8664),
+            "laravel-lsp-windows-x64.exe"
+        );
+        assert_eq!(
+            LaravelExtension::platform_binary_name(Os::Windows, Architecture::Aarch64),
+            "laravel-lsp-windows-arm64.exe"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Responds to reviewer feedback on [zed-industries/extensions#6674](https://github.com/zed-industries/extensions/pull/6674): instead of shipping separate glibc and musl Linux binaries and probing the host filesystem at runtime to choose between them, ship **one statically-linked musl binary per Linux arch** and delete the detection entirely.

A static musl binary runs on glibc distros, Alpine (musl), and NixOS (no loader at the standard path) alike — the same approach Zed uses for its own remote server, and the same pattern the gleam/tombi/codebook/todo-highlight extensions use.

## Changes

- **`.github/workflows/release.yml`**: drop the two `*-unknown-linux-gnu` matrix entries; the musl targets now publish under the plain `laravel-lsp-linux-x64` / `laravel-lsp-linux-arm64` asset names (still cross-compiled via cargo-zigbuild, which already produces fully static binaries — verified with `file` on the 0.6.0 assets).
- **`src/lib.rs`**: remove `is_musl_libc()` / `detect_musl()` and the `is_musl` branch of `platform_binary_name()` — no more environment probing from the extension.
- **`laravel-lsp`**: add **mimalloc** as the global allocator, gated to `target_env = "musl"`. musl's default allocator serializes multithreaded allocation behind a global lock (documented 7–20x regressions for parse-heavy workloads); mimalloc restores glibc-parity performance. Chosen over jemalloc because it cross-compiles cleanly under zigbuild and has no aarch64 page-size trap (jemalloc cross-builds abort on 16K-page kernels like Asahi Linux).

## Backward compatibility

None needed: each extension version downloads assets from its own version tag, so existing extension versions keep resolving their old asset names against old releases. `worktree.which()` PATH lookups are unaffected.

## Known trade-offs

- musl's resolver ignores NSS plugins: DB hostnames in `.env` that only resolve via mDNS (`.local`) or systemd-resolved need an IP or `/etc/hosts` entry. localhost, Docker-network DNS, and `host.docker.internal` all work (zig bundles musl 1.2.5, which includes the DNS TCP-fallback fix).
- `#[global_allocator]` covers Rust allocations; tree-sitter/bundled-SQLite C mallocs stay on musl malloc. Acceptable — revisit only if profiling shows C-side contention.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy`, `cargo test` green on both crates (2 extension tests, 2,553 LSP tests)
- [ ] CI green on this PR
- [ ] Release workflow dry-run (`workflow_dispatch`) builds all 6 assets — to be done when we cut the release

## Status

**Holding as draft** until the reviewer on zed-industries/extensions#6674 responds on direction. If they prefer merge-as-is, this lands in the following release instead.