### PR TITLE
perf: ⚡️ Indexing overhaul — kill the O(n²), single-parse resolution, external-edit convergence, honest progress

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -19,7 +19,7 @@ fn find_view_calls(php_content: &str) -> Vec<String> {
         if let Some(start_pos) = line.find("view(") {
             let after_view = &line[start_pos + 5..];
 
-            if let Some(quote_start) = after_view.find(|c| c == '\'' || c == '"') {
+            if let Some(quote_start) = after_view.find(['\'', '"']) {
                 let quote_char = after_view.chars().nth(quote_start).unwrap();
                 let after_quote = &after_view[quote_start + 1..];
 

--- a/laravel-lsp/Cargo.toml
+++ b/laravel-lsp/Cargo.toml
@@ -99,6 +99,14 @@ tempfile = "3.27"
 name = "route_cache"
 harness = false
 
+# Magic-member resolution benchmark — reproduces the O(n²) fresh-cache-per-file
+# pass vs a single shared ClassViewCache across N referencing files. Same custom
+# timing harness (no criterion dependency); run with
+# `cargo bench --bench magic_members`.
+[[bench]]
+name = "magic_members"
+harness = false
+
 [profile.release]
 lto = true
 opt-level = 3

--- a/laravel-lsp/Cargo.toml
+++ b/laravel-lsp/Cargo.toml
@@ -68,6 +68,12 @@ arc-swap = "1.9"
 # SalsaActor::pattern_cache for context.
 dashmap = "6"
 
+# Data-parallel freshness pass over the on-disk pattern cache on startup:
+# ~40k entries each need an mtime stat + position-index rebuild, which is
+# embarrassingly parallel. Already compiled transitively (salsa depends on
+# it), so this direct dep adds no new crate to the build.
+rayon = "1"
+
 # The release binaries for Linux are statically-linked musl builds (one
 # binary runs on glibc distros, Alpine, and NixOS alike), but musl's
 # default allocator serializes multithreaded allocation behind a global

--- a/laravel-lsp/benches/magic_members.rs
+++ b/laravel-lsp/benches/magic_members.rs
@@ -62,10 +62,14 @@ use std::time::{Duration, Instant};
 use laravel_lsp::class_hierarchy_index::{classes_in_file, ClassHierarchyIndex};
 use laravel_lsp::class_locator::reset_locator_cache;
 use laravel_lsp::laravel_introspector::chain::reset_parsed_file_cache;
-use laravel_lsp::member_resolver::{resolve_member_access_entries, ClassViewCache};
+use laravel_lsp::member_capture::capture_member_context;
+use laravel_lsp::member_resolver::{
+    resolve_member_access_entries, resolve_member_access_entries_with_context, ClassViewCache,
+};
 use laravel_lsp::parser::{language_php, parse_php};
 use laravel_lsp::queries::extract_all_php_patterns;
-use laravel_lsp::salsa_impl::{Confidence, MemberAccessReferenceData};
+use laravel_lsp::salsa_impl::{Confidence, MemberAccessReferenceData, MemberContextData};
+use laravel_lsp::symbol_index::MagicMemberEntry;
 
 /// Member accesses each caller file reads off its typed receiver.
 const ACCESSES_PER_CALLER: usize = 6;
@@ -197,10 +201,12 @@ class Controller{caller_idx}
 }
 
 /// Pre-captured caller input: source (the resolver re-parses the live tree) plus
-/// its captured `->member` reference sites.
+/// its captured `->member` reference sites and a synthetic file path (the M1
+/// capture keys vendor/Blade decisions off it).
 struct CallerInput {
     source: String,
     refs: Vec<Arc<MemberAccessReferenceData>>,
+    path: PathBuf,
 }
 
 /// An on-disk synthetic project plus the pre-captured caller inputs and the
@@ -316,7 +322,8 @@ class LegacyBase extends Model {
         .map(|i| {
             let source = caller_php(i, i % pool);
             let refs = capture_refs(&source);
-            CallerInput { source, refs }
+            let path = root.join(format!("app/Http/Controllers/Controller{i}.php"));
+            CallerInput { source, refs, path }
         })
         .collect();
 
@@ -452,6 +459,110 @@ fn p2_persistent(corpus: &Corpus) -> (Duration, usize) {
     (start.elapsed(), total)
 }
 
+// ─── M1: single-parse capture (tree re-parse vs captured context) ──────────
+
+/// Build the parse-time context for every caller, timed separately — this is
+/// the ONE-TIME capture cost the resolve passes trade the per-file re-parse
+/// for. Runs on the same corpus the M1 resolve regimes use.
+fn m1_capture_contexts(corpus: &Corpus) -> (Vec<MemberContextData>, Duration) {
+    let start = Instant::now();
+    let contexts: Vec<MemberContextData> = corpus
+        .callers
+        .iter()
+        .map(|c| {
+            let tree = parse_php(&c.source).expect("parse caller");
+            capture_member_context(&c.path, &c.source, Some(&tree), &c.refs, false)
+                .expect("caller with member refs captures context")
+        })
+        .collect();
+    (contexts, start.elapsed())
+}
+
+/// M1 disabled: today's re-parse path — each caller is re-parsed from source at
+/// resolve time (`resolve_member_access_entries` parses `source` internally).
+fn m1_tree_reparse(corpus: &Corpus) -> (Duration, usize) {
+    reset_all_global_caches();
+    let cache = ClassViewCache::new();
+    let start = Instant::now();
+    let mut total = 0;
+    for c in &corpus.callers {
+        let entries = resolve_member_access_entries(
+            &c.source,
+            &c.refs,
+            &corpus.index,
+            &cache,
+            &corpus.root,
+            None,
+        );
+        total += black_box(entries).len();
+    }
+    (start.elapsed(), total)
+}
+
+/// Assert the two M1 paths resolve the SAME entries — canonicalized
+/// (fqcn, member, line, column, end_column) and sorted, so a divergence in an
+/// FQCN or position can't slip past a matching count. Runs before the timed
+/// regimes; panics on divergence so a broken capture fails the bench loudly.
+fn m1_assert_entries_equivalent(corpus: &Corpus, contexts: &[MemberContextData]) {
+    let canon = |v: Vec<MagicMemberEntry>| -> Vec<(String, String, u32, u32, u32)> {
+        v.into_iter()
+            .map(|e| (e.fqcn, e.member, e.line, e.column, e.end_column))
+            .collect()
+    };
+    let cache = ClassViewCache::new();
+    let mut tree: Vec<(String, String, u32, u32, u32)> = Vec::new();
+    let mut captured: Vec<(String, String, u32, u32, u32)> = Vec::new();
+    for (c, ctx) in corpus.callers.iter().zip(contexts.iter()) {
+        tree.extend(canon(resolve_member_access_entries(
+            &c.source,
+            &c.refs,
+            &corpus.index,
+            &cache,
+            &corpus.root,
+            None,
+        )));
+        captured.extend(canon(resolve_member_access_entries_with_context(
+            ctx,
+            &c.refs,
+            &corpus.index,
+            &cache,
+            &corpus.root,
+            None,
+        )));
+    }
+    tree.sort();
+    captured.sort();
+    assert!(
+        tree == captured,
+        "M1: captured entries diverge from the tree path (canonical fqcn/member/pos): \
+         {} tree vs {} captured",
+        tree.len(),
+        captured.len()
+    );
+}
+
+/// M1 enabled: resolve from the captured context — NO re-parse at resolve time.
+/// `contexts` were built once by [`m1_capture_contexts`] (its cost is reported
+/// separately); this measures only the resolve half.
+fn m1_captured(corpus: &Corpus, contexts: &[MemberContextData]) -> (Duration, usize) {
+    reset_all_global_caches();
+    let cache = ClassViewCache::new();
+    let start = Instant::now();
+    let mut total = 0;
+    for (c, ctx) in corpus.callers.iter().zip(contexts.iter()) {
+        let entries = resolve_member_access_entries_with_context(
+            ctx,
+            &c.refs,
+            &corpus.index,
+            &cache,
+            &corpus.root,
+            None,
+        );
+        total += black_box(entries).len();
+    }
+    (start.elapsed(), total)
+}
+
 // ─── Reporting ─────────────────────────────────────────────────────────────
 
 fn report(part: &str, n: usize, off: (Duration, usize), on: (Duration, usize)) {
@@ -537,6 +648,28 @@ fn main() {
             n,
             p2_reset_per_file(&miss_corpus),
             p2_persistent(&miss_corpus),
+        );
+
+        // M1 — single-parse capture. Same corpus as P1's n/10 pool (the real
+        // app shape). Disabled = today's re-parse-at-resolve; enabled = resolve
+        // from context captured at parse. The capture cost is reported on its
+        // OWN line — it is paid ONCE at parse (amortized across every later
+        // resolve: warm rebuild, save-refresh, find-references), not per resolve.
+        println!("--------------------------------------------------------");
+        let (contexts, capture_cost) = m1_capture_contexts(&pool_corpus);
+        // Canonical-entry equivalence (fqcn/member/pos, sorted) BEFORE timing —
+        // a matching count alone must not pass as equal.
+        m1_assert_entries_equivalent(&pool_corpus, &contexts);
+        report(
+            "M1 single-parse capture, n/10 pool",
+            n,
+            m1_tree_reparse(&pool_corpus),
+            m1_captured(&pool_corpus, &contexts),
+        );
+        println!(
+            "    capture  : {:>10.2?}  ({:.2} us/caller, paid once at parse)",
+            capture_cost,
+            per_file_us(capture_cost, n)
         );
     }
 

--- a/laravel-lsp/benches/magic_members.rs
+++ b/laravel-lsp/benches/magic_members.rs
@@ -1,0 +1,549 @@
+//! Magic-member resolution benchmark — measures each caching optimization's
+//! ISOLATED contribution to the whole-project "build semantic index" pass.
+//!
+//! # What the build pass does, and where the cost was
+//!
+//! The build resolves every captured `$receiver->member` site in every
+//! non-vendor file. Each referencing file's receivers resolve to a class via
+//! [`laravel_lsp::laravel_introspector`]'s `analyze`, and most projects funnel
+//! through a small set of *shared ancestors* — a base `Model`, a base
+//! controller, common traits. Three costs stacked up:
+//!
+//! * **P1** — each `spawn_blocking` worker built its own `ClassViewCache`, so a
+//!   model referenced from N files was analyzed N times.
+//! * **P3** — `analyze` re-read + re-parsed each ancestor (base model, traits)
+//!   *inside every call*, and parsed each file twice (structure + use-aliases).
+//! * **P2** — an FQCN not resolvable via Composer/PSR-4 fell back to a full
+//!   `WalkDir` of `app/`/`vendor/`, repeated once per referencing file.
+//!
+//! # How this bench stays HONEST
+//!
+//! Old-vs-new code can't coexist in one binary, so instead of a bogus
+//! "before/after" it measures **each optimization by toggling it** — running the
+//! same corpus with the relevant cache **disabled** (reset before every file, so
+//! it can never accumulate a hit) vs **enabled** (shared/warm). Every regime
+//! resets the *other* two caches to the same state before each file, so each
+//! number isolates exactly one optimization with no warm-cache confound.
+//!
+//! Three shapes, each targeting the optimization it actually exercises:
+//!
+//! 1. **P1 — shared `ClassViewCache`**, measured on the *shared-model-pool*
+//!    shape (many callers → a small model set — the real app shape). Fresh cache
+//!    per file vs one shared cache. On a 1:1 distinct-model shape P1 is ~1× *by
+//!    design* (no receiver FQCN repeats, so nothing to share) — that shape is
+//!    NOT the win and isn't reported as one.
+//! 2. **P3 — parsed-file memo**, measured on distinct models with shared
+//!    ancestors: cache reset-per-file (every ancestor re-parsed each call) vs
+//!    persistent (each ancestor parsed once).
+//! 3. **P2 — locator walk cache**, measured on a corpus whose ancestor is NOT
+//!    PSR-4-resolvable (forcing the WalkDir fallback): cache reset-per-file
+//!    (walk repeated) vs persistent (walked once).
+//!
+//! ## Running
+//!
+//! ```text
+//! cargo bench --bench magic_members
+//! MAGIC_BENCH_SCALES=200,1000 cargo bench --bench magic_members   # custom scales
+//! ```
+//!
+//! ## Synthetic-data caveat
+//!
+//! This corpus is **synthetic** — shapes approximate a typical Laravel app, but
+//! file counts and per-file access counts are generator parameters, not
+//! measurements of any project. The numbers show the *shape* of each cost
+//! (constant vs linear-in-file-count), not a wall-clock prediction.
+
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use laravel_lsp::class_hierarchy_index::{classes_in_file, ClassHierarchyIndex};
+use laravel_lsp::class_locator::reset_locator_cache;
+use laravel_lsp::laravel_introspector::chain::reset_parsed_file_cache;
+use laravel_lsp::member_resolver::{resolve_member_access_entries, ClassViewCache};
+use laravel_lsp::parser::{language_php, parse_php};
+use laravel_lsp::queries::extract_all_php_patterns;
+use laravel_lsp::salsa_impl::{Confidence, MemberAccessReferenceData};
+
+/// Member accesses each caller file reads off its typed receiver.
+const ACCESSES_PER_CALLER: usize = 6;
+
+// ─── Corpus generators ────────────────────────────────────────────────────
+
+fn base_model_php() -> &'static str {
+    r#"<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Concerns\HasAudit;
+use App\Concerns\Sluggable;
+
+class BaseModel extends Model
+{
+    use HasAudit;
+    use Sluggable;
+
+    protected $fillable = ['id', 'created_by', 'updated_by'];
+
+    public function creator()
+    {
+        return $this->belongsTo(BaseModel::class, 'created_by');
+    }
+}
+"#
+}
+
+fn has_audit_trait_php() -> &'static str {
+    r#"<?php
+namespace App\Concerns;
+
+trait HasAudit
+{
+    public function auditLog()
+    {
+        return $this->hasMany(BaseModel::class);
+    }
+
+    public function getAuditedAtAttribute()
+    {
+        return $this->updated_at;
+    }
+}
+"#
+}
+
+fn sluggable_trait_php() -> &'static str {
+    r#"<?php
+namespace App\Concerns;
+
+trait Sluggable
+{
+    protected $sluggableColumns = ['slug', 'title'];
+
+    public function scopeBySlug($query, $slug)
+    {
+        return $query->where('slug', $slug);
+    }
+
+    public function getSlugAttribute()
+    {
+        return $this->attributes['slug'] ?? '';
+    }
+}
+"#
+}
+
+/// A concrete model extending the shared base + composing the shared traits.
+/// `base` is the parent class name so a corpus can point every model at an
+/// ancestor that is (or isn't) PSR-4-resolvable.
+fn model_php(idx: usize, base: &str) -> String {
+    format!(
+        r#"<?php
+namespace App\Models;
+
+class Model{idx} extends {base}
+{{
+    protected $fillable = ['name{idx}', 'email{idx}', 'status{idx}'];
+
+    public function scopeActive{idx}($query)
+    {{
+        return $query->where('active', true);
+    }}
+
+    public function related{idx}()
+    {{
+        return $this->hasMany(BaseModel::class);
+    }}
+}}
+"#
+    )
+}
+
+/// Caller `caller_idx` reads several members off a `Model{model_idx}` receiver,
+/// forcing the full receiver chain (`Model{model_idx}` → base → traits) to build.
+fn caller_php(caller_idx: usize, model_idx: usize) -> String {
+    let members = [
+        format!("$m->name{model_idx}"),
+        format!("$m->active{model_idx}()"),
+        format!("$m->related{model_idx}()"),
+        "$m->slug".to_string(),
+        "$m->bySlug('x')".to_string(),
+        "$m->auditLog()".to_string(),
+    ];
+    let reads = members
+        .iter()
+        .take(ACCESSES_PER_CALLER)
+        .enumerate()
+        .map(|(i, expr)| format!("        $v{i} = {expr};"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        r#"<?php
+namespace App\Http\Controllers;
+
+use App\Models\Model{model_idx};
+
+class Controller{caller_idx}
+{{
+    public function show(Model{model_idx} $m)
+    {{
+{reads}
+    }}
+}}
+"#
+    )
+}
+
+/// Pre-captured caller input: source (the resolver re-parses the live tree) plus
+/// its captured `->member` reference sites.
+struct CallerInput {
+    source: String,
+    refs: Vec<Arc<MemberAccessReferenceData>>,
+}
+
+/// An on-disk synthetic project plus the pre-captured caller inputs and the
+/// class→file index the resolver consults.
+struct Corpus {
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+    index: ClassHierarchyIndex,
+    callers: Vec<CallerInput>,
+}
+
+fn write_and_index(index: &mut ClassHierarchyIndex, path: &Path, body: &str) {
+    fs::create_dir_all(path.parent().unwrap()).expect("create parent dir");
+    fs::write(path, body).expect("write source file");
+    index.insert_file(path, classes_in_file(path, body));
+}
+
+/// Capture a caller's member accesses — the exact shape `handle_get_patterns`
+/// stores in the pattern cache.
+fn capture_refs(source: &str) -> Vec<Arc<MemberAccessReferenceData>> {
+    let tree = parse_php(source).expect("parse caller");
+    let lang = language_php();
+    extract_all_php_patterns(&tree, source, &lang)
+        .expect("extract patterns")
+        .member_accesses
+        .iter()
+        .map(|m| {
+            Arc::new(MemberAccessReferenceData {
+                member: m.member.to_string(),
+                receiver: m.receiver.to_string(),
+                receiver_byte_start: m.receiver_byte_start,
+                receiver_byte_end: m.receiver_byte_end,
+                is_nullsafe: m.is_nullsafe,
+                form: m.form,
+                line: m.row as u32,
+                column: m.column as u32,
+                end_column: m.end_column as u32,
+                declaring_fqcn: None,
+                kind: None,
+                confidence: Confidence::Unresolved,
+            })
+        })
+        .collect()
+}
+
+/// Build a corpus: shared ancestors + `pool` models + `n` callers (caller `i`
+/// targets `Model{i % pool}`). `resolvable_base` selects whether every model
+/// extends the PSR-4-resolvable `BaseModel` (fast-path resolution) or an
+/// ancestor that is NOT PSR-4-resolvable (forcing the locator WalkDir).
+fn build_corpus(n: usize, pool: usize, resolvable_base: bool) -> Corpus {
+    let pool = pool.clamp(1, n.max(1));
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let root = dir.path().to_path_buf();
+    let mut index = ClassHierarchyIndex::default();
+
+    fs::write(
+        root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#,
+    )
+    .expect("write composer.json");
+
+    write_and_index(
+        &mut index,
+        &root.join("app/Models/BaseModel.php"),
+        base_model_php(),
+    );
+    write_and_index(
+        &mut index,
+        &root.join("app/Concerns/HasAudit.php"),
+        has_audit_trait_php(),
+    );
+    write_and_index(
+        &mut index,
+        &root.join("app/Concerns/Sluggable.php"),
+        sluggable_trait_php(),
+    );
+
+    // The parent every model extends. For the locator-miss shape we make models
+    // extend a base whose FQCN has no PSR-4 shape and no composer mapping, and
+    // we do NOT register it in the index or place it on a PSR-4 path — so
+    // resolving it drops through to the WalkDir fallback every time.
+    let base = if resolvable_base {
+        "BaseModel"
+    } else {
+        // A namespaced-but-unmapped ancestor: `Legacy\Support\LegacyBase` won't
+        // match the `App\` PSR-4 prefix, so the resolver walks to find it.
+        write_and_index(
+            &mut index,
+            // Placed somewhere the app-side basename walk CAN find it, but only
+            // via WalkDir (no PSR-4 shape resolves `Legacy\Support\LegacyBase`).
+            &root.join("app/Legacy/LegacyBase.php"),
+            r#"<?php
+namespace Legacy\Support;
+use Illuminate\Database\Eloquent\Model;
+class LegacyBase extends Model {
+    protected $fillable = ['id'];
+    public function scopeLegacy($query) { return $query; }
+}
+"#,
+        );
+        "\\Legacy\\Support\\LegacyBase"
+    };
+
+    for i in 0..pool {
+        write_and_index(
+            &mut index,
+            &root.join(format!("app/Models/Model{i}.php")),
+            &model_php(i, base),
+        );
+    }
+
+    let callers = (0..n)
+        .map(|i| {
+            let source = caller_php(i, i % pool);
+            let refs = capture_refs(&source);
+            CallerInput { source, refs }
+        })
+        .collect();
+
+    Corpus {
+        _dir: dir,
+        root,
+        index,
+        callers,
+    }
+}
+
+// ─── Measurement primitives ────────────────────────────────────────────────
+
+/// Reset all three global/shared caches to a cold state. Called between regimes
+/// (and, where a regime "disables" a cache, before every file) so no warm-cache
+/// state leaks across a measurement.
+fn reset_all_global_caches() {
+    reset_parsed_file_cache();
+    reset_locator_cache();
+}
+
+/// Resolve one caller against `index`/`root` with the given `ClassViewCache`.
+fn resolve_one(corpus: &Corpus, caller: &CallerInput, cache: &ClassViewCache) -> usize {
+    let entries = resolve_member_access_entries(
+        &caller.source,
+        &caller.refs,
+        &corpus.index,
+        cache,
+        &corpus.root,
+        None,
+    );
+    black_box(entries).len()
+}
+
+fn per_file_us(elapsed: Duration, files: usize) -> f64 {
+    if files == 0 {
+        0.0
+    } else {
+        elapsed.as_secs_f64() * 1e6 / files as f64
+    }
+}
+
+// ─── P1: shared ClassViewCache (shared-model-pool shape) ───────────────────
+
+/// P1 disabled: fresh `ClassViewCache` per file (today's per-worker shape). The
+/// parsed-file + locator caches stay PERSISTENT and identical across both P1
+/// regimes so they don't confound the comparison — only the ClassViewCache
+/// sharing differs.
+fn p1_fresh(corpus: &Corpus) -> (Duration, usize) {
+    reset_all_global_caches();
+    let start = Instant::now();
+    let mut total = 0;
+    for c in &corpus.callers {
+        let cache = ClassViewCache::new();
+        total += resolve_one(corpus, c, &cache);
+    }
+    (start.elapsed(), total)
+}
+
+/// P1 enabled: one shared `ClassViewCache` for all files.
+fn p1_shared(corpus: &Corpus) -> (Duration, usize) {
+    reset_all_global_caches();
+    let cache = ClassViewCache::new();
+    let start = Instant::now();
+    let mut total = 0;
+    for c in &corpus.callers {
+        total += resolve_one(corpus, c, &cache);
+    }
+    (start.elapsed(), total)
+}
+
+// ─── P3: parsed-file memo (distinct models, shared ancestors) ──────────────
+
+/// P3 disabled: reset the parsed-file cache before EVERY file, so each `analyze`
+/// re-reads + re-parses every ancestor (the pre-optimization behavior). Uses a
+/// fresh `ClassViewCache` per file too (holding P1 constant-off), and keeps the
+/// locator cache warm so only the parse cost differs.
+fn p3_reset_per_file(corpus: &Corpus) -> (Duration, usize) {
+    reset_all_global_caches();
+    let start = Instant::now();
+    let mut total = 0;
+    for c in &corpus.callers {
+        reset_parsed_file_cache(); // disable the memo: every ancestor re-parsed
+        let cache = ClassViewCache::new();
+        total += resolve_one(corpus, c, &cache);
+    }
+    (start.elapsed(), total)
+}
+
+/// P3 enabled: parsed-file memo persists across files (each ancestor parsed
+/// once). Fresh `ClassViewCache` per file so this isolates the parse memo, not P1.
+fn p3_persistent(corpus: &Corpus) -> (Duration, usize) {
+    reset_all_global_caches();
+    let start = Instant::now();
+    let mut total = 0;
+    for c in &corpus.callers {
+        let cache = ClassViewCache::new();
+        total += resolve_one(corpus, c, &cache);
+    }
+    (start.elapsed(), total)
+}
+
+// ─── P2: locator walk cache (unresolvable ancestor → WalkDir) ──────────────
+
+/// P2 disabled: reset the locator cache before every file, so the unresolvable
+/// ancestor is re-walked on each caller. Parsed-file cache reset too, so the
+/// walk cost isn't masked by the parse memo; fresh `ClassViewCache` per file.
+fn p2_reset_per_file(corpus: &Corpus) -> (Duration, usize) {
+    reset_all_global_caches();
+    let start = Instant::now();
+    let mut total = 0;
+    for c in &corpus.callers {
+        reset_locator_cache();
+        reset_parsed_file_cache();
+        let cache = ClassViewCache::new();
+        total += resolve_one(corpus, c, &cache);
+    }
+    (start.elapsed(), total)
+}
+
+/// P2 enabled: locator cache persists (ancestor walked once, then cached). Reset
+/// the parsed-file cache per file so ONLY the locator caching differs from the
+/// disabled regime above.
+fn p2_persistent(corpus: &Corpus) -> (Duration, usize) {
+    reset_all_global_caches();
+    let start = Instant::now();
+    let mut total = 0;
+    for c in &corpus.callers {
+        reset_parsed_file_cache();
+        let cache = ClassViewCache::new();
+        total += resolve_one(corpus, c, &cache);
+    }
+    (start.elapsed(), total)
+}
+
+// ─── Reporting ─────────────────────────────────────────────────────────────
+
+fn report(part: &str, n: usize, off: (Duration, usize), on: (Duration, usize)) {
+    let (off_dur, off_entries) = off;
+    let (on_dur, on_entries) = on;
+    // Equivalence: toggling a pure memo must not change what's resolved.
+    assert_eq!(
+        off_entries, on_entries,
+        "{part}: entry count changed when toggling the cache — not pure memoization"
+    );
+    let speedup = off_dur.as_secs_f64() / on_dur.as_secs_f64().max(f64::EPSILON);
+    println!("  [{part}] {off_entries} entries resolved");
+    println!(
+        "    disabled : {:>10.2?}  ({:.2} us/caller)",
+        off_dur,
+        per_file_us(off_dur, n)
+    );
+    println!(
+        "    enabled  : {:>10.2?}  ({:.2} us/caller)",
+        on_dur,
+        per_file_us(on_dur, n)
+    );
+    println!("    speedup  : {speedup:.2}x");
+}
+
+fn parse_scales() -> Vec<usize> {
+    match std::env::var("MAGIC_BENCH_SCALES") {
+        Ok(raw) => raw
+            .split(',')
+            .filter_map(|s| s.trim().parse::<usize>().ok())
+            .collect(),
+        Err(_) => vec![200, 1000, 5000],
+    }
+}
+
+fn main() {
+    let scales = parse_scales();
+    println!("magic-member resolution benchmark — SYNTHETIC corpus");
+    println!(
+        "each optimization measured in isolation (toggled on/off), other caches held constant"
+    );
+    println!("shared ancestors: BaseModel + 2 traits | accesses/caller: {ACCESSES_PER_CALLER}");
+
+    for &n in &scales {
+        println!("\n========================================================");
+        println!("SCALE: {n} callers");
+
+        // P1 — shared ClassViewCache. The shape that shows it: many callers over
+        // a small model pool (n/10). On 1:1 it's ~1x BY DESIGN (below).
+        println!("--------------------------------------------------------");
+        let pool_corpus = build_corpus(n, (n / 10).max(1), true);
+        report(
+            "P1 shared cache, n/10 pool",
+            n,
+            p1_fresh(&pool_corpus),
+            p1_shared(&pool_corpus),
+        );
+
+        // P1 on the 1:1 shape — reported honestly as ~1x (no receiver FQCN
+        // repeats, so a shared ClassViewCache has nothing to collapse).
+        let distinct_corpus = build_corpus(n, n, true);
+        report(
+            "P1 shared cache, 1:1 (expected ~1x by design)",
+            n,
+            p1_fresh(&distinct_corpus),
+            p1_shared(&distinct_corpus),
+        );
+
+        // P3 — parsed-file memo, distinct models with shared ancestors.
+        println!("--------------------------------------------------------");
+        report(
+            "P3 parsed-file memo, 1:1",
+            n,
+            p3_reset_per_file(&distinct_corpus),
+            p3_persistent(&distinct_corpus),
+        );
+
+        // P2 — locator walk cache, ancestor forced through the WalkDir fallback.
+        println!("--------------------------------------------------------");
+        let miss_corpus = build_corpus(n, n, false);
+        report(
+            "P2 locator walk cache, 1:1 (unresolvable ancestor)",
+            n,
+            p2_reset_per_file(&miss_corpus),
+            p2_persistent(&miss_corpus),
+        );
+    }
+
+    println!("\nNOTE: synthetic corpus; absolute times are machine-dependent. Each");
+    println!("'speedup' is that ONE optimization toggled on vs off with the other");
+    println!("caches held constant — an honest per-Part contribution, not a headline.");
+    println!("P1 on the 1:1 shape is ~1x by construction (no shared receiver FQCNs);");
+    println!("its win is the n/10 pool shape. Reset hooks make the comparison");
+    println!("apples-to-apples (no warm-cache carryover between regimes).");
+}

--- a/laravel-lsp/src/cache_manager.rs
+++ b/laravel-lsp/src/cache_manager.rs
@@ -62,6 +62,29 @@ fn get_cache_file(project_root: &Path) -> Option<PathBuf> {
     get_cache_dir(project_root).map(|dir| dir.join("cache.json"))
 }
 
+/// Delete every on-disk cache for `project_root`.
+///
+/// All of the LSP's disk caches live in the same per-project directory
+/// (this module's `cache.json`, plus `pattern_cache.bin`, `magic_cache.bin`,
+/// `command_cache.bin`, and the vendor-alias cache — each sibling module
+/// derives the identical `{cache_dir}/{project-hash}/` path), so one
+/// directory removal wipes them all. Used by the `laravel.reindexProject`
+/// command: with the disk caches gone, the next warming pass restores
+/// nothing and rebuilds everything from source — a genuinely cold reindex.
+///
+/// A missing directory is success (nothing to clear), not an error; the
+/// modules that later save their caches recreate the directory themselves.
+pub fn clear_disk_caches(project_root: &Path) -> std::io::Result<()> {
+    let Some(dir) = get_cache_dir(project_root) else {
+        // No resolvable home directory — nowhere a cache could live.
+        return Ok(());
+    };
+    match fs::remove_dir_all(&dir) {
+        Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(e),
+        _ => Ok(()),
+    }
+}
+
 /// Stored file modification time
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileMtime {

--- a/laravel-lsp/src/cache_manager/tests.rs
+++ b/laravel-lsp/src/cache_manager/tests.rs
@@ -91,3 +91,28 @@ fn test_xdg_cache_path() {
     assert!(cache_dir.is_some());
     println!("Cache dir for {:?}: {:?}", project_root, cache_dir.unwrap());
 }
+
+#[test]
+fn test_clear_disk_caches_removes_dir_and_is_idempotent() {
+    // A unique tempdir as the project root gives a unique cache-dir hash, so
+    // this test's disk writes/deletes are isolated to their own directory
+    // under the real per-user cache root and can't collide with another run.
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // Seed the per-project cache dir with a stand-in for the .bin/.json caches.
+    let cache_dir = get_cache_dir(project_root).expect("cache dir resolvable");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    std::fs::write(cache_dir.join("pattern_cache.bin"), b"stale").unwrap();
+    assert!(cache_dir.exists(), "precondition: cache dir seeded");
+
+    // Clearing removes the whole per-project directory.
+    clear_disk_caches(project_root).expect("clear must succeed");
+    assert!(
+        !cache_dir.exists(),
+        "clear_disk_caches must remove the per-project cache dir"
+    );
+
+    // Idempotent: clearing an already-absent dir is success, not an error.
+    clear_disk_caches(project_root).expect("clearing a missing dir is a no-op success");
+}

--- a/laravel-lsp/src/class_locator.rs
+++ b/laravel-lsp/src/class_locator.rs
@@ -15,11 +15,202 @@
 //! atypical layouts (e.g. `src/` instead of `app/`), the caller can extend
 //! the search roots.
 
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
+use lru::LruCache;
 use walkdir::WalkDir;
 
 use crate::path_containment::path_within_root;
+
+/// How long a *negative* (unresolved) walk result is trusted before it's
+/// re-walked. Positive entries are revalidated by an `exists()` + containment
+/// check on every hit — but a miss has nothing to re-stat, so a class created
+/// after the miss was cached would stay invisible forever without a bound. This
+/// matches the repo's existing file-existence cache TTL (5 min): the window
+/// where a just-created model isn't yet resolvable, absent an explicit
+/// [`invalidate_project`]. See the Fork-2 note on why the file watcher can't be
+/// the sole invalidation trigger (its globs don't cover `app/Models/` etc.).
+const NEGATIVE_TTL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
+/// Upper bound on cached walk results. The key is a *basename* per project, so
+/// the live set is small; the cap just guarantees the memo can't grow unbounded
+/// over a long session. The LRU evicts the coldest basenames past this.
+const LOCATOR_CACHE_CAP: usize = 4096;
+
+/// A cached WalkDir result plus when it was recorded (for the negative-entry
+/// TTL).
+#[derive(Clone)]
+struct CacheEntry {
+    /// `Some(path)` = the walk found this file; `None` = the walk found nothing.
+    path: Option<PathBuf>,
+    /// When this entry was written. Only consulted for negative entries.
+    cached_at: std::time::Instant,
+}
+
+/// Process-wide memo for the **basename WalkDir fallback only**, keyed by
+/// `(canonical project root, simple class name, include_vendor)`.
+///
+/// # Why only the walk is cached
+///
+/// Resolution has two tiers. The first — Composer autoload + the cheap PSR-4
+/// *shape* probes — is fast and, crucially, *precedence- and containment-correct
+/// by construction* (it re-checks app-vs-vendor ordering and [`path_within_root`]
+/// every call). Caching its positives would be a correctness trap: a cached
+/// vendor hit couldn't be shadowed by a later app-side file, and a cached path
+/// could bypass the containment guard on a since-swapped symlink. So we run that
+/// tier live on every call and it stays free of stale precedence.
+///
+/// Only the **last-resort basename `WalkDir`** is memoized — that's the
+/// expensive part (a full `app/`/`src/` walk, or the entire `vendor/` tree for
+/// the app-or-vendor variant), and during the index build the same unresolvable
+/// ancestor is walked once per referencing file. That walk runs *after* the
+/// precedence-ordered tiers already failed, so its result carries no precedence
+/// decision to go stale; the only freshness concerns are "file since deleted"
+/// and "class since created", both handled below.
+///
+/// Freshness: a positive entry is revalidated on every hit with `exists()`
+/// **and** [`path_within_root`] (so a deleted file *or* a since-swapped
+/// out-of-root symlink falls back to a fresh walk); a negative entry expires
+/// after [`NEGATIVE_TTL`], and both are dropped immediately by
+/// [`invalidate_project`] on any watched `.php` create/delete.
+///
+/// Bounded `LruCache` behind a `Mutex` (lru mutates on read to reorder;
+/// `spawn_blocking` workers share it, so the lock guards the O(1) get/put only).
+type LocatorKey = (PathBuf, String, bool);
+type LocatorCache = Mutex<LruCache<LocatorKey, CacheEntry>>;
+fn locator_cache() -> &'static LocatorCache {
+    static CACHE: OnceLock<LocatorCache> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(LruCache::new(NonZeroUsize::new(LOCATOR_CACHE_CAP).unwrap())))
+}
+
+/// Clear the walk-result memo. Test/bench only.
+#[doc(hidden)]
+pub fn reset_locator_cache() {
+    locator_cache().lock().unwrap().clear();
+}
+
+/// Canonicalize the project root once per process (canonicalize is a syscall;
+/// the root never changes during a session). Mirrors `ComposerAutoload`'s key
+/// normalization so both caches agree on what "this project" means.
+fn canonical_root(root: &Path) -> PathBuf {
+    static ROOTS: OnceLock<Mutex<HashMap<PathBuf, PathBuf>>> = OnceLock::new();
+    let roots = ROOTS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut map = roots.lock().expect("class_locator root cache poisoned");
+    map.entry(root.to_path_buf())
+        .or_insert_with(|| root.canonicalize().unwrap_or_else(|_| root.to_path_buf()))
+        .clone()
+}
+
+/// The basename WalkDir fallback, memoized. Runs `find_php_class_file_impl` only
+/// on a cache miss and caches the result (positive or negative). Positive hits
+/// are revalidated with `exists()` **and** [`path_within_root`]; negative hits
+/// expire after [`NEGATIVE_TTL`].
+///
+/// This is the ONLY cached tier — callers run the precedence-correct
+/// Composer/PSR-4 tiers live before reaching here.
+fn cached_walk(class_name: &str, root: &Path, include_vendor: bool) -> Option<PathBuf> {
+    let key = (canonical_root(root), class_name.to_string(), include_vendor);
+    if let Some(hit) = locator_cache().lock().unwrap().get(&key).cloned() {
+        match &hit.path {
+            // Positive hit — trust it only while the file still exists AND still
+            // resolves inside the project root (a swapped-in symlink could now
+            // escape it). Re-applying the containment guard here mirrors the
+            // uncached path exactly.
+            Some(path) if path.exists() && path_within_root(path, root) => {
+                return Some(path.clone())
+            }
+            // Stale positive (deleted, moved, or now-escaping) — re-walk.
+            Some(_) => {}
+            // Negative hit — reuse until the TTL lapses, then re-walk so a
+            // since-created class becomes discoverable even without a watcher event.
+            None if hit.cached_at.elapsed() < NEGATIVE_TTL => return None,
+            None => {}
+        }
+    }
+    walk_and_cache(&key, class_name, root, include_vendor)
+}
+
+/// Run the uncached WalkDir and store its result under `key`. Shared by
+/// [`cached_walk`] (on a cache miss) and [`live_app_walk`] (the precedence
+/// re-confirmation), so both compute and cache identically.
+fn walk_and_cache(
+    key: &LocatorKey,
+    class_name: &str,
+    root: &Path,
+    include_vendor: bool,
+) -> Option<PathBuf> {
+    let resolved = find_php_class_file_impl(class_name, root, include_vendor);
+    locator_cache().lock().unwrap().put(
+        key.clone(),
+        CacheEntry {
+            path: resolved.clone(),
+            cached_at: std::time::Instant::now(),
+        },
+    );
+    resolved
+}
+
+/// A LIVE app-only walk that bypasses a cached app-*negative* (but refreshes the
+/// cache with the result). Used only on the app-or-vendor precedence path: when
+/// the cached app walk said "miss" and vendor would otherwise win, this
+/// re-confirms app is genuinely empty right now — so a since-created app file
+/// (in a directory the watcher doesn't cover, e.g. `app/Models/`, `Modules/…`)
+/// shadows vendor exactly as a fully-live app-then-vendor walk would.
+///
+/// A cached app-*positive* is trusted as-is (still revalidated by exists +
+/// containment) — only the negative is bypassed, and only in the rare branch
+/// where a vendor positive is about to be returned, so the miss-walk perf win is
+/// preserved for the common all-miss case.
+///
+/// ## Deliberate trade-off (accepted)
+///
+/// For a vendor-only, non-PSR-4 class this re-walks `app/` on *every* lookup
+/// (the cached app-negative is intentionally bypassed here). This is chosen over
+/// honoring the negative TTL because honoring it would reintroduce the
+/// precedence bug where a stale app-negative lets vendor shadow a since-created
+/// app file (issue: CON2/CON3 lineage). It is **not** a regression: the
+/// pre-refactor resolver ran BOTH a live `app/` walk AND a live 31k-file
+/// `vendor/` walk on every call, so "cached vendor positive + one live app-only
+/// walk" is strictly faster than that baseline even in this worst case. Build
+/// time is unaffected — Part 1's shared `ClassViewCache` already dedupes
+/// resolution to once per FQCN per build.
+fn live_app_walk(class_name: &str, root: &Path) -> Option<PathBuf> {
+    let key = (canonical_root(root), class_name.to_string(), false);
+    // Trust a still-valid cached app-positive without re-walking.
+    if let Some(hit) = locator_cache().lock().unwrap().get(&key).cloned() {
+        if let Some(path) = &hit.path {
+            if path.exists() && path_within_root(path, root) {
+                return Some(path.clone());
+            }
+        }
+    }
+    // Cached miss (or stale positive) — re-walk live and refresh the cache.
+    walk_and_cache(&key, class_name, root, false)
+}
+
+/// Drop every cached walk result for `project_root`. Called by the file watcher
+/// on a `.php` create/delete so a newly-added class (previously a cached miss)
+/// becomes discoverable, and a moved/renamed one isn't served from a stale
+/// positive.
+pub fn invalidate_project(project_root: &Path) {
+    let key_root = canonical_root(project_root);
+    // `LruCache` has no `retain`; rebuild without this root's entries. The cache
+    // is small (bounded) and invalidation is rare (a watched create/delete), so
+    // the O(n) rebuild is fine.
+    let mut cache = locator_cache().lock().unwrap();
+    let keep: Vec<(LocatorKey, CacheEntry)> = cache
+        .iter()
+        .filter(|((root, _, _), _)| root != &key_root)
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    cache.clear();
+    for (k, v) in keep {
+        cache.put(k, v);
+    }
+}
 
 /// Locate the PHP source file for a given class name.
 ///
@@ -30,6 +221,9 @@ use crate::path_containment::path_within_root;
 /// Returns the first matching file path, or `None` when the class can't be
 /// found. Does not parse the file to verify the class name inside — relies on
 /// Laravel's strong convention that file basename matches class name.
+///
+/// The precedence-ordered tiers (Composer autoload, PSR-4 shape) run live on
+/// every call; only the final basename walk is memoized (see [`cached_walk`]).
 pub fn find_php_class_file(class_name: &str, root: &Path) -> Option<PathBuf> {
     // Composer autoload is the authoritative source for any FQCN with
     // a declared PSR-4 prefix. If it resolves the class — whether to
@@ -54,12 +248,10 @@ pub fn find_php_class_file(class_name: &str, root: &Path) -> Option<PathBuf> {
         return Some(path);
     }
 
-    // Last resort: basename walk under `app/` (and `src/`). Vendor is
-    // intentionally not walked here — it's huge and the Composer
-    // step above already handles all conventionally-installed
-    // packages. Inheritance walking, which can legitimately need to
-    // scan vendor by basename, calls `find_php_class_file_in_app_or_vendor`.
-    find_php_class_file_impl(class_name, root, false)
+    // Last resort: basename walk under `app/` (and `src/`) — the expensive tier,
+    // memoized. Vendor is intentionally not walked here; the app-or-vendor entry
+    // point below handles inheritance walks that legitimately need vendor.
+    cached_walk(class_name, root, false)
 }
 
 /// Same as [`find_php_class_file`] but ALSO searches `vendor/` so the
@@ -71,6 +263,9 @@ pub fn find_php_class_file(class_name: &str, root: &Path) -> Option<PathBuf> {
 /// it only for inheritance walking, where the search depth is bounded
 /// (≤10 levels) and the result is cached behind ModelMetadata anyway.
 /// app/-side definitions still win — they're checked first.
+///
+/// As with [`find_php_class_file`], the precedence tiers run live; only the
+/// (here, vendor-spanning and thus most expensive) basename walk is memoized.
 pub fn find_php_class_file_in_app_or_vendor(class_name: &str, root: &Path) -> Option<PathBuf> {
     // Composer first (same reasoning as `find_php_class_file`). For
     // the inheritance walker this is normally enough — parent classes
@@ -88,13 +283,25 @@ pub fn find_php_class_file_in_app_or_vendor(class_name: &str, root: &Path) -> Op
         return Some(path);
     }
 
-    // Last resort: basename walk app/, then vendor/. The vendor walk
-    // is reserved for this app-or-vendor entry point because the
-    // inheritance walker is bounded in depth and cached.
-    if let Some(path) = find_php_class_file_impl(class_name, root, false) {
+    // Last resort: basename walk app/, then vendor/ — both memoized. app/ is
+    // tried first so an app-side definition shadows a vendor one.
+    if let Some(path) = cached_walk(class_name, root, false) {
         return Some(path);
     }
-    find_php_class_file_impl(class_name, root, true)
+
+    // App walk missed (possibly a *cached* miss). Before letting vendor win, do a
+    // live app re-walk that bypasses the app-negative cache — otherwise a stale
+    // app-negative (whose file lives in a watcher-uncovered dir) would let vendor
+    // wrongly shadow a since-created app file. Only pay this when vendor actually
+    // resolves; vendor-walk positives are rare (non-PSR-4 classes), so the common
+    // all-miss case keeps its cached-negative fast path.
+    let vendor = cached_walk(class_name, root, true);
+    if vendor.is_some() {
+        if let Some(app) = live_app_walk(class_name, root) {
+            return Some(app);
+        }
+    }
+    vendor
 }
 
 /// Heuristic FQCN → file path mapping for projects without an
@@ -238,6 +445,7 @@ fn search_roots(root: &Path) -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
     use tempfile::TempDir;
 
     /// Spin up a Laravel-shaped tempdir with the given (path, body)
@@ -251,6 +459,21 @@ mod tests {
         }
         let root = dir.path().to_path_buf();
         (dir, root)
+    }
+
+    /// Serialize the cache-behavior tests. The `locator_cache` is process-global,
+    /// and Rust runs tests in parallel — so a test that asserts on *cache
+    /// persistence* (a cached negative still hiding a file, a `peek` on state)
+    /// would race another test's `reset_locator_cache()`. Each such test holds
+    /// this guard for its duration, then `reset_locator_cache()` starts it clean.
+    /// Returns a guard; keep it bound (`let _g = ...;`) for the whole test.
+    fn serial_cache_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        // Recover from a poisoned lock (a panicking serial test) so one failure
+        // doesn't cascade into "poisoned" failures for every later serial test.
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
     }
 
     #[test]
@@ -370,5 +593,273 @@ mod tests {
         let (_dir, root) = project_with_files(&[("app/Services/Foo.php", "<?php\nclass Foo {}")]);
         let path = find_php_class_file("Foo", &root).expect("bare-name walk");
         assert!(path.ends_with("app/Services/Foo.php"));
+    }
+
+    // ─── Walk-fallback cache (Part 2) ─────────────────────────────────────
+    //
+    // Only the last-resort basename WalkDir is memoized — the Composer/PSR-4
+    // tiers run live every call. So these tests use *shapeless* names (no
+    // `App\` PSR-4 prefix that the fast path would resolve), which fall through
+    // to the cached walk. `reset_locator_cache()` at the top of each isolates
+    // it from the process-global cache other tests populate.
+
+    /// Peek a cache entry under the lock without disturbing LRU order much.
+    fn peek(root: &Path, name: &str, vendor: bool) -> Option<Option<PathBuf>> {
+        let key = (canonical_root(root), name.to_string(), vendor);
+        locator_cache()
+            .lock()
+            .unwrap()
+            .get(&key)
+            .map(|e| e.path.clone())
+    }
+
+    #[test]
+    fn cached_walk_miss_is_reused_as_negative_entry() {
+        let _g = serial_cache_guard();
+        reset_locator_cache();
+        // `Ghost` has no namespace → no PSR-4 shape → falls through to the walk,
+        // which finds nothing and records a negative entry.
+        let (_dir, root) = project_with_files(&[("app/Services/Real.php", "<?php\nclass Real {}")]);
+        assert!(find_php_class_file("Ghost", &root).is_none());
+        assert_eq!(
+            peek(&root, "Ghost", false),
+            Some(None),
+            "the walk miss should be recorded as a negative cache entry"
+        );
+        assert!(find_php_class_file("Ghost", &root).is_none());
+    }
+
+    #[test]
+    fn cached_walk_positive_revalidates_after_file_deleted() {
+        let _g = serial_cache_guard();
+        reset_locator_cache();
+        // Shapeless name → resolved by the walk and cached as a positive.
+        let (_dir, root) =
+            project_with_files(&[("app/Services/Gadget.php", "<?php\nclass Gadget {}")]);
+        let found = find_php_class_file("Gadget", &root).expect("walk resolves once");
+        assert_eq!(peek(&root, "Gadget", false), Some(Some(found.clone())));
+        std::fs::remove_file(&found).unwrap();
+        // The cached positive points at a now-missing file — revalidation
+        // (`exists()`) must reject it and re-walk to None.
+        assert!(
+            find_php_class_file("Gadget", &root).is_none(),
+            "a deleted file must not be served from a stale positive cache entry"
+        );
+    }
+
+    #[test]
+    fn cached_walk_positive_revalidates_containment_on_hit() {
+        // CON3: a positive hit is re-checked with `path_within_root`, not just
+        // `exists()`. Seed the cache with an entry whose file exists but resolves
+        // OUTSIDE the project root (an escaping symlink target) — it must be
+        // rejected and re-walked, not served.
+        let _g = serial_cache_guard();
+        reset_locator_cache();
+        let (_dir, root) = project_with_files(&[("app/Services/Real.php", "<?php\nclass Real {}")]);
+
+        // A real file living outside the project root.
+        let outside_dir = TempDir::new().unwrap();
+        let outside = outside_dir.path().join("Escapee.php");
+        std::fs::write(&outside, "<?php\nclass Escapee {}").unwrap();
+
+        // Manually seed a positive cache entry pointing at the out-of-root file.
+        let key = (canonical_root(&root), "Escapee".to_string(), false);
+        locator_cache().lock().unwrap().put(
+            key,
+            CacheEntry {
+                path: Some(outside.clone()),
+                cached_at: std::time::Instant::now(),
+            },
+        );
+
+        // The file exists, so a bare `exists()` check would serve it — but the
+        // containment guard must reject an out-of-root path and re-walk (which
+        // finds nothing inside the project).
+        assert!(
+            find_php_class_file("Escapee", &root).is_none(),
+            "an out-of-root cached path must be rejected by the containment re-check, not served"
+        );
+    }
+
+    #[test]
+    fn fast_path_precedence_re_evaluated_live_app_shadows_vendor() {
+        // CON2: because the Composer/PSR-4 tiers are NOT cached, a later app-side
+        // file shadows an earlier vendor resolution with no invalidation needed.
+        //
+        // First call: only the vendor file exists, so `App\Widgets\Panel`'s app
+        // PSR-4 shape misses and the app-or-vendor lookup resolves to vendor.
+        let _g = serial_cache_guard();
+        reset_locator_cache();
+        let (dir, root) = project_with_files(&[(
+            "vendor/acme/widgets/src/Panel.php",
+            "<?php\nnamespace App\\Widgets;\nclass Panel {}",
+        )]);
+        // No app file yet: the vendor PSR-4 heuristic (lowercased vendor/pkg)
+        // won't match `App\Widgets\...`, so this falls to the vendor walk.
+        let first =
+            find_php_class_file_in_app_or_vendor("App\\Widgets\\Panel", &root).expect("resolves");
+        assert!(
+            first.to_string_lossy().contains("vendor/"),
+            "with no app file, resolution lands in vendor; got {first:?}"
+        );
+
+        // Now create the app-side PSR-4 file for the SAME FQCN.
+        let app_file = dir.path().join("app/Widgets/Panel.php");
+        std::fs::create_dir_all(app_file.parent().unwrap()).unwrap();
+        std::fs::write(&app_file, "<?php\nnamespace App\\Widgets;\nclass Panel {}").unwrap();
+
+        // The next call must return the APP file: the live PSR-4 shape tier
+        // (`App\` → `app/`) runs before the cached walk and shadows it. No
+        // invalidate_project call — precedence is simply never cached.
+        let second =
+            find_php_class_file_in_app_or_vendor("App\\Widgets\\Panel", &root).expect("resolves");
+        assert!(
+            second.ends_with("app/Widgets/Panel.php"),
+            "the live app PSR-4 tier must shadow the earlier vendor result; got {second:?}"
+        );
+    }
+
+    #[test]
+    fn walk_tier_precedence_app_shadows_vendor_after_cached_vendor_hit() {
+        // The residual precedence bug: an FQCN that reaches the WALK tier (no
+        // `App\` prefix, not PSR-4-resolvable) resolves to vendor and caches an
+        // app-NEGATIVE. Then an app-side file is created in a watcher-uncovered
+        // dir (no invalidate_project). A fully-live app-then-vendor walk would
+        // now return APP — the cached app-negative must NOT let vendor shadow it.
+        let _g = serial_cache_guard();
+        reset_locator_cache();
+
+        // `Modules\Blog\Thing`: first namespace segment is `modules` (not `app`),
+        // so the app PSR-4 shape misses. The vendor file is placed under a
+        // package dir that does NOT match the `vendor/modules/blog` heuristic
+        // shape, so the vendor PSR-4 heuristic misses too — BOTH tiers fall
+        // through to `cached_walk`, which is exactly what we must exercise.
+        let (dir, root) = project_with_files(&[(
+            "vendor/acme/legacy/src/Thing.php",
+            "<?php\nnamespace Modules\\Blog;\nclass Thing {}",
+        )]);
+
+        // Call 1: app-walk misses (caches an app-negative), vendor-walk finds
+        // Thing.php by basename → resolves to vendor.
+        let first = find_php_class_file_in_app_or_vendor("Modules\\Blog\\Thing", &root)
+            .expect("vendor walk resolves");
+        assert!(
+            first.to_string_lossy().contains("vendor/"),
+            "with no app file, the walk lands in vendor; got {first:?}"
+        );
+
+        // Create the app-side file in an UNWATCHED dir (app/Blog — the file
+        // watcher covers only Controllers/routes/migrations/views/livewire/
+        // vendor/Inertia, never app/Blog). NO invalidate_project call.
+        let app_file = dir.path().join("app/Blog/Thing.php");
+        std::fs::create_dir_all(app_file.parent().unwrap()).unwrap();
+        std::fs::write(&app_file, "<?php\nnamespace Modules\\Blog;\nclass Thing {}").unwrap();
+
+        // Call 2: the cached app-negative must NOT let the cached vendor positive
+        // win. A live app re-walk finds the new app file, which shadows vendor —
+        // matching a fully-live app-then-vendor walk.
+        let second =
+            find_php_class_file_in_app_or_vendor("Modules\\Blog\\Thing", &root).expect("resolves");
+        assert!(
+            second.ends_with("app/Blog/Thing.php"),
+            "a since-created app file must shadow the cached vendor result (live app re-walk); got {second:?}"
+        );
+
+        // And it self-heals the cache: a third call returns app from the now-
+        // positive app cache entry without another live walk.
+        let third =
+            find_php_class_file_in_app_or_vendor("Modules\\Blog\\Thing", &root).expect("resolves");
+        assert!(third.ends_with("app/Blog/Thing.php"));
+    }
+
+    #[test]
+    fn walk_tier_all_miss_stays_cached_no_extra_walk() {
+        // Perf guard: when BOTH app and vendor walks miss, the live app re-walk
+        // must NOT fire (vendor is None), so the cached-negative fast path is
+        // preserved for the common repeated-miss case. We assert the negative is
+        // cached and reused.
+        let _g = serial_cache_guard();
+        reset_locator_cache();
+        let (_dir, root) = project_with_files(&[("app/Services/Real.php", "<?php\nclass Real {}")]);
+
+        assert!(find_php_class_file_in_app_or_vendor("Modules\\Blog\\Ghost", &root).is_none());
+        // Both tiers cached negative.
+        assert_eq!(peek(&root, "Modules\\Blog\\Ghost", false), Some(None));
+        assert_eq!(peek(&root, "Modules\\Blog\\Ghost", true), Some(None));
+        // Repeat still None, served from cache.
+        assert!(find_php_class_file_in_app_or_vendor("Modules\\Blog\\Ghost", &root).is_none());
+    }
+
+    #[test]
+    fn invalidate_project_lets_newly_created_walk_class_resolve() {
+        let _g = serial_cache_guard();
+        reset_locator_cache();
+        // Shapeless miss cached; create the file; invalidate; now it resolves.
+        let (dir, root) = project_with_files(&[("app/Services/Real.php", "<?php\nclass Real {}")]);
+        assert!(find_php_class_file("Fresh", &root).is_none());
+
+        std::fs::write(
+            dir.path().join("app/Services/Fresh.php"),
+            "<?php\nclass Fresh {}",
+        )
+        .unwrap();
+
+        // Before invalidation the cached negative still hides it.
+        assert!(find_php_class_file("Fresh", &root).is_none());
+
+        invalidate_project(&root);
+        let found = find_php_class_file("Fresh", &root)
+            .expect("after invalidation the newly created class resolves");
+        assert!(found.ends_with("app/Services/Fresh.php"));
+    }
+
+    #[test]
+    fn negative_walk_entry_expires_after_ttl() {
+        let _g = serial_cache_guard();
+        reset_locator_cache();
+        // The Fork-2 fallback: a cached walk miss must stop hiding a class
+        // created after it, even without a watcher event. Back-date the entry.
+        let (dir, root) = project_with_files(&[("app/Services/Real.php", "<?php\nclass Real {}")]);
+        assert!(find_php_class_file("Later", &root).is_none());
+
+        std::fs::write(
+            dir.path().join("app/Services/Later.php"),
+            "<?php\nclass Later {}",
+        )
+        .unwrap();
+        let key = (canonical_root(&root), "Later".to_string(), false);
+        locator_cache().lock().unwrap().put(
+            key,
+            CacheEntry {
+                path: None,
+                cached_at: std::time::Instant::now() - (NEGATIVE_TTL + Duration::from_secs(1)),
+            },
+        );
+
+        let found = find_php_class_file("Later", &root)
+            .expect("an expired negative entry must re-resolve and find the new class");
+        assert!(found.ends_with("app/Services/Later.php"));
+    }
+
+    #[test]
+    fn invalidate_project_only_clears_its_own_root() {
+        let _g = serial_cache_guard();
+        reset_locator_cache();
+        // Invalidating one project must not evict another project's entries.
+        let (_dir_a, root_a) = project_with_files(&[("app/Services/A.php", "<?php\nclass A {}")]);
+        let (_dir_b, root_b) = project_with_files(&[("app/Services/B.php", "<?php\nclass B {}")]);
+        find_php_class_file("A", &root_a).expect("A resolves via walk");
+        find_php_class_file("B", &root_b).expect("B resolves via walk");
+
+        invalidate_project(&root_a);
+
+        assert!(
+            peek(&root_b, "B", false).is_some(),
+            "project B's cache entry must survive project A's invalidation"
+        );
+        assert!(
+            peek(&root_a, "A", false).is_none(),
+            "project A's entry must be gone after its invalidation"
+        );
     }
 }

--- a/laravel-lsp/src/class_locator.rs
+++ b/laravel-lsp/src/class_locator.rs
@@ -86,8 +86,21 @@ fn locator_cache() -> &'static LocatorCache {
     CACHE.get_or_init(|| Mutex::new(LruCache::new(NonZeroUsize::new(LOCATOR_CACHE_CAP).unwrap())))
 }
 
-/// Clear the walk-result memo. Test/bench only.
-#[doc(hidden)]
+/// Clear the walk-result memo.
+///
+/// Drops every entry (positive and negative) from the process-global
+/// class-locator cache. Two production callers rely on this:
+///
+/// * The `laravel.reindexProject` command, which resets all process-global
+///   memos before a cold rebuild so a stale walk result can't survive the
+///   reindex.
+/// * The isolation benchmarks/tests, which clear the memo between passes to
+///   measure (or assert on) cold vs. warm behavior.
+///
+/// The memo is otherwise self-freshening (positive hits are revalidated with
+/// `exists()` + [`path_within_root`]; negatives expire after [`NEGATIVE_TTL`];
+/// watched `.php` create/delete calls [`invalidate_project`]), so this full
+/// reset is only needed when the caller wants a guaranteed-clean slate.
 pub fn reset_locator_cache() {
     locator_cache().lock().unwrap().clear();
 }

--- a/laravel-lsp/src/composer_autoload.rs
+++ b/laravel-lsp/src/composer_autoload.rs
@@ -183,6 +183,83 @@ impl ComposerAutoload {
         dirs
     }
 
+    /// The project's own first-party PSR-4 source-root directories — the
+    /// `autoload` / `autoload-dev` mappings from the project `composer.json`
+    /// (`App\` → `app/`, `Database\Factories\` → `database/factories/`, and any
+    /// custom `Modules\` / `src/` layout). Used to widen the file watcher so an
+    /// external edit to *any* first-party source dir — not just the four
+    /// hardcoded ones — converges the magic-member index (M2).
+    ///
+    /// Vendor package roots (from `installed.json`) are deliberately excluded:
+    /// the existing `vendor/**` watcher globs already cover them, and a
+    /// `composer update` rewriting thousands of vendor files must not fan the
+    /// widened watcher out across the whole dependency tree.
+    ///
+    /// Filters, in order (each guards a real failure mode):
+    /// - **fail-closed containment** — a root that can't be proven inside the
+    ///   project root is dropped, the same [`path_within_root`] guard
+    ///   [`resolve`](Self::resolve) applies before any on-disk touch (a
+    ///   `..`-bearing or absolute PSR-4 value);
+    /// - **vendor exclusion** — anything under `<root>/vendor` (every
+    ///   `installed.json` root) is dropped;
+    /// - **root-equals-project** — a `"Foo\\": ""` mapping resolves to the
+    ///   project root itself, whose `**/*.php` glob would sweep compiled Blade
+    ///   under `storage/framework/views` and every other unindexed tree — dropped;
+    /// - **existence** — only directories that exist on disk are worth a watcher;
+    /// - **subsumption dedup** — a root nested under another kept root (e.g.
+    ///   `app/Models` under `App\` → `app/`) is redundant, its files already
+    ///   matched by the ancestor's recursive glob, so only the shallowest is kept.
+    ///
+    /// Comparisons run in canonical path space (so the macOS `/var`→`/private/var`
+    /// symlinked-tempdir case, and a vendor dir reached through a symlink, compare
+    /// correctly), but the returned paths are the **original** (un-canonicalized)
+    /// roots — matching the initialized-root-relative style of the watcher's fixed
+    /// globs.
+    pub fn project_source_roots(&self) -> Vec<PathBuf> {
+        let canonical_root = self
+            .project_root
+            .canonicalize()
+            .unwrap_or_else(|_| self.project_root.clone());
+        let vendor = self.project_root.join("vendor");
+        let canonical_vendor = vendor.canonicalize().unwrap_or(vendor);
+
+        // Keep each surviving root as (canonical-for-comparison, original-to-return).
+        let mut candidates: Vec<(PathBuf, PathBuf)> = Vec::new();
+        for (_prefix, source_roots) in &self.prefixes {
+            for root in source_roots {
+                if !path_within_root(root, &self.project_root) {
+                    continue;
+                }
+                if !root.is_dir() {
+                    continue;
+                }
+                let canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
+                if canonical.starts_with(&canonical_vendor) {
+                    continue;
+                }
+                if canonical == canonical_root {
+                    continue;
+                }
+                if !candidates.iter().any(|(c, _)| c == &canonical) {
+                    candidates.push((canonical, root.clone()));
+                }
+            }
+        }
+
+        // Shallowest-first, then drop any root nested under one already kept.
+        candidates.sort_by_key(|(canon, _)| canon.components().count());
+        let mut kept_canonical: Vec<PathBuf> = Vec::new();
+        let mut kept: Vec<PathBuf> = Vec::new();
+        for (canonical, original) in candidates {
+            if kept_canonical.iter().any(|k| canonical.starts_with(k)) {
+                continue;
+            }
+            kept_canonical.push(canonical);
+            kept.push(original);
+        }
+        kept
+    }
+
     /// Parse autoload data fresh from disk. Doesn't touch the cache —
     /// callers should normally use [`for_project`] instead.
     pub fn load(project_root: &Path) -> Self {

--- a/laravel-lsp/src/composer_autoload/tests.rs
+++ b/laravel-lsp/src/composer_autoload/tests.rs
@@ -228,3 +228,149 @@ fn resolve_namespace_dirs_returns_empty_for_unknown_or_nonexistent() {
         .resolve_namespace_dirs("App\\View\\Components")
         .is_empty());
 }
+
+// ── project_source_roots (M2 — file-watcher widening) ──────────────────────
+
+/// Assert a `project_source_roots` result contains a root ending in `suffix`,
+/// path-separator-agnostic.
+fn has_root_ending(roots: &[PathBuf], suffix: &str) -> bool {
+    roots.iter().any(|r| r.ends_with(suffix))
+}
+
+#[test]
+fn source_roots_return_app_and_dev_roots_deduped() {
+    // Both `autoload` (App\ → app/) and `autoload-dev` (Tests\ → tests/) roots
+    // are surfaced; installed.json vendor roots are NOT.
+    let composer = r#"{
+        "autoload": { "psr-4": { "App\\": "app/" } },
+        "autoload-dev": { "psr-4": { "Tests\\": "tests/" } }
+    }"#;
+    let installed = r#"{
+        "packages": [
+            {
+                "name": "acme/pkg",
+                "autoload": { "psr-4": { "Acme\\Pkg\\": "src/" } },
+                "install-path": "../acme/pkg"
+            }
+        ]
+    }"#;
+    let (_dir, root) = project_with_files(&[
+        ("composer.json", composer),
+        ("app/Models/User.php", "<?php"),
+        ("tests/Feature/ExampleTest.php", "<?php"),
+        ("vendor/composer/installed.json", installed),
+        ("vendor/acme/pkg/src/Thing.php", "<?php"),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let roots = autoload.project_source_roots();
+
+    assert!(
+        has_root_ending(&roots, "app"),
+        "app root missing: {roots:?}"
+    );
+    assert!(
+        has_root_ending(&roots, "tests"),
+        "autoload-dev tests root missing: {roots:?}"
+    );
+    assert!(
+        !roots
+            .iter()
+            .any(|r| r.components().any(|c| c.as_os_str() == "vendor")),
+        "vendor package roots must be excluded: {roots:?}"
+    );
+}
+
+#[test]
+fn source_roots_drop_subsumed_nested_root() {
+    // `App\Models\` → app/Models is nested under `App\` → app; only the
+    // shallowest survives, its recursive glob already covers the nested one.
+    let composer = r#"{
+        "autoload": {
+            "psr-4": {
+                "App\\": "app/",
+                "App\\Models\\": "app/Models/"
+            }
+        }
+    }"#;
+    let (_dir, root) = project_with_files(&[
+        ("composer.json", composer),
+        ("app/Models/User.php", "<?php"),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let roots = autoload.project_source_roots();
+
+    assert!(
+        has_root_ending(&roots, "app"),
+        "app root missing: {roots:?}"
+    );
+    assert!(
+        !has_root_ending(&roots, "app/Models"),
+        "nested app/Models root must be subsumed: {roots:?}"
+    );
+}
+
+#[test]
+fn source_roots_skip_root_equal_to_project_and_nonexistent_dirs() {
+    // `Root\\` → "" resolves to the project root itself (whose `**/*.php` would
+    // sweep storage/compiled Blade) — skipped. `Ghost\\` → ghost/ doesn't
+    // exist on disk — skipped. `App\\` → app/ survives.
+    let composer = r#"{
+        "autoload": {
+            "psr-4": {
+                "Root\\": "",
+                "Ghost\\": "ghost/",
+                "App\\": "app/"
+            }
+        }
+    }"#;
+    let (_dir, root) = project_with_files(&[
+        ("composer.json", composer),
+        ("app/Models/User.php", "<?php"),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let roots = autoload.project_source_roots();
+
+    assert_eq!(roots.len(), 1, "only app/ should survive: {roots:?}");
+    assert!(
+        has_root_ending(&roots, "app"),
+        "app root missing: {roots:?}"
+    );
+}
+
+#[test]
+fn source_roots_drop_root_escaping_project_via_containment_guard() {
+    // The fail-closed `path_within_root` guard must drop a PSR-4 value that
+    // escapes the project — even one pointing at a directory that really exists
+    // (so `is_dir` alone wouldn't catch it). `outside` is a sibling tempdir
+    // (absolute, on-disk, outside the project root); a `PathBuf::join` of an
+    // absolute value replaces the base, so `Evil\\` maps straight to it. A
+    // regression removing the containment guard would let it through and fail
+    // this test.
+    let outside = TempDir::new().unwrap();
+    let composer = format!(
+        r#"{{ "autoload": {{ "psr-4": {{ "Evil\\": "{}", "App\\": "app/" }} }} }}"#,
+        outside.path().display()
+    );
+    let (_dir, root) = project_with_files(&[
+        ("composer.json", &composer),
+        ("app/Models/User.php", "<?php"),
+    ]);
+    let autoload = ComposerAutoload::load(&root);
+    let roots = autoload.project_source_roots();
+
+    assert!(
+        has_root_ending(&roots, "app"),
+        "app root missing: {roots:?}"
+    );
+    let outside_canon = outside
+        .path()
+        .canonicalize()
+        .unwrap_or_else(|_| outside.path().to_path_buf());
+    assert!(
+        !roots.iter().any(|r| {
+            let rc = r.canonicalize().unwrap_or_else(|_| r.clone());
+            rc.starts_with(&outside_canon)
+        }),
+        "an escaping PSR-4 root must be dropped by the containment guard: {roots:?}"
+    );
+}

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, RwLock};
 use tracing::{debug, info, warn};
 
 /// Read a string column from a sqlx Row, falling back to a `Vec<u8>` +
@@ -184,6 +184,269 @@ fn classify_postgres_error(raw_error: &str, db_name: &str, candidates_str: &str)
     )
 }
 
+/// How long the circuit breaker stays open after a failed schema fetch
+/// before allowing a single half-open probe. A fixed cooldown (deliberately
+/// NOT exponential): every connection-failure class behaves identically —
+/// tune this one constant if 30s proves too eager or too lazy. Also the
+/// background loop's retry cadence while the DB is down.
+pub const DB_BREAKER_COOLDOWN: Duration = Duration::from_secs(30);
+
+/// Steady-state refresh interval for the background loop when the DB is
+/// healthy. Matches [`DatabaseSchema::is_valid`]'s 60s TTL so the served
+/// cache is never more than one interval stale.
+pub const DB_REFRESH_HEALTHY_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Connect/acquire timeout for the background schema fetch. Only the
+/// detached background loop ever connects — interactive requests read the
+/// in-memory cache and never block — so this can afford to be patient.
+pub const DB_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Extra budget, on top of [`DB_CONNECT_TIMEOUT`], for the post-connect
+/// schema queries (identity probe + SHOW TABLES/COLUMNS and the
+/// per-driver equivalents). The whole background fetch is wrapped in a
+/// `timeout` of `DB_CONNECT_TIMEOUT + DB_FETCH_QUERY_BUDGET` so a
+/// connected-but-stalled server can never hang the loop forever — it
+/// always reaches success/failure/timeout and updates the breaker.
+/// Sized well above the ~2.5s a 600-table schema costs.
+pub const DB_FETCH_QUERY_BUDGET: Duration = Duration::from_secs(30);
+
+/// What a caller may do right now, per [`CircuitBreaker::allow_attempt`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Attempt {
+    /// Breaker closed — normal fetch allowed.
+    Closed,
+    /// Breaker open (cooling down, or a probe is already in flight) — deny;
+    /// return "no schema" without touching the database.
+    Open,
+    /// Cooldown elapsed — this caller is the single half-open probe.
+    HalfOpen,
+}
+
+/// Internal breaker state. `Open` and `HalfOpen` both carry the instant the
+/// state was entered so time-based transitions are pure functions of the
+/// injected `now`.
+#[derive(Debug, Clone, Copy)]
+enum BreakerState {
+    Closed,
+    Open { since: Instant },
+    HalfOpen { since: Instant },
+}
+
+/// Pure, synchronous, time-injected circuit breaker guarding database
+/// schema fetches.
+///
+/// With the database down, every completion/diagnostic/pre-warm used to
+/// reconnect and pay the full connect timeout. The breaker makes failure
+/// cheap: after any failed fetch it opens for [`DB_BREAKER_COOLDOWN`],
+/// during which attempts are denied instantly. After the cooldown exactly
+/// one half-open probe is allowed through; success closes the breaker,
+/// failure re-opens it for another cooldown.
+///
+/// All transitions take `now: Instant` as a parameter — no clocks, no
+/// async, no I/O — so the whole state machine is unit-testable without a
+/// database (see `database/tests.rs`).
+#[derive(Debug)]
+pub struct CircuitBreaker {
+    state: BreakerState,
+    cooldown: Duration,
+}
+
+impl CircuitBreaker {
+    pub fn new(cooldown: Duration) -> Self {
+        Self {
+            state: BreakerState::Closed,
+            cooldown,
+        }
+    }
+
+    /// Gate a fetch attempt. Returns [`Attempt::HalfOpen`] at most once per
+    /// cooldown window: the transition to `HalfOpen` happens here, so a
+    /// second caller arriving while the probe is outstanding gets
+    /// [`Attempt::Open`].
+    ///
+    /// A probe that never reports back (a fetch path that returns `None`
+    /// without recording failure, or a hung connect) would otherwise wedge
+    /// the breaker in `HalfOpen` forever — so an aged-out `HalfOpen` re-arms
+    /// into a fresh probe after another cooldown. Self-healing by
+    /// construction.
+    pub fn allow_attempt(&mut self, now: Instant) -> Attempt {
+        match self.state {
+            BreakerState::Closed => Attempt::Closed,
+            BreakerState::Open { since } | BreakerState::HalfOpen { since } => {
+                if now.duration_since(since) >= self.cooldown {
+                    self.state = BreakerState::HalfOpen { since: now };
+                    Attempt::HalfOpen
+                } else {
+                    Attempt::Open
+                }
+            }
+        }
+    }
+
+    /// Record a failed fetch. Returns `true` only on the Closed→Open
+    /// transition — the FIRST failure of a new outage episode, i.e. the
+    /// moment to notify the user. A failed half-open probe re-opens the
+    /// breaker but returns `false`: same outage, no fresh notification.
+    pub fn record_failure(&mut self, now: Instant) -> bool {
+        let just_opened = matches!(self.state, BreakerState::Closed);
+        self.state = BreakerState::Open { since: now };
+        just_opened
+    }
+
+    /// Record a successful fetch: close the breaker from any state. Returns
+    /// `true` only on a genuine recovery edge — Open/HalfOpen→Closed — the
+    /// moment to tell the user the DB is back. Returns `false` when already
+    /// Closed (a routine healthy refresh, or the very first successful fetch
+    /// from a fresh breaker), so startup and steady-state refreshes stay
+    /// silent. Mirrors [`Self::record_failure`]'s Closed→Open edge return.
+    /// The next failure after this is a NEW outage episode (fresh toast).
+    pub fn record_success(&mut self) -> bool {
+        let recovered = matches!(
+            self.state,
+            BreakerState::Open { .. } | BreakerState::HalfOpen { .. }
+        );
+        self.state = BreakerState::Closed;
+        recovered
+    }
+
+    /// How long until the breaker would next allow an attempt, given `now`.
+    /// Drives the background refresh loop's sleep so it wakes exactly when
+    /// the next half-open probe is due:
+    /// - `None` — closed (healthy); the caller sleeps its own steady-state
+    ///   refresh interval.
+    /// - `Some(d)` — open/half-open; `d` is the remaining cooldown before
+    ///   the next probe (saturating to zero once elapsed).
+    pub fn cooldown_remaining(&self, now: Instant) -> Option<Duration> {
+        match self.state {
+            BreakerState::Closed => None,
+            BreakerState::Open { since } | BreakerState::HalfOpen { since } => {
+                Some(self.cooldown.saturating_sub(now.duration_since(since)))
+            }
+        }
+    }
+}
+
+/// Coarse classification of a database connection failure. The breaker's
+/// backoff is UNIFORM across classes — only the user-facing notification
+/// text differs (see [`outage_toast_message`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutageClass {
+    /// Scenario 1: the server couldn't be reached at all — DNS failure,
+    /// connection refused, or a connect timeout.
+    Unreachable,
+    /// Scenario 2: the server was reached but the connection was rejected —
+    /// bad credentials, unknown database, missing privileges.
+    Rejected,
+    /// Scenario 0: no usable database configuration. A normal state for
+    /// projects without a DB — never notified.
+    NotConfigured,
+    /// Anything else — notified with a generic message.
+    Other,
+}
+
+/// Classify a RAW driver error string (before the per-driver classifiers
+/// compose their remediation-rich messages) into an [`OutageClass`].
+/// Substring matching on well-known driver/OS error markers, lowercased for
+/// robustness — the same pragmatic approach `classify_mysql_error` takes,
+/// and for the same reason: by this layer the error is already a `String`.
+pub fn outage_class_from_raw(raw_error: &str) -> OutageClass {
+    let raw = raw_error.to_lowercase();
+    // Auth / unknown-database / privilege markers across MySQL (1045, 1044,
+    // 1049), Postgres (28P01, 28000, 3D000), and SQL Server ("Login failed").
+    const REJECTED: &[&str] = &[
+        "access denied",
+        "1045 (28000)",
+        "1044 (42000)",
+        "1049 (42000)",
+        "unknown database",
+        "28p01",
+        "28000",
+        "3d000",
+        "password authentication failed",
+        "login failed",
+        "does not exist",
+    ];
+    // Network-level markers: TCP refused/reset, DNS lookup failures, and
+    // timeouts (sqlx reports a connect that exceeds `acquire_timeout` as
+    // "pool timed out while waiting for an open connection").
+    const UNREACHABLE: &[&str] = &[
+        "connection refused",
+        "2003",
+        "could not connect",
+        "timed out",
+        "timeout",
+        "failed to lookup address",
+        "name or service not known",
+        "nodename nor servname",
+        "no route to host",
+        "network is unreachable",
+        "connection reset",
+        "broken pipe",
+    ];
+    if REJECTED.iter().any(|m| raw.contains(m)) {
+        return OutageClass::Rejected;
+    }
+    if UNREACHABLE.iter().any(|m| raw.contains(m)) {
+        return OutageClass::Unreachable;
+    }
+    OutageClass::Other
+}
+
+/// The one-per-outage toast text for a breaker Closed→Open transition, or
+/// `None` for classes that must stay silent (a project without a database
+/// is a normal state, not an outage).
+///
+/// `detail` is the remediation-rich message the per-driver classifiers
+/// composed (it names the exact endpoints tried, which is more truthful
+/// than a single host:port when Sail fallbacks are in play).
+pub fn outage_toast_message(class: OutageClass, detail: &str) -> Option<String> {
+    let retry = DB_BREAKER_COOLDOWN.as_secs();
+    match class {
+        OutageClass::NotConfigured => None,
+        OutageClass::Unreachable => Some(format!(
+            "Laravel: can't reach the database — is it running? DB-aware \
+             completions and diagnostics are disabled until it's reachable \
+             (the LSP retries every {retry}s). {detail}"
+        )),
+        OutageClass::Rejected => Some(format!(
+            "Laravel: reached the database but the connection was rejected — \
+             check the credentials and that the database exists. DB-aware \
+             completions and diagnostics are disabled until it connects \
+             (the LSP retries every {retry}s). {detail}"
+        )),
+        OutageClass::Other => Some(format!(
+            "Laravel: database connection failed, so DB-aware completions \
+             and diagnostics are disabled until it recovers (the LSP \
+             retries every {retry}s). {detail}"
+        )),
+    }
+}
+
+/// Details of an outage — emitted when the breaker transitions Closed→Open
+/// (the start of an outage episode).
+#[derive(Debug, Clone)]
+pub struct DbOutageEvent {
+    pub class: OutageClass,
+    /// The classified, remediation-rich error message from the driver layer.
+    pub message: String,
+}
+
+/// A breaker edge worth telling the user about. The provider can't talk
+/// LSP, so `main.rs` listens on a channel of these and sends the (single)
+/// toast for each edge, no matter which caller — pre-warm, completion,
+/// diagnostics, hover — drove the breaker there.
+///
+/// Both edges fire exactly once per transition: `Outage` on Closed→Open
+/// (retry probes inside the same outage are silent), `Reconnected` on
+/// Open/HalfOpen→Closed (a routine already-healthy refresh is silent).
+#[derive(Debug, Clone)]
+pub enum DbBreakerEvent {
+    /// The database just became unreachable/unusable.
+    Outage(DbOutageEvent),
+    /// The database just came back after an outage.
+    Reconnected,
+}
+
 /// Build the `user[:password]` userinfo segment of a `driver://userinfo@…`
 /// connection URL.
 ///
@@ -250,6 +513,45 @@ struct ConnCandidate {
     success_note: Option<String>,
 }
 
+/// A Sail/Docker TCP endpoint detected for the database — the host-side bind
+/// IP and forwarded port, plus a note on how it was found (compose file or
+/// APP_PORT). Produced by [`DatabaseSchemaProvider::detect_sail_endpoint`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DetectedEndpoint {
+    host: String,
+    port: u16,
+    note: String,
+}
+
+/// Count a line's leading spaces (YAML indentation). Tabs are not valid YAML
+/// indentation; a line indented with tabs yields 0 here and simply fails the
+/// indentation checks — fail-open, never a panic.
+fn indent_spaces(line: &str) -> usize {
+    line.chars().take_while(|c| *c == ' ').count()
+}
+
+/// Is `trimmed` a `key:` line that INTRODUCES a nested block (rather than a
+/// `key: value` scalar)? Used to match `services:`, a service header, and
+/// `ports:`. A block is introduced when what follows the `:` is empty, a
+/// `#` comment, or a YAML tag (`!`-prefixed, e.g. `ports: !override` /
+/// `!reset` — standard in Sail override files — or `!!seq`): the tag
+/// annotates the block on the lines below, so `ports: !override` IS the
+/// `ports:` key. A plain inline scalar (`ports: 3306:3306`) is still rejected.
+fn line_is_key(trimmed: &str, key: &str) -> bool {
+    match trimmed.strip_prefix(key) {
+        Some(rest) => {
+            let rest = rest.trim_start();
+            if let Some(after) = rest.strip_prefix(':') {
+                let after = after.trim_start();
+                after.is_empty() || after.starts_with('#') || after.starts_with('!')
+            } else {
+                false
+            }
+        }
+        None => false,
+    }
+}
+
 /// Cached database schema with expiration
 #[derive(Debug, Clone)]
 pub struct DatabaseSchema {
@@ -304,7 +606,13 @@ pub struct DatabaseConnectionError {
     pub driver: String,
 }
 
-/// Database schema provider with caching
+/// Database schema provider with caching.
+///
+/// `Clone` is cheap and share-state: every field is an `Arc` (or a
+/// `PathBuf`), so a clone is the same logical provider — same cache, same
+/// breaker. This lets callers lift the handle out of an
+/// `Arc<RwLock<Option<…>>>` guard and drop the guard before an await.
+#[derive(Clone)]
 pub struct DatabaseSchemaProvider {
     /// Project root path
     project_root: PathBuf,
@@ -316,6 +624,16 @@ pub struct DatabaseSchemaProvider {
     last_error: Arc<RwLock<Option<DatabaseConnectionError>>>,
     /// Whether we've attempted a connection
     connection_attempted: Arc<RwLock<bool>>,
+    /// Circuit breaker guarding schema fetches. Lives ENTIRELY in the
+    /// background refresh loop (`refresh_tick`) — interactive callers never
+    /// touch it. After a failed fetch the loop opens the breaker and backs
+    /// off; interactive reads just see a stale/absent cache. See
+    /// [`CircuitBreaker`].
+    breaker: Arc<RwLock<CircuitBreaker>>,
+    /// Where breaker edges are announced — one `Outage` per outage episode,
+    /// one `Reconnected` per recovery. `None` until `main.rs` wires the
+    /// toast listener.
+    event_tx: Arc<RwLock<Option<mpsc::UnboundedSender<DbBreakerEvent>>>>,
 }
 
 impl DatabaseSchemaProvider {
@@ -327,7 +645,15 @@ impl DatabaseSchemaProvider {
             config_cache: Arc::new(RwLock::new(None)),
             last_error: Arc::new(RwLock::new(None)),
             connection_attempted: Arc::new(RwLock::new(false)),
+            breaker: Arc::new(RwLock::new(CircuitBreaker::new(DB_BREAKER_COOLDOWN))),
+            event_tx: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Register the channel on which breaker edges (`Outage` / `Reconnected`)
+    /// are announced. Called once by the LSP layer when the provider is set up.
+    pub async fn set_event_channel(&self, tx: mpsc::UnboundedSender<DbBreakerEvent>) {
+        *self.event_tx.write().await = Some(tx);
     }
 
     /// Test helper: seed the schema cache directly so tests can exercise
@@ -358,43 +684,134 @@ impl DatabaseSchemaProvider {
         *self.connection_attempted.read().await
     }
 
-    /// Set connection error
-    async fn set_error(&self, driver: &str, message: &str) {
+    /// Record a failed fetch: store the error for `get_last_error`, feed
+    /// the circuit breaker, and — exactly when this failure OPENS the
+    /// breaker (Closed→Open, the first failure of an outage episode) —
+    /// announce it on the outage channel. Failed half-open probes while
+    /// the outage continues re-open the breaker silently, so the user
+    /// sees ONE notification per outage, not one per retry.
+    ///
+    /// Every driver's failure path funnels through here, which is what
+    /// makes the breaker cover mysql/pgsql/sqlite/sqlsrv with one hook.
+    async fn set_error(&self, driver: &str, message: &str, class: OutageClass) {
         *self.last_error.write().await = Some(DatabaseConnectionError {
             message: message.to_string(),
             driver: driver.to_string(),
         });
-    }
-
-    /// Clear connection error
-    async fn clear_error(&self) {
-        *self.last_error.write().await = None;
-    }
-
-    /// Get database schema, using cache if valid
-    pub async fn get_schema(&self) -> Option<DatabaseSchema> {
-        // Check cache first
-        {
-            let cache = self.schema_cache.read().await;
-            if let Some(ref schema) = *cache {
-                if schema.is_valid() {
-                    debug!("Using cached database schema");
-                    return Some(schema.clone());
-                }
+        let just_opened = self.breaker.write().await.record_failure(Instant::now());
+        if just_opened {
+            if let Some(tx) = self.event_tx.read().await.as_ref() {
+                let _ = tx.send(DbBreakerEvent::Outage(DbOutageEvent {
+                    class,
+                    message: message.to_string(),
+                }));
             }
         }
+    }
 
-        // Cache miss or expired, fetch fresh schema
-        info!("Fetching fresh database schema");
-        let schema = self.fetch_schema().await?;
-
-        // Update cache
-        {
-            let mut cache = self.schema_cache.write().await;
-            *cache = Some(schema.clone());
+    /// Record a successful fetch: clear the stored error and close the
+    /// breaker. On a genuine recovery edge (Open/HalfOpen→Closed) announce
+    /// `Reconnected` on the channel — exactly once per outage→recovery
+    /// cycle. A routine already-healthy refresh closes silently. A later
+    /// failure then counts as a NEW outage episode (fresh toast).
+    async fn clear_error(&self) {
+        *self.last_error.write().await = None;
+        let recovered = self.breaker.write().await.record_success();
+        if recovered {
+            if let Some(tx) = self.event_tx.read().await.as_ref() {
+                let _ = tx.send(DbBreakerEvent::Reconnected);
+            }
         }
+    }
 
-        Some(schema)
+    /// Get the database schema **from the in-memory cache only** — the
+    /// interactive read path.
+    ///
+    /// This is called from LSP request handlers (completion, diagnostics,
+    /// hover, exists/unique). tower-lsp dispatches at most a handful of
+    /// handlers concurrently, so a handler that blocked on a DB connect
+    /// would starve unrelated requests (a plain view/route hover froze for
+    /// ~30s during an outage — the isolation bug this design fixes).
+    /// Therefore this method NEVER connects, NEVER touches the breaker or a
+    /// lock, and NEVER blocks: it returns the last-known-good schema
+    /// (served stale on purpose — the background loop keeps it fresh) or
+    /// `None` on a cold miss. All connecting happens off the request path
+    /// in [`Self::refresh_tick`].
+    pub async fn get_schema(&self) -> Option<DatabaseSchema> {
+        self.schema_cache.read().await.clone()
+    }
+
+    /// One iteration of the background refresh loop — the ONLY place that
+    /// connects. Returns how long the caller should sleep before the next
+    /// tick.
+    ///
+    /// Flow: consult the breaker; if it allows (closed, or a half-open
+    /// probe is due), run a whole-fetch-timeout-bounded fetch. Success
+    /// fills the cache and closes the breaker (via `clear_error`); failure
+    /// or timeout opens it (via `set_error`) and emits the one-per-outage
+    /// event on the Closed→Open edge. The next sleep is derived from the
+    /// resulting breaker state: [`DB_BREAKER_COOLDOWN`] while open (the
+    /// retry/HalfOpen cadence), `healthy_interval` while closed.
+    ///
+    /// Detached from any tower-lsp request slot, so a slow or stalled fetch
+    /// here can never starve interactive requests.
+    pub async fn refresh_tick(
+        &self,
+        connect_timeout: Duration,
+        healthy_interval: Duration,
+    ) -> Duration {
+        let attempt = self.breaker.write().await.allow_attempt(Instant::now());
+        if attempt != Attempt::Open {
+            self.fetch_and_store(connect_timeout).await;
+        }
+        self.breaker
+            .read()
+            .await
+            .cooldown_remaining(Instant::now())
+            .unwrap_or(healthy_interval)
+    }
+
+    /// Background-only: run one whole-fetch-timeout-bounded fetch and, on
+    /// success, publish it to the interactive cache. The timeout bounds the
+    /// ENTIRE fetch — connect AND the post-connect identity probe / schema
+    /// queries — so a connected-but-stalled server can't wedge the loop; on
+    /// timeout we record a failure so the breaker opens and the loop backs
+    /// off. `set_error` / `clear_error` inside `fetch_schema` drive the
+    /// breaker + notification; the timeout branch records the failure the
+    /// cancelled fetch never got to. Returns whether the cache was updated.
+    async fn fetch_and_store(&self, connect_timeout: Duration) -> bool {
+        let budget = connect_timeout + DB_FETCH_QUERY_BUDGET;
+        self.run_bounded_fetch(budget, self.fetch_schema(connect_timeout))
+            .await
+    }
+
+    /// Apply the whole-fetch timeout and cache/breaker bookkeeping to an
+    /// arbitrary fetch future. Split out from [`Self::fetch_and_store`] so
+    /// the timeout→breaker-open path is unit-testable with an injected slow
+    /// future (no live DB needed).
+    async fn run_bounded_fetch<F>(&self, budget: Duration, fetch: F) -> bool
+    where
+        F: std::future::Future<Output = Option<DatabaseSchema>>,
+    {
+        match tokio::time::timeout(budget, fetch).await {
+            Ok(Some(schema)) => {
+                *self.schema_cache.write().await = Some(schema);
+                true
+            }
+            // fetch_schema already recorded the error (set_error) on the way out.
+            Ok(None) => false,
+            Err(_) => {
+                let msg = format!(
+                    "Database schema fetch timed out after {budget:?} — the server \
+                     accepted a connection but a schema query stalled. Check the \
+                     database server's health / load."
+                );
+                warn!("{}", msg);
+                self.set_error("timeout", &msg, OutageClass::Unreachable)
+                    .await;
+                false
+            }
+        }
     }
 
     /// Get list of table names
@@ -525,29 +942,43 @@ impl DatabaseSchemaProvider {
         info!("Database schema cache invalidated");
     }
 
-    /// Fetch fresh schema from database
-    async fn fetch_schema(&self) -> Option<DatabaseSchema> {
+    /// Fetch fresh schema from database. `connect_timeout` bounds
+    /// connection establishment for every driver (sqlx `acquire_timeout`;
+    /// explicit `tokio::time::timeout` for tiberius, which has no built-in
+    /// connect timeout and would otherwise hang on the OS default for an
+    /// unreachable host).
+    async fn fetch_schema(&self, connect_timeout: Duration) -> Option<DatabaseSchema> {
         // Mark that we've attempted a connection
         *self.connection_attempted.write().await = true;
 
         let config = match self.get_database_config().await {
             Some(c) => c,
             None => {
-                self.set_error("unknown", "Database configuration not found in .env")
-                    .await;
+                // Scenario 0 — no DB configured. The breaker still opens
+                // (don't re-parse config every request) but the class keeps
+                // the notification silent: this is a normal state.
+                self.set_error(
+                    "unknown",
+                    "Database configuration not found in .env",
+                    OutageClass::NotConfigured,
+                )
+                .await;
                 return None;
             }
         };
 
         let result = match config.driver.as_str() {
-            "mysql" | "mariadb" => self.fetch_mysql_schema(&config).await,
-            "pgsql" | "postgres" => self.fetch_postgres_schema(&config).await,
-            "sqlite" => self.fetch_sqlite_schema(&config).await,
-            "sqlsrv" => self.fetch_sqlserver_schema(&config).await,
+            "mysql" | "mariadb" => self.fetch_mysql_schema(&config, connect_timeout).await,
+            "pgsql" | "postgres" => self.fetch_postgres_schema(&config, connect_timeout).await,
+            "sqlite" => self.fetch_sqlite_schema(&config, connect_timeout).await,
+            "sqlsrv" => self.fetch_sqlserver_schema(&config, connect_timeout).await,
             _ => {
+                // Not a connection outage — the LSP simply can't speak this
+                // driver. Silent (NotConfigured), the warn! log tells the story.
                 self.set_error(
                     &config.driver,
                     &format!("Unsupported database driver: {}", config.driver),
+                    OutageClass::NotConfigured,
                 )
                 .await;
                 warn!("Unsupported database driver: {}", config.driver);
@@ -727,38 +1158,71 @@ impl DatabaseSchemaProvider {
         })
     }
 
-    /// Extract the connection block for a specific driver from config/database.php
-    fn extract_connection_block(&self, content: &str, driver: &str) -> Option<String> {
-        // Find 'driver_name' => [
-        let pattern = format!(r#"['"]{driver}['"]\s*=>\s*\["#);
-        let regex = Regex::new(&pattern).ok()?;
+    /// Extract the connection block for a specific connection name from
+    /// config/database.php.
+    ///
+    /// Two forms are supported:
+    /// 1. **Inline array** (the common case) — `'mysql' => [ ... ]`.
+    /// 2. **Variable reference** — `'mysql' => $mysql`, where the block is
+    ///    defined elsewhere as `$mysql = [ ... ]`. Laravel apps (Sail's own
+    ///    published `config/database.php` among them) often factor a
+    ///    connection into a `$mysql` variable and reference it in
+    ///    `'connections' => [ 'mysql' => $mysql ]`. Without this, the block
+    ///    came back empty and EVERY setting (host, database, credentials)
+    ///    silently fell back to hardcoded defaults, ignoring `.env`.
+    ///
+    /// Fails open (returns `None`) when neither form matches — the caller
+    /// then uses its hardcoded defaults, the prior behaviour.
+    fn extract_connection_block(&self, content: &str, connection: &str) -> Option<String> {
+        let name = regex::escape(connection);
 
-        let match_start = regex.find(content)?.end();
+        // Form 1: inline array — `'mysql' => [`.
+        let inline = format!(r#"['"]{name}['"]\s*=>\s*\["#);
+        if let Ok(re) = Regex::new(&inline) {
+            if let Some(m) = re.find(content) {
+                if let Some(block) = Self::extract_bracketed_block(content, m.end()) {
+                    return Some(block);
+                }
+            }
+        }
 
-        // Find the matching closing bracket
-        let remaining = &content[match_start..];
+        // Form 2: variable reference — `'mysql' => $mysql` → find `$mysql = [`.
+        let var_ref = format!(r#"['"]{name}['"]\s*=>\s*\$([A-Za-z_]\w*)"#);
+        let var_name = Regex::new(&var_ref)
+            .ok()?
+            .captures(content)?
+            .get(1)?
+            .as_str()
+            .to_string();
+
+        // Locate the variable's array definition. Requiring `= [` here means a
+        // definition that is itself a bare `$other` (an alias) does NOT match —
+        // one level of resolution only, so there's no self-reference loop.
+        let def = format!(r#"\${}\s*=\s*\["#, regex::escape(&var_name));
+        let def_match = Regex::new(&def).ok()?.find(content)?;
+        Self::extract_bracketed_block(content, def_match.end())
+    }
+
+    /// Given `content` and a byte offset pointing just PAST an opening `[`,
+    /// return the substring up to (not including) the matching `]` via
+    /// bracket-depth counting, or `None` if unbalanced. `char_indices` keeps
+    /// the slice boundary on a valid char boundary; brackets are ASCII.
+    fn extract_bracketed_block(content: &str, after_open_bracket: usize) -> Option<String> {
+        let remaining = content.get(after_open_bracket..)?;
         let mut depth = 1;
-        let mut end_pos = 0;
-
-        for (i, c) in remaining.chars().enumerate() {
+        for (i, c) in remaining.char_indices() {
             match c {
                 '[' => depth += 1,
                 ']' => {
                     depth -= 1;
                     if depth == 0 {
-                        end_pos = i;
-                        break;
+                        return Some(remaining[..i].to_string());
                     }
                 }
                 _ => {}
             }
         }
-
-        if end_pos > 0 {
-            Some(remaining[..end_pos].to_string())
-        } else {
-            None
-        }
+        None
     }
 
     /// Parse an optional setting from the connection block. Same env() chain
@@ -998,7 +1462,11 @@ impl DatabaseSchemaProvider {
     /// 3. **TCP** with the configured host, plus a `127.0.0.1` fallback
     ///    for Sail / Docker Compose setups where the configured host is a
     ///    container service name unresolvable from outside Docker.
-    async fn fetch_mysql_schema(&self, config: &DatabaseConfig) -> Option<DatabaseSchema> {
+    async fn fetch_mysql_schema(
+        &self,
+        config: &DatabaseConfig,
+        connect_timeout: Duration,
+    ) -> Option<DatabaseSchema> {
         use sqlx::mysql::MySqlPoolOptions;
         use sqlx::Row;
 
@@ -1019,7 +1487,7 @@ impl DatabaseSchemaProvider {
             );
             match MySqlPoolOptions::new()
                 .max_connections(1)
-                .acquire_timeout(Duration::from_secs(5))
+                .acquire_timeout(connect_timeout)
                 .connect(&cand.url)
                 .await
             {
@@ -1061,7 +1529,8 @@ impl DatabaseSchemaProvider {
                 let raw_err = last_err.unwrap_or_else(|| "(no error captured)".to_string());
                 let msg = classify_mysql_error(&raw_err, &config.database, &candidates_str);
                 warn!("{}", msg);
-                self.set_error("mysql", &msg).await;
+                self.set_error("mysql", &msg, outage_class_from_raw(&raw_err))
+                    .await;
                 return None;
             }
         };
@@ -1258,21 +1727,460 @@ impl DatabaseSchemaProvider {
         })
     }
 
+    /// Does `host` look like a Docker Compose service name (rather than a
+    /// real hostname or IP)? Service names are the trigger for the Sail
+    /// fallbacks: bare word, no dots, not `localhost`, not `127.0.0.1`.
+    /// From the LSP's vantage point (outside the Docker network) a service
+    /// name doesn't resolve, so we look for a mapped host port instead.
+    fn is_docker_service_name(host: &str) -> bool {
+        !host.is_empty()
+            && !host.contains('.')
+            && !host.eq_ignore_ascii_case("localhost")
+            && host != "127.0.0.1"
+    }
+
+    /// Should Sail/Docker bind-IP detection run for this host?
+    ///
+    /// A superset of [`Self::is_docker_service_name`] that ALSO covers a
+    /// plain loopback primary — `127.0.0.1` or `localhost`. Those are the
+    /// default when `DB_HOST` is unset, yet the DB may actually live on
+    /// another loopback IP (Herd owns `127.0.0.1`, so Sail is pinned to
+    /// `127.0.0.2` via `APP_PORT`). Detection then adds the real
+    /// `127.0.0.2` endpoint after the literal primary.
+    ///
+    /// Deliberately does NOT run for an explicit non-loopback host — a real
+    /// IP (`192.168.x`, a public IP), a domain, or an explicit `127.0.0.2`:
+    /// the user named the endpoint precisely, so we honour it verbatim
+    /// (`is_docker_service_name` already rejects dotted hosts).
+    fn should_attempt_sail_detection(host: &str) -> bool {
+        Self::is_docker_service_name(host)
+            || host.eq_ignore_ascii_case("localhost")
+            || host == "127.0.0.1"
+    }
+
     /// Build the ordered list of host candidates to try. The primary
     /// (configured) host is always first; if it looks like a Docker Compose
-    /// service name (no dots, not `localhost`) we add `127.0.0.1` as a
-    /// fallback so Sail / Docker Compose setups work without the LSP needing
-    /// to be inside the Docker network.
+    /// service name we add `127.0.0.1` as a backstop so Sail / Docker
+    /// Compose setups work without the LSP needing to be inside the Docker
+    /// network.
     fn host_candidates(primary: &str) -> Vec<String> {
         let mut candidates = vec![primary.to_string()];
-        if !primary.is_empty()
-            && !primary.contains('.')
-            && !primary.eq_ignore_ascii_case("localhost")
-            && primary != "127.0.0.1"
-        {
+        if Self::is_docker_service_name(primary) {
             candidates.push("127.0.0.1".to_string());
         }
         candidates
+    }
+
+    /// The ordered `(host, port, success_note)` TCP endpoints to try, shared
+    /// by the MySQL and Postgres candidate builders:
+    /// 1. the configured `host:port` (primary),
+    /// 2. any Sail/Docker endpoint detected from a compose file or APP_PORT
+    ///    (see [`Self::detect_sail_endpoint`]) — this is what finds a DB
+    ///    bound to a non-`127.0.0.1` loopback IP like `127.0.0.2`,
+    /// 3. the `127.0.0.1` backstop (present only for service-name hosts).
+    ///
+    /// Deduplicated on `(host, port)` so a detected `127.0.0.1:<port>`
+    /// doesn't also emit the backstop twice.
+    fn tcp_endpoints(&self, config: &DatabaseConfig) -> Vec<(String, u16, Option<String>)> {
+        const SAIL_BACKSTOP_NOTE: &str =
+            "Looks like a Sail / Docker Compose setup — the LSP runs outside Docker, so the \
+             service hostname doesn't resolve, but the mapped host port on 127.0.0.1 does.";
+
+        let hosts = Self::host_candidates(&config.host);
+        let mut eps: Vec<(String, u16, Option<String>)> = Vec::new();
+
+        // 1. Primary configured host:port.
+        eps.push((hosts[0].clone(), config.port, None));
+
+        // 2. Detected Sail/Docker endpoint (carries its OWN host + port — the
+        //    forwarded host port may differ from the driver's internal port).
+        if let Some(ep) = self.detect_sail_endpoint(config) {
+            if !eps.iter().any(|(h, p, _)| *h == ep.host && *p == ep.port) {
+                eps.push((ep.host, ep.port, Some(ep.note)));
+            }
+        }
+
+        // 3. 127.0.0.1 backstop — only present in `hosts` for service names.
+        for h in hosts.iter().skip(1) {
+            if !eps
+                .iter()
+                .any(|(host, p, _)| host == h && *p == config.port)
+            {
+                eps.push((h.clone(), config.port, Some(SAIL_BACKSTOP_NOTE.to_string())));
+            }
+        }
+
+        eps
+    }
+
+    /// Detect a Sail/Docker TCP endpoint for the database when `config.host`
+    /// is a Docker service name. Mike's setup is the motivating case: Herd
+    /// owns `127.0.0.1`, so Docker/Sail confines every service to
+    /// `127.0.0.2`, and the DB is at `127.0.0.2:3306` — a host the old
+    /// `mysql` service-name + hardcoded `127.0.0.1` candidates never tried.
+    ///
+    /// Layered, first non-empty wins:
+    /// 1. compose override (`docker-compose.override.yml` etc.),
+    /// 2. base compose (`docker-compose.yml` etc.),
+    /// 3. `APP_PORT` in `.env` (e.g. `127.0.0.2:80` → bind IP `127.0.0.2`).
+    ///
+    /// Fails open at every step (returns `None`) — never panics, never
+    /// guesses — so a malformed compose file just falls through to the next
+    /// layer, then to the `127.0.0.1` backstop.
+    fn detect_sail_endpoint(&self, config: &DatabaseConfig) -> Option<DetectedEndpoint> {
+        if !Self::should_attempt_sail_detection(&config.host) {
+            return None;
+        }
+
+        const OVERRIDE: &[&str] = &[
+            "docker-compose.override.yml",
+            "docker-compose.override.yaml",
+            "compose.override.yaml",
+            "compose.override.yml",
+        ];
+        const BASE: &[&str] = &[
+            "docker-compose.yml",
+            "docker-compose.yaml",
+            "compose.yaml",
+            "compose.yml",
+        ];
+
+        self.detect_from_compose_files(config, OVERRIDE)
+            .or_else(|| self.detect_from_compose_files(config, BASE))
+            .or_else(|| self.detect_from_app_port(config))
+    }
+
+    /// Try each compose filename in order; the first that yields a forwarded
+    /// endpoint for the DB service wins.
+    fn detect_from_compose_files(
+        &self,
+        config: &DatabaseConfig,
+        filenames: &[&str],
+    ) -> Option<DetectedEndpoint> {
+        for filename in filenames {
+            let path = self.project_root.join(filename);
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            if let Some((host, port)) = self.parse_compose_ports(&content, config) {
+                debug!("🗄️  Sail detection: {host}:{port} for DB service from {filename}");
+                return Some(DetectedEndpoint {
+                    note: format!(
+                        "Sail / Docker Compose: DB port forwarded to {host}:{port}, \
+                         detected from {filename}."
+                    ),
+                    host,
+                    port,
+                });
+            }
+        }
+        None
+    }
+
+    /// `APP_PORT` (Sail's web-container bind) often carries the loopback IP
+    /// the whole project is pinned to — e.g. `APP_PORT=127.0.0.2:80`. If it
+    /// has an `IP:PORT` shape with a valid IPv4, reuse that IP and pair it
+    /// with the DB's configured port.
+    fn detect_from_app_port(&self, config: &DatabaseConfig) -> Option<DetectedEndpoint> {
+        let app_port = self.resolve_env("APP_PORT")?;
+        let (ip, _web_port) = app_port.split_once(':')?;
+        let host = Self::normalize_bind_ip(ip.trim())?;
+        // A plain 127.0.0.1 bind (or a wildcard that normalises to it) is
+        // already covered by the 127.0.0.1 backstop — which, for a
+        // service-name host, is always present and carries the correct
+        // SAIL_BACKSTOP_NOTE. Emitting it here too would only add a
+        // misattributed "from APP_PORT" note that dedupe then drops. Only a
+        // non-loopback-default bind (e.g. 127.0.0.2) is worth a candidate.
+        if host == "127.0.0.1" {
+            return None;
+        }
+        Some(DetectedEndpoint {
+            note: format!(
+                "Sail / Docker Compose: DB host {host} taken from the APP_PORT bind IP in .env."
+            ),
+            host,
+            port: config.port,
+        })
+    }
+
+    /// Parse a compose file's YAML for the DB service's forwarded host
+    /// endpoint. Targeted, dependency-free, and fail-open: locate
+    /// `services:` → the DB service block (by `config.host`, else the known
+    /// driver service names) → its `ports:` list → the entry whose CONTAINER
+    /// (target) port equals `config.port`, returning that entry's host-side
+    /// `(bind_ip, host_port)`. Returns `None` on any ambiguity.
+    fn parse_compose_ports(&self, content: &str, config: &DatabaseConfig) -> Option<(String, u16)> {
+        let lines: Vec<&str> = content.lines().collect();
+        for name in self.compose_service_names(config) {
+            if let Some(items) = Self::service_ports_items(&lines, &name) {
+                if let Some(ep) = self.select_forwarded_endpoint(&items, config) {
+                    return Some(ep);
+                }
+            }
+        }
+        None
+    }
+
+    /// The service names to look for, in precedence order: the configured
+    /// host first, then the conventional service names for the driver.
+    fn compose_service_names(&self, config: &DatabaseConfig) -> Vec<String> {
+        let mut names = vec![config.host.clone()];
+        let extra: &[&str] = match config.driver.as_str() {
+            "mysql" | "mariadb" => &["mysql", "mariadb"],
+            "pgsql" | "postgres" => &["pgsql", "postgres", "postgresql"],
+            _ => &[],
+        };
+        for e in extra {
+            if !names.iter().any(|n| n == e) {
+                names.push((*e).to_string());
+            }
+        }
+        names
+    }
+
+    /// Extract the raw `(indent, content)` lines of a named service's
+    /// `ports:` list. Indentation-aware, comment/blank tolerant.
+    fn service_ports_items(lines: &[&str], service: &str) -> Option<Vec<(usize, String)>> {
+        let is_skippable = |l: &str| l.trim().is_empty() || l.trim_start().starts_with('#');
+
+        // 1. Top-level `services:` key.
+        let services_idx = lines
+            .iter()
+            .position(|l| indent_spaces(l) == 0 && line_is_key(l.trim_start(), "services"))?;
+
+        // 2. The indent of `services:`'s direct children (first real child).
+        let child_indent = lines[services_idx + 1..]
+            .iter()
+            .find(|l| !is_skippable(l))
+            .map(|l| indent_spaces(l))?;
+        if child_indent == 0 {
+            return None;
+        }
+
+        // 3. Find the service header at `child_indent`.
+        let mut i = services_idx + 1;
+        let mut body_start = None;
+        while i < lines.len() {
+            let line = lines[i];
+            if is_skippable(line) {
+                i += 1;
+                continue;
+            }
+            let ind = indent_spaces(line);
+            if ind < child_indent {
+                break; // left the services block
+            }
+            if ind == child_indent && line_is_key(line.trim_start(), service) {
+                body_start = Some(i + 1);
+                break;
+            }
+            i += 1;
+        }
+        let body_start = body_start?;
+
+        // The service body's direct-child indent (first real line of the
+        // body). `ports:` must live here — matching a bare `ports:` at ANY
+        // deeper indent would read a NESTED one (e.g. under an `x-*` compose
+        // extension field) that textually precedes the real service-level
+        // list, returning a confident wrong binding. The first non-skippable
+        // line after the header is either a body child (deeper) or a sibling/
+        // dedent (<= child_indent, i.e. no body of its own) → None.
+        let body_indent = lines[body_start..]
+            .iter()
+            .find(|l| !is_skippable(l))
+            .map(|l| indent_spaces(l))?;
+        if body_indent <= child_indent {
+            return None;
+        }
+
+        // 4. Find `ports:` at the service body's direct-child indent only.
+        let mut j = body_start;
+        let mut ports = None;
+        while j < lines.len() {
+            let line = lines[j];
+            if is_skippable(line) {
+                j += 1;
+                continue;
+            }
+            let ind = indent_spaces(line);
+            if ind <= child_indent {
+                break; // left the service body
+            }
+            // Skip nested content (deeper than a direct child, e.g. an
+            // `x-meta:` block's own `ports:`); only a direct child counts.
+            if ind == body_indent && line_is_key(line.trim_start(), "ports") {
+                ports = Some((j + 1, ind));
+                break;
+            }
+            j += 1;
+        }
+        let (ports_start, ports_indent) = ports?;
+
+        // 5. Collect the ports list lines (deeper than `ports:`).
+        let mut items = Vec::new();
+        let mut k = ports_start;
+        while k < lines.len() {
+            let line = lines[k];
+            if is_skippable(line) {
+                k += 1;
+                continue;
+            }
+            let ind = indent_spaces(line);
+            if ind <= ports_indent {
+                break;
+            }
+            items.push((ind, line.trim_start().to_string()));
+            k += 1;
+        }
+        (!items.is_empty()).then_some(items)
+    }
+
+    /// Group the ports lines into entries (`-` starts an entry; deeper lines
+    /// continue it) and return the first entry whose container port matches
+    /// `config.port`, as `(bind_ip, host_port)`.
+    fn select_forwarded_endpoint(
+        &self,
+        items: &[(usize, String)],
+        config: &DatabaseConfig,
+    ) -> Option<(String, u16)> {
+        let mut groups: Vec<Vec<String>> = Vec::new();
+        for (_, content) in items {
+            if content.starts_with('-') {
+                groups.push(vec![content.clone()]);
+            } else {
+                // Continuation line: attach to the current entry, or bail if
+                // it appears before any `-` (malformed).
+                groups.last_mut()?.push(content.clone());
+            }
+        }
+        groups
+            .iter()
+            .find_map(|group| self.endpoint_from_group(group, config))
+    }
+
+    /// Parse a single ports entry — short form (`ip:host:container`) or long
+    /// form (`target:`/`published:`/`host_ip:`) — into `(bind_ip, host_port)`
+    /// if its container port matches `config.port`.
+    fn endpoint_from_group(
+        &self,
+        group: &[String],
+        config: &DatabaseConfig,
+    ) -> Option<(String, u16)> {
+        let head = group[0].strip_prefix('-')?.trim();
+        let head_is_field = head
+            .split_once(':')
+            .map(|(k, _)| {
+                matches!(
+                    k.trim(),
+                    "target" | "published" | "host_ip" | "protocol" | "mode" | "name"
+                )
+            })
+            .unwrap_or(false);
+
+        if group.len() > 1 || head.is_empty() || head_is_field {
+            // Long-form mapping: build a small key→value map.
+            let mut map: HashMap<String, String> = HashMap::new();
+            if head_is_field {
+                if let Some((k, v)) = head.split_once(':') {
+                    map.insert(k.trim().to_string(), v.trim().to_string());
+                }
+            }
+            for cont in &group[1..] {
+                if let Some((k, v)) = cont.split_once(':') {
+                    map.insert(k.trim().to_string(), v.trim().to_string());
+                }
+            }
+            self.endpoint_from_longform(&map, config)
+        } else {
+            self.endpoint_from_shortform(head, config)
+        }
+    }
+
+    /// Parse a short-form ports string: `container`, `host:container`, or
+    /// `ip:host:container`, with an optional `/proto` suffix. `${VAR}` and
+    /// `${VAR:-default}` are resolved BEFORE splitting (the `:-` default
+    /// syntax itself contains a colon).
+    fn endpoint_from_shortform(&self, raw: &str, config: &DatabaseConfig) -> Option<(String, u16)> {
+        let unquoted = raw
+            .trim()
+            .trim_matches(|c: char| c == '\'' || c == '"')
+            .trim();
+        let resolved = self.resolve_compose_vars(unquoted);
+        let no_proto = resolved.split('/').next().unwrap_or(&resolved).trim();
+        let parts: Vec<&str> = no_proto.split(':').map(|p| p.trim()).collect();
+
+        let (bind_ip, host_port_str, container_str) = match parts.as_slice() {
+            // A bare container port maps to a RANDOM host port — unusable.
+            [_container] => return None,
+            [host_port, container] => ("", *host_port, *container),
+            [ip, host_port, container] => (*ip, *host_port, *container),
+            _ => return None,
+        };
+
+        let container: u16 = container_str.parse().ok()?;
+        if container != config.port {
+            return None;
+        }
+        let host_port: u16 = host_port_str.parse().ok()?;
+        let host = Self::normalize_bind_ip(bind_ip)?;
+        Some((host, host_port))
+    }
+
+    /// Parse a long-form ports mapping (`target`/`published`/`host_ip`) into
+    /// `(bind_ip, host_port)` if `target` matches `config.port`.
+    fn endpoint_from_longform(
+        &self,
+        map: &HashMap<String, String>,
+        config: &DatabaseConfig,
+    ) -> Option<(String, u16)> {
+        let clean = |s: &str| -> String {
+            self.resolve_compose_vars(
+                s.trim()
+                    .trim_matches(|c: char| c == '\'' || c == '"')
+                    .trim(),
+            )
+        };
+        let target: u16 = clean(map.get("target")?).trim().parse().ok()?;
+        if target != config.port {
+            return None;
+        }
+        let host_port: u16 = clean(map.get("published")?).trim().parse().ok()?;
+        let host = match map.get("host_ip") {
+            Some(ip) => Self::normalize_bind_ip(clean(ip).trim())?,
+            None => "127.0.0.1".to_string(),
+        };
+        Some((host, host_port))
+    }
+
+    /// Resolve `${VAR}` and `${VAR:-default}` in a compose value via
+    /// [`Self::resolve_env`], falling back to the default (or empty) when the
+    /// var is unset. Bare `$VAR` is not handled (Sail uses the braced form).
+    fn resolve_compose_vars(&self, s: &str) -> String {
+        let Ok(re) = Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}") else {
+            return s.to_string();
+        };
+        re.replace_all(s, |caps: &regex::Captures| {
+            let var = &caps[1];
+            let default = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+            self.resolve_env(var).unwrap_or_else(|| default.to_string())
+        })
+        .into_owned()
+    }
+
+    /// Normalise a compose/APP_PORT bind IP into a URL host:
+    /// - empty → `127.0.0.1` (the compose default when no bind IP is given),
+    /// - `0.0.0.0` / `::` / `*` → `127.0.0.1` (wildcard binds are reachable
+    ///   on loopback),
+    /// - a valid IPv4 literal → itself,
+    /// - anything else (hostnames, IPv6 literals) → `None` (fail open).
+    fn normalize_bind_ip(ip: &str) -> Option<String> {
+        let ip = ip.trim();
+        if ip.is_empty() || ip == "0.0.0.0" || ip == "::" || ip == "[::]" || ip == "*" {
+            return Some("127.0.0.1".to_string());
+        }
+        ip.parse::<std::net::Ipv4Addr>()
+            .ok()
+            .map(|_| ip.to_string())
     }
 
     /// Build the ordered list of MySQL connection candidates. Priority:
@@ -1319,27 +2227,20 @@ impl DatabaseSchemaProvider {
         }
 
         // TCP candidates. Always added — these are the fallback path when
-        // neither URL nor socket are configured, OR when those fail.
-        for host in Self::host_candidates(&config.host) {
-            let is_sail_fallback = host == "127.0.0.1" && host != config.host;
+        // neither URL nor socket are configured, OR when those fail. The
+        // endpoint list is: configured host → any detected Sail/Docker bind
+        // (e.g. 127.0.0.2, or a custom forwarded port) → 127.0.0.1 backstop.
+        for (host, port, note) in self.tcp_endpoints(config) {
             out.push(ConnCandidate {
-                label: format!("tcp {}:{}", host, config.port),
+                label: format!("tcp {host}:{port}"),
                 url: format!(
                     "mysql://{}@{}:{}/{}",
                     userinfo(&config.username, &config.password),
                     host,
-                    config.port,
+                    port,
                     config.database
                 ),
-                success_note: if is_sail_fallback {
-                    Some(
-                        "Looks like a Sail / Docker Compose setup — the LSP runs outside Docker, \
-                         so the service hostname doesn't work, but the mapped host port does."
-                            .to_string(),
-                    )
-                } else {
-                    None
-                },
+                success_note: note,
             });
         }
 
@@ -1373,22 +2274,17 @@ impl DatabaseSchemaProvider {
             });
         }
 
-        for host in Self::host_candidates(&config.host) {
-            let is_sail_fallback = host == "127.0.0.1" && host != config.host;
+        for (host, port, note) in self.tcp_endpoints(config) {
             out.push(ConnCandidate {
-                label: format!("tcp {}:{}", host, config.port),
+                label: format!("tcp {host}:{port}"),
                 url: format!(
                     "postgres://{}@{}:{}/{}",
                     userinfo(&config.username, &config.password),
                     host,
-                    config.port,
+                    port,
                     config.database
                 ),
-                success_note: if is_sail_fallback {
-                    Some("Sail / Docker Compose fallback to 127.0.0.1.".to_string())
-                } else {
-                    None
-                },
+                success_note: note,
             });
         }
 
@@ -1397,7 +2293,11 @@ impl DatabaseSchemaProvider {
 
     /// Fetch schema from PostgreSQL. Same candidate priority as
     /// `fetch_mysql_schema`: DB_URL → unix_socket → TCP with Sail fallback.
-    async fn fetch_postgres_schema(&self, config: &DatabaseConfig) -> Option<DatabaseSchema> {
+    async fn fetch_postgres_schema(
+        &self,
+        config: &DatabaseConfig,
+        connect_timeout: Duration,
+    ) -> Option<DatabaseSchema> {
         use sqlx::postgres::PgPoolOptions;
 
         let candidates = self.build_postgres_candidates(config);
@@ -1408,7 +2308,7 @@ impl DatabaseSchemaProvider {
         for cand in &candidates {
             match PgPoolOptions::new()
                 .max_connections(1)
-                .acquire_timeout(Duration::from_secs(5))
+                .acquire_timeout(connect_timeout)
                 .connect(&cand.url)
                 .await
             {
@@ -1443,7 +2343,8 @@ impl DatabaseSchemaProvider {
                 let raw_err = last_err.unwrap_or_else(|| "(no error captured)".to_string());
                 let msg = classify_postgres_error(&raw_err, &config.database, &candidates_str);
                 warn!("{}", msg);
-                self.set_error("pgsql", &msg).await;
+                self.set_error("pgsql", &msg, outage_class_from_raw(&raw_err))
+                    .await;
                 return None;
             }
         };
@@ -1498,7 +2399,11 @@ impl DatabaseSchemaProvider {
     }
 
     /// Fetch schema from SQLite
-    async fn fetch_sqlite_schema(&self, config: &DatabaseConfig) -> Option<DatabaseSchema> {
+    async fn fetch_sqlite_schema(
+        &self,
+        config: &DatabaseConfig,
+        connect_timeout: Duration,
+    ) -> Option<DatabaseSchema> {
         use sqlx::sqlite::SqlitePoolOptions;
         use sqlx::Row;
 
@@ -1515,7 +2420,10 @@ impl DatabaseSchemaProvider {
                 db_path
             );
             warn!("{}", msg);
-            self.set_error("sqlite", &msg).await;
+            // Scenario 2-shaped: the "server" (filesystem) is fine, the
+            // configured database itself is missing — same remediation
+            // family as an unknown database ("check that it exists").
+            self.set_error("sqlite", &msg, OutageClass::Rejected).await;
             return None;
         }
 
@@ -1523,15 +2431,17 @@ impl DatabaseSchemaProvider {
 
         let pool = match SqlitePoolOptions::new()
             .max_connections(1)
-            .acquire_timeout(Duration::from_secs(5))
+            .acquire_timeout(connect_timeout)
             .connect(&url)
             .await
         {
             Ok(p) => p,
             Err(e) => {
+                let raw_err = e.to_string();
                 let msg = format!("SQLite connection failed: {}. Check DB_DATABASE in .env", e);
                 warn!("{}", msg);
-                self.set_error("sqlite", &msg).await;
+                self.set_error("sqlite", &msg, outage_class_from_raw(&raw_err))
+                    .await;
                 return None;
             }
         };
@@ -1588,8 +2498,15 @@ impl DatabaseSchemaProvider {
         })
     }
 
-    /// Fetch schema from SQL Server
-    async fn fetch_sqlserver_schema(&self, config: &DatabaseConfig) -> Option<DatabaseSchema> {
+    /// Fetch schema from SQL Server. tiberius has no built-in connect
+    /// timeout, so both the raw TCP connect and the TDS handshake are
+    /// wrapped in `tokio::time::timeout` — an unreachable sqlsrv host
+    /// otherwise hangs on the OS default (minutes).
+    async fn fetch_sqlserver_schema(
+        &self,
+        config: &DatabaseConfig,
+        connect_timeout: Duration,
+    ) -> Option<DatabaseSchema> {
         use tiberius::{AuthMethod, Client, Config};
         use tokio::net::TcpStream;
         use tokio_util::compat::TokioAsyncWriteCompatExt;
@@ -1601,27 +2518,60 @@ impl DatabaseSchemaProvider {
         tib_config.authentication(AuthMethod::sql_server(&config.username, &config.password));
         tib_config.trust_cert();
 
-        let tcp = match TcpStream::connect(tib_config.get_addr()).await {
-            Ok(t) => t,
-            Err(e) => {
+        let tcp = match tokio::time::timeout(
+            connect_timeout,
+            TcpStream::connect(tib_config.get_addr()),
+        )
+        .await
+        {
+            Ok(Ok(t)) => t,
+            Ok(Err(e)) => {
                 let msg = format!(
                     "SQL Server TCP connection failed: {}. Check DB_HOST, DB_PORT in .env",
                     e
                 );
                 warn!("{}", msg);
-                self.set_error("sqlsrv", &msg).await;
+                self.set_error("sqlsrv", &msg, OutageClass::Unreachable)
+                    .await;
+                return None;
+            }
+            Err(_) => {
+                let msg = format!(
+                    "SQL Server TCP connection timed out after {:?}. Check DB_HOST, DB_PORT in .env",
+                    connect_timeout
+                );
+                warn!("{}", msg);
+                self.set_error("sqlsrv", &msg, OutageClass::Unreachable)
+                    .await;
                 return None;
             }
         };
 
         tcp.set_nodelay(true).ok();
 
-        let mut client = match Client::connect(tib_config, tcp.compat_write()).await {
-            Ok(c) => c,
-            Err(e) => {
+        let mut client = match tokio::time::timeout(
+            connect_timeout,
+            Client::connect(tib_config, tcp.compat_write()),
+        )
+        .await
+        {
+            Ok(Ok(c)) => c,
+            Ok(Err(e)) => {
+                let raw_err = e.to_string();
                 let msg = format!("SQL Server connection failed: {}. Check DB_DATABASE, DB_USERNAME, DB_PASSWORD in .env", e);
                 warn!("{}", msg);
-                self.set_error("sqlsrv", &msg).await;
+                self.set_error("sqlsrv", &msg, outage_class_from_raw(&raw_err))
+                    .await;
+                return None;
+            }
+            Err(_) => {
+                let msg = format!(
+                    "SQL Server handshake timed out after {:?}. Check DB_HOST, DB_PORT in .env",
+                    connect_timeout
+                );
+                warn!("{}", msg);
+                self.set_error("sqlsrv", &msg, OutageClass::Unreachable)
+                    .await;
                 return None;
             }
         };

--- a/laravel-lsp/src/database/tests.rs
+++ b/laravel-lsp/src/database/tests.rs
@@ -591,3 +591,1195 @@ fn postgres_candidates_empty_password_url_has_no_colon() {
     );
     assert!(!tcp.url.contains(":@"), "got: {}", tcp.url);
 }
+
+// ---------------------------------------------------------------------------
+// Circuit breaker state machine (pure, time-injected — no DB, no async)
+// ---------------------------------------------------------------------------
+
+const COOLDOWN: Duration = Duration::from_secs(30);
+
+fn breaker() -> CircuitBreaker {
+    CircuitBreaker::new(COOLDOWN)
+}
+
+#[test]
+fn breaker_starts_closed_and_allows_attempts() {
+    let mut b = breaker();
+    let now = Instant::now();
+    assert_eq!(b.allow_attempt(now), Attempt::Closed);
+    // Closed → no cooldown pending → loop refreshes at the healthy cadence.
+    assert_eq!(b.cooldown_remaining(now), None);
+}
+
+#[test]
+fn breaker_first_failure_opens_and_signals_new_outage() {
+    let mut b = breaker();
+    let t0 = Instant::now();
+    assert!(
+        b.record_failure(t0),
+        "Closed→Open is the start of an outage episode"
+    );
+    assert_eq!(b.allow_attempt(t0 + Duration::from_secs(1)), Attempt::Open);
+    // Open → a cooldown is pending (~29s left after 1s).
+    assert_eq!(
+        b.cooldown_remaining(t0 + Duration::from_secs(1)),
+        Some(COOLDOWN - Duration::from_secs(1))
+    );
+}
+
+#[test]
+fn breaker_denies_until_cooldown_elapses() {
+    let mut b = breaker();
+    let t0 = Instant::now();
+    b.record_failure(t0);
+    assert_eq!(
+        b.allow_attempt(t0 + COOLDOWN - Duration::from_millis(1)),
+        Attempt::Open
+    );
+    assert_eq!(
+        b.cooldown_remaining(t0 + COOLDOWN - Duration::from_millis(1)),
+        Some(Duration::from_millis(1))
+    );
+}
+
+#[test]
+fn breaker_allows_exactly_one_probe_after_cooldown() {
+    let mut b = breaker();
+    let t0 = Instant::now();
+    b.record_failure(t0);
+    assert_eq!(b.allow_attempt(t0 + COOLDOWN), Attempt::HalfOpen);
+    // A second caller while the probe is outstanding is denied.
+    assert_eq!(
+        b.allow_attempt(t0 + COOLDOWN + Duration::from_millis(1)),
+        Attempt::Open
+    );
+}
+
+#[test]
+fn breaker_probe_success_closes() {
+    let mut b = breaker();
+    let t0 = Instant::now();
+    b.record_failure(t0);
+    assert_eq!(b.allow_attempt(t0 + COOLDOWN), Attempt::HalfOpen);
+    b.record_success();
+    let after = t0 + COOLDOWN + Duration::from_secs(1);
+    assert_eq!(b.allow_attempt(after), Attempt::Closed);
+    assert_eq!(b.cooldown_remaining(after), None);
+}
+
+#[test]
+fn breaker_cooldown_remaining_saturates_to_zero_once_elapsed() {
+    let mut b = breaker();
+    let t0 = Instant::now();
+    b.record_failure(t0);
+    // Past the cooldown but before allow_attempt flips it to half-open:
+    // the next probe is due now, so zero remaining (loop sleeps 0, retries).
+    assert_eq!(
+        b.cooldown_remaining(t0 + COOLDOWN + Duration::from_secs(5)),
+        Some(Duration::ZERO)
+    );
+}
+
+#[test]
+fn breaker_probe_failure_reopens_without_new_outage_signal() {
+    let mut b = breaker();
+    let t0 = Instant::now();
+    assert!(b.record_failure(t0), "first failure = new outage");
+    assert_eq!(b.allow_attempt(t0 + COOLDOWN), Attempt::HalfOpen);
+    assert!(
+        !b.record_failure(t0 + COOLDOWN),
+        "failed probe = same outage, no fresh notification"
+    );
+    // Re-opened: denied for another full cooldown, then a new probe.
+    assert_eq!(
+        b.allow_attempt(t0 + COOLDOWN + COOLDOWN - Duration::from_secs(1)),
+        Attempt::Open
+    );
+    assert_eq!(b.allow_attempt(t0 + COOLDOWN + COOLDOWN), Attempt::HalfOpen);
+}
+
+#[test]
+fn breaker_failure_after_recovery_signals_fresh_outage() {
+    let mut b = breaker();
+    let t0 = Instant::now();
+    assert!(b.record_failure(t0));
+    assert_eq!(b.allow_attempt(t0 + COOLDOWN), Attempt::HalfOpen);
+    b.record_success(); // reconnected
+    assert!(
+        b.record_failure(t0 + COOLDOWN + Duration::from_secs(60)),
+        "a failure after a successful reconnect is a NEW outage episode"
+    );
+}
+
+#[test]
+fn breaker_stuck_probe_self_heals_after_cooldown() {
+    let mut b = breaker();
+    let t0 = Instant::now();
+    b.record_failure(t0);
+    // Probe goes out at t0+30s and never reports back (e.g. a fetch path
+    // that bails without recording failure).
+    assert_eq!(b.allow_attempt(t0 + COOLDOWN), Attempt::HalfOpen);
+    // Still guarded while the probe ages...
+    assert_eq!(
+        b.allow_attempt(t0 + COOLDOWN + COOLDOWN - Duration::from_secs(1)),
+        Attempt::Open
+    );
+    // ...but after another cooldown the breaker re-arms a fresh probe
+    // instead of staying wedged in HalfOpen forever.
+    assert_eq!(b.allow_attempt(t0 + COOLDOWN + COOLDOWN), Attempt::HalfOpen);
+}
+
+#[test]
+fn record_success_reports_recovery_edge_only() {
+    let mut b = breaker();
+    let t0 = Instant::now();
+
+    // Fresh breaker (already Closed): the first successful fetch is a
+    // healthy startup, NOT a recovery — no reconnect toast.
+    assert!(
+        !b.record_success(),
+        "healthy startup must not signal a reconnect"
+    );
+
+    // Open → Closed is a genuine recovery edge.
+    b.record_failure(t0);
+    assert!(b.record_success(), "Open→Closed is a recovery edge");
+
+    // HalfOpen → Closed is a genuine recovery edge (a probe succeeded).
+    b.record_failure(t0);
+    assert_eq!(b.allow_attempt(t0 + COOLDOWN), Attempt::HalfOpen);
+    assert!(b.record_success(), "HalfOpen→Closed is a recovery edge");
+
+    // Already Closed → Closed is a routine steady-state refresh — silent.
+    assert!(
+        !b.record_success(),
+        "an already-healthy refresh must not signal a reconnect"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Outage classification (scenario 1: unreachable / scenario 2: rejected)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn outage_class_connection_refused_is_unreachable() {
+    assert_eq!(
+        outage_class_from_raw("tcp 127.0.0.1:3306: Connection refused (os error 61)"),
+        OutageClass::Unreachable
+    );
+}
+
+#[test]
+fn outage_class_pool_timeout_is_unreachable() {
+    assert_eq!(
+        outage_class_from_raw("pool timed out while waiting for an open connection"),
+        OutageClass::Unreachable
+    );
+}
+
+#[test]
+fn outage_class_dns_failure_is_unreachable() {
+    assert_eq!(
+        outage_class_from_raw(
+            "failed to lookup address information: nodename nor servname provided, or not known"
+        ),
+        OutageClass::Unreachable
+    );
+}
+
+#[test]
+fn outage_class_mysql_access_denied_is_rejected() {
+    assert_eq!(
+        outage_class_from_raw(
+            "error returned from database: 1045 (28000): Access denied for user 'root'@'localhost'"
+        ),
+        OutageClass::Rejected
+    );
+}
+
+#[test]
+fn outage_class_mysql_unknown_database_is_rejected() {
+    assert_eq!(
+        outage_class_from_raw("error returned from database: 1049 (42000): Unknown database 'app'"),
+        OutageClass::Rejected
+    );
+}
+
+#[test]
+fn outage_class_postgres_bad_password_is_rejected() {
+    assert_eq!(
+        outage_class_from_raw("28P01: password authentication failed for user \"postgres\""),
+        OutageClass::Rejected
+    );
+}
+
+#[test]
+fn outage_class_sqlserver_login_failed_is_rejected() {
+    assert_eq!(
+        outage_class_from_raw("Login failed for user 'sa'."),
+        OutageClass::Rejected
+    );
+}
+
+#[test]
+fn outage_class_unrecognized_error_is_other() {
+    assert_eq!(
+        outage_class_from_raw("something exploded in a novel way"),
+        OutageClass::Other
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Notification text selection (scenario-specific; scenario 0 silent)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn toast_unreachable_asks_if_db_is_running_and_carries_detail() {
+    let msg = outage_toast_message(
+        OutageClass::Unreachable,
+        "Couldn't reach [tcp 127.0.0.1:3306]",
+    )
+    .expect("scenario 1 must notify");
+    assert!(msg.contains("is it running"), "got: {msg}");
+    assert!(
+        msg.contains("Couldn't reach [tcp 127.0.0.1:3306]"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn toast_rejected_points_at_credentials_and_carries_detail() {
+    let msg = outage_toast_message(OutageClass::Rejected, "MySQL rejected the credentials")
+        .expect("scenario 2 must notify");
+    assert!(msg.contains("rejected"), "got: {msg}");
+    assert!(msg.contains("credentials"), "got: {msg}");
+    assert!(msg.contains("MySQL rejected the credentials"), "got: {msg}");
+}
+
+#[test]
+fn toast_not_configured_is_silent() {
+    assert!(
+        outage_toast_message(OutageClass::NotConfigured, "no config").is_none(),
+        "a project without a database is a normal state, not an outage"
+    );
+}
+
+#[test]
+fn toast_other_is_generic_but_present() {
+    let msg = outage_toast_message(OutageClass::Other, "weird error").expect("must notify");
+    assert!(msg.contains("database connection failed"), "got: {msg}");
+    assert!(msg.contains("weird error"), "got: {msg}");
+}
+
+// ---------------------------------------------------------------------------
+// Provider-level notification gating: one Outage per outage episode, one
+// Reconnected per recovery. Exercises the set_error/clear_error breaker
+// hooks and the event channel end to end — still no real database.
+// ---------------------------------------------------------------------------
+
+/// Unwrap a breaker event as an outage, failing loudly on a reconnect.
+fn expect_outage(event: DbBreakerEvent) -> DbOutageEvent {
+    match event {
+        DbBreakerEvent::Outage(o) => o,
+        DbBreakerEvent::Reconnected => panic!("expected an Outage event, got Reconnected"),
+    }
+}
+
+#[tokio::test]
+async fn outage_channel_fires_once_per_outage_and_rearms_on_reconnect() {
+    let provider = DatabaseSchemaProvider::new(PathBuf::from("/tmp"));
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    provider.set_event_channel(tx).await;
+
+    let refused = "tcp 127.0.0.1:3306: Connection refused (os error 61)";
+    provider
+        .set_error("mysql", refused, OutageClass::Unreachable)
+        .await;
+    provider
+        .set_error("mysql", refused, OutageClass::Unreachable)
+        .await;
+
+    let first = expect_outage(rx.try_recv().expect("first failure announces the outage"));
+    assert_eq!(first.class, OutageClass::Unreachable);
+    assert_eq!(first.message, refused);
+    assert!(
+        rx.try_recv().is_err(),
+        "continuing failures in the same outage must not re-announce"
+    );
+
+    provider.clear_error().await; // successful reconnect closes the breaker
+    assert!(
+        matches!(rx.try_recv(), Ok(DbBreakerEvent::Reconnected)),
+        "recovery announces exactly one Reconnected"
+    );
+
+    provider
+        .set_error("mysql", refused, OutageClass::Unreachable)
+        .await;
+    let second = expect_outage(
+        rx.try_recv()
+            .expect("a NEW outage after reconnect announces exactly once more"),
+    );
+    assert_eq!(second.class, OutageClass::Unreachable);
+}
+
+#[tokio::test]
+async fn reconnect_event_fires_once_per_recovery_and_not_on_healthy_startup() {
+    let provider = DatabaseSchemaProvider::new(PathBuf::from("/tmp"));
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    provider.set_event_channel(tx).await;
+
+    // Healthy startup: a first successful fetch from a fresh (Closed)
+    // breaker must NOT toast "reconnected".
+    provider.clear_error().await;
+    assert!(
+        rx.try_recv().is_err(),
+        "healthy startup emits no reconnect toast"
+    );
+
+    // Outage → recovery: exactly one Reconnected on the recovery edge.
+    provider
+        .set_error("mysql", "Connection refused", OutageClass::Unreachable)
+        .await;
+    let _ = expect_outage(rx.try_recv().expect("outage announced"));
+    provider.clear_error().await;
+    assert!(
+        matches!(rx.try_recv(), Ok(DbBreakerEvent::Reconnected)),
+        "recovery announces exactly one Reconnected"
+    );
+
+    // A second successful refresh (already Closed) is steady state — silent.
+    provider.clear_error().await;
+    assert!(
+        rx.try_recv().is_err(),
+        "an already-healthy refresh emits no reconnect toast"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Isolation: interactive accessors are pure cache reads and NEVER connect.
+// This is the key regression guard for the freeze bug — a DB-touching LSP
+// request handler that blocked on a connect starved unrelated requests.
+// ---------------------------------------------------------------------------
+
+fn schema_with(tables: &[&str], cached_at: Instant) -> DatabaseSchema {
+    DatabaseSchema {
+        tables: tables.iter().map(|t| t.to_string()).collect(),
+        columns: HashMap::new(),
+        columns_with_types: HashMap::new(),
+        cached_at,
+    }
+}
+
+#[tokio::test]
+async fn interactive_accessors_are_cache_only_and_never_connect() {
+    // Cache cold, and (a /tmp project with no config/database.php) the DB is
+    // effectively "down". Interactive reads must return empty WITHOUT ever
+    // attempting a connection.
+    let provider = DatabaseSchemaProvider::new(PathBuf::from("/tmp"));
+
+    assert!(provider.get_schema().await.is_none());
+    assert!(provider.get_tables().await.is_empty());
+    assert!(provider.get_columns("users").await.is_empty());
+    assert!(provider.get_columns_with_types("users").await.is_empty());
+
+    assert!(
+        !provider.was_connection_attempted().await,
+        "interactive reads must NEVER connect — only the background loop does"
+    );
+}
+
+#[tokio::test]
+async fn interactive_get_schema_serves_stale_cache() {
+    let provider = DatabaseSchemaProvider::new(PathBuf::from("/tmp"));
+    // A schema older than the 60s TTL — is_valid() is false…
+    let stale = schema_with(&["users"], Instant::now() - Duration::from_secs(120));
+    assert!(!stale.is_valid());
+    provider.set_test_schema(stale).await;
+
+    // …but interactive reads serve last-known-good regardless of TTL. The
+    // background loop is responsible for refreshing it, not the reader.
+    let tables = provider.get_tables().await;
+    assert_eq!(tables, vec!["users".to_string()]);
+    assert!(!provider.was_connection_attempted().await);
+}
+
+// ---------------------------------------------------------------------------
+// Background refresh loop: owns connect + breaker + notification, off the
+// request path. Exercised without a live DB via the no-config failure path,
+// the injected-slow-future timeout path, and the pure breaker cadence.
+// ---------------------------------------------------------------------------
+
+/// The background loop's per-tick sleep should be roughly a full cooldown
+/// when the breaker is open — within one second of it, allowing for the
+/// microseconds of wall-clock drift between opening the breaker and reading
+/// the remaining cooldown back.
+fn assert_backs_off_on_cooldown(sleep: Duration) {
+    assert!(
+        sleep <= COOLDOWN && sleep > COOLDOWN - Duration::from_secs(1),
+        "expected ~cooldown backoff, got {sleep:?}"
+    );
+}
+
+#[tokio::test]
+async fn refresh_tick_failure_opens_breaker_backs_off_and_notifies_once() {
+    // /tmp has no config/database.php, so fetch_schema fails fast.
+    let provider = DatabaseSchemaProvider::new(PathBuf::from("/tmp"));
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    provider.set_event_channel(tx).await;
+
+    let sleep = provider
+        .refresh_tick(Duration::from_secs(1), Duration::from_secs(60))
+        .await;
+
+    assert!(
+        provider.was_connection_attempted().await,
+        "the background tick DOES fetch"
+    );
+    // Breaker opened → back off on the cooldown, not the healthy interval.
+    assert_backs_off_on_cooldown(sleep);
+    // Exactly one outage event (no config → NotConfigured → silent toast,
+    // but the edge still fires on the channel).
+    let event = expect_outage(rx.try_recv().expect("first failure announces the outage"));
+    assert_eq!(event.class, OutageClass::NotConfigured);
+    assert!(rx.try_recv().is_err(), "only one event per outage episode");
+
+    // A second immediate tick is denied by the open breaker: no re-fetch,
+    // no second event, still backing off on the cooldown.
+    let sleep2 = provider
+        .refresh_tick(Duration::from_secs(1), Duration::from_secs(60))
+        .await;
+    assert_backs_off_on_cooldown(sleep2);
+    assert!(rx.try_recv().is_err(), "open breaker suppresses re-fetch");
+}
+
+#[tokio::test]
+async fn whole_fetch_timeout_opens_breaker_instead_of_hanging() {
+    let provider = DatabaseSchemaProvider::new(PathBuf::from("/tmp"));
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    provider.set_event_channel(tx).await;
+
+    // A fetch that "connects" but then stalls far longer than the budget —
+    // the connected-but-stalled-server case that used to hang forever
+    // (post-connect queries were unbounded). A tiny budget vs a long stall
+    // makes the timeout fire near-instantly without hanging the test.
+    let budget = Duration::from_millis(20);
+    let stalled = async {
+        tokio::time::sleep(Duration::from_secs(3600)).await;
+        Some(schema_with(&["users"], Instant::now()))
+    };
+    let stored = provider.run_bounded_fetch(budget, stalled).await;
+
+    assert!(!stored, "a timed-out fetch must not fill the cache");
+    assert!(provider.get_schema().await.is_none());
+    let event = expect_outage(
+        rx.try_recv()
+            .expect("timeout opens the breaker and notifies"),
+    );
+    assert_eq!(
+        event.class,
+        OutageClass::Unreachable,
+        "a stalled server is treated as unreachable"
+    );
+}
+
+#[tokio::test]
+async fn run_bounded_fetch_success_fills_cache() {
+    let provider = DatabaseSchemaProvider::new(PathBuf::from("/tmp"));
+    let fetched = async { Some(schema_with(&["users", "posts"], Instant::now())) };
+    let stored = provider
+        .run_bounded_fetch(Duration::from_secs(5), fetched)
+        .await;
+    assert!(stored);
+    assert_eq!(
+        provider.get_tables().await,
+        vec!["users".to_string(), "posts".to_string()]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sail / Docker bind-IP detection: find a DB bound to a non-127.0.0.1
+// loopback IP (Mike's Herd setup pins Sail to 127.0.0.2). Temp-dir fixtures
+// only — never touches the SQLite test-project/.env. Layered precedence:
+// compose override → base compose → APP_PORT → 127.0.0.1 backstop.
+// ---------------------------------------------------------------------------
+
+use tempfile::TempDir;
+
+/// TCP candidate labels from a builder, in order.
+fn tcp_labels(candidates: &[super::ConnCandidate]) -> Vec<String> {
+    candidates
+        .iter()
+        .filter(|c| c.label.starts_with("tcp "))
+        .map(|c| c.label.clone())
+        .collect()
+}
+
+fn write(dir: &std::path::Path, name: &str, content: &str) {
+    std::fs::write(dir.join(name), content).unwrap();
+}
+
+/// A mysql config whose host is the Docker service name `mysql`.
+fn mysql_service_cfg() -> super::DatabaseConfig {
+    make_config_with(None, None, "mysql")
+}
+
+#[test]
+fn sail_override_bind_ip_becomes_a_candidate() {
+    let dir = TempDir::new().unwrap();
+    // FORWARD_DB_PORT unset → the `:-3306` default applies.
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    image: 'mysql:8'\n    ports:\n      - '127.0.0.2:${FORWARD_DB_PORT:-3306}:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cands = provider.build_mysql_candidates(&mysql_service_cfg());
+    assert_eq!(
+        tcp_labels(&cands),
+        vec![
+            "tcp mysql:3306".to_string(),
+            "tcp 127.0.0.2:3306".to_string(),
+            "tcp 127.0.0.1:3306".to_string(),
+        ],
+        "detected bind IP goes after the service name and before the backstop"
+    );
+}
+
+#[test]
+fn sail_custom_forward_port_uses_host_port_not_container() {
+    let dir = TempDir::new().unwrap();
+    write(dir.path(), ".env", "FORWARD_DB_PORT=33061\n");
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    ports:\n      - '127.0.0.2:${FORWARD_DB_PORT:-3306}:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cands = provider.build_mysql_candidates(&mysql_service_cfg());
+    assert!(
+        tcp_labels(&cands).contains(&"tcp 127.0.0.2:33061".to_string()),
+        "the forwarded HOST port (33061) is used, not the container port; got {:?}",
+        tcp_labels(&cands)
+    );
+}
+
+#[test]
+fn sail_detects_from_base_compose_when_no_override() {
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "docker-compose.yml",
+        "services:\n  mysql:\n    ports:\n      - '127.0.0.2:3306:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cands = provider.build_mysql_candidates(&mysql_service_cfg());
+    assert!(tcp_labels(&cands).contains(&"tcp 127.0.0.2:3306".to_string()));
+}
+
+#[test]
+fn sail_override_without_match_falls_through_to_base() {
+    let dir = TempDir::new().unwrap();
+    // Override maps a DIFFERENT container port → no match for DB port 3306.
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    ports:\n      - '127.0.0.9:9999:9999'\n",
+    );
+    write(
+        dir.path(),
+        "docker-compose.yml",
+        "services:\n  mysql:\n    ports:\n      - '127.0.0.3:3306:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cands = provider.build_mysql_candidates(&mysql_service_cfg());
+    let labels = tcp_labels(&cands);
+    assert!(
+        labels.contains(&"tcp 127.0.0.3:3306".to_string()),
+        "got {labels:?}"
+    );
+    assert!(
+        !labels.iter().any(|l| l.contains("127.0.0.9")),
+        "got {labels:?}"
+    );
+}
+
+#[test]
+fn sail_detects_from_app_port_bind_ip() {
+    let dir = TempDir::new().unwrap();
+    write(dir.path(), ".env", "APP_PORT=127.0.0.2:80\n");
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cands = provider.build_mysql_candidates(&mysql_service_cfg());
+    // The DB's own port (3306) is paired with the APP_PORT bind IP.
+    assert!(tcp_labels(&cands).contains(&"tcp 127.0.0.2:3306".to_string()));
+}
+
+#[test]
+fn app_port_without_ip_yields_no_extra_candidate() {
+    let dir = TempDir::new().unwrap();
+    write(dir.path(), ".env", "APP_PORT=80\n");
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cands = provider.build_mysql_candidates(&mysql_service_cfg());
+    assert_eq!(
+        tcp_labels(&cands),
+        vec![
+            "tcp mysql:3306".to_string(),
+            "tcp 127.0.0.1:3306".to_string()
+        ],
+        "APP_PORT with no IP falls straight through to the 127.0.0.1 backstop"
+    );
+}
+
+#[test]
+fn sail_precedence_override_beats_base_and_app_port() {
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    ports:\n      - '127.0.0.2:3306:3306'\n",
+    );
+    write(
+        dir.path(),
+        "docker-compose.yml",
+        "services:\n  mysql:\n    ports:\n      - '127.0.0.3:3306:3306'\n",
+    );
+    write(dir.path(), ".env", "APP_PORT=127.0.0.4:80\n");
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let labels = tcp_labels(&provider.build_mysql_candidates(&mysql_service_cfg()));
+    assert!(
+        labels.contains(&"tcp 127.0.0.2:3306".to_string()),
+        "override wins: {labels:?}"
+    );
+    assert!(
+        !labels
+            .iter()
+            .any(|l| l.contains("127.0.0.3") || l.contains("127.0.0.4")),
+        "{labels:?}"
+    );
+}
+
+#[test]
+fn sail_dedupes_detected_loopback_against_backstop() {
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    ports:\n      - '127.0.0.1:3306:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let labels = tcp_labels(&provider.build_mysql_candidates(&mysql_service_cfg()));
+    assert_eq!(
+        labels.iter().filter(|l| *l == "tcp 127.0.0.1:3306").count(),
+        1,
+        "a detected 127.0.0.1 must not duplicate the backstop: {labels:?}"
+    );
+    assert_eq!(
+        labels,
+        vec![
+            "tcp mysql:3306".to_string(),
+            "tcp 127.0.0.1:3306".to_string()
+        ]
+    );
+}
+
+#[test]
+fn detection_skipped_when_host_is_already_an_ip() {
+    let dir = TempDir::new().unwrap();
+    // Even with a compose file present, an IP host bypasses detection.
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    ports:\n      - '127.0.0.9:3306:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cfg = make_config_with(None, None, "127.0.0.2");
+    let labels = tcp_labels(&provider.build_mysql_candidates(&cfg));
+    assert_eq!(
+        labels,
+        vec!["tcp 127.0.0.2:3306".to_string()],
+        "an IP host is used verbatim — no service-name heuristic, no compose scan"
+    );
+}
+
+#[test]
+fn sail_detection_feeds_postgres_candidates_too() {
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  pgsql:\n    ports:\n      - '127.0.0.2:5432:5432'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let mut cfg = make_config_with(None, None, "pgsql");
+    cfg.driver = "pgsql".to_string();
+    cfg.port = 5432;
+    let labels = tcp_labels(&provider.build_postgres_candidates(&cfg));
+    assert_eq!(
+        labels,
+        vec![
+            "tcp pgsql:5432".to_string(),
+            "tcp 127.0.0.2:5432".to_string(),
+            "tcp 127.0.0.1:5432".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn sail_long_form_ports_mapping_is_parsed() {
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    ports:\n      - target: 3306\n        published: 33061\n        host_ip: 127.0.0.2\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let labels = tcp_labels(&provider.build_mysql_candidates(&mysql_service_cfg()));
+    assert!(
+        labels.contains(&"tcp 127.0.0.2:33061".to_string()),
+        "long-form target/published/host_ip mapping: {labels:?}"
+    );
+}
+
+#[test]
+fn normalize_bind_ip_maps_wildcards_to_loopback() {
+    assert_eq!(
+        DatabaseSchemaProvider::normalize_bind_ip("0.0.0.0").as_deref(),
+        Some("127.0.0.1")
+    );
+    assert_eq!(
+        DatabaseSchemaProvider::normalize_bind_ip("::").as_deref(),
+        Some("127.0.0.1")
+    );
+    assert_eq!(
+        DatabaseSchemaProvider::normalize_bind_ip("").as_deref(),
+        Some("127.0.0.1")
+    );
+    assert_eq!(
+        DatabaseSchemaProvider::normalize_bind_ip("127.0.0.2").as_deref(),
+        Some("127.0.0.2")
+    );
+    // Hostnames / IPv6 literals fail open.
+    assert_eq!(
+        DatabaseSchemaProvider::normalize_bind_ip("db.example.com"),
+        None
+    );
+}
+
+// ---- nested-`ports:` mis-parse regression + APP_PORT loopback guard ----
+
+#[test]
+fn nested_ports_under_extension_field_is_ignored() {
+    // `x-meta` is a legal compose extension field; its nested `ports:` list
+    // appears textually BEFORE the real service-level one. The parser must
+    // read the service-level binding, not the nested decoy.
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    x-meta:\n      ports:\n        - '10.0.0.1:9999:3306'\n    ports:\n      - '127.0.0.2:33061:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let labels = tcp_labels(&provider.build_mysql_candidates(&mysql_service_cfg()));
+    assert!(
+        labels.contains(&"tcp 127.0.0.2:33061".to_string()),
+        "must read the REAL service-level ports, got {labels:?}"
+    );
+    assert!(
+        !labels
+            .iter()
+            .any(|l| l.contains("10.0.0.1") || l.contains(":9999")),
+        "must NOT read the nested x-meta ports, got {labels:?}"
+    );
+}
+
+#[test]
+fn nested_ports_only_yields_no_detection() {
+    // The service has ONLY a nested `x-meta.ports:` and no direct `ports:`.
+    // Ambiguity → None (never read the nested one); fall to the backstop.
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    x-meta:\n      ports:\n        - '10.0.0.1:9999:3306'\n    image: 'mysql:8'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let labels = tcp_labels(&provider.build_mysql_candidates(&mysql_service_cfg()));
+    assert_eq!(
+        labels,
+        vec![
+            "tcp mysql:3306".to_string(),
+            "tcp 127.0.0.1:3306".to_string()
+        ],
+        "a nested-only ports list must not be read; got {labels:?}"
+    );
+}
+
+#[test]
+fn service_level_ports_before_nested_still_wins() {
+    // Order-independence: the real `ports:` appears BEFORE a later nested one.
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    ports:\n      - '127.0.0.2:33061:3306'\n    x-meta:\n      ports:\n        - '10.0.0.1:9999:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let labels = tcp_labels(&provider.build_mysql_candidates(&mysql_service_cfg()));
+    assert!(
+        labels.contains(&"tcp 127.0.0.2:33061".to_string()),
+        "got {labels:?}"
+    );
+    assert!(
+        !labels.iter().any(|l| l.contains("10.0.0.1")),
+        "got {labels:?}"
+    );
+}
+
+#[test]
+fn app_port_loopback_bind_yields_no_app_port_candidate() {
+    // APP_PORT=127.0.0.1:80 → the backstop already covers 127.0.0.1, so
+    // detect_from_app_port returns None and the sole 127.0.0.1 candidate
+    // carries the backstop note (not a misattributed APP_PORT note).
+    let dir = TempDir::new().unwrap();
+    write(dir.path(), ".env", "APP_PORT=127.0.0.1:80\n");
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cfg = mysql_service_cfg();
+    assert!(
+        provider.detect_from_app_port(&cfg).is_none(),
+        "a 127.0.0.1 APP_PORT bind must not produce an APP_PORT-attributed candidate"
+    );
+    let cands = provider.build_mysql_candidates(&cfg);
+    let backstop = cands
+        .iter()
+        .find(|c| c.label == "tcp 127.0.0.1:3306")
+        .expect("backstop present");
+    assert!(
+        backstop
+            .success_note
+            .as_deref()
+            .unwrap_or("")
+            .contains("Sail"),
+        "the 127.0.0.1 candidate carries the backstop note, not APP_PORT attribution"
+    );
+    assert_eq!(
+        tcp_labels(&cands),
+        vec![
+            "tcp mysql:3306".to_string(),
+            "tcp 127.0.0.1:3306".to_string()
+        ]
+    );
+}
+
+// ---- broadened gate: detection also runs for a plain-loopback primary ----
+
+#[test]
+fn should_attempt_sail_detection_covers_loopback_but_not_explicit_ips() {
+    assert!(DatabaseSchemaProvider::should_attempt_sail_detection(
+        "mysql"
+    ));
+    assert!(DatabaseSchemaProvider::should_attempt_sail_detection(
+        "127.0.0.1"
+    ));
+    assert!(DatabaseSchemaProvider::should_attempt_sail_detection(
+        "localhost"
+    ));
+    assert!(DatabaseSchemaProvider::should_attempt_sail_detection(
+        "Localhost"
+    ));
+    // Explicit, precisely-named hosts are honoured verbatim — no detection.
+    assert!(!DatabaseSchemaProvider::should_attempt_sail_detection(
+        "127.0.0.2"
+    ));
+    assert!(!DatabaseSchemaProvider::should_attempt_sail_detection(
+        "192.168.1.50"
+    ));
+    assert!(!DatabaseSchemaProvider::should_attempt_sail_detection(
+        "db.example.com"
+    ));
+}
+
+#[test]
+fn loopback_host_with_app_port_detects_second_loopback_ip() {
+    // The Decision Cloud case: DB_HOST=127.0.0.1 but Sail is pinned to
+    // 127.0.0.2 via APP_PORT. Literal primary first, detected second.
+    let dir = TempDir::new().unwrap();
+    write(dir.path(), ".env", "APP_PORT=127.0.0.2:80\n");
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cfg = make_config_with(None, None, "127.0.0.1");
+    assert_eq!(
+        tcp_labels(&provider.build_mysql_candidates(&cfg)),
+        vec![
+            "tcp 127.0.0.1:3306".to_string(),
+            "tcp 127.0.0.2:3306".to_string()
+        ],
+        "literal 127.0.0.1 primary first, detected 127.0.0.2 second"
+    );
+}
+
+#[test]
+fn localhost_host_with_app_port_detects_loopback_ip() {
+    let dir = TempDir::new().unwrap();
+    write(dir.path(), ".env", "APP_PORT=127.0.0.2:80\n");
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cfg = make_config_with(None, None, "localhost");
+    assert_eq!(
+        tcp_labels(&provider.build_mysql_candidates(&cfg)),
+        vec![
+            "tcp localhost:3306".to_string(),
+            "tcp 127.0.0.2:3306".to_string()
+        ],
+        "the literal 'localhost' primary is kept; 127.0.0.2 is added"
+    );
+}
+
+#[test]
+fn loopback_host_with_compose_detects_bind_ip() {
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    ports:\n      - '127.0.0.2:3306:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cfg = make_config_with(None, None, "127.0.0.1");
+    assert_eq!(
+        tcp_labels(&provider.build_mysql_candidates(&cfg)),
+        vec![
+            "tcp 127.0.0.1:3306".to_string(),
+            "tcp 127.0.0.2:3306".to_string()
+        ]
+    );
+}
+
+#[test]
+fn loopback_host_with_matching_app_port_yields_only_primary() {
+    // APP_PORT bound to 127.0.0.1 → the 127.0.0.1 guard returns None, and a
+    // loopback primary has no backstop, so just the single primary remains.
+    let dir = TempDir::new().unwrap();
+    write(dir.path(), ".env", "APP_PORT=127.0.0.1:80\n");
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cfg = make_config_with(None, None, "127.0.0.1");
+    assert_eq!(
+        tcp_labels(&provider.build_mysql_candidates(&cfg)),
+        vec!["tcp 127.0.0.1:3306".to_string()]
+    );
+}
+
+#[test]
+fn explicit_non_loopback_host_skips_detection_even_with_app_port() {
+    // A precisely-named host must be honoured verbatim — no APP_PORT/compose
+    // second-guessing, even when a signal is present.
+    for host in ["192.168.1.50", "db.example.com", "127.0.0.2"] {
+        let dir = TempDir::new().unwrap();
+        write(dir.path(), ".env", "APP_PORT=127.0.0.9:80\n");
+        write(
+            dir.path(),
+            "docker-compose.override.yml",
+            "services:\n  mysql:\n    ports:\n      - '127.0.0.8:3306:3306'\n",
+        );
+        let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+        let cfg = make_config_with(None, None, host);
+        assert_eq!(
+            tcp_labels(&provider.build_mysql_candidates(&cfg)),
+            vec![format!("tcp {host}:3306")],
+            "explicit host {host} must skip detection"
+        );
+    }
+}
+
+// ---- YAML merge tags (`!override` / `!reset`) — the real Sail override shape ----
+
+#[test]
+fn line_is_key_accepts_yaml_tag_but_not_inline_scalar() {
+    use super::line_is_key;
+    // A `!`-tag introduces the block below the key.
+    assert!(line_is_key("ports: !override", "ports"));
+    assert!(line_is_key("ports: !reset", "ports"));
+    assert!(line_is_key("ports:  !override  # note", "ports"));
+    // Still a key when bare or comment-only.
+    assert!(line_is_key("ports:", "ports"));
+    assert!(line_is_key("ports: # inline list follows", "ports"));
+    // A real inline scalar is NOT a block-introducing key.
+    assert!(!line_is_key("ports: 3306:3306", "ports"));
+    assert!(!line_is_key("image: mysql:8", "ports"));
+}
+
+/// The exact Decision Cloud override: `ports: !override` binding the DB to
+/// 127.0.0.2, layered over a base compose that binds to 127.0.0.1.
+const DC_OVERRIDE: &str = "services:\n  mysql:\n    ports: !override\n      - '127.0.0.2:3306:3306'\n  pgsql:\n    ports: !override\n      - '127.0.0.2:5432:5432'\n";
+const DC_BASE: &str = "services:\n  mysql:\n    ports:\n      - '${FORWARD_DB_PORT:-3306}:3306'\n";
+
+#[test]
+fn sail_override_with_merge_tag_wins_over_base() {
+    let dir = TempDir::new().unwrap();
+    write(dir.path(), "docker-compose.override.yml", DC_OVERRIDE);
+    write(dir.path(), "docker-compose.yml", DC_BASE);
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let labels = tcp_labels(&provider.build_mysql_candidates(&mysql_service_cfg()));
+    assert_eq!(
+        labels,
+        vec![
+            "tcp mysql:3306".to_string(),
+            "tcp 127.0.0.2:3306".to_string(),
+            "tcp 127.0.0.1:3306".to_string(),
+        ],
+        "the `!override` block must be read (127.0.0.2), beating base's 127.0.0.1"
+    );
+}
+
+#[test]
+fn sail_override_merge_tag_with_loopback_host() {
+    let dir = TempDir::new().unwrap();
+    write(dir.path(), "docker-compose.override.yml", DC_OVERRIDE);
+    write(dir.path(), "docker-compose.yml", DC_BASE);
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cfg = make_config_with(None, None, "127.0.0.1");
+    assert_eq!(
+        tcp_labels(&provider.build_mysql_candidates(&cfg)),
+        vec![
+            "tcp 127.0.0.1:3306".to_string(),
+            "tcp 127.0.0.2:3306".to_string()
+        ]
+    );
+}
+
+#[test]
+fn sail_override_merge_tag_custom_host_port() {
+    let dir = TempDir::new().unwrap();
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    ports: !override\n      - '127.0.0.2:33061:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let labels = tcp_labels(&provider.build_mysql_candidates(&mysql_service_cfg()));
+    assert!(
+        labels.contains(&"tcp 127.0.0.2:33061".to_string()),
+        "the forwarded host port under a `!override` tag is honoured; got {labels:?}"
+    );
+}
+
+#[test]
+fn sail_override_merge_tag_feeds_postgres_too() {
+    let dir = TempDir::new().unwrap();
+    write(dir.path(), "docker-compose.override.yml", DC_OVERRIDE);
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let mut cfg = make_config_with(None, None, "pgsql");
+    cfg.driver = "pgsql".to_string();
+    cfg.port = 5432;
+    assert_eq!(
+        tcp_labels(&provider.build_postgres_candidates(&cfg)),
+        vec![
+            "tcp pgsql:5432".to_string(),
+            "tcp 127.0.0.2:5432".to_string(),
+            "tcp 127.0.0.1:5432".to_string(),
+        ]
+    );
+}
+
+// ---- variable-referenced connection block (Sail's `'mysql' => $mysql`) ----
+
+/// A Sail-style config where the connection is factored into a `$mysql`
+/// variable and referenced from `connections` (the real Decision Cloud shape).
+const CONFIG_VAR_FORM: &str = r#"<?php
+$mysql = [
+    'driver' => 'mysql',
+    'host' => env('DB_HOST', '127.0.0.1'),
+    'port' => env('DB_PORT', '3306'),
+    'database' => env('DB_DATABASE', 'laravel'),
+    'username' => env('DB_USERNAME', 'root'),
+    'password' => env('DB_PASSWORD', ''),
+];
+$mysqlUnbuffered = $mysql;
+return [
+    'default' => env('DB_CONNECTION', 'mysql'),
+    'connections' => [
+        'mysql' => $mysql,
+        'mysql_unbuffered' => $mysqlUnbuffered,
+    ],
+];
+"#;
+
+fn write_config_php(dir: &std::path::Path, content: &str) {
+    std::fs::create_dir_all(dir.join("config")).unwrap();
+    std::fs::write(dir.join("config").join("database.php"), content).unwrap();
+}
+
+const DC_ENV: &str =
+    "DB_CONNECTION=mysql\nDB_HOST=mysql\nDB_DATABASE=cashlender\nDB_USERNAME=sail\nDB_PASSWORD=password\n";
+
+#[test]
+fn extract_connection_block_inline_form_still_works() {
+    let provider = DatabaseSchemaProvider::new(PathBuf::from("/tmp"));
+    let content = "'connections' => [\n  'mysql' => [\n    'driver' => 'mysql',\n    'host' => env('DB_HOST', '127.0.0.1'),\n  ],\n]";
+    let block = provider
+        .extract_connection_block(content, "mysql")
+        .expect("inline array must resolve");
+    assert!(block.contains("'host' => env('DB_HOST'"), "got: {block}");
+}
+
+#[test]
+fn extract_connection_block_variable_form_resolves() {
+    let provider = DatabaseSchemaProvider::new(PathBuf::from("/tmp"));
+    let block = provider
+        .extract_connection_block(CONFIG_VAR_FORM, "mysql")
+        .expect("`'mysql' => $mysql` must resolve to the $mysql array");
+    assert!(block.contains("'host' => env('DB_HOST'"), "got: {block}");
+    assert!(
+        block.contains("'database' => env('DB_DATABASE'"),
+        "got: {block}"
+    );
+}
+
+#[test]
+fn extract_connection_block_undefined_variable_is_none() {
+    let provider = DatabaseSchemaProvider::new(PathBuf::from("/tmp"));
+    let content = "'connections' => [\n  'mysql' => $missing,\n]";
+    assert!(
+        provider
+            .extract_connection_block(content, "mysql")
+            .is_none(),
+        "an undefined variable reference must fail open to None (→ defaults)"
+    );
+}
+
+#[tokio::test]
+async fn variable_referenced_connection_resolves_env_not_defaults() {
+    let dir = TempDir::new().unwrap();
+    write_config_php(dir.path(), CONFIG_VAR_FORM);
+    write(dir.path(), ".env", DC_ENV);
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cfg = provider.get_database_config().await.expect("config parsed");
+    // Before the fix these were all hardcoded defaults (127.0.0.1 / laravel /
+    // root / ""), silently ignoring .env.
+    assert_eq!(cfg.host, "mysql");
+    assert_eq!(cfg.database, "cashlender");
+    assert_eq!(cfg.username, "sail");
+    assert_eq!(cfg.password, "password");
+    assert_eq!(cfg.port, 3306);
+}
+
+#[tokio::test]
+async fn decision_cloud_end_to_end_variable_config_plus_sail_override() {
+    let dir = TempDir::new().unwrap();
+    write_config_php(dir.path(), CONFIG_VAR_FORM);
+    write(dir.path(), ".env", DC_ENV);
+    write(
+        dir.path(),
+        "docker-compose.override.yml",
+        "services:\n  mysql:\n    ports: !override\n      - '127.0.0.2:3306:3306'\n",
+    );
+    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    let cfg = provider.get_database_config().await.expect("config parsed");
+    assert_eq!(cfg.host, "mysql", "the real DB_HOST feeds detection");
+
+    let labels = tcp_labels(&provider.build_mysql_candidates(&cfg));
+    assert!(
+        labels.contains(&"tcp mysql:3306".to_string()),
+        "primary service-name candidate present: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"tcp 127.0.0.2:3306".to_string()),
+        "Sail override 127.0.0.2 detected once the host is correct: {labels:?}"
+    );
+}

--- a/laravel-lsp/src/file_watcher.rs
+++ b/laravel-lsp/src/file_watcher.rs
@@ -9,11 +9,16 @@
 //! Design choices, in case they need revisiting later:
 //!
 //! 1. **Glob-scoped, not project-wide.** We only ask the client to
-//!    notify us about files under the four Laravel directories we
-//!    actually index: `app/Http/Controllers`, the configured view
-//!    paths, the Livewire path (if any), and `routes/`. A
-//!    `composer install` that rewrites thousands of files in
-//!    `vendor/` produces zero notifications.
+//!    notify us about files we actually index: the project's PSR-4
+//!    source roots (from `composer.json` — `app/`, `src/`, any custom
+//!    `Modules\` mapping), the configured view paths, the Livewire path
+//!    (if any), `routes/`, `database/migrations/`, `vendor/`, and the
+//!    Inertia pages dir. The PSR-4 roots (M2) are what make an external
+//!    edit to *any* first-party source dir — not just the hardcoded
+//!    controllers path — converge the magic-member index. A
+//!    `composer install` that rewrites thousands of files in `vendor/`
+//!    still produces one debounced incremental batch, not a project-wide
+//!    rebuild.
 //!
 //! 2. **Server-initiated dynamic registration.** Zed's view paths and
 //!    Livewire path depend on the project's `config/view.php` and
@@ -28,11 +33,12 @@
 //!    the file pays the parse cost lazily. Spreads work across user-
 //!    driven queries instead of bunching it.
 //!
-//! 4. **No debounce.** Per-event work is ~50µs (a DashMap remove + an
-//!    actor message). Even a 2000-file burst from `git checkout` drains
-//!    in <100ms — invisible. If we ever add eager re-parsing, a quiet-
-//!    period debouncer is the right addition; without it, the work is
-//!    too cheap to coalesce.
+//! 4. **Debounced magic-index convergence.** Per-event pattern-cache
+//!    work is ~50µs (a DashMap remove + an actor message), too cheap to
+//!    coalesce on its own. But since M2 the watched path *also* drives a
+//!    dependency-tracked magic-member reconverge, which IS worth
+//!    coalescing: a `git checkout` burst is collapsed into one debounced
+//!    incremental batch (see `schedule_magic_rebuild` in `main.rs`).
 //!
 //! 5. **Open-document precedence.** If a file is currently open in the
 //!    editor, its in-memory authoritative content is the editor buffer,
@@ -68,10 +74,21 @@ pub const METHOD: &str = "workspace/didChangeWatchedFiles";
 /// `SalsaActor::handle_register_project_files` enumerates, so the
 /// pattern_cache only ever holds entries for files we're also
 /// watching.
+///
+/// `psr4_roots` are the project's first-party PSR-4 source roots
+/// (`ComposerAutoload::project_source_roots`) — each gets a recursive
+/// `**/*.php` glob so an external edit to any first-party source dir
+/// converges the magic-member index (M2). A root whose recursive glob is
+/// already emitted verbatim (an exact string match against an earlier
+/// glob) is skipped; a merely-overlapping glob (`app/**/*.php` over the
+/// fixed `app/Http/Controllers/**/*.php`) is left in place — duplicate
+/// events collapse in the idempotent watched-files handler, so the
+/// overlap is harmless.
 pub fn build_watchers(
     root: &Path,
     view_paths: &[PathBuf],
     livewire_path: Option<&Path>,
+    psr4_roots: &[PathBuf],
 ) -> Vec<FileSystemWatcher> {
     // Watch creates, changes, and deletes — all three matter for
     // keeping the pattern cache aligned with disk. The LSP spec's
@@ -80,12 +97,15 @@ pub fn build_watchers(
     let kind = Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete);
 
     // 5 fixed (controllers, routes, migrations, vendor php + blade) + 4 Inertia
-    // page-extension globs + 1 optional livewire + 2 per view path.
-    let mut watchers = Vec::with_capacity(10 + 2 * view_paths.len());
+    // page-extension globs + 1 optional livewire + 2 per view path + 1 per PSR-4
+    // source root.
+    let mut watchers = Vec::with_capacity(10 + 2 * view_paths.len() + psr4_roots.len());
 
     // Controllers — current default path. If a project moves them, we
     // miss those changes until a future improvement makes this glob
-    // configurable. Acceptable for v1.
+    // configurable. Acceptable for v1. (The PSR-4 roots below usually
+    // cover `app/` too, but this stays as a floor for a project whose
+    // `composer.json` we couldn't read.)
     watchers.push(FileSystemWatcher {
         glob_pattern: GlobPattern::String(format!(
             "{}/app/Http/Controllers/**/*.php",
@@ -164,6 +184,33 @@ pub fn build_watchers(
         });
     }
 
+    // First-party PSR-4 source roots (M2). Each gets a recursive `**/*.php`
+    // glob (which also matches `.blade.php`) so an external edit to any
+    // first-party source dir — `app/`, `src/`, a custom `Modules\` layout —
+    // reaches the watched-files handler and converges the magic-member index.
+    // Skip a root whose glob exactly duplicates one already emitted; a merely
+    // overlapping glob is left in place (the handler is idempotent).
+    let mut existing: std::collections::HashSet<String> = watchers
+        .iter()
+        .filter_map(|w| match &w.glob_pattern {
+            GlobPattern::String(s) => Some(s.clone()),
+            GlobPattern::Relative(_) => None,
+        })
+        .collect();
+    for src_root in psr4_roots {
+        let glob = format!("{}/**/*.php", src_root.display());
+        // Skip a glob already emitted — whether by a fixed watcher or an
+        // earlier PSR-4 root this call (defensive: `project_source_roots`
+        // already dedups, but two identical roots must never double-register).
+        if !existing.insert(glob.clone()) {
+            continue;
+        }
+        watchers.push(FileSystemWatcher {
+            glob_pattern: GlobPattern::String(glob),
+            kind,
+        });
+    }
+
     watchers
 }
 
@@ -174,8 +221,9 @@ pub fn build_registration(
     root: &Path,
     view_paths: &[PathBuf],
     livewire_path: Option<&Path>,
+    psr4_roots: &[PathBuf],
 ) -> Registration {
-    let watchers = build_watchers(root, view_paths, livewire_path);
+    let watchers = build_watchers(root, view_paths, livewire_path, psr4_roots);
     let opts = DidChangeWatchedFilesRegistrationOptions { watchers };
     Registration {
         id: REGISTRATION_ID.to_string(),

--- a/laravel-lsp/src/file_watcher/tests.rs
+++ b/laravel-lsp/src/file_watcher/tests.rs
@@ -11,7 +11,7 @@ fn watchers_cover_all_four_indexed_directories() {
     let root = PathBuf::from("/projects/laravel-app");
     let view_paths = vec![root.join("resources/views")];
     let livewire = root.join("app/Livewire");
-    let watchers = build_watchers(&root, &view_paths, Some(&livewire));
+    let watchers = build_watchers(&root, &view_paths, Some(&livewire), &[]);
 
     let globs: Vec<String> = watchers
         .iter()
@@ -56,7 +56,7 @@ fn watchers_cover_all_four_indexed_directories() {
 fn watchers_omit_livewire_when_not_configured() {
     let root = PathBuf::from("/projects/no-livewire-app");
     let view_paths = vec![root.join("resources/views")];
-    let watchers = build_watchers(&root, &view_paths, None);
+    let watchers = build_watchers(&root, &view_paths, None, &[]);
 
     let has_livewire = watchers.iter().any(|w| match &w.glob_pattern {
         GlobPattern::String(s) => s.contains("Livewire"),
@@ -78,7 +78,7 @@ fn watchers_register_each_configured_view_path() {
         root.join("themes/dark/views"),
         root.join("themes/light/views"),
     ];
-    let watchers = build_watchers(&root, &view_paths, None);
+    let watchers = build_watchers(&root, &view_paths, None, &[]);
 
     for view_path in &view_paths {
         let has_blade = watchers.iter().any(|w| match &w.glob_pattern {
@@ -94,7 +94,7 @@ fn watchers_register_each_configured_view_path() {
 #[test]
 fn watchers_request_create_change_and_delete_events() {
     let root = PathBuf::from("/projects/test");
-    let watchers = build_watchers(&root, &[root.join("resources/views")], None);
+    let watchers = build_watchers(&root, &[root.join("resources/views")], None, &[]);
 
     let all_three = WatchKind::Create | WatchKind::Change | WatchKind::Delete;
     for w in &watchers {
@@ -109,7 +109,7 @@ fn watchers_request_create_change_and_delete_events() {
 #[test]
 fn registration_has_correct_method_and_id() {
     let root = PathBuf::from("/projects/test");
-    let reg = build_registration(&root, &[root.join("resources/views")], None);
+    let reg = build_registration(&root, &[root.join("resources/views")], None, &[]);
     assert_eq!(reg.method, METHOD);
     assert_eq!(reg.id, REGISTRATION_ID);
     assert!(reg.register_options.is_some(), "options must be serialized");
@@ -120,7 +120,7 @@ fn registration_options_round_trip_through_serde() {
     let root = PathBuf::from("/projects/test");
     let view_paths = vec![root.join("resources/views")];
     let livewire = root.join("app/Livewire");
-    let reg = build_registration(&root, &view_paths, Some(&livewire));
+    let reg = build_registration(&root, &view_paths, Some(&livewire), &[]);
 
     // The client deserializes our register_options into
     // DidChangeWatchedFilesRegistrationOptions. Verify the value we
@@ -145,7 +145,7 @@ fn watchers_include_inertia_page_globs() {
     // #10) — one watcher glob per supported extension so external page
     // create/delete invalidates the existence cache.
     let root = PathBuf::from("/projects/laravel-app");
-    let watchers = build_watchers(&root, &[root.join("resources/views")], None);
+    let watchers = build_watchers(&root, &[root.join("resources/views")], None, &[]);
 
     let globs: Vec<String> = watchers
         .iter()
@@ -169,7 +169,7 @@ fn watchers_include_inertia_page_globs() {
 #[test]
 fn watchers_include_vendor_php_and_blade_globs() {
     let root = PathBuf::from("/projects/laravel-app");
-    let watchers = build_watchers(&root, &[root.join("resources/views")], None);
+    let watchers = build_watchers(&root, &[root.join("resources/views")], None, &[]);
 
     let globs: Vec<String> = watchers
         .iter()
@@ -192,5 +192,78 @@ fn watchers_include_vendor_php_and_blade_globs() {
             .any(|g| g.contains("/vendor/") && g.ends_with("*.blade.php")),
         "missing vendor blade glob: {:?}",
         globs
+    );
+}
+
+fn globs_of(watchers: &[FileSystemWatcher]) -> Vec<String> {
+    watchers
+        .iter()
+        .map(|w| match &w.glob_pattern {
+            GlobPattern::String(s) => s.clone(),
+            GlobPattern::Relative(_) => unreachable!("we always emit absolute"),
+        })
+        .collect()
+}
+
+#[test]
+fn watchers_include_a_recursive_glob_per_psr4_root() {
+    // Each first-party PSR-4 source root (M2) gets its own recursive `**/*.php`
+    // glob so an external edit anywhere under it converges the magic index.
+    let root = PathBuf::from("/projects/laravel-app");
+    let psr4 = vec![root.join("app"), root.join("src")];
+    let watchers = build_watchers(&root, &[root.join("resources/views")], None, &psr4);
+
+    let globs = globs_of(&watchers);
+    for src in &psr4 {
+        let expected = format!("{}/**/*.php", src.display());
+        assert!(
+            globs.iter().any(|g| g == &expected),
+            "missing PSR-4 glob {expected}: {globs:?}"
+        );
+    }
+}
+
+#[test]
+fn psr4_glob_that_exactly_duplicates_an_existing_one_is_skipped() {
+    // A PSR-4 root whose recursive glob is byte-identical to one already
+    // emitted must not produce a duplicate watcher. The Inertia pages dir
+    // isn't `*.php`, and the fixed globs are all more specific, so the only
+    // way to collide is to hand in a root that reproduces a fixed glob — here
+    // we prove the dedup by counting: two identical roots yield one glob.
+    let root = PathBuf::from("/projects/laravel-app");
+    let psr4 = vec![root.join("app"), root.join("app")];
+    let watchers = build_watchers(&root, &[root.join("resources/views")], None, &psr4);
+
+    let expected = format!("{}/app/**/*.php", root.display());
+    let count = globs_of(&watchers)
+        .into_iter()
+        .filter(|g| g == &expected)
+        .count();
+    assert_eq!(count, 1, "duplicate PSR-4 roots must collapse to one glob");
+}
+
+#[test]
+fn overlapping_psr4_glob_coexists_with_fixed_controllers_glob() {
+    // `app/**/*.php` overlaps — but is not byte-identical to — the fixed
+    // `app/Http/Controllers/**/*.php`. Both must be present: the overlap is
+    // harmless (the watched-files handler is idempotent), and dropping the
+    // fixed one would narrow coverage on a project whose composer.json we
+    // couldn't read.
+    let root = PathBuf::from("/projects/laravel-app");
+    let psr4 = vec![root.join("app")];
+    let watchers = build_watchers(&root, &[root.join("resources/views")], None, &psr4);
+
+    let globs = globs_of(&watchers);
+    assert!(
+        globs
+            .iter()
+            .any(|g| g == &format!("{}/app/**/*.php", root.display())),
+        "missing widened app glob: {globs:?}"
+    );
+    assert!(
+        globs
+            .iter()
+            .any(|g| g == &format!("{}/app/Http/Controllers/**/*.php", root.display())),
+        "fixed controllers glob must survive alongside the widened app glob: {globs:?}"
     );
 }

--- a/laravel-lsp/src/indexing_progress.rs
+++ b/laravel-lsp/src/indexing_progress.rs
@@ -34,15 +34,83 @@ pub const RENAME_TOKEN: &str = "laravel-lsp/rename";
 /// the user can't see anyway. Slower and the bar feels jumpy.
 const REPORT_THROTTLE: Duration = Duration::from_millis(150);
 
-/// Portion of the unified indexing bar allotted to the parse phase
-/// (per-file tree-sitter parsing). The remainder (`100 - PARSE_SPAN`)
-/// belongs to the magic-member resolve phase, so the two loops fill
-/// disjoint slices of one monotonic 0→100% bar instead of each racing
-/// 0→100 against its own denominator (which made the bar visibly fill
-/// and then reset mid-index). The split is an eyeballed weighting —
-/// tune it against the per-phase timings the warm task logs on a cold
-/// run ("parse …, magic-resolve …").
+// ── Slice map ────────────────────────────────────────────────────────
+// The unified 0→100% bar is carved into disjoint per-phase slices so it
+// stays monotonic (no phase resets to 0). Two branches, because the work
+// profile differs sharply:
+//
+//   COLD (nothing restored from the pattern disk cache — first launch or
+//   a schema-invalidated cache): the disk load does nothing, so parsing
+//   dominates. Layout:  parse 0..PARSE_SPAN │ magic-build PARSE_SPAN..100.
+//
+//   WARM (disk cache restored ≥1 file): the ~40k-entry disk-cache load
+//   and the granular magic re-resolve dominate; parsing is a small burst
+//   over the changed files. Layout:
+//     load 0..LOAD_SPAN │ parse LOAD_SPAN..WARM_PARSE_TOP │
+//     bulk-op boundary band WARM_PARSE_TOP..WARM_RESOLVE_BASE │
+//     re-resolve WARM_RESOLVE_BASE..100.
+//
+// All values are eyeballed weightings — tune against the per-phase
+// timings the warm task logs ("parse …, magic-resolve …"). The priority
+// is NEVER FREEZE + monotonic, not proportional accuracy.
+
+/// Top of the disk-cache **load** slice on a warm reload (`load
+/// 0..LOAD_SPAN`). The load restores ~40k entries — an mtime stat +
+/// position-index rebuild each — the dominant early warm cost, so it
+/// earns a wide early slice. Unused on a cold start: with no cache the
+/// load is instant and reports nothing, and cold parse owns
+/// `0..PARSE_SPAN` instead.
+pub const LOAD_SPAN: u32 = 40;
+
+/// Top of the **cold** parse slice: parse `0..PARSE_SPAN`, magic-build
+/// `PARSE_SPAN..100`. Parsing is the dominant cold cost.
 pub const PARSE_SPAN: u32 = 75;
+
+/// Top of the **warm** parse slice: parse `LOAD_SPAN..WARM_PARSE_TOP`, a
+/// small burst over the changed files. The
+/// `WARM_PARSE_TOP..WARM_RESOLVE_BASE` gap above it is the boundary band
+/// where the opaque bulk phases (disk-cache save, magic-restore decode,
+/// index import) advance the bar with forced phase messages.
+pub const WARM_PARSE_TOP: u32 = 48;
+
+/// Base of the **warm** re-resolve slice: the granular magic re-resolve
+/// (`refresh_files_magic`) fills `WARM_RESOLVE_BASE..100`. Call sites
+/// clamp with `max(parse_top)` so a cold-parse / warm-magic mix (pattern
+/// cache stale but magic cache fresh) continues from `PARSE_SPAN` instead
+/// of jumping backwards.
+pub const WARM_RESOLVE_BASE: u32 = 55;
+
+// Compile-time warm slice-layout invariant: load, parse, boundary band,
+// and re-resolve are strictly ordered and the re-resolve slice is
+// non-empty (its base sits below 100).
+const _: () = assert!(
+    LOAD_SPAN < WARM_PARSE_TOP && WARM_PARSE_TOP < WARM_RESOLVE_BASE && WARM_RESOLVE_BASE < 100,
+);
+
+/// Choose the parse phase's `(base, top)` slice of the unified bar from
+/// two *independent* signals, so all three reload shapes pace sensibly
+/// and stay monotonic:
+///
+/// - `cache_scanned` — did the disk-cache load slice run? True whenever a
+///   cache existed and was scanned (entries restored OR dropped), so the
+///   bar already climbed to [`LOAD_SPAN`]. Sets the **base**: parse
+///   continues from `LOAD_SPAN`, or from `0` on a true cold start.
+/// - `has_cached_hits` — is this a small changed set (the warm shape)?
+///   Sets the **top**: a warm burst tops out at [`WARM_PARSE_TOP`]; a
+///   large re-parse (all-dropped, or cold) runs up to [`PARSE_SPAN`].
+///
+/// Shapes: fully-warm → `LOAD_SPAN..WARM_PARSE_TOP`; all-dropped →
+/// `LOAD_SPAN..PARSE_SPAN` (the sensible hybrid — the load ran but every
+/// file must re-parse); fully-cold → `0..PARSE_SPAN`.
+pub fn parse_slice(cache_scanned: bool, has_cached_hits: bool) -> (u32, u32) {
+    let base = if cache_scanned { LOAD_SPAN } else { 0 };
+    let top = if has_cached_hits {
+        WARM_PARSE_TOP
+    } else {
+        PARSE_SPAN
+    };
+    (base, top)
+}
 
 /// Map `done / total` into the `base..=base + span` slice of a single
 /// 0–100% progress bar. Multi-phase pipelines give each phase a
@@ -72,6 +140,24 @@ pub struct IndexingProgress {
     /// Set to false after `end` runs so `Drop` doesn't double-end.
     active: bool,
     last_report: Instant,
+    /// Highest percentage sent so far on a *determinate* bar, used to floor
+    /// every later report so the fill never moves backwards within a
+    /// session (a work-done bar that snaps 40→0 across a phase hand-off
+    /// looks broken). `None` marks an *indeterminate* spinner (begun with
+    /// no percentage): those pass their percentage through untouched — a
+    /// spinner has no fill to protect. See [`clamp_monotonic`].
+    last_pct: Option<u32>,
+}
+
+/// Floor `new` at `last` so a determinate bar never decreases: a later
+/// report may raise the fill or hold it, never lower it. `None` (a report
+/// with no percentage) holds at `last`. Pure and total so the monotonic
+/// guarantee is unit-testable without a mock client.
+fn clamp_monotonic(new: Option<u32>, last: u32) -> u32 {
+    match new {
+        Some(p) => p.max(last),
+        None => last,
+    }
 }
 
 impl IndexingProgress {
@@ -132,6 +218,11 @@ impl IndexingProgress {
             token,
             active: true,
             last_report: Instant::now(),
+            // Seed the monotonic floor with the initial fill: a fresh
+            // session (or reindex) begins here, so nothing before it
+            // constrains the bar. `None` here means indeterminate — the
+            // clamp is bypassed entirely for spinners.
+            last_pct: percentage,
         })
     }
 
@@ -152,6 +243,19 @@ impl IndexingProgress {
             return;
         }
         self.last_report = Instant::now();
+
+        // Floor the fill on a determinate bar so it never moves backwards;
+        // the message always updates, only the percentage is clamped, so a
+        // phase-transition report still shows its text while the bar holds.
+        // Indeterminate spinners (`last_pct == None`) pass through untouched.
+        let percentage = match self.last_pct {
+            Some(last) => {
+                let sent = clamp_monotonic(percentage, last);
+                self.last_pct = Some(sent);
+                Some(sent)
+            }
+            None => percentage,
+        };
 
         self.client
             .send_notification::<ProgressNotification>(ProgressParams {
@@ -261,6 +365,203 @@ mod tests {
     fn empty_phase_reports_its_base() {
         assert_eq!(weighted_pct(0, 0, 0, PARSE_SPAN), 0);
         assert_eq!(weighted_pct(0, 0, PARSE_SPAN, 100 - PARSE_SPAN), PARSE_SPAN);
+    }
+
+    /// The warm disk-cache load slice fills `0..LOAD_SPAN` — the ~40k
+    /// entries the reporter animates while the freshness pass runs.
+    #[test]
+    fn warm_load_slice_fills_zero_to_load_span() {
+        assert_eq!(weighted_pct(0, 40_000, 0, LOAD_SPAN), 0);
+        assert_eq!(weighted_pct(40_000, 40_000, 0, LOAD_SPAN), LOAD_SPAN);
+    }
+
+    /// The warm slices meet at their boundaries: load tops out at
+    /// LOAD_SPAN where parse begins, parse tops out at WARM_PARSE_TOP,
+    /// and the re-resolve slice runs WARM_RESOLVE_BASE..100. (The const
+    /// ordering itself is a compile-time assert by the consts.)
+    #[test]
+    fn warm_slices_meet_at_their_boundaries() {
+        // load → parse hand-off at LOAD_SPAN.
+        assert_eq!(weighted_pct(9, 9, 0, LOAD_SPAN), LOAD_SPAN);
+        assert_eq!(
+            weighted_pct(0, 5, LOAD_SPAN, WARM_PARSE_TOP - LOAD_SPAN),
+            LOAD_SPAN,
+        );
+        // parse tops out at WARM_PARSE_TOP.
+        assert_eq!(
+            weighted_pct(5, 5, LOAD_SPAN, WARM_PARSE_TOP - LOAD_SPAN),
+            WARM_PARSE_TOP,
+        );
+        // re-resolve runs WARM_RESOLVE_BASE..100.
+        assert_eq!(
+            weighted_pct(0, 300, WARM_RESOLVE_BASE, 100 - WARM_RESOLVE_BASE),
+            WARM_RESOLVE_BASE,
+        );
+        assert_eq!(
+            weighted_pct(300, 300, WARM_RESOLVE_BASE, 100 - WARM_RESOLVE_BASE),
+            100,
+        );
+    }
+
+    /// Walk the whole warm reload — load slice, parse slice, boundary-band
+    /// phase reports, then the re-resolve slice — and assert the bar never
+    /// moves backwards, including across every hand-off.
+    #[test]
+    fn warm_reload_bar_is_monotonic_non_decreasing() {
+        let mut last = 0;
+        let mut check = |pct: u32, at: &str| {
+            assert!(pct >= last, "bar regressed at {at}: {pct} < {last}");
+            last = pct;
+        };
+        // Disk-cache load: the dominant early warm phase (prime total so
+        // integer division exercises every rounding step).
+        let load_total = 40_003;
+        for done in 0..=load_total {
+            check(weighted_pct(done, load_total, 0, LOAD_SPAN), "load");
+        }
+        // Parse burst: a handful of changed files, base = LOAD_SPAN.
+        for done in 0..=3 {
+            check(
+                weighted_pct(done, 3, LOAD_SPAN, WARM_PARSE_TOP - LOAD_SPAN),
+                "parse",
+            );
+        }
+        // Boundary band: the forced phase reports the opaque bulk ops
+        // emit — save/restore at the parse top, import at the resolve base.
+        check(WARM_PARSE_TOP, "save/restore boundary");
+        check(WARM_RESOLVE_BASE, "import boundary");
+        // Granular re-resolve: the dominant late warm phase.
+        let total = 137;
+        for done in 0..=total {
+            check(
+                weighted_pct(done, total, WARM_RESOLVE_BASE, 100 - WARM_RESOLVE_BASE),
+                "re-resolve",
+            );
+        }
+        assert_eq!(last, 100);
+    }
+
+    /// `parse_slice` picks the right `(base, top)` for each of the three
+    /// reload shapes — the base continues the load slice iff the cache was
+    /// scanned, the top widens iff this isn't a small warm changed set.
+    #[test]
+    fn parse_slice_covers_the_three_reload_shapes() {
+        // fully-warm: cache scanned, small changed set.
+        assert_eq!(parse_slice(true, true), (LOAD_SPAN, WARM_PARSE_TOP));
+        // all-dropped: cache scanned, but every file must re-parse.
+        assert_eq!(parse_slice(true, false), (LOAD_SPAN, PARSE_SPAN));
+        // fully-cold: no cache scanned, everything parses from 0.
+        assert_eq!(parse_slice(false, false), (0, PARSE_SPAN));
+        // base < top holds for every shape (a non-empty parse slice).
+        for &(base, top) in &[
+            parse_slice(true, true),
+            parse_slice(true, false),
+            parse_slice(false, false),
+        ] {
+            assert!(base < top, "empty parse slice: {base}..{top}");
+        }
+    }
+
+    /// The all-dropped warm reload (a composer update / branch switch bumps
+    /// every cached file's mtime → the load slice ran but restored nothing,
+    /// so every file re-parses). This is the shape that regressed: the load
+    /// slice climbed to LOAD_SPAN, then the parse transition snapped the bar
+    /// to 0. Assert `parse_slice` bases parse at LOAD_SPAN and the full
+    /// load → parse → magic sequence never decreases and reaches 100.
+    #[test]
+    fn all_dropped_reload_is_monotonic_from_load_span() {
+        let (parse_base, parse_top) = parse_slice(true, false);
+        assert_eq!(
+            parse_base, LOAD_SPAN,
+            "parse must continue from the load slice"
+        );
+        assert_eq!(parse_top, PARSE_SPAN);
+        let resolve_base = parse_top.max(WARM_RESOLVE_BASE);
+        assert_eq!(
+            resolve_base, PARSE_SPAN,
+            "large re-parse hands magic PARSE_SPAN..100"
+        );
+
+        let mut last = 0;
+        let mut check = |pct: u32, at: &str| {
+            assert!(pct >= last, "bar regressed at {at}: {pct} < {last}");
+            last = pct;
+        };
+        // Load slice: every entry dropped, but the reporter still advanced.
+        let load_total = 40_003;
+        for done in 0..=load_total {
+            check(weighted_pct(done, load_total, 0, LOAD_SPAN), "load");
+        }
+        // Parse: the whole project re-parses, base = LOAD_SPAN.
+        let parse_total = 40_003;
+        for done in 0..=parse_total {
+            check(
+                weighted_pct(done, parse_total, parse_base, parse_top - parse_base),
+                "parse",
+            );
+        }
+        // Magic: PARSE_SPAN..100.
+        let magic_total = 137;
+        for done in 0..=magic_total {
+            check(
+                weighted_pct(done, magic_total, resolve_base, 100 - resolve_base),
+                "magic",
+            );
+        }
+        assert_eq!(last, 100);
+    }
+
+    /// Mixed branch: the pattern disk cache was stale (cold parse,
+    /// slice 0..PARSE_SPAN) but the magic cache restored (warm
+    /// re-resolve). The call site clamps the resolve base with
+    /// `max(parse_top)`, so the re-resolve continues from PARSE_SPAN
+    /// instead of jumping back to WARM_RESOLVE_BASE.
+    #[test]
+    fn cold_parse_warm_resolve_stays_monotonic() {
+        let parse_top = PARSE_SPAN; // cold parse tops out here
+        let resolve_base = parse_top.max(WARM_RESOLVE_BASE);
+        assert_eq!(resolve_base, PARSE_SPAN);
+        assert_eq!(
+            weighted_pct(9, 9, 0, parse_top),
+            weighted_pct(0, 50, resolve_base, 100 - resolve_base),
+        );
+        assert_eq!(weighted_pct(50, 50, resolve_base, 100 - resolve_base), 100);
+    }
+
+    /// A decreasing input sequence must come out non-decreasing, and a
+    /// `None` report must hold the last value — the structural guarantee
+    /// that a determinate bar never snaps backwards (e.g. the load slice's
+    /// ~40 → a parse transition's 0 on an all-dropped warm reload).
+    #[test]
+    fn clamp_monotonic_never_decreases() {
+        // Raw inputs a caller might send across phase hand-offs, including
+        // a backwards jump (40 → 0) and holds (None).
+        let inputs = [
+            Some(0),
+            Some(10),
+            Some(40),
+            Some(0),  // backwards jump — must be floored to 40
+            None,     // hold — stays at 40
+            Some(25), // still below the floor — stays at 40
+            Some(55),
+            None,
+            Some(100),
+        ];
+        let mut last = 0;
+        let mut outputs = Vec::new();
+        for new in inputs {
+            last = clamp_monotonic(new, last);
+            outputs.push(last);
+        }
+        // Output is non-decreasing.
+        for pair in outputs.windows(2) {
+            assert!(pair[1] >= pair[0], "regressed: {} < {}", pair[1], pair[0]);
+        }
+        assert_eq!(outputs, [0, 10, 40, 40, 40, 40, 55, 55, 100]);
+        // None on its own is a pure hold.
+        assert_eq!(clamp_monotonic(None, 73), 73);
+        // A raise still raises.
+        assert_eq!(clamp_monotonic(Some(90), 73), 90);
     }
 
     #[test]

--- a/laravel-lsp/src/indexing_progress.rs
+++ b/laravel-lsp/src/indexing_progress.rs
@@ -34,6 +34,30 @@ pub const RENAME_TOKEN: &str = "laravel-lsp/rename";
 /// the user can't see anyway. Slower and the bar feels jumpy.
 const REPORT_THROTTLE: Duration = Duration::from_millis(150);
 
+/// Portion of the unified indexing bar allotted to the parse phase
+/// (per-file tree-sitter parsing). The remainder (`100 - PARSE_SPAN`)
+/// belongs to the magic-member resolve phase, so the two loops fill
+/// disjoint slices of one monotonic 0→100% bar instead of each racing
+/// 0→100 against its own denominator (which made the bar visibly fill
+/// and then reset mid-index). The split is an eyeballed weighting —
+/// tune it against the per-phase timings the warm task logs on a cold
+/// run ("parse …, magic-resolve …").
+pub const PARSE_SPAN: u32 = 75;
+
+/// Map `done / total` into the `base..=base + span` slice of a single
+/// 0–100% progress bar. Multi-phase pipelines give each phase a
+/// disjoint `(base, span)` slice so the combined bar is monotonic —
+/// no per-phase reset to 0%. Saturating and clamped: the result never
+/// exceeds 100, `done > total` pins to the top of the slice, and
+/// `total == 0` (nothing to do in this phase) reports `base`.
+pub fn weighted_pct(done: usize, total: usize, base: u32, span: u32) -> u32 {
+    if total == 0 {
+        return base.min(100);
+    }
+    let filled = (done.min(total) as u64 * u64::from(span) / total as u64) as u32;
+    base.saturating_add(filled).min(100)
+}
+
 /// Active progress handle. `report` is throttled so call sites don't
 /// need to be careful about update frequency. `end` consumes self; drop
 /// without ending also ends (with a fallback message) so a panic in the
@@ -183,5 +207,70 @@ impl Drop for IndexingProgress {
                 })
                 .await;
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase_one_fills_zero_to_parse_span() {
+        assert_eq!(weighted_pct(0, 40, 0, PARSE_SPAN), 0);
+        assert_eq!(weighted_pct(40, 40, 0, PARSE_SPAN), PARSE_SPAN);
+    }
+
+    #[test]
+    fn phase_two_fills_parse_span_to_one_hundred() {
+        let span = 100 - PARSE_SPAN;
+        assert_eq!(weighted_pct(0, 40, PARSE_SPAN, span), PARSE_SPAN);
+        assert_eq!(weighted_pct(40, 40, PARSE_SPAN, span), 100);
+    }
+
+    /// Walk both phases end-to-end (awkward prime total so integer
+    /// division exercises every rounding step) and assert the unified
+    /// bar never moves backwards — including across the phase hand-off.
+    #[test]
+    fn unified_bar_is_monotonic_non_decreasing() {
+        let total = 137;
+        let mut last = 0;
+        for done in 0..=total {
+            let pct = weighted_pct(done, total, 0, PARSE_SPAN);
+            assert!(pct >= last, "phase 1 regressed at {done}: {pct} < {last}");
+            last = pct;
+        }
+        for done in 0..=total {
+            let pct = weighted_pct(done, total, PARSE_SPAN, 100 - PARSE_SPAN);
+            assert!(pct >= last, "phase 2 regressed at {done}: {pct} < {last}");
+            last = pct;
+        }
+        assert_eq!(last, 100);
+    }
+
+    #[test]
+    fn phase_boundary_is_continuous() {
+        // Phase 1's final report and phase 2's first report meet at
+        // exactly PARSE_SPAN — no gap, no backwards jump at the hand-off.
+        assert_eq!(
+            weighted_pct(9, 9, 0, PARSE_SPAN),
+            weighted_pct(0, 9, PARSE_SPAN, 100 - PARSE_SPAN),
+        );
+    }
+
+    #[test]
+    fn empty_phase_reports_its_base() {
+        assert_eq!(weighted_pct(0, 0, 0, PARSE_SPAN), 0);
+        assert_eq!(weighted_pct(0, 0, PARSE_SPAN, 100 - PARSE_SPAN), PARSE_SPAN);
+    }
+
+    #[test]
+    fn result_is_clamped() {
+        // base + span overshooting 100 clamps.
+        assert_eq!(weighted_pct(10, 10, 90, 20), 100);
+        // done > total pins to the top of the slice, never past it.
+        assert_eq!(weighted_pct(50, 10, 0, PARSE_SPAN), PARSE_SPAN);
+        // An absurd base still clamps to 100 (with and without work).
+        assert_eq!(weighted_pct(0, 5, 150, 10), 100);
+        assert_eq!(weighted_pct(0, 0, 150, 10), 100);
     }
 }

--- a/laravel-lsp/src/laravel_introspector/chain.rs
+++ b/laravel-lsp/src/laravel_introspector/chain.rs
@@ -126,10 +126,20 @@ fn parsed_file_cache() -> &'static ParsedCache {
     CACHE.get_or_init(|| Mutex::new(LruCache::new(NonZeroUsize::new(PARSED_CACHE_CAP).unwrap())))
 }
 
-/// Clear the parsed-file memo. Test/bench only — lets a benchmark measure the
-/// cold vs warm cost of this optimization in isolation, and keeps global state
-/// from leaking between tests that assert on cache behavior.
-#[doc(hidden)]
+/// Clear the parsed-file memo.
+///
+/// Drops every cached `(FileStamp, Arc<ParsedClassFile>)` from the
+/// process-global parsed-file cache. Two production callers rely on this:
+///
+/// * The `laravel.reindexProject` command, which resets all process-global
+///   memos before a cold rebuild so a stale parse can't survive the reindex.
+/// * The isolation benchmarks/tests, which clear the memo between passes to
+///   measure the cold vs. warm cost of this optimization, and to keep global
+///   state from leaking between tests that assert on cache behavior.
+///
+/// The memo is otherwise self-freshening — each lookup re-stats the file and
+/// rebuilds on a changed [`FileStamp`] — so this full reset is only needed
+/// when the caller wants a guaranteed-clean slate.
 pub fn reset_parsed_file_cache() {
     parsed_file_cache().lock().unwrap().clear();
 }

--- a/laravel-lsp/src/laravel_introspector/chain.rs
+++ b/laravel-lsp/src/laravel_introspector/chain.rs
@@ -37,12 +37,17 @@
 //! (microseconds per file) that this hasn't been a bottleneck.
 
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::SystemTime;
+
+use lru::LruCache;
 
 use crate::class_locator::find_php_class_file;
 use crate::laravel_introspector::walker::{
-    extract_php_structure, PhpMethodInfo, PhpPropertyInfo, PhpStructure, PhpStructureKind,
-    PhpVisibility,
+    extract_php_structure, PhpFileStructure, PhpMethodInfo, PhpPropertyInfo, PhpStructure,
+    PhpStructureKind, PhpVisibility,
 };
 use crate::query_chain::extract_use_aliases;
 
@@ -50,6 +55,127 @@ use crate::query_chain::extract_use_aliases;
 /// by the previous separate walkers; protects against pathological
 /// trait composition graphs.
 const MAX_DEPTH: usize = 10;
+
+/// Upper bound on parsed class files held in the memo. Bounded so the cache
+/// can't grow without limit for the process lifetime — a 31k-file vendor tree
+/// would otherwise retain every parsed structure (each holding every method's
+/// full `body_source`). 2048 comfortably covers a project's live ancestor set
+/// (base models, common traits, the models under active edit) while capping
+/// worst-case footprint; the LRU evicts the coldest entries past that.
+const PARSED_CACHE_CAP: usize = 2048;
+
+/// A file's identity for cache freshness: its last-modified time **and** byte
+/// size. mtime alone is not enough — an mtime-preserving rewrite (`cp -p`,
+/// `rsync --times`) or two saves within one filesystem mtime tick (1s
+/// granularity on some filesystems) would leave mtime unchanged while the
+/// content differs. Pairing size closes those holes cheaply: `metadata` already
+/// returns both in one stat, and a content change that keeps the exact same
+/// byte length *and* the same mtime is vanishingly unlikely for source edits.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct FileStamp {
+    mtime: SystemTime,
+    size: u64,
+}
+
+impl FileStamp {
+    /// Stat `path` for its (mtime, size). `None` when the file can't be stat'd
+    /// or has no modified time — such a file is parsed fresh every call (correct,
+    /// just uncached) rather than risking a stale hit.
+    fn of(path: &Path) -> Option<Self> {
+        let meta = std::fs::metadata(path).ok()?;
+        Some(FileStamp {
+            mtime: meta.modified().ok()?,
+            size: meta.len(),
+        })
+    }
+}
+
+/// One class file parsed once: its structural outline plus its `use`-alias map.
+/// Not a `*Data` transfer type — it never crosses the Salsa async boundary; it's
+/// a purely in-process memo entry.
+struct ParsedClassFile {
+    structure: PhpFileStructure,
+    aliases: HashMap<String, String>,
+}
+
+/// Process-wide memo of parsed class files, keyed by path and revalidated by
+/// (mtime, size).
+///
+/// # Why
+///
+/// The inheritance walker re-reads and re-parses each ancestor (a base `Model`,
+/// common traits) once per analysis, and every referencing file triggers an
+/// analysis — so the shared ancestors were parsed over and over during the index
+/// build. Worse, each site parsed *twice* (once for the structure, once for the
+/// use-aliases). This memo reads + parses a file once and hands back both from a
+/// single tree, shared as an `Arc`.
+///
+/// Freshness: the cached entry stores the file's [`FileStamp`] (mtime **and**
+/// size); a lookup re-stats and rebuilds when either differs, so an edit — even
+/// an mtime-preserving one — is picked up on the next analysis. No manual
+/// invalidation, no TTL: read-current semantics preserved.
+///
+/// Bounded: an `LruCache` capped at [`PARSED_CACHE_CAP`] so the memo can't grow
+/// unbounded over a long session. `Mutex` because `lru::LruCache` mutates on
+/// read (it promotes the touched entry to most-recently-used), and `analyze`
+/// runs on the parallel `spawn_blocking` index workers — the lock is held only
+/// for the O(1) get/put, never across the parse.
+type ParsedCache = Mutex<LruCache<PathBuf, (FileStamp, Arc<ParsedClassFile>)>>;
+fn parsed_file_cache() -> &'static ParsedCache {
+    static CACHE: OnceLock<ParsedCache> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(LruCache::new(NonZeroUsize::new(PARSED_CACHE_CAP).unwrap())))
+}
+
+/// Clear the parsed-file memo. Test/bench only — lets a benchmark measure the
+/// cold vs warm cost of this optimization in isolation, and keeps global state
+/// from leaking between tests that assert on cache behavior.
+#[doc(hidden)]
+pub fn reset_parsed_file_cache() {
+    parsed_file_cache().lock().unwrap().clear();
+}
+
+/// Read + parse `path` once (structure + use-aliases), memoized and revalidated
+/// by (mtime, size). Returns `None` only when the file can't be read.
+///
+/// The stamp is read up front; if it matches the cached entry we return the
+/// shared `Arc` without touching the file contents. On a miss (or a changed
+/// stamp) we read + parse once and cache.
+fn parsed_class_file(path: &Path) -> Option<Arc<ParsedClassFile>> {
+    let stamp = FileStamp::of(path);
+    if let Some(stamp) = stamp {
+        // Scope the lock to the O(1) lookup — never held across the parse below.
+        if let Some((cached_stamp, parsed)) = parsed_file_cache().lock().unwrap().get(path) {
+            if *cached_stamp == stamp {
+                return Some(parsed.clone());
+            }
+        }
+    }
+    // Miss, changed stamp, or unstattable file — read + parse once. A single
+    // parse feeds both the structure and the use-aliases (previously two parses).
+    let content = std::fs::read_to_string(path).ok()?;
+    let tree = crate::parser::parse_php(&content).ok();
+    let structure = match &tree {
+        Some(t) => crate::laravel_introspector::walker::extract_php_structure_from_tree(
+            t,
+            content.as_bytes(),
+        ),
+        // Parse failure yields the same empty structure `extract_php_structure`
+        // would — callers already treat that as "no classes here".
+        None => PhpFileStructure::default(),
+    };
+    let aliases = match &tree {
+        Some(t) => extract_use_aliases(t, &content),
+        None => HashMap::new(),
+    };
+    let parsed = Arc::new(ParsedClassFile { structure, aliases });
+    if let Some(stamp) = stamp {
+        parsed_file_cache()
+            .lock()
+            .unwrap()
+            .put(path.to_path_buf(), (stamp, parsed.clone()));
+    }
+    Some(parsed)
+}
 
 /// Fully-qualified Laravel base classes / attributes referenced during
 /// classification. Centralised so version-bumps to Laravel that move
@@ -375,9 +501,10 @@ fn analyze_from_prefixed(content: &str) -> Option<ClassView> {
 /// any class — empty class bodies still yield a view (with empty
 /// surfaces).
 pub fn analyze(file_path: &Path, project_root: &Path) -> Option<ClassView> {
-    let content = std::fs::read_to_string(file_path).ok()?;
-    let structure = extract_php_structure(&content);
-    let aliases = parse_use_aliases(&content);
+    // Read + parse once via the mtime-revalidated memo (structure + aliases).
+    let parsed = parsed_class_file(file_path)?;
+    let structure = &parsed.structure;
+    let aliases = &parsed.aliases;
 
     // Pick the first class declaration; most Laravel files have exactly
     // one. Interfaces/traits/enums aren't classified as Laravel "class"
@@ -423,9 +550,9 @@ pub fn analyze(file_path: &Path, project_root: &Path) -> Option<ClassView> {
     // (the test fixture `Orphan extends SomeVendorClass` declares
     // `$table = 'orphans'`). The caller asked about a specific file;
     // surface whatever Laravel patterns it carries.
-    let scopes = compute_scopes(&all_methods, &aliases, &namespace);
+    let scopes = compute_scopes(&all_methods, aliases, &namespace);
     let accessors = compute_accessors(&all_methods);
-    let relationships = compute_relationships(&all_methods, &aliases, namespace.as_deref());
+    let relationships = compute_relationships(&all_methods, aliases, namespace.as_deref());
     let casts = compute_casts(&all_methods, &all_properties);
     let table_name = compute_table_name(&all_properties);
     let column_surface = compute_column_surface(&all_methods, &all_properties, &casts);
@@ -479,11 +606,11 @@ fn walk_class_chain(
         return;
     }
 
-    let Ok(content) = std::fs::read_to_string(path) else {
+    let Some(parsed) = parsed_class_file(path) else {
         return;
     };
-    let structure = extract_php_structure(&content);
-    let aliases = parse_use_aliases(&content);
+    let structure = &parsed.structure;
+    let aliases = &parsed.aliases;
     let namespace = structure.namespace.clone();
 
     for class in &structure.structures {
@@ -523,7 +650,7 @@ fn walk_class_chain(
         // Recurse into composed traits at this depth (traits compose
         // INTO the class; they're not "deeper" inheritance).
         for trait_name in &class.trait_uses {
-            let fqcn = resolve_to_fqcn(trait_name, namespace.as_deref(), &aliases);
+            let fqcn = resolve_to_fqcn(trait_name, namespace.as_deref(), aliases);
             if let Some(trait_path) = find_php_class_file(&fqcn, project_root) {
                 walk_class_chain(
                     &trait_path,
@@ -541,7 +668,7 @@ fn walk_class_chain(
         // Builder __callStatic surface (separate concern); we don't
         // pull them in here as "inherited" on user models.
         if let Some(parent_raw) = &class.extends_raw {
-            let parent_fqcn = resolve_to_fqcn(parent_raw, namespace.as_deref(), &aliases);
+            let parent_fqcn = resolve_to_fqcn(parent_raw, namespace.as_deref(), aliases);
             if parent_fqcn != ELOQUENT_MODEL_FQCN {
                 if let Some(parent_path) = find_php_class_file(&parent_fqcn, project_root) {
                     walk_class_chain(
@@ -597,11 +724,11 @@ pub fn extends_eloquent_model(file_path: &Path, project_root: &Path) -> bool {
         if !visited.insert(canonical) {
             return false;
         }
-        let Ok(content) = std::fs::read_to_string(&p) else {
+        let Some(parsed) = parsed_class_file(&p) else {
             return false;
         };
-        let structure = extract_php_structure(&content);
-        let aliases = parse_use_aliases(&content);
+        let structure = &parsed.structure;
+        let aliases = &parsed.aliases;
         let Some(class) = structure
             .structures
             .iter()
@@ -612,7 +739,7 @@ pub fn extends_eloquent_model(file_path: &Path, project_root: &Path) -> bool {
         let Some(parent_raw) = class.extends_raw.as_deref() else {
             return false;
         };
-        let parent_fqcn = resolve_to_fqcn(parent_raw, structure.namespace.as_deref(), &aliases);
+        let parent_fqcn = resolve_to_fqcn(parent_raw, structure.namespace.as_deref(), aliases);
         let resolved_basename = parent_fqcn.rsplit('\\').next().unwrap_or(&parent_fqcn);
         if resolved_basename == "Model" {
             return true;

--- a/laravel-lsp/src/laravel_introspector/chain/tests.rs
+++ b/laravel-lsp/src/laravel_introspector/chain/tests.rs
@@ -651,3 +651,133 @@ class Portfolio {
     assert!(map.contains_key("id"));
     assert!(map.contains_key("created_at"));
 }
+
+// ---- Parsed-class-file memo (Part 3) -----------------------------------
+
+#[test]
+fn parsed_class_file_reuses_cached_parse_for_same_stamp() {
+    reset_parsed_file_cache();
+    // Two lookups of an unchanged file return the *same* Arc — proof the
+    // second didn't re-read + re-parse (the ancestor re-parse this memo kills).
+    let (_dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Portfolio extends Model {}
+"#,
+    );
+    let first = parsed_class_file(&path).expect("parses once");
+    let second = parsed_class_file(&path).expect("cache hit");
+    assert!(
+        std::sync::Arc::ptr_eq(&first, &second),
+        "an unchanged file must serve the cached parse, not re-parse"
+    );
+}
+
+#[test]
+fn parsed_class_file_re_parses_on_same_mtime_changed_size() {
+    reset_parsed_file_cache();
+    // CON1/CON4: freshness is (mtime AND size), so a content change that the
+    // filesystem records with the SAME mtime (a coarse-granularity same-tick
+    // rewrite, or an mtime-preserving `cp -p`) is still caught by the size
+    // dimension. Here we pin the mtime to the exact prior value and change the
+    // byte length — the memo must re-parse, not serve stale.
+    let (dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+class Portfolio { public function alpha() {} }
+"#,
+    );
+    let before = parsed_class_file(&path).expect("first parse");
+    let pinned_mtime = std::fs::metadata(&path).unwrap().modified().unwrap();
+    assert!(before.structure.structures[0]
+        .methods
+        .iter()
+        .any(|m| m.name == "alpha"));
+
+    // Rewrite with DIFFERENT-LENGTH content, then force the mtime back to its
+    // exact previous value — mtime alone would now (falsely) say "unchanged".
+    fs::write(
+        &path,
+        r#"<?php
+namespace App\Models;
+class Portfolio { public function beta() {} public function gamma() {} }
+"#,
+    )
+    .unwrap();
+    filetime_set(&path, pinned_mtime);
+    // Sanity: the mtime really is identical, so only size differs.
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().modified().unwrap(),
+        pinned_mtime,
+        "test precondition: mtime must be pinned identical"
+    );
+
+    let after = parsed_class_file(&path).expect("re-parse after same-mtime edit");
+    assert!(
+        after.structure.structures[0]
+            .methods
+            .iter()
+            .any(|m| m.name == "beta"),
+        "a same-mtime, changed-size edit must be re-parsed (size closes the hole)"
+    );
+    let _ = dir;
+}
+
+#[test]
+fn parsed_class_file_repicks_up_edits_via_mtime() {
+    reset_parsed_file_cache();
+    // An edit changes the file's mtime, so the memo must re-read and reflect
+    // the new content — read-current semantics, no manual invalidation.
+    let (dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+class Portfolio { public function alpha() {} }
+"#,
+    );
+    let before = parsed_class_file(&path).expect("first parse");
+    assert!(before.structure.structures[0]
+        .methods
+        .iter()
+        .any(|m| m.name == "alpha"));
+
+    // Rewrite with a different method. Bump the mtime explicitly — some
+    // filesystems have coarse mtime resolution, so a same-second rewrite could
+    // otherwise share the previous timestamp and mask the change.
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    fs::write(
+        &path,
+        r#"<?php
+namespace App\Models;
+class Portfolio { public function beta() {} }
+"#,
+    )
+    .unwrap();
+    let new_mtime = std::time::SystemTime::now();
+    filetime_set(&path, new_mtime);
+
+    let after = parsed_class_file(&path).expect("re-parse after edit");
+    assert!(
+        !std::sync::Arc::ptr_eq(&before, &after),
+        "a changed mtime must invalidate the cached parse"
+    );
+    assert!(
+        after.structure.structures[0]
+            .methods
+            .iter()
+            .any(|m| m.name == "beta"),
+        "the re-parse must reflect the edited content"
+    );
+    let _ = dir;
+}
+
+/// Force a file's mtime forward without pulling in the `filetime` crate — set
+/// it via a fresh write timestamp by touching through `File::set_modified`
+/// (stable since Rust 1.75), so the test's mtime bump is deterministic.
+fn filetime_set(path: &std::path::Path, when: std::time::SystemTime) {
+    let f = std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .expect("open for mtime bump");
+    f.set_modified(when).expect("set mtime");
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -66,6 +66,7 @@ pub mod php_variable_rename;
 pub mod queries;
 pub mod query_chain;
 pub mod references;
+pub mod reindex;
 pub mod rename;
 pub mod route_binding;
 pub mod route_chain;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -99,6 +99,10 @@ pub mod member_resolver;
 // Controller/Volt → Blade view-variable type inference (magic members in Blade)
 pub mod view_var_index;
 
+// M1 single-parse capture: compile a file's own-source resolution context at
+// parse so the magic-member resolve passes never re-read/re-parse it.
+pub mod member_capture;
+
 // Re-export commonly used types
 pub use config::find_project_root;
 pub use queries::{EchoPhpMatch, ExtractedBladePatterns, ExtractedPhpPatterns};

--- a/laravel-lsp/src/magic_disk_cache.rs
+++ b/laravel-lsp/src/magic_disk_cache.rs
@@ -61,7 +61,15 @@ use crate::view_var_index::ViewRender;
 /// v3: per-file receiver dependencies + controller view renders (#80) — the
 /// incremental save flow needs both alive after a cache-warm restart, where
 /// the resolution pass that would otherwise populate them never runs.
-const SCHEMA_VERSION: u32 = 3;
+/// v4: FQCN→file resolution correctness fixes — the class-locator now
+/// re-establishes app-over-vendor precedence and the `path_within_root`
+/// containment guard on every lookup (they were previously skippable on a
+/// cached hit). Entries a pre-fix build persisted may hold an edge-case
+/// misresolution (a vendor class where app should have won, or an out-of-root
+/// path), so a warm v3 cache is discarded and the project re-indexed with the
+/// corrected resolver rather than trusting stale entries. Parsing did not
+/// change, so the pattern/config disk caches are intentionally NOT bumped.
+const SCHEMA_VERSION: u32 = 4;
 
 const CACHE_FILENAME: &str = "magic_cache.bin";
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3095,6 +3095,16 @@ async fn build_magic_member_entries(
     let implementers = salsa.snapshot_implementers().await.unwrap_or_default();
     let root = root.to_path_buf();
 
+    // One `ClassViewCache` shared across every worker in all three passes.
+    // Before, each `spawn_blocking` built its own, so a class referenced from N
+    // files was analyzed N times (O(n²) — Eloquent `Model`, base controllers,
+    // common traits paid over and over). The cache is now a concurrent
+    // (`DashMap`-backed) memo, so one `Arc` cloned into each worker means each
+    // FQCN is analyzed once *total* for the whole build. Lifetime = this build
+    // pass: it's dropped when the function returns, so the next rebuild starts
+    // cold (edit-freshness across builds is byte-identical to before).
+    let classviews = Arc::new(laravel_lsp::member_resolver::ClassViewCache::new());
+
     // ── Pass 1: build the view-variable index ────────────────────────────
     // Scan non-vendor controllers (PHP with `view()` calls) for render sites,
     // resolving each passed variable's type so Blade accesses can be typed.
@@ -3115,16 +3125,16 @@ async fn build_magic_member_entries(
         for path in view_targets {
             let permit_owner = vv_sem.clone();
             let class_files = class_files.clone();
+            let classviews = classviews.clone();
             let root = root.clone();
             vv_handles.push(tokio::spawn(async move {
                 let _permit = permit_owner.acquire_owned().await.ok()?;
                 tokio::task::spawn_blocking(move || {
                     let source = std::fs::read_to_string(&path).ok()?;
-                    let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
                     let renders = laravel_lsp::view_var_index::view_renders_in_file(
                         &source,
                         &*class_files,
-                        &mut classviews,
+                        &classviews,
                         &root,
                     );
                     (!renders.is_empty()).then_some((path, renders))
@@ -3182,12 +3192,12 @@ async fn build_magic_member_entries(
         let facade_aliases = facade_aliases.clone();
         let macros = macros.clone();
         let implementers = implementers.clone();
+        let classviews = classviews.clone();
         let root = root.clone();
         magic_handles.push(tokio::spawn(async move {
             let _permit = permit_owner.acquire_owned().await.ok()?;
             tokio::task::spawn_blocking(move || {
                 let source = std::fs::read_to_string(&path).ok()?;
-                let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
                 let mut deps = HashSet::new();
                 let resolver = laravel_lsp::member_resolver::SnapshotResolver {
                     class_files,
@@ -3200,7 +3210,7 @@ async fn build_magic_member_entries(
                     &source,
                     &data.member_access_refs,
                     &resolver,
-                    &mut classviews,
+                    &classviews,
                     &root,
                     Some(&mut deps),
                 );
@@ -3270,11 +3280,11 @@ async fn build_magic_member_entries(
             let implementers = implementers.clone();
             let view_var_index = view_var_index.clone();
             let view_paths = view_paths.clone();
+            let classviews = classviews.clone();
             let root = root.clone();
             blade_handles.push(tokio::spawn(async move {
                 let _permit = permit_owner.acquire_owned().await.ok()?;
                 tokio::task::spawn_blocking(move || {
-                    let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
                     // Container-aware resolver so `app('key')->member` accesses in
                     // Blade/Volt resolve to the bound model during indexing.
                     let resolver = laravel_lsp::member_resolver::SnapshotResolver {
@@ -3308,7 +3318,7 @@ async fn build_magic_member_entries(
                             laravel_lsp::view_var_index::volt_property_types(
                                 src,
                                 &resolver,
-                                &mut classviews,
+                                &classviews,
                                 &root,
                             )
                         })
@@ -3316,7 +3326,7 @@ async fn build_magic_member_entries(
                         laravel_lsp::view_var_index::mfc_volt_property_types(
                             &path,
                             &resolver,
-                            &mut classviews,
+                            &classviews,
                             &root,
                         )
                     } else {
@@ -3330,7 +3340,7 @@ async fn build_magic_member_entries(
                             &prop_types,
                             &data.blade_loops,
                             &resolver,
-                            &mut classviews,
+                            &classviews,
                             &root,
                             Some(&mut deps),
                         )
@@ -3343,7 +3353,7 @@ async fn build_magic_member_entries(
                             &view_var_index,
                             &data.blade_loops,
                             &resolver,
-                            &mut classviews,
+                            &classviews,
                             &root,
                             Some(&mut deps),
                         )
@@ -3374,6 +3384,16 @@ async fn build_magic_member_entries(
             }
         }
     }
+
+    // Cache effectiveness: `misses` is the number of distinct FQCNs analyzed
+    // for the whole build; `hits` is every lookup that reused a prior analysis.
+    // A high hit ratio is the shared cache doing its job — an ancestor class /
+    // model is analyzed once total instead of once per referencing file.
+    info!(
+        "🪄 magic build ClassViewCache: {} distinct classes analyzed, {} cache hits",
+        classviews.misses(),
+        classviews.hits(),
+    );
 
     laravel_lsp::magic_disk_cache::MagicCacheData {
         entries: magic_entries,
@@ -6116,11 +6136,11 @@ impl LaravelLanguageServer {
                 .map(|vv| vv.renders_for(path).is_some())
                 .unwrap_or(false);
             if !patterns.views.is_empty() || had_renders {
-                let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
+                let classviews = laravel_lsp::member_resolver::ClassViewCache::new();
                 let renders = laravel_lsp::view_var_index::view_renders_in_file(
                     content,
                     &*class_files,
-                    &mut classviews,
+                    &classviews,
                     &root,
                 );
                 if let Ok(mut vv) = self.view_vars.write() {
@@ -6159,7 +6179,7 @@ impl LaravelLanguageServer {
         let is_volt =
             is_blade && laravel_lsp::livewire_resolver::source_contains_volt_signature(content);
 
-        let mut classviews = laravel_lsp::member_resolver::ClassViewCache::new();
+        let classviews = laravel_lsp::member_resolver::ClassViewCache::new();
         let mut deps: HashSet<String> = HashSet::new();
         // Container-aware resolver shared by all three resolution paths so
         // `app('key')->member` resolves to the bound model. Fetched here — after
@@ -6184,7 +6204,7 @@ impl LaravelLanguageServer {
             let prop_types = laravel_lsp::view_var_index::volt_property_types(
                 content,
                 &resolver,
-                &mut classviews,
+                &classviews,
                 &root,
             );
             laravel_lsp::view_var_index::resolve_volt_member_accesses(
@@ -6192,7 +6212,7 @@ impl LaravelLanguageServer {
                 &prop_types,
                 &patterns.blade_loops,
                 &resolver,
-                &mut classviews,
+                &classviews,
                 &root,
                 Some(&mut deps),
             )
@@ -6215,7 +6235,7 @@ impl LaravelLanguageServer {
                         &vv,
                         &patterns.blade_loops,
                         &resolver,
-                        &mut classviews,
+                        &classviews,
                         &root,
                         Some(&mut deps),
                     ),
@@ -6228,7 +6248,7 @@ impl LaravelLanguageServer {
                 content,
                 &patterns.member_access_refs,
                 &resolver,
-                &mut classviews,
+                &classviews,
                 &root,
                 Some(&mut deps),
             )

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3107,6 +3107,7 @@ const MAX_CONCURRENT_MAGIC_PARSES: usize = 8;
 /// Shared by the warm build and the debounced incremental rebuild so both run
 /// byte-for-byte the same resolution. Returns empty when the class hierarchy
 /// snapshot is empty (nothing to resolve against).
+#[allow(clippy::too_many_arguments)]
 async fn build_magic_member_entries(
     salsa: &SalsaHandle,
     pattern_cache: &Arc<
@@ -3115,12 +3116,16 @@ async fn build_magic_member_entries(
     root: &Path,
     view_paths: &[PathBuf],
     max_concurrent: usize,
-    // First-load progress handle. Drives the "Building semantic index N of M…"
+    // First-load progress handle. Drives the "Resolving members in N of M…"
     // status while PHP member accesses resolve — the slow phase on big projects
     // that previously ran silently (the file-parse loop has nothing to report
     // on a cache-warm start, so the bar otherwise sits frozen). `None` on the
     // incremental save-refresh path, which has no progress UI.
     mut progress: Option<&mut laravel_lsp::indexing_progress::IndexingProgress>,
+    // Where this phase's slice of the unified progress bar starts: reports
+    // map into `progress_base..=100`, continuing from wherever the parse
+    // phase left the bar instead of restarting at 0%.
+    progress_base: u32,
     // Shared persistent view-var index. The pass-1 build publishes into it
     // wholesale so the incremental save flow (#80) can later update single
     // files and resolve Blade accesses without another project pass.
@@ -3346,9 +3351,14 @@ async fn build_magic_member_entries(
         }
         magic_done += 1;
         if let Some(p) = progress.as_deref_mut() {
-            let pct = ((magic_done.saturating_mul(100) / magic_total.max(1)) as u32).min(100);
+            let pct = laravel_lsp::indexing_progress::weighted_pct(
+                magic_done,
+                magic_total,
+                progress_base,
+                100u32.saturating_sub(progress_base),
+            );
             p.report(
-                format!("Indexing {magic_done} of {magic_total} files…"),
+                format!("Resolving members in {magic_done} of {magic_total} files…"),
                 Some(pct),
                 false,
             )
@@ -4637,8 +4647,10 @@ impl LaravelLanguageServer {
     /// cache parsed patterns for efficient reference lookups.
     /// Register the project's PHP/Blade files with Salsa and kick off the
     /// pattern-cache warming task. If `progress` is provided it'll drive the
-    /// "Discovering files" → "Indexing X of N" → "Indexed" status-bar updates;
-    /// pass `None` from any code path that just needs the registration done
+    /// "Discovering files" → "Parsing X of N" → "Resolving members in X of N"
+    /// → "Indexed" status-bar updates (one monotonic 0→100% bar — the two
+    /// per-file loops fill disjoint slices split at `PARSE_SPAN`); pass
+    /// `None` from any code path that just needs the registration done
     /// without UI (e.g. re-registration after a config change).
     ///
     /// `guard`, when present, is the [`laravel_lsp::reindex::IndexingFlightGuard`]
@@ -4838,8 +4850,9 @@ impl LaravelLanguageServer {
             // would otherwise drop it.
             if let Some(p) = progress.as_mut() {
                 // Parse phase transition: still at 0% — the per-file
-                // updates below increment from here to 100.
-                p.report("Indexing project files…", Some(0), true).await;
+                // updates below increment from here to PARSE_SPAN, and
+                // the magic-member resolve continues on to 100.
+                p.report("Parsing project files…", Some(0), true).await;
             }
 
             let paths = match salsa.list_project_files().await {
@@ -4876,6 +4889,11 @@ impl LaravelLanguageServer {
             }
 
             let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_PARSES));
+
+            // Per-phase wall-clock for the summary log below — the
+            // parse/resolve ratio it reports is what PARSE_SPAN (the
+            // progress-bar split) is tuned against.
+            let parse_started = std::time::Instant::now();
 
             // Spawn one task per file we still need to parse. The
             // semaphore ensures we never have more than N parses running
@@ -4977,20 +4995,30 @@ impl LaravelLanguageServer {
                 if let Some(p) = progress.as_mut() {
                     // Progress is over the files we're actually parsing
                     // this session, not the total project size. Showing
-                    // "Indexing 12 of 12 files" after a warm restart
+                    // "Parsing 12 of 12 files" after a warm restart
                     // gives accurate feedback for the work in progress;
                     // the user already saw the cached restore land in
                     // the "Loading cached index…" step before this.
-                    let denom = to_parse.max(1);
-                    let pct = ((completed.saturating_mul(100) / denom) as u32).min(100);
+                    //
+                    // The parse loop owns the 0..=PARSE_SPAN slice of the
+                    // unified bar; the magic-member resolve below continues
+                    // from PARSE_SPAN, so the bar fills 0→100 monotonically
+                    // instead of resetting between the two phases.
+                    let pct = laravel_lsp::indexing_progress::weighted_pct(
+                        completed,
+                        to_parse,
+                        0,
+                        laravel_lsp::indexing_progress::PARSE_SPAN,
+                    );
                     p.report(
-                        format!("Indexing {} of {} files…", completed, to_parse),
+                        format!("Parsing {} of {} files…", completed, to_parse),
                         Some(pct),
                         false,
                     )
                     .await;
                 }
             }
+            let parse_elapsed = parse_started.elapsed();
             // Split the combined parse results: patterns go to the shared
             // cache, class-hierarchy nodes to the actor-owned index. Files
             // with no class declarations contribute no hierarchy entry.
@@ -5065,6 +5093,7 @@ impl LaravelLanguageServer {
             // (~135s on a real app) after any edit-then-restart.
             // Disk read on the blocking pool so it never stalls the async
             // runtime (the file can be large on a big project).
+            let magic_started = std::time::Instant::now();
             let restored = {
                 let root_for_load = root_for_save.clone();
                 tokio::task::spawn_blocking(move || {
@@ -5180,6 +5209,15 @@ impl LaravelLanguageServer {
                 if evicted > 0 {
                     server_for_warm.schedule_magic_cache_save().await;
                 }
+                // The resolve phase (which owns the PARSE_SPAN..=100 slice
+                // of the unified bar) never runs on a restore, so without
+                // this the bar would freeze at PARSE_SPAN% until `end()`.
+                // One forced report walks it to 100 so the bar always
+                // completes, warm or cold.
+                if let Some(p) = progress.as_mut() {
+                    p.report("Restored member index from cache.", Some(100), true)
+                        .await;
+                }
             } else {
                 // Resolve fresh, drive progress (the file-parse loop had nothing
                 // to report on a cache-warm start), persist for next time, then
@@ -5193,6 +5231,7 @@ impl LaravelLanguageServer {
                     &view_paths_for_warm,
                     MAX_CONCURRENT_PARSES,
                     progress.as_mut(),
+                    laravel_lsp::indexing_progress::PARSE_SPAN,
                     &view_vars_for_warm,
                 )
                 .await;
@@ -5226,6 +5265,7 @@ impl LaravelLanguageServer {
                     }
                 }
             }
+            let magic_elapsed = magic_started.elapsed();
             // The reference indexes are built — ask the client to refresh code
             // lenses requested while warming was still in progress (those
             // resolved against an empty index and read 0). Fire-and-forget, so
@@ -5241,8 +5281,8 @@ impl LaravelLanguageServer {
 
             let elapsed = started_at.elapsed();
             info!(
-                "🔥 Laravel: pattern cache warmed ({} newly parsed, {} from disk, total {}, in {:?})",
-                imported, cached_hits, total, elapsed
+                "🔥 Laravel: pattern cache warmed ({} newly parsed, {} from disk, total {}, in {:?}; parse {:?}, magic-resolve {:?})",
+                imported, cached_hits, total, elapsed, parse_elapsed, magic_elapsed
             );
 
             if let Some(p) = progress {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3381,10 +3381,12 @@ async fn build_magic_member_entries(
                 progress_base,
                 100u32.saturating_sub(progress_base),
             );
+            // The final report is forced so a sub-throttle finish can't
+            // drop the top-of-slice update and strand the bar mid-slice.
             p.report(
                 format!("Resolving members in {magic_done} of {magic_total} files…"),
                 Some(pct),
-                false,
+                magic_done == magic_total,
             )
             .await;
         }
@@ -4674,10 +4676,13 @@ impl LaravelLanguageServer {
     /// cache parsed patterns for efficient reference lookups.
     /// Register the project's PHP/Blade files with Salsa and kick off the
     /// pattern-cache warming task. If `progress` is provided it'll drive the
-    /// "Discovering files" → "Parsing X of N" → "Resolving members in X of N"
-    /// → "Indexed" status-bar updates (one monotonic 0→100% bar — the two
-    /// per-file loops fill disjoint slices split at `PARSE_SPAN`); pass
-    /// `None` from any code path that just needs the registration done
+    /// "Loading N of M cached entries" → "Parsing X of N" → "Resolving
+    /// members in X of N" → "Indexed" status-bar updates (one monotonic
+    /// 0→100% bar — the phases fill disjoint slices split per branch: cold
+    /// is parse-dominant (`0..PARSE_SPAN..100`), warm is load- and
+    /// re-resolve-dominant (`LOAD_SPAN`, `WARM_PARSE_TOP`,
+    /// `WARM_RESOLVE_BASE`); see the slice map in `indexing_progress`);
+    /// pass `None` from any code path that just needs the registration done
     /// without UI (e.g. re-registration after a config change).
     ///
     /// `guard`, when present, is the [`laravel_lsp::reindex::IndexingFlightGuard`]
@@ -4761,17 +4766,75 @@ impl LaravelLanguageServer {
         let pattern_cache = self.salsa.pattern_cache();
         let root_for_load = root_path.to_path_buf();
         let cache_for_load = pattern_cache.clone();
-        let load_result = tokio::task::spawn_blocking(move || {
-            laravel_lsp::pattern_disk_cache::load_into(&cache_for_load, &root_for_load)
-        })
-        .await
-        .unwrap_or_default();
+        // The load is a sync, parallel (rayon) pass over ~40k cache
+        // entries — a multi-second stall on a cold FS that previously ran
+        // under a single static "Loading cached index…" message and read
+        // as frozen. It publishes live counts into `load_progress`; a
+        // concurrent throttled reporter here renders them into the load
+        // slice (0..LOAD_SPAN) while the blocking task runs. spawn_blocking
+        // keeps the rayon pass off the async runtime; the select loop lets
+        // the reporter fire on a timer without blocking the load.
+        let load_progress = Arc::new(laravel_lsp::pattern_disk_cache::LoadProgress::default());
+        let lp_for_task = load_progress.clone();
+        let mut load_task = tokio::task::spawn_blocking(move || {
+            laravel_lsp::pattern_disk_cache::load_into_reporting(
+                &cache_for_load,
+                &root_for_load,
+                Some(lp_for_task.as_ref()),
+            )
+        });
+        let load_result = loop {
+            tokio::select! {
+                res = &mut load_task => break res.unwrap_or_default(),
+                _ = tokio::time::sleep(std::time::Duration::from_millis(150)) => {
+                    if let Some(p) = progress.as_mut() {
+                        let total = load_progress.total.load(std::sync::atomic::Ordering::Relaxed);
+                        // total stays 0 until the cache is decoded (and on a
+                        // cold start with no cache it never moves) — only
+                        // report once there's a real denominator.
+                        if total > 0 {
+                            let done =
+                                load_progress.done.load(std::sync::atomic::Ordering::Relaxed);
+                            let pct = laravel_lsp::indexing_progress::weighted_pct(
+                                done,
+                                total,
+                                0,
+                                laravel_lsp::indexing_progress::LOAD_SPAN,
+                            );
+                            p.report(
+                                format!("Loading {done} of {total} cached entries…"),
+                                Some(pct),
+                                false,
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
+        };
         let (restored, dropped) = (load_result.restored, load_result.dropped);
         if restored + dropped > 0 {
             info!(
                 "🗄️  Disk cache: restored {} fresh entries, dropped {} stale",
                 restored, dropped
             );
+        }
+        // Complete the load slice cleanly: the final throttled report above
+        // may have been dropped, and a warm reload's parse phase starts at
+        // LOAD_SPAN — a forced report guarantees the bar reaches the
+        // hand-off. Gated on `restored > 0` (not `restored + dropped`): the
+        // warm parse base is LOAD_SPAN only when entries were restored, so
+        // an all-dropped reload stays a cold start and this must NOT jump
+        // the bar to LOAD_SPAN ahead of a parse phase that begins at 0.
+        if restored > 0 {
+            if let Some(p) = progress.as_mut() {
+                p.report(
+                    format!("Loaded {restored} cached entries."),
+                    Some(laravel_lsp::indexing_progress::LOAD_SPAN),
+                    true,
+                )
+                .await;
+            }
         }
         // Re-import the restored files' class-hierarchy nodes. Without this the
         // hierarchy index is empty on a warm start (no parse runs for
@@ -4850,6 +4913,15 @@ impl LaravelLanguageServer {
         // For the granular restore's per-file re-resolution (it reuses the
         // same machinery as the save-time dependents pass).
         let server_for_warm = self.clone_for_spawn();
+        // Did the disk-cache load slice actually run? True whenever the
+        // cache existed and was scanned — restored OR dropped — because the
+        // load reporter advances the bar over `0..LOAD_SPAN` for every
+        // decoded entry regardless of freshness. The warming task keys its
+        // parse-slice *base* off this (not off `cached_hits`): on an
+        // all-dropped reload the load slice climbed to LOAD_SPAN but
+        // nothing was restored, so parsing must CONTINUE from LOAD_SPAN
+        // rather than snap back to 0.
+        let cache_scanned = restored + dropped > 0;
         tokio::spawn(async move {
             // `progress` moves into this task — when warming finishes (or
             // hits an early return) we call `end` to clear the status bar.
@@ -4871,16 +4943,6 @@ impl LaravelLanguageServer {
             tokio::task::spawn_blocking(laravel_lsp::queries::prewarm_query_cache)
                 .await
                 .ok();
-
-            // Discovery is done — transition to "Indexing" phase. Forced
-            // so the user sees the phase change even if the throttle
-            // would otherwise drop it.
-            if let Some(p) = progress.as_mut() {
-                // Parse phase transition: still at 0% — the per-file
-                // updates below increment from here to PARSE_SPAN, and
-                // the magic-member resolve continues on to 100.
-                p.report("Parsing project files…", Some(0), true).await;
-            }
 
             let paths = match salsa.list_project_files().await {
                 Ok(p) => p,
@@ -4914,6 +4976,25 @@ impl LaravelLanguageServer {
                     cached_hits, to_parse
                 );
             }
+            // Parse slice `parse_base..parse_top` of the unified bar, chosen
+            // from two independent signals (see `parse_slice`): the base
+            // continues the load slice when the cache was scanned (so an
+            // all-dropped reload doesn't snap the bar back to 0), the top
+            // reflects how much is being re-parsed. Three shapes: fully-warm
+            // → LOAD_SPAN..WARM_PARSE_TOP; all-dropped → LOAD_SPAN..PARSE_SPAN;
+            // fully-cold → 0..PARSE_SPAN.
+            let (parse_base, parse_top) =
+                laravel_lsp::indexing_progress::parse_slice(cache_scanned, cached_hits > 0);
+
+            // Discovery is done — transition to the parse phase. Forced so
+            // the user sees the phase change even if the throttle would
+            // drop it. Reported at `parse_base` (not 0) so a warm reload
+            // continues from where the load slice left the bar instead of
+            // resetting to 0%.
+            if let Some(p) = progress.as_mut() {
+                p.report("Parsing project files…", Some(parse_base), true)
+                    .await;
+            }
 
             let semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_PARSES));
 
@@ -4922,13 +5003,14 @@ impl LaravelLanguageServer {
             // progress-bar split) is tuned against.
             let parse_started = std::time::Instant::now();
 
-            // Spawn one task per file we still need to parse. The
+            // Spawn one task per file we still need to parse into a
+            // JoinSet, which we drain in COMPLETION order below. The
             // semaphore ensures we never have more than N parses running
             // (or holding parsed-tree memory) at once.
-            let mut handles = Vec::with_capacity(to_parse);
+            let mut parse_set = tokio::task::JoinSet::new();
             for path in paths_to_parse {
                 let permit_owner = semaphore.clone();
-                handles.push(tokio::spawn(async move {
+                parse_set.spawn(async move {
                     let _permit = match permit_owner.acquire_owned().await {
                         Ok(p) => p,
                         Err(_) => return None,
@@ -4994,28 +5076,35 @@ impl LaravelLanguageServer {
                     .ok()
                     .flatten();
                     parsed.map(|(data, nodes)| (path, data, nodes))
-                }));
+                });
             }
 
-            // Collect all parse results into a single buffer, then bulk-
-            // import directly into the shared DashMap-backed pattern cache
-            // via SalsaHandle::bulk_import_patterns. That call bypasses
-            // the actor's mpsc channel entirely — see the comment on
-            // SalsaActor::pattern_cache and SalsaHandle::bulk_import_patterns
+            // Drain the JoinSet in COMPLETION order into a single buffer,
+            // then bulk-import directly into the shared DashMap-backed
+            // pattern cache via SalsaHandle::bulk_import_patterns. That call
+            // bypasses the actor's mpsc channel entirely — see the comment
+            // on SalsaActor::pattern_cache and SalsaHandle::bulk_import_patterns
             // for the architectural why. With this path: warming on a
             // 40k-file project takes ~7s wall (~6.5s parse + ~10ms import).
             //
-            // Progress reports are emitted as each handle completes. The
-            // IndexingProgress helper throttles internally so we don't
-            // need to be careful about emitting every iteration.
+            // `join_next` yields each task AS IT FINISHES, not in spawn
+            // order. This is load-bearing for the progress bar: awaiting the
+            // handles in spawn order stalled `completed` on the first slow
+            // file (this project has 6–23 MB seeder files that parse for
+            // seconds), freezing the bar mid-slice while the fast files
+            // finished invisibly in the background, then draining the
+            // backlog in one jump. Completion-order draining lets every
+            // finished file advance the bar smoothly regardless of size or
+            // spawn position. The buffer still gathers every result (order
+            // doesn't matter — it's bulk-imported as a set).
             let mut buffer: Vec<(
                 PathBuf,
                 Arc<laravel_lsp::salsa_impl::ParsedPatternsData>,
                 Vec<laravel_lsp::class_hierarchy_index::ClassNode>,
             )> = Vec::with_capacity(to_parse);
             let mut completed = 0usize;
-            for h in handles {
-                if let Ok(Some(pair)) = h.await {
+            while let Some(res) = parse_set.join_next().await {
+                if let Ok(Some(pair)) = res {
                     buffer.push(pair);
                 }
                 completed += 1;
@@ -5027,20 +5116,24 @@ impl LaravelLanguageServer {
                     // the user already saw the cached restore land in
                     // the "Loading cached index…" step before this.
                     //
-                    // The parse loop owns the 0..=PARSE_SPAN slice of the
-                    // unified bar; the magic-member resolve below continues
-                    // from PARSE_SPAN, so the bar fills 0→100 monotonically
-                    // instead of resetting between the two phases.
+                    // The parse loop owns the parse_base..parse_top slice of
+                    // the unified bar (branch-weighted above); the phases
+                    // below continue from parse_top, so the bar fills 0→100
+                    // monotonically instead of resetting between phases.
+                    // The final report is forced: a warm reload parses its
+                    // handful of files in a sub-throttle burst, and if the
+                    // `completed == to_parse` report were dropped the bar
+                    // would stick mid-slice for the whole post-parse tail.
                     let pct = laravel_lsp::indexing_progress::weighted_pct(
                         completed,
                         to_parse,
-                        0,
-                        laravel_lsp::indexing_progress::PARSE_SPAN,
+                        parse_base,
+                        parse_top - parse_base,
                     );
                     p.report(
                         format!("Parsing {} of {} files…", completed, to_parse),
                         Some(pct),
-                        false,
+                        completed == to_parse,
                     )
                     .await;
                 }
@@ -5068,27 +5161,63 @@ impl LaravelLanguageServer {
 
             // Persist the entire live pattern_cache (cached restores +
             // freshly parsed entries) so the next LSP startup can skip
-            // most of the work. Runs on the blocking pool because it's
-            // sync I/O — and we don't gate user-visible warming
-            // completion on it; the save just runs and logs its outcome.
-            let cache_for_save = pattern_cache_for_warm.clone();
-            let root_for_save_inner = root_for_save.clone();
-            // Snapshot the (now fully populated: restored + freshly parsed)
-            // hierarchy so it's persisted alongside the patterns and survives
-            // the next warm restart.
-            let hierarchy_for_save = salsa.snapshot_hierarchy_nodes().await.unwrap_or_default();
-            let save_result = tokio::task::spawn_blocking(move || {
-                laravel_lsp::pattern_disk_cache::save_from(
-                    &cache_for_save,
-                    &hierarchy_for_save,
-                    &root_for_save_inner,
-                )
-            })
-            .await;
-            match save_result {
-                Ok(Ok(n)) => info!("🗄️  Disk cache: saved {} entries", n),
-                Ok(Err(e)) => debug!("Disk cache save failed: {}", e),
-                Err(e) => debug!("Disk cache save task panicked: {}", e),
+            // most of the work. Skipped on a no-change reload: when this
+            // session parsed nothing (`to_parse == 0`) and the disk
+            // restore dropped no stale entries (`dropped == 0`), the
+            // in-memory cache is exactly what's already on disk, and the
+            // full stat + clone + encode + rewrite pass would persist
+            // nothing new. Any fresh parse or dropped entry disables the
+            // skip, so real changes are always saved.
+            //
+            // When it runs, the save is SPAWNED fire-and-forget and does
+            // NOT gate completion: on a cold reindex the encode + write of
+            // ~47k M1-inflated entries takes ~42s, and blocking `end()` on
+            // it made the whole index look like it took 96s when the actual
+            // parse + resolve finished in ~54s. The magic phase and `end()`
+            // now proceed immediately; the cache persists in the background.
+            // No progress phase is shown for it — the bar flows parse →
+            // magic → end without a save step.
+            //
+            // Concurrency: two saves can overlap (a reindex fires while a
+            // prior background save is still writing), so `save_from` writes
+            // to a per-call unique temp file and atomically renames it onto
+            // the cache path — last writer wins on a complete, valid file;
+            // neither can observe the other's partial bytes.
+            //
+            // Durability: a process exit mid-save loses that save. That's
+            // fine — the cache is advisory; the next startup just re-parses
+            // what wasn't persisted.
+            if to_parse == 0 && dropped == 0 {
+                info!("🗄️  Disk cache: unchanged since last save, skipping rewrite");
+            } else {
+                let cache_for_save = pattern_cache_for_warm.clone();
+                let root_for_save_inner = root_for_save.clone();
+                // Clone the actor handle into the background task so the
+                // hierarchy snapshot (its only critical-path cost otherwise)
+                // also happens off the warming path.
+                let salsa_for_save = salsa.clone();
+                tokio::spawn(async move {
+                    // Snapshot the (now fully populated: restored + freshly
+                    // parsed) hierarchy so it's persisted alongside the
+                    // patterns and survives the next warm restart.
+                    let hierarchy_for_save = salsa_for_save
+                        .snapshot_hierarchy_nodes()
+                        .await
+                        .unwrap_or_default();
+                    let save_result = tokio::task::spawn_blocking(move || {
+                        laravel_lsp::pattern_disk_cache::save_from(
+                            &cache_for_save,
+                            &hierarchy_for_save,
+                            &root_for_save_inner,
+                        )
+                    })
+                    .await;
+                    match save_result {
+                        Ok(Ok(n)) => info!("🗄️  Disk cache: saved {} entries (background)", n),
+                        Ok(Err(e)) => debug!("Disk cache save failed: {}", e),
+                        Err(e) => debug!("Disk cache save task panicked: {}", e),
+                    }
+                });
             }
 
             // Build the inverted symbol index now that pattern_cache
@@ -5120,6 +5249,15 @@ impl LaravelLanguageServer {
             // (~135s on a real app) after any edit-then-restart.
             // Disk read on the blocking pool so it never stalls the async
             // runtime (the file can be large on a big project).
+            //
+            // The restore (read + decode + prune) is one opaque blocking
+            // op with no per-item hook — a forced phase report at the
+            // parse boundary keeps the bar showing live text instead of
+            // reading as dead while it runs.
+            if let Some(p) = progress.as_mut() {
+                p.report("Restoring member index…", Some(parse_top), true)
+                    .await;
+            }
             let magic_started = std::time::Instant::now();
             let restored = {
                 let root_for_load = root_for_save.clone();
@@ -5139,6 +5277,11 @@ impl LaravelLanguageServer {
                 .flatten()
             };
             if let Some((data, evicted)) = restored {
+                // Warm reload: the granular re-resolve below owns the
+                // rest of the bar. Clamped to the parse slice's actual
+                // top so a cold-parse/warm-magic mix (pattern cache
+                // stale, magic cache fresh) can't jump the bar backwards.
+                let resolve_base = parse_top.max(laravel_lsp::indexing_progress::WARM_RESOLVE_BASE);
                 if evicted > 0 {
                     info!(
                         "🪄 Magic-member restore: evicted {} deleted file(s) from cache",
@@ -5168,6 +5311,13 @@ impl LaravelLanguageServer {
                     .filter(|(path, _)| changed_set.contains(path))
                     .flat_map(|(_, renders)| renders.iter().map(|r| r.view_name.clone()))
                     .collect();
+                // Bulk import is the next opaque op — advance the bar to
+                // the resolve base with a forced phase message so the
+                // hand-off into the re-resolve slice stays visible.
+                if let Some(p) = progress.as_mut() {
+                    p.report("Importing member index…", Some(resolve_base), true)
+                        .await;
+                }
                 match import_magic_data(&salsa, &magic_deps_for_warm, entries).await {
                     Ok(n) => info!("🪄 Magic-member index: {} entries (restored from disk)", n),
                     Err(e) => debug!("Magic-member restore import failed: {}", e),
@@ -5227,7 +5377,11 @@ impl LaravelLanguageServer {
                             "🪄 Granular magic restore: re-resolving {} changed/dependent file(s)",
                             work.len()
                         );
-                        server_for_warm.refresh_files_magic(work).await;
+                        // The dominant warm phase — it drives the
+                        // resolve_base..=100 slice of the unified bar.
+                        server_for_warm
+                            .refresh_files_magic(work, progress.as_mut(), resolve_base)
+                            .await;
                     }
                 }
                 // Deleted files were pruned from the live index above; the
@@ -5236,11 +5390,11 @@ impl LaravelLanguageServer {
                 if evicted > 0 {
                     server_for_warm.schedule_magic_cache_save().await;
                 }
-                // The resolve phase (which owns the PARSE_SPAN..=100 slice
-                // of the unified bar) never runs on a restore, so without
-                // this the bar would freeze at PARSE_SPAN% until `end()`.
-                // One forced report walks it to 100 so the bar always
-                // completes, warm or cold.
+                // Walk the bar to 100 unconditionally: on a no-change
+                // reload the granular re-resolve above has no work (so
+                // nothing else fills the resolve slice), and when it did
+                // run its last throttled report may have been dropped.
+                // One forced report guarantees completion either way.
                 if let Some(p) = progress.as_mut() {
                     p.report("Restored member index from cache.", Some(100), true)
                         .await;
@@ -5258,11 +5412,19 @@ impl LaravelLanguageServer {
                     &view_paths_for_warm,
                     MAX_CONCURRENT_PARSES,
                     progress.as_mut(),
-                    laravel_lsp::indexing_progress::PARSE_SPAN,
+                    parse_top,
                     &view_vars_for_warm,
                 )
                 .await;
                 if !magic_data.entries.is_empty() {
+                    // The resolve loop above filled the bar to 100; the
+                    // save + import below are opaque bulk ops that can
+                    // still take seconds on a big project, so forced
+                    // phase messages keep the (full) bar showing live
+                    // text until `end()`.
+                    if let Some(p) = progress.as_mut() {
+                        p.report("Saving member index…", Some(100), true).await;
+                    }
                     // Persist on the blocking pool (sync I/O), handing the
                     // data back so the import below still owns it — no clone.
                     let root_for_msave = root_for_save.clone();
@@ -5285,6 +5447,9 @@ impl LaravelLanguageServer {
                             Default::default()
                         }
                     };
+                    if let Some(p) = progress.as_mut() {
+                        p.report("Importing member index…", Some(100), true).await;
+                    }
                     match import_magic_data(&salsa, &magic_deps_for_warm, magic_data.entries).await
                     {
                         Ok(n) => info!("🪄 Magic-member index: {} entries", n),
@@ -6401,14 +6566,27 @@ impl LaravelLanguageServer {
             "🪄 Incremental magic refresh: re-resolving {} dependent file(s)",
             work.len()
         );
-        self.refresh_files_magic(work).await;
+        // No progress UI on the incremental path — this runs behind
+        // did_save, not the startup indexing bar.
+        self.refresh_files_magic(work, None, 0).await;
     }
 
     /// Re-resolve a set of files through the per-file magic refresh at
     /// bounded concurrency. Shared by the save-time dependents pass and the
     /// granular startup restore (#80). Open buffers are authoritative;
     /// everything else reads from disk on the blocking pool.
-    async fn refresh_files_magic(&self, work: HashSet<PathBuf>) {
+    ///
+    /// `progress` drives the `progress_base..=100` slice of the unified
+    /// indexing bar on the warm-startup call — the dominant warm phase,
+    /// which previously ran silent and read as a frozen bar. The
+    /// incremental save-refresh callers have no progress UI and pass
+    /// `None` (base then unused).
+    async fn refresh_files_magic(
+        &self,
+        work: HashSet<PathBuf>,
+        mut progress: Option<&mut laravel_lsp::indexing_progress::IndexingProgress>,
+        progress_base: u32,
+    ) {
         let sem = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_MAGIC_PARSES));
         let mut handles = Vec::with_capacity(work.len());
         for dep in work {
@@ -6421,8 +6599,28 @@ impl LaravelLanguageServer {
                 Some(())
             }));
         }
+        let total = handles.len();
+        let mut done = 0usize;
         for h in handles {
             let _ = h.await;
+            done += 1;
+            if let Some(p) = progress.as_deref_mut() {
+                let pct = laravel_lsp::indexing_progress::weighted_pct(
+                    done,
+                    total,
+                    progress_base,
+                    100u32.saturating_sub(progress_base),
+                );
+                // Throttled: the warm caller posts a forced 100% report
+                // right after this returns, so a dropped final update
+                // here can't strand the bar.
+                p.report(
+                    format!("Resolving members in {done} of {total} files…"),
+                    Some(pct),
+                    false,
+                )
+                .await;
+            }
         }
         // Reference counts may have changed project-wide.
         let _ = self.client.code_lens_refresh().await;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -1938,6 +1938,16 @@ struct LaravelLanguageServer {
     /// warning, flooding the Problems panel.
     warm_complete: Arc<std::sync::atomic::AtomicBool>,
 
+    /// `true` while an indexing pass (initial warm OR a `laravel.reindexProject`
+    /// reindex) is running. Guards against concurrent passes: both the startup
+    /// warm and the reindex command claim it via
+    /// [`laravel_lsp::reindex::IndexingFlightGuard`], and a reindex triggered
+    /// while another pass holds it no-ops instead of running two warming
+    /// pipelines over the same shared caches (which would race the
+    /// full-replace magic-member import). The guard clears it on drop, so a
+    /// panicking warming task can't leave it stuck raised.
+    indexing_in_flight: Arc<std::sync::atomic::AtomicBool>,
+
     /// Project-wide index of column/table definitions parsed from
     /// `database/migrations/*.php`. Powers goto-definition on chain literals
     /// (column → migration line, table → create-table migration). Built at init
@@ -4151,6 +4161,7 @@ impl LaravelLanguageServer {
             database_diagnostic_shown: Arc::new(RwLock::new(false)),
             route_index: Arc::new(RwLock::new(None)),
             warm_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            indexing_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             migration_index: Arc::new(RwLock::new(None)),
             command_index: Arc::new(RwLock::new(None)),
             vendor_translation_namespaces: Arc::new(RwLock::new(None)),
@@ -4366,6 +4377,88 @@ impl LaravelLanguageServer {
         }
     }
 
+    /// Run a full cold reindex in response to the `laravel.reindexProject`
+    /// command (dispatched by the "Laravel: Reindex project" code action).
+    ///
+    /// "Cold" means every cached artifact is thrown away and rebuilt from
+    /// source, in this order:
+    ///
+    /// 1. **Claim the indexing-flight guard.** If another pass — the startup
+    ///    warm or a prior reindex — already holds it, this trigger no-ops:
+    ///    two warming pipelines over the same shared caches would race the
+    ///    full-replace magic-member import. The guard releases on drop, so
+    ///    the flag can't stick if a warming task panics.
+    /// 2. **Wipe the on-disk caches** (pattern, magic, command, config,
+    ///    vendor) so the warming pass restores nothing and re-parses all.
+    /// 3. **Reset the process-global memos** (class locator, parsed-file) so
+    ///    no stale walk result or parse survives the rebuild.
+    /// 4. **Clear the in-memory indexes** (pattern cache, symbol index, class
+    ///    hierarchy, per-file LRU caches) so warming re-parses every file.
+    /// 5. **Re-run the standard registration + warming pipeline** with a
+    ///    work-done progress bar, holding the guard until warming completes.
+    ///
+    /// Reuses the existing warming pipeline ([`Self::register_project_files_with_salsa`])
+    /// rather than duplicating the parse/build logic.
+    async fn trigger_reindex(&self) {
+        // 1. Serialize against any other indexing pass.
+        let Some(guard) =
+            laravel_lsp::reindex::IndexingFlightGuard::try_acquire(self.indexing_in_flight.clone())
+        else {
+            info!("🔁 Reindex requested but an indexing pass is already running — ignoring");
+            return;
+        };
+
+        let Some(root) = self.root_path.read().await.clone() else {
+            info!("🔁 Reindex requested but no project root is set — ignoring");
+            return; // guard drops here, releasing the flag
+        };
+
+        info!("🔁 Reindex: full cold rebuild of {:?}", root);
+
+        // Suppress the unused-symbol diagnostic while the reference indexes are
+        // torn down and rebuilt — the warming task flips this back to `true`
+        // when it finishes (mirrors the startup gate). Without this, a
+        // diagnostics pass during the rebuild would see an empty index and
+        // flag every lensed symbol as unused.
+        self.warm_complete
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+
+        // 2. Disk caches — blocking filesystem I/O, so off the async runtime.
+        let root_for_clear = root.clone();
+        match tokio::task::spawn_blocking(move || {
+            laravel_lsp::cache_manager::clear_disk_caches(&root_for_clear)
+        })
+        .await
+        {
+            Ok(Ok(())) => info!("🔁 Reindex: disk caches cleared"),
+            Ok(Err(e)) => warn!("🔁 Reindex: clearing disk caches failed: {}", e),
+            Err(e) => warn!("🔁 Reindex: disk-cache clear task panicked: {}", e),
+        }
+
+        // 3. Process-global memos (both promoted from test-only to production
+        // callers for exactly this reset).
+        laravel_lsp::class_locator::reset_locator_cache();
+        laravel_lsp::laravel_introspector::chain::reset_parsed_file_cache();
+
+        // 4. In-memory actor indexes — one message for an atomic wipe.
+        if let Err(e) = self.salsa.clear_reindex_state().await {
+            warn!("🔁 Reindex: clearing in-memory indexes failed: {}", e);
+        }
+
+        // 5. Re-run the standard pipeline with progress, handing the guard to
+        // the warming task so the flag stays raised until warming completes.
+        let progress = laravel_lsp::indexing_progress::IndexingProgress::begin(
+            self.client.clone(),
+            laravel_lsp::indexing_progress::INDEXING_TOKEN,
+            "Laravel",
+            "Reindexing project…",
+            Some(0),
+        )
+        .await;
+        self.register_project_files_with_salsa(&root, progress, Some(guard))
+            .await;
+    }
+
     /// Register project files with Salsa for reference finding
     ///
     /// This scans key directories (controllers, views, Livewire, routes) and
@@ -4376,10 +4469,19 @@ impl LaravelLanguageServer {
     /// "Discovering files" → "Indexing X of N" → "Indexed" status-bar updates;
     /// pass `None` from any code path that just needs the registration done
     /// without UI (e.g. re-registration after a config change).
+    ///
+    /// `guard`, when present, is the [`laravel_lsp::reindex::IndexingFlightGuard`]
+    /// claimed by the caller (startup warm or the reindex command). It's moved
+    /// into the spawned warming task and dropped when warming completes, so the
+    /// "indexing in flight" flag stays raised for the whole pass — not just the
+    /// synchronous registration prefix — and a concurrent reindex trigger
+    /// no-ops until warming finishes. Callers that don't serialize (the
+    /// config-change re-register) pass `None`.
     async fn register_project_files_with_salsa(
         &self,
         root_path: &Path,
         progress: Option<laravel_lsp::indexing_progress::IndexingProgress>,
+        guard: Option<laravel_lsp::reindex::IndexingFlightGuard>,
     ) {
         let config = match self.get_cached_config().await {
             Some(c) => c,
@@ -4542,6 +4644,12 @@ impl LaravelLanguageServer {
             // `progress` moves into this task — when warming finishes (or
             // hits an early return) we call `end` to clear the status bar.
             let mut progress = progress;
+            // The indexing-flight guard (if any) moves in too and is dropped
+            // when this task returns — by any path, including the early
+            // returns below — releasing the "indexing in flight" flag only
+            // once warming has actually completed. `_` because we never touch
+            // it; we just tie its lifetime to the task.
+            let _indexing_guard = guard;
             let started_at = std::time::Instant::now();
 
             // Defensively prewarm the global query cache on this thread
@@ -6679,8 +6787,11 @@ impl LaravelLanguageServer {
                 // mid-session config change, where flashing a status-bar
                 // entry for a re-index would feel surprising. The
                 // user-facing first-load progress is wired into
-                // `initialized()` instead.
-                self.register_project_files_with_salsa(&discovered_root, None)
+                // `initialized()` instead. No flight guard: this re-register
+                // isn't a user-triggered reindex, and the reindex command
+                // guards itself against the passes that matter (startup + a
+                // second reindex).
+                self.register_project_files_with_salsa(&discovered_root, None, None)
                     .await;
 
                 // Re-validate all open documents since config changed (view paths, component paths, etc.)
@@ -16043,6 +16154,7 @@ return [
             database_diagnostic_shown: self.database_diagnostic_shown.clone(),
             route_index: self.route_index.clone(),
             warm_complete: self.warm_complete.clone(),
+            indexing_in_flight: self.indexing_in_flight.clone(),
             migration_index: self.migration_index.clone(),
             command_index: self.command_index.clone(),
             vendor_translation_namespaces: self.vendor_translation_namespaces.clone(),
@@ -20512,7 +20624,16 @@ impl LanguageServer for LaravelLanguageServer {
                 }),
 
                 // ✅ Code actions for quick fixes (create missing views, etc.)
+                // and the always-available "Laravel: Reindex project" action
+                // (a `source`-kind action carrying the reindex command).
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+
+                // ✅ Execute-command provider — the server-side commands a
+                // client may invoke via `workspace/executeCommand`. Currently
+                // just `laravel.reindexProject`, which the reindex code action
+                // dispatches. Declared from the reindex module so the
+                // capability and the `execute_command` handler can't drift.
+                execute_command_provider: Some(laravel_lsp::reindex::execute_command_options()),
 
                 // ✅ Document symbol provider — populates outline panels
                 // (Zed outline, Helix symbol picker, Neovim aerial, etc.) with
@@ -20731,8 +20852,17 @@ impl LanguageServer for LaravelLanguageServer {
                     ),
                 }
 
+                // Claim the indexing-flight guard for the startup warm so a
+                // `laravel.reindexProject` triggered while first-load is still
+                // running no-ops instead of racing it. At startup the flag is
+                // free, so this normally succeeds; if it somehow doesn't, we
+                // pass `None` and warming proceeds unguarded (the pre-existing
+                // behavior) rather than skipping the initial index.
+                let startup_guard = laravel_lsp::reindex::IndexingFlightGuard::try_acquire(
+                    server.indexing_in_flight.clone(),
+                );
                 server
-                    .register_project_files_with_salsa(&root, progress.take())
+                    .register_project_files_with_salsa(&root, progress.take(), startup_guard)
                     .await;
             } else {
                 info!("Config not available for project file registration");
@@ -22987,18 +23117,21 @@ impl LanguageServer for LaravelLanguageServer {
         let uri = &params.text_document.uri;
         let context = &params.context;
 
-        // Early return if no diagnostics in context
-        if context.diagnostics.is_empty() {
-            return Ok(None);
-        }
-
         info!(
             "🔧 code_action called for {} with {} diagnostics",
             uri,
             context.diagnostics.len()
         );
 
-        let mut actions = Vec::new();
+        // The "Laravel: Reindex project" action is always offered for PHP/Blade
+        // files (subject to the request's `only` filter), independent of cursor
+        // position and diagnostics — that's how a Zed extension exposes a global
+        // command. Seed the response with it, then append the diagnostic-driven
+        // quick-fixes below. Unlike those, this action needs no project root or
+        // diagnostics, so it survives the "no diagnostics" case that used to
+        // early-return.
+        let mut actions =
+            laravel_lsp::reindex::global_code_actions(uri.path(), context.only.as_deref());
 
         // Get root path for Livewire (needs to calculate view path)
         let root_guard = self.root_path.read().await;
@@ -23060,6 +23193,24 @@ impl LanguageServer for LaravelLanguageServer {
             info!("🔧 Returning {} code actions", actions.len());
             Ok(Some(actions))
         }
+    }
+
+    /// Handle `workspace/executeCommand`. The only command we declare is
+    /// `laravel.reindexProject` (see `execute_command_provider` in
+    /// `initialize`), dispatched by the "Laravel: Reindex project" code action.
+    async fn execute_command(
+        &self,
+        params: ExecuteCommandParams,
+    ) -> jsonrpc::Result<Option<serde_json::Value>> {
+        info!("⚙️  execute_command: {}", params.command);
+        if params.command == laravel_lsp::reindex::REINDEX_COMMAND {
+            self.trigger_reindex().await;
+        } else {
+            warn!("execute_command: unknown command {}", params.command);
+        }
+        // No result payload — the reindex runs in the background and reports
+        // progress via the status bar, not a command return value.
+        Ok(None)
     }
 
     async fn completion(

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2070,6 +2070,21 @@ struct LaravelLanguageServer {
     /// schedule call cancels the previous timer, so a burst of saves
     /// produces one disk write after the burst settles.
     magic_cache_save_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
+
+    /// Session-only LRU of vendor files whose own magic-member usages were
+    /// lazily indexed on `did_open`. The eager build skips vendor files as
+    /// usage *sites*, so find-references would omit a vendor file's own
+    /// occurrence lines — opening one fills that gap via
+    /// [`Self::refresh_file_magic`]. Because `did_close` deliberately never
+    /// evicts (see the note there), these entries would otherwise accumulate
+    /// monotonically; on overflow the OLDEST opened vendor file's session
+    /// contributions are removed again (see
+    /// [`Self::record_vendor_open_magic`]). Tracks ONLY paths added via the
+    /// on-open path — never eager app files or saved files.
+    /// `std::sync::Mutex`, not `RwLock`: `lru` mutates on read to reorder
+    /// recency, and every critical section is a short map op (same rationale
+    /// as the `class_locator` cache).
+    vendor_open_magic_lru: Arc<std::sync::Mutex<lru::LruCache<PathBuf, ()>>>,
     /// Dominant Inertia page extension (`vue` / `tsx` / `jsx` / `svelte`),
     /// detected once at startup by counting files under `resources/js/Pages/`.
     /// Used as the default for the "create page" code action and to break
@@ -2086,6 +2101,15 @@ struct LaravelLanguageServer {
 
 /// Default Salsa debounce delay in milliseconds
 const DEFAULT_SALSA_DEBOUNCE_MS: u64 = 200;
+
+/// Cap on `vendor_open_magic_lru`: how many opened vendor files keep their
+/// on-open magic-member contributions alive at once. Tunable — raising it
+/// trades memory (entries + receiver deps per file) for a longer-lived
+/// session index; 128 comfortably exceeds the number of vendor files a
+/// session realistically has open or recently browsed, so an evicted file
+/// still sitting open in the editor is practically impossible (and even
+/// then, re-opening or saving it re-indexes it).
+const VENDOR_OPEN_MAGIC_LRU_CAP: usize = 128;
 
 // NOTE: Blade directives are now dynamically discovered via get_all_blade_directives()
 // which scans the Laravel framework, app service providers, and packages.
@@ -4355,6 +4379,9 @@ impl LaravelLanguageServer {
                 laravel_lsp::view_var_index::ViewVarIndex::new(),
             )),
             magic_cache_save_handle: Arc::new(RwLock::new(None)),
+            vendor_open_magic_lru: Arc::new(std::sync::Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(VENDOR_OPEN_MAGIC_LRU_CAP).unwrap(),
+            ))),
             inertia_default_ext: Arc::new(RwLock::new(None)),
         }
     }
@@ -6678,6 +6705,37 @@ impl LaravelLanguageServer {
         }
 
         changed_views
+    }
+
+    /// Bound the session growth of on-open vendor magic indexing: record
+    /// `path` in `vendor_open_magic_lru` and, on overflow, remove the OLDEST
+    /// previously-opened vendor file's session contributions — the same
+    /// removal a delete performs on the magic side: `reindex_file_magic` with
+    /// empty entries (which keeps the file's literal symbols alive via the
+    /// pattern-cache re-insert) plus its recorded receiver deps. Without this
+    /// bound the entries would accumulate for the whole session, because
+    /// `did_close` deliberately never evicts (references-multibuffer
+    /// rationale — see the note there). With the cap at
+    /// [`VENDOR_OPEN_MAGIC_LRU_CAP`], evicting a file that is *still open* is
+    /// practically impossible; if it ever happens its own-file references
+    /// simply go missing again until the next re-open or save re-indexes it.
+    async fn record_vendor_open_magic(&self, path: &Path) {
+        let evicted = {
+            let mut lru = self.vendor_open_magic_lru.lock().unwrap();
+            // `push` returns the displaced pair: the SAME key on a re-open
+            // (a recency touch — must not evict the entries we just wrote),
+            // or the LRU-oldest entry on overflow.
+            match lru.push(path.to_path_buf(), ()) {
+                Some((old, ())) if old != path => Some(old),
+                _ => None,
+            }
+        };
+        if let Some(old) = evicted {
+            let _ = self.salsa.reindex_file_magic(old.clone(), Vec::new()).await;
+            if let Ok(mut deps) = self.magic_deps.write() {
+                deps.remove_file(&old);
+            }
+        }
     }
 
     /// Schedule the debounced re-save of the magic disk cache. Call after
@@ -16647,6 +16705,7 @@ return [
             magic_deps: self.magic_deps.clone(),
             view_vars: self.view_vars.clone(),
             magic_cache_save_handle: self.magic_cache_save_handle.clone(),
+            vendor_open_magic_lru: self.vendor_open_magic_lru.clone(),
             inertia_default_ext: self.inertia_default_ext.clone(),
         }
     }
@@ -21607,6 +21666,27 @@ impl LanguageServer for LaravelLanguageServer {
                 debug!("Failed to update Salsa database: {}", e);
             }
             info!("   ⏱️  salsa.update_file: {:?}", t2.elapsed());
+
+            // The eager magic build skips vendor files as usage *sites*, so
+            // find-references omits a vendor file's own `$model->member`
+            // occurrence lines (goto/hover already work — only the reference
+            // set is incomplete). Opening the file is the signal to lazily
+            // fill that gap: resolve THIS file's usages and add them to the
+            // reverse index. Runs AFTER `update_file` so the refresh parses
+            // the just-opened buffer; awaited inline (one cheap file) so an
+            // immediate find-references can't race the insert. Session-only:
+            // `refresh_file_magic` never schedules a magic-cache save, so
+            // these entries don't leak into the disk cache or the next cold
+            // start. No dependents/ripple wrapper — opening a file changes no
+            // class surface, so there is nothing to converge.
+            if file_path.components().any(|c| c.as_os_str() == "vendor")
+                && file_path.to_string_lossy().ends_with(".php")
+            {
+                let t = std::time::Instant::now();
+                self.refresh_file_magic(&file_path, &text).await;
+                self.record_vendor_open_magic(&file_path).await;
+                info!("   ⏱️  vendor on-open magic refresh: {:?}", t.elapsed());
+            }
         }
 
         // Validate and publish diagnostics for Blade files

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -1844,6 +1844,41 @@ fn get_laravel_validation_rules() -> Vec<ValidationRuleInfo> {
     ]
 }
 
+/// One accumulated external (watched-file) `.php` change, awaiting the
+/// debounced incremental magic-member batch (M2). Snapshotted at event time so
+/// the batch can run the same pre/post surface diff `did_save` runs, without a
+/// project-size gate.
+///
+/// `old_surfaces` / `old_render_views` are the file's fqcn→surface-signature
+/// map and rendered view names *before* the change — captured on the first
+/// event for a path in a burst (first-event-wins: a later event must not
+/// overwrite the true pre-state, since an interleaved query may already have
+/// re-parsed the hierarchy). For a deleted path they're snapshotted *before*
+/// `remove_file` tears the hierarchy nodes down. `deleted` is only an advisory
+/// hint: whether the file actually exists is decided by re-reading it *at drain*
+/// (see `run_magic_batch_once`), because two overlapping notifications for the
+/// same path with opposite existence can leave this flag stale.
+#[derive(Debug, Clone, Default)]
+struct PendingWatchedChange {
+    old_surfaces: std::collections::HashMap<String, u64>,
+    old_render_views: Vec<String>,
+    deleted: bool,
+}
+
+/// Shared state for the debounced watched-files magic batch (M2). The pending
+/// map and the `running` flag live under ONE mutex on purpose: it makes the
+/// scheduler's "a task is live → don't spawn" decision and the task's "map
+/// empty → relinquish liveness and exit" decision atomic against each other.
+/// Splitting them (a separate pending lock + a `JoinHandle::is_finished`
+/// liveness check) reintroduces a lost-wakeup race — a producer can record an
+/// event and see the not-yet-returned task as live, skip spawning, and strand
+/// the event with no task to drain it. One lock closes that window.
+#[derive(Default)]
+struct WatchedBatchState {
+    pending: HashMap<PathBuf, PendingWatchedChange>,
+    running: bool,
+}
+
 /// The main Laravel Language Server struct
 /// This holds all the state for our LSP
 #[derive(Clone)]
@@ -1868,10 +1903,20 @@ struct LaravelLanguageServer {
     pending_rescans: Arc<RwLock<HashSet<RescanType>>>,
     /// Handle for the rescan debounce timer
     rescan_debounce_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
-    /// Handle for the debounced full magic-member index rebuild. Coalesces
-    /// rapid edits into one project-wide reconverge (the "full" half of the
-    /// hybrid incremental refresh; the per-file refresh is the "instant" half).
+    /// Handle for the debounced watched-files magic-member batch task (M2),
+    /// kept solely so the handler tests can await the task to observe
+    /// convergence. Liveness (spawn-vs-skip) is NOT decided from this handle —
+    /// that would race the task's exit — but from `WatchedBatchState::running`
+    /// under the state mutex. Coalesces an external-edit burst (git pull,
+    /// formatter, branch switch) into one dependency-tracked incremental
+    /// reconverge; a batch already draining is never aborted.
     magic_rebuild_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
+    /// Accumulated external `.php` changes + the batch task's liveness flag,
+    /// under one mutex (see [`WatchedBatchState`]). Producer:
+    /// `did_change_watched_files` records events and spawns a task iff none is
+    /// running. Consumer: the batch task drains it and clears `running` when it
+    /// finds the map empty — both decisions serialized on this one lock.
+    magic_batch_state: Arc<tokio::sync::Mutex<WatchedBatchState>>,
     /// File existence cache with TTL (path -> (exists, cached_at))
     /// This avoids blocking I/O in async context for file_exists checks
     file_exists_cache: Arc<RwLock<HashMap<PathBuf, (bool, Instant)>>>,
@@ -4269,6 +4314,7 @@ impl LaravelLanguageServer {
             pending_rescans: Arc::new(RwLock::new(HashSet::new())),
             rescan_debounce_handle: Arc::new(RwLock::new(None)),
             magic_rebuild_handle: Arc::new(RwLock::new(None)),
+            magic_batch_state: Arc::new(tokio::sync::Mutex::new(WatchedBatchState::default())),
             file_exists_cache: Arc::new(RwLock::new(HashMap::new())),
             cached_config: Arc::new(RwLock::new(None)),
             cached_livewire: Arc::new(RwLock::new(None)),
@@ -6207,11 +6253,15 @@ impl LaravelLanguageServer {
             return; // body-only edit — nothing beyond this file can change
         }
 
-        // The ripple runs in the background so did_save returns promptly.
+        // The ripple runs in the background so did_save returns promptly. The
+        // saved file was already refreshed by the per-file pass above, so it's
+        // the sole exclusion here.
         let server = self.clone_for_spawn();
+        let mut already_refreshed = HashSet::new();
+        already_refreshed.insert(path.clone());
         tokio::spawn(async move {
             server
-                .refresh_magic_dependents(&path, changed_classes, changed_views)
+                .refresh_magic_dependents(&already_refreshed, changed_classes, changed_views)
                 .await;
         });
     }
@@ -6225,9 +6275,14 @@ impl LaravelLanguageServer {
     /// semaphore keeps CPU bounded throughout. (An earlier revision fell
     /// back to the full rebuild above 500 dependents; on a real project
     /// that fallback *was* the long re-index it existed to prevent.)
+    ///
+    /// `already_refreshed` are the files the caller has *itself* re-resolved
+    /// this pass (the saved file on the save path; every changed present file
+    /// on the watched-batch path) — they're removed from the work set so a
+    /// file already converged isn't parsed twice.
     async fn refresh_magic_dependents(
         &self,
-        saved: &Path,
+        already_refreshed: &HashSet<PathBuf>,
         changed_classes: Vec<String>,
         changed_views: Vec<String>,
     ) {
@@ -6269,7 +6324,9 @@ impl LaravelLanguageServer {
             }
         }
 
-        work.remove(saved); // already refreshed by the per-file pass
+        for p in already_refreshed {
+            work.remove(p); // already refreshed by the caller's per-file pass
+        }
         if work.is_empty() {
             return;
         }
@@ -6292,27 +6349,7 @@ impl LaravelLanguageServer {
             let permit_owner = sem.clone();
             handles.push(tokio::spawn(async move {
                 let _permit = permit_owner.acquire_owned().await.ok()?;
-                let buffered = match Url::from_file_path(&dep) {
-                    Ok(url) => server
-                        .documents
-                        .read()
-                        .await
-                        .get(&url)
-                        .map(|(content, _)| content.clone()),
-                    Err(()) => None,
-                };
-                let content = match buffered {
-                    Some(c) => c,
-                    None => {
-                        let dep_for_read = dep.clone();
-                        tokio::task::spawn_blocking(move || {
-                            std::fs::read_to_string(&dep_for_read).ok()
-                        })
-                        .await
-                        .ok()
-                        .flatten()?
-                    }
-                };
+                let content = server.read_file_for_magic(&dep).await?;
                 server.refresh_file_magic(&dep, &content).await;
                 Some(())
             }));
@@ -6676,72 +6713,259 @@ impl LaravelLanguageServer {
         }
     }
 
-    /// Schedule the debounced project-wide magic-member reconverge. No longer
-    /// part of the per-save path (#80 — saves use the dependency-tracked
-    /// incremental refresh); this remains the reconverge after external
-    /// (watched-file) changes, whose ripples the save-time diff never saw.
-    /// The debounce coalesces bursts (git checkout touching hundreds of
-    /// files) into one rebuild.
+    /// Schedule the debounced watched-files magic-member batch (M2). Coalesces
+    /// an external-edit burst (git pull, formatter, branch switch) into one
+    /// dependency-tracked incremental reconverge, whose ripples the save-time
+    /// diff never saw. No longer part of the per-save path (#80 — saves use the
+    /// dependency-tracked incremental refresh directly).
+    ///
+    /// **Non-aborting, self-extending, single-lock liveness.** The producer
+    /// (`did_change_watched_files`) has already recorded its snapshots into
+    /// `magic_batch_state.pending` before calling this. Under the *same* state
+    /// mutex the task uses to decide its exit, we check `running`: if a task is
+    /// already live it will observe the just-recorded events itself (the map is
+    /// the signal), so we skip; otherwise we set `running = true` and spawn.
+    ///
+    /// Serializing the spawn decision and the task's exit decision on one lock
+    /// is what closes the lost-wakeup race: a task only clears `running` while
+    /// holding this lock *and* having just seen the map empty, so any event a
+    /// producer records is either visible to that in-lock emptiness check (task
+    /// loops and drains it) or recorded after `running` was cleared (this
+    /// producer sees `running == false` and spawns). Never aborting a running
+    /// task also means a batch already draining can't lose its snapshots.
     async fn schedule_magic_rebuild(&self) {
-        if let Some(handle) = self.magic_rebuild_handle.write().await.take() {
-            handle.abort();
+        {
+            let mut state = self.magic_batch_state.lock().await;
+            if state.running {
+                return; // a live task will observe the recorded events itself
+            }
+            state.running = true;
         }
         let server = self.clone_for_spawn();
         let handle = tokio::spawn(async move {
-            sleep(Duration::from_millis(MAGIC_REBUILD_DEBOUNCE_MS)).await;
-            server.rebuild_magic_index_full().await;
+            server.run_magic_watched_batch().await;
         });
+        // Stored only so the handler tests can await convergence; liveness is
+        // `state.running`, never `handle.is_finished()` (which would race exit).
         *self.magic_rebuild_handle.write().await = Some(handle);
     }
 
-    /// Re-resolve the whole project's magic-member reverse index from the
-    /// current pattern cache. Reuses the exact warm-build passes via
-    /// [`build_magic_member_entries`]; `build_symbol_index` clears the index
-    /// first (literals + magic) so the append below can't duplicate.
+    /// The watched-files incremental batch task (M2). Debounces, then drains
+    /// `magic_batch_state.pending` and converges the magic-member index for
+    /// exactly the changed files plus their dependency blast radius — work
+    /// proportional to the change, never to project size, so there is no size
+    /// gate. Loops while the burst keeps arriving inside the debounce window,
+    /// and re-loops if the map refilled while a drain was in flight, so nothing
+    /// is dropped. Relinquishes liveness (`running = false`) only under the
+    /// state lock, having just observed the map empty in the same critical
+    /// section — the other half of the invariant in `schedule_magic_rebuild`.
+    async fn run_magic_watched_batch(&self) {
+        loop {
+            // Quiet-period debounce: sleep, and if more events landed during the
+            // sleep, sleep again — coalescing the whole burst into one drain.
+            sleep(Duration::from_millis(MAGIC_REBUILD_DEBOUNCE_MS)).await;
+            loop {
+                let count = self.magic_batch_state.lock().await.pending.len();
+                if count == 0 {
+                    break; // nothing accumulated — fall through to the exit check
+                }
+                let before = count;
+                sleep(Duration::from_millis(MAGIC_REBUILD_DEBOUNCE_MS)).await;
+                if self.magic_batch_state.lock().await.pending.len() == before {
+                    break; // no new events during the last window — drain now
+                }
+            }
+
+            // Drain-or-exit, atomic under the state lock: if the map is empty we
+            // clear `running` and return *inside* the critical section, so a
+            // producer can't observe us as live-but-about-to-exit. Otherwise we
+            // take the batch (leaving `running == true`) and process it.
+            let batch = {
+                let mut state = self.magic_batch_state.lock().await;
+                if state.pending.is_empty() {
+                    state.running = false;
+                    return;
+                }
+                std::mem::take(&mut state.pending)
+            };
+            self.run_magic_batch_once(batch).await;
+            // Loop: any events that refilled the map while we drained are picked
+            // up by the next debounce, never a rival task (`running` is still
+            // true, so `schedule_magic_rebuild` skips spawning).
+        }
+    }
+
+    /// Converge the magic-member index for one drained batch of watched changes.
+    /// Mirrors the save path's pre/post surface diff (`refresh_magic_on_save` →
+    /// `refresh_magic_dependents`), but over a set of externally-changed files
+    /// instead of one saved buffer:
     ///
-    /// Gated on project size: on very large projects the full reconverge is too
-    /// heavy to run per edit-settle, so it is skipped and the per-file refresh
-    /// remains the only incremental path there.
-    async fn rebuild_magic_index_full(&self) {
-        let Some(root) = self.root_path.read().await.clone() else {
-            return;
-        };
-        let view_paths = match self.cached_config.read().await.as_ref() {
-            Some(c) => c.view_paths.clone(),
-            None => return,
-        };
-        let pattern_cache = self.salsa.pattern_cache();
+    /// Existence is decided **at drain**, by re-reading the file — not from the
+    /// recorded `deleted` flag, which two overlapping notifications for one path
+    /// can leave stale. `read_file_for_magic` returning `None` means the file is
+    /// gone *right now*, so it takes the delete path regardless of the flag:
+    ///
+    /// - **present, non-vendor** files are re-resolved in full
+    ///   (`refresh_file_magic`) — own contribution + per-file changed views —
+    ///   exactly as a save would;
+    /// - **present, vendor** files get a surfaces-only pass (parse + hierarchy
+    ///   update via `get_patterns`, no own-contribution resolution) so a vendor
+    ///   base-class change still ripples to app subclasses, without eagerly
+    ///   indexing vendor usage sites the build passes deliberately skip;
+    /// - **gone** files (a real delete, or a flag-race present-but-missing)
+    ///   contribute their pre-change surface FQCNs and render views to the blast
+    ///   radius, and are purged from `magic_deps` / `view_vars` (the
+    ///   watched-delete path previously leaked both — only the Salsa
+    ///   `RemoveFile` symbol/hierarchy eviction ran).
+    ///
+    /// The unioned `changed_classes` / `changed_views` then drive the same
+    /// `refresh_magic_dependents` blast radius as a save, excluding the present
+    /// files already refreshed here.
+    async fn run_magic_batch_once(&self, batch: HashMap<PathBuf, PendingWatchedChange>) {
+        let mut changed_classes: HashSet<String> = HashSet::new();
+        let mut changed_views: HashSet<String> = HashSet::new();
+        let mut refreshed: HashSet<PathBuf> = HashSet::new();
 
-        const MAX_FULL_REBUILD_FILES: usize = 15_000;
-        if pattern_cache.len() > MAX_FULL_REBUILD_FILES {
-            debug!(
-                "🪄 Project too large ({} files) — skipping debounced full magic rebuild; per-file refresh only",
-                pattern_cache.len()
-            );
-            return;
+        for (path, pending) in batch {
+            let is_vendor = path.components().any(|c| c.as_os_str() == "vendor");
+
+            // Authoritative existence check: read the file NOW. `None` = gone,
+            // whatever the advisory `deleted` flag says (a flag-race across
+            // overlapping notifications can leave it present-but-missing).
+            let content = self.read_file_for_magic(&path).await;
+
+            let Some(content) = content else {
+                // Gone: post-change surface is empty, so every pre-change FQCN is
+                // a changed class and every rendered view a changed view. Purge
+                // the file's own dep + render contributions (Salsa RemoveFile
+                // only evicts symbol/hierarchy — this closes the leak). Applies
+                // to vendor too: purge is a no-op there (build passes skip vendor
+                // usage sites), and the old surfaces still ripple to subclasses.
+                changed_classes.extend(pending.old_surfaces.into_keys());
+                changed_views.extend(pending.old_render_views);
+                if let Ok(mut deps) = self.magic_deps.write() {
+                    deps.remove_file(&path);
+                }
+                if let Ok(mut vv) = self.view_vars.write() {
+                    vv.remove_file(&path);
+                }
+                continue;
+            };
+
+            if is_vendor {
+                // Surfaces-only: parse to refresh the hierarchy node, then diff
+                // the surface so a vendor base-class change ripples to app
+                // subclasses. No own-contribution resolution, no place in the
+                // dependent work set (preserve the build-pass vendor exclusion).
+                let _ = self.salsa.get_patterns(path.clone()).await;
+                let new_surfaces = self
+                    .salsa
+                    .file_class_surfaces(path.clone())
+                    .await
+                    .unwrap_or_default();
+                changed_classes.extend(laravel_lsp::class_hierarchy_index::surface_map_diff(
+                    &pending.old_surfaces,
+                    &new_surfaces,
+                ));
+                continue;
+            }
+
+            // Present, non-vendor: full per-file refresh, same as a save.
+            let views = self.refresh_file_magic(&path, &content).await;
+            let new_surfaces = self
+                .salsa
+                .file_class_surfaces(path.clone())
+                .await
+                .unwrap_or_default();
+            changed_classes.extend(laravel_lsp::class_hierarchy_index::surface_map_diff(
+                &pending.old_surfaces,
+                &new_surfaces,
+            ));
+            changed_views.extend(views);
+            refreshed.insert(path);
         }
 
-        if let Err(e) = self.salsa.build_symbol_index().await {
-            debug!("Symbol index rebuild failed: {}", e);
+        // The per-file passes above already mutated the live indexes — keep the
+        // disk cache converging regardless of ripple size.
+        self.schedule_magic_cache_save().await;
+
+        if changed_classes.is_empty() && changed_views.is_empty() {
             return;
         }
-        let data = build_magic_member_entries(
-            &self.salsa,
-            &pattern_cache,
-            &root,
-            &view_paths,
-            MAX_CONCURRENT_MAGIC_PARSES,
-            None, // save-refresh path has no first-load progress UI
-            &self.view_vars,
+        self.refresh_magic_dependents(
+            &refreshed,
+            changed_classes.into_iter().collect(),
+            changed_views.into_iter().collect(),
         )
         .await;
-        match import_magic_data(&self.salsa, &self.magic_deps, data.entries).await {
-            Ok(n) => info!("🪄 Magic-member index reconverged: {} entries", n),
-            Err(e) => debug!("Magic reconverge failed: {}", e),
+    }
+
+    /// Read a file's authoritative content for a magic refresh: the open editor
+    /// buffer if the file is open (its unsaved content is authoritative), else
+    /// the on-disk bytes read on the blocking pool. `None` if neither is
+    /// available (the file was deleted between the watched event and the drain).
+    async fn read_file_for_magic(&self, path: &Path) -> Option<String> {
+        if let Ok(url) = Url::from_file_path(path) {
+            if let Some((content, _)) = self.documents.read().await.get(&url) {
+                return Some(content.clone());
+            }
         }
-        // Counts changed — ask the client to re-resolve code lenses.
-        let _ = self.client.code_lens_refresh().await;
-        self.schedule_magic_cache_save().await;
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || std::fs::read_to_string(&path).ok())
+            .await
+            .ok()
+            .flatten()
+    }
+
+    /// Record one external `.php` change into `magic_batch_state.pending` for
+    /// the debounced batch (M2), capturing the file's pre-change surface
+    /// snapshot.
+    ///
+    /// **First-event-wins for the snapshot.** If the path is already pending,
+    /// only its `deleted` hint is updated — the original pre-change surfaces are
+    /// kept, because by now an interleaved query may have re-parsed the
+    /// hierarchy and a fresh snapshot would no longer be the true pre-state. The
+    /// double-check on re-lock closes the window between computing the snapshot
+    /// and inserting it. (`deleted` is only advisory; the batch decides real
+    /// existence by re-reading at drain — see `run_magic_batch_once`.)
+    ///
+    /// The caller MUST invoke this *before* the arm's Salsa mutation — in
+    /// particular before `remove_file`, which eagerly tears down the very
+    /// hierarchy nodes the surface snapshot reads.
+    async fn record_watched_change(&self, path: &Path, deleted: bool) {
+        {
+            let mut state = self.magic_batch_state.lock().await;
+            if let Some(entry) = state.pending.get_mut(path) {
+                entry.deleted = deleted;
+                return;
+            }
+        }
+        // First event for this path — snapshot the pre-change surface + renders.
+        let old_surfaces = self
+            .salsa
+            .file_class_surfaces(path.to_path_buf())
+            .await
+            .unwrap_or_default();
+        let old_render_views = self
+            .view_vars
+            .read()
+            .ok()
+            .and_then(|vv| {
+                vv.renders_for(path)
+                    .map(|rs| rs.iter().map(|r| r.view_name.clone()).collect::<Vec<_>>())
+            })
+            .unwrap_or_default();
+        self.magic_batch_state
+            .lock()
+            .await
+            .pending
+            .entry(path.to_path_buf())
+            .or_insert(PendingWatchedChange {
+                old_surfaces,
+                old_render_views,
+                deleted,
+            })
+            .deleted = deleted;
     }
 
     /// Execute all pending rescans
@@ -16356,6 +16580,7 @@ return [
             pending_rescans: self.pending_rescans.clone(),
             rescan_debounce_handle: self.rescan_debounce_handle.clone(),
             magic_rebuild_handle: self.magic_rebuild_handle.clone(),
+            magic_batch_state: self.magic_batch_state.clone(),
             file_exists_cache: self.file_exists_cache.clone(),
             cached_config: self.cached_config.clone(),
             cached_livewire: self.cached_livewire.clone(),
@@ -21054,16 +21279,25 @@ impl LanguageServer for LaravelLanguageServer {
                 // We use dynamic registration (not declared in
                 // `initialize`) because the view paths and livewire
                 // path depend on project config we only just loaded.
+                // First-party PSR-4 source roots (M2) widen the watcher beyond
+                // the hardcoded controllers path so an external edit to any
+                // source dir converges the magic-member index. The autoload is
+                // process-cached, already loaded by resolution paths this run.
+                let psr4_roots =
+                    laravel_lsp::composer_autoload::ComposerAutoload::for_project(&root)
+                        .project_source_roots();
                 let registration = laravel_lsp::file_watcher::build_registration(
                     &root,
                     &config.view_paths,
                     config.livewire_path.as_deref(),
+                    &psr4_roots,
                 );
                 match server.client.register_capability(vec![registration]).await {
                     Ok(_) => info!(
-                        "🛡️  Registered file watcher: {} view paths, livewire={}",
+                        "🛡️  Registered file watcher: {} view paths, livewire={}, {} PSR-4 source root(s)",
                         config.view_paths.len(),
-                        config.livewire_path.is_some()
+                        config.livewire_path.is_some(),
+                        psr4_roots.len()
                     ),
                     Err(e) => debug!(
                         "File watcher registration failed (client may not support it): {}",
@@ -21547,6 +21781,9 @@ impl LanguageServer for LaravelLanguageServer {
         let mut skipped_open = 0usize;
         let mut migrations_changed = false;
         let mut commands_changed = false;
+        // Did this batch record any `.php` magic change? Gates the debounced
+        // incremental batch — an Inertia-only burst does no magic work.
+        let mut magic_dirty = false;
 
         for change in params.changes {
             if open_docs.contains(&change.uri) {
@@ -21582,6 +21819,16 @@ impl LanguageServer for LaravelLanguageServer {
             }
             if !migrations_changed && path.to_string_lossy().contains("database/migrations") {
                 migrations_changed = true;
+            }
+            // Snapshot the file's pre-change surface for the incremental magic
+            // batch (M2) BEFORE the arm's Salsa mutation runs — critically,
+            // before a DELETE's `remove_file` tears down the hierarchy nodes the
+            // snapshot reads. `.php` covers `.blade.php` too. First-event-wins
+            // is enforced inside `record_watched_change`.
+            if path.to_string_lossy().ends_with(".php") {
+                let is_delete = matches!(change.typ, FileChangeType::DELETED);
+                self.record_watched_change(&path, is_delete).await;
+                magic_dirty = true;
             }
             match change.typ {
                 FileChangeType::CREATED => {
@@ -21679,23 +21926,29 @@ impl LanguageServer for LaravelLanguageServer {
             }
         }
 
-        // External PHP changes (git pull, formatter outside Zed) bypass the
-        // save-time incremental refresh entirely — their surface diffs were
-        // never computed, so the dependency-tracked path can't see their
-        // ripples. The debounced full reconverge (still gated on project
-        // size) restores the old guarantee that the magic index converges
-        // after disk-level changes. Saves no longer trigger this (#80);
-        // external edits are the one remaining caller.
+        // A watched create/delete changes which FQCNs resolve to a file, so
+        // drop the FQCN→file resolution cache for this project (a new class
+        // becomes resolvable, a removed one stops). This covers the watched
+        // paths (controllers, PSR-4 source roots, views, livewire, vendor);
+        // any still-unwatched path relies on the locator's negative-entry TTL
+        // — see the Fork-2 note in class_locator. Inertia-only bursts count
+        // here too (a new/removed page file), hence the counter gate rather
+        // than `magic_dirty`.
         if created_or_changed + deleted > 0 {
-            // Drop the FQCN→file resolution cache for this project so a
-            // watched create/delete is reflected immediately (a new class
-            // becomes resolvable, a removed one stops resolving). This covers
-            // the watched paths (controllers, views, livewire, vendor);
-            // unwatched app paths (e.g. `app/Models/`) rely on the locator's
-            // negative-entry TTL instead — see the Fork-2 note in class_locator.
             if let Some(root) = self.initialized_root.read().await.clone() {
                 laravel_lsp::class_locator::invalidate_project(&root);
             }
+        }
+
+        // External PHP changes (git pull, formatter outside Zed) bypass the
+        // save-time incremental refresh entirely — their surface diffs were
+        // never computed, so the dependency-tracked path can't see their
+        // ripples. Their pre-change surfaces are now recorded in
+        // `magic_batch_state.pending`; the debounced incremental batch (M2)
+        // diffs pre/post per file and re-resolves only the actual blast radius,
+        // scaling with change size rather than project size — so no size gate.
+        // Saves no longer trigger this (#80); external edits are the one caller.
+        if magic_dirty {
             self.schedule_magic_rebuild().await;
         }
     }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -1968,10 +1968,20 @@ struct LaravelLanguageServer {
     /// built; cleared on a provider/composer rescan. Used by semantic-token
     /// highlighting to reject non-directive `@`-text.
     cached_directive_names: Arc<RwLock<Option<HashSet<String>>>>,
-    /// Database schema provider for exists:/unique: validation rules
+    /// Database schema provider for exists:/unique: validation rules.
+    /// Outage notifications are edge-triggered by the provider's circuit
+    /// breaker (one toast per outage episode, re-armed on reconnect) — see
+    /// `init_database_schema_provider` for the listener wiring.
     database_schema: Arc<RwLock<Option<laravel_lsp::database::DatabaseSchemaProvider>>>,
-    /// Whether we've shown the database connection error diagnostic this session
-    database_diagnostic_shown: Arc<RwLock<bool>>,
+    /// Idempotency guard for `init_database_schema_provider`, which is
+    /// called from two startup sites. Holds the root the live background
+    /// tasks (refresh loop + outage-channel listener) were started for,
+    /// plus their `JoinHandle`s. A re-init for the SAME root is a no-op
+    /// (this is what stops the duplicate-outage-toast bug — two providers
+    /// meant two breakers, each firing its own toast); a re-init for a
+    /// DIFFERENT root aborts these tasks before starting fresh. So exactly
+    /// one provider / loop / listener / breaker is live at a time.
+    db_provider_task: Arc<tokio::sync::Mutex<Option<(PathBuf, Vec<tokio::task::JoinHandle<()>>)>>>,
     /// Cached index of named routes discovered across project / packages / framework.
     /// Populated at init by walking routes/, vendor/*/routes/, and content-matched
     /// vendor PHP files. Replaces the legacy hard-coded route-file scan.
@@ -4083,9 +4093,11 @@ impl LaravelLanguageServer {
         };
 
         if items.is_empty() {
-            // Distinguish two empty-result causes for the log/diagnostic:
-            // (a) DB is unreachable — actionable, user can fix .env. Show a
-            //     one-time INFO toast so they discover the dependency.
+            // Distinguish two empty-result causes for the log:
+            // (a) DB is unreachable — the user was already notified by the
+            //     circuit-breaker toast when the outage began (one per
+            //     outage episode, wired in init_database_schema_provider),
+            //     so just log here.
             // (b) DB is reachable but the specific table/columns aren't in
             //     the introspected schema (e.g., user typed a typo, table
             //     was dropped, schema cache stale). Stay silent — toasting
@@ -4099,7 +4111,6 @@ impl LaravelLanguageServer {
                      DB connection error: {}",
                     ctx.expecting, error.message
                 );
-                self.maybe_notify_db_unreachable(&error.message).await;
             } else {
                 info!(
                     "🔗 chain completion: matched {:?} but produced 0 items — \
@@ -4296,47 +4307,6 @@ impl LaravelLanguageServer {
         }
     }
 
-    /// Send a one-time notification informing the user that table and
-    /// column autocomplete requires a working DB connection. Shares the
-    /// `database_diagnostic_shown` flag with the existing exists:/unique:
-    /// diagnostic path, so the user only sees ONE notification per LSP
-    /// session no matter how they hit the unreachable DB.
-    ///
-    /// Uses `window/showMessageRequest` (with a Dismiss action) rather than
-    /// `window/showMessage` because the latter auto-dismisses after a few
-    /// seconds — the user may not even see it if they're typing. With an
-    /// action button, the notification stays until they explicitly click it.
-    async fn maybe_notify_db_unreachable(&self, error_message: &str) {
-        let mut shown = self.database_diagnostic_shown.write().await;
-        if *shown {
-            return;
-        }
-        *shown = true;
-        drop(shown);
-
-        let message = format!(
-            "Laravel: Database is unreachable, so table and column \
-             autocompletion is disabled. Fix DB connectivity in .env \
-             (DB_HOST / DB_PORT / credentials) and reload the window to \
-             enable. Error: {error_message}"
-        );
-        let actions = vec![tower_lsp::lsp_types::MessageActionItem {
-            title: "Dismiss".to_string(),
-            properties: Default::default(),
-        }];
-        // We don't care about the response — the only action is "Dismiss".
-        // The point of using show_message_request is that the notification
-        // persists until the user clicks.
-        let _ = self
-            .client
-            .show_message_request(
-                tower_lsp::lsp_types::MessageType::WARNING,
-                message,
-                Some(actions),
-            )
-            .await;
-    }
-
     fn new(client: Client) -> Self {
         Self {
             client,
@@ -4365,7 +4335,7 @@ impl LaravelLanguageServer {
             cached_validation_rule_names: Arc::new(RwLock::new(Vec::new())),
             cached_directive_names: Arc::new(RwLock::new(None)),
             database_schema: Arc::new(RwLock::new(None)),
-            database_diagnostic_shown: Arc::new(RwLock::new(false)),
+            db_provider_task: Arc::new(tokio::sync::Mutex::new(None)),
             route_index: Arc::new(RwLock::new(None)),
             warm_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             indexing_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -7976,11 +7946,110 @@ impl LaravelLanguageServer {
         diagnostics
     }
 
-    /// Initialize the database schema provider for exists:/unique: validation rules
+    /// Initialize the database schema provider for exists:/unique: validation
+    /// rules — **idempotent**. Called from two startup sites (the
+    /// config-discovery flow and the `initialized` background task), so it
+    /// guards against setting up a second provider: a second call for the
+    /// same root is a no-op, and a call for a different root aborts the old
+    /// tasks first. Exactly one provider / refresh loop / channel listener /
+    /// breaker is ever live — which is what keeps a single outage from
+    /// producing two toasts (two breakers, each firing its own).
     async fn init_database_schema_provider(&self, root: &Path) {
-        use laravel_lsp::database::DatabaseSchemaProvider;
+        use laravel_lsp::database::{outage_toast_message, DatabaseSchemaProvider, DbBreakerEvent};
 
-        let provider = DatabaseSchemaProvider::new(root.to_path_buf());
+        let root_buf = root.to_path_buf();
+
+        // Idempotency guard. Held across the whole init so the two startup
+        // sites serialize: the first sets everything up and stores the task
+        // handles; the second sees the same root and returns. No other code
+        // locks `db_provider_task`, so holding it across the awaits below
+        // can't deadlock.
+        let mut task_guard = self.db_provider_task.lock().await;
+        match task_guard.as_ref() {
+            Some((existing_root, _)) if *existing_root == root_buf => {
+                debug!(
+                    "🗄️  DB schema provider already initialised for {:?} — skipping re-init",
+                    root_buf
+                );
+                return;
+            }
+            Some((existing_root, handles)) => {
+                info!(
+                    "🗄️  DB schema provider root changed ({:?} → {:?}) — aborting old tasks",
+                    existing_root, root_buf
+                );
+                for handle in handles {
+                    handle.abort();
+                }
+            }
+            None => {}
+        }
+
+        let provider = DatabaseSchemaProvider::new(root_buf.clone());
+
+        // Wire the breaker-edge notifications. The provider's circuit
+        // breaker — which lives entirely in the background refresh loop
+        // below — announces each edge on this channel: `Outage` on the
+        // Closed→Open transition (the FIRST failure of an outage episode;
+        // retry probes inside the same outage are silent), and
+        // `Reconnected` on the recovery edge (Open/HalfOpen→Closed). So the
+        // user sees exactly one outage toast then, when the DB comes back,
+        // exactly one reconnect toast. Outage text is scenario-specific
+        // (unreachable vs rejected vs generic); "no DB configured" maps to
+        // `None` and stays silent.
+        //
+        // Both use `window/showMessageRequest` (a persistent toast with a
+        // Dismiss action), NOT `window/showMessage` (auto-dismissing): the
+        // outage message is dense — scenario diagnosis, what to check, and
+        // the retry cadence — and needs time to read, so it stays until the
+        // user dismisses it. It can no longer linger misleadingly after
+        // recovery, because the `Reconnected` toast fires on the recovery
+        // edge and corrects the picture.
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<DbBreakerEvent>();
+        provider.set_event_channel(event_tx).await;
+        let toast_client = self.client.clone();
+        let listener_handle = tokio::spawn(async move {
+            use tower_lsp::lsp_types::{MessageActionItem, MessageType};
+            // A single Dismiss action makes the toast persistent — it stays
+            // until the user clicks, rather than auto-fading in a few seconds.
+            let dismiss = || {
+                vec![MessageActionItem {
+                    title: "Dismiss".to_string(),
+                    properties: Default::default(),
+                }]
+            };
+            // Ends when the provider (and with it the sender) is dropped
+            // or replaced by a re-init.
+            while let Some(event) = event_rx.recv().await {
+                match event {
+                    DbBreakerEvent::Outage(outage) => {
+                        let Some(message) = outage_toast_message(outage.class, &outage.message)
+                        else {
+                            info!(
+                                "🗄️  DB circuit breaker opened silently ({:?}): {}",
+                                outage.class, outage.message
+                            );
+                            continue;
+                        };
+                        // We don't act on the response — the only action is
+                        // Dismiss; the point is that the toast persists.
+                        let _ = toast_client
+                            .show_message_request(MessageType::WARNING, message, Some(dismiss()))
+                            .await;
+                    }
+                    DbBreakerEvent::Reconnected => {
+                        let _ = toast_client
+                            .show_message_request(
+                                MessageType::INFO,
+                                "Laravel: database reconnected — DB-aware features re-enabled."
+                                    .to_string(),
+                                Some(dismiss()),
+                            )
+                            .await;
+                    }
+                }
+            }
+        });
 
         // Log config status but always store provider
         // Errors will be handled when completions are requested
@@ -7995,41 +8064,58 @@ impl LaravelLanguageServer {
             false
         };
 
-        // Always store provider - errors handled when completions requested
+        // Always store provider - interactive reads hit its in-memory cache.
         *self.database_schema.write().await = Some(provider);
 
-        // Pre-warm the schema cache in the background. The cold fetch costs
-        // ~50ms for SHOW TABLES + ~4ms per table for SHOW COLUMNS — on a
-        // 600-table schema that's ~2.5s. Doing it here, in parallel with
-        // vendor/app provider rescans and pattern cache warming, means the
-        // user's first `DB::table('|')` completion hits a warm cache and
-        // returns instantly. Skipped when there's no config (nothing to
-        // introspect and the toast would be noise).
+        // Track the live background tasks so they can be aborted on a root
+        // change. The listener is always running; the refresh loop is pushed
+        // below when there's a DB config.
+        let mut task_handles = vec![listener_handle];
+
+        // Spawn the SINGLE background refresh loop — the only code that ever
+        // connects to the database. It owns connect + fetch + cache-fill +
+        // circuit breaker + outage notification, entirely off the tower-lsp
+        // request-dispatch slots, so a slow or dead database can never
+        // starve interactive requests (hover/goto/completion on a non-DB
+        // target stays instant during an outage — the isolation bug this
+        // design fixes). The first tick doubles as the pre-warm: a cold
+        // ~2.5s fetch for a 600-table schema, after which interactive
+        // `DB::table('|')` completions hit a warm cache.
+        //
+        // Cadence is driven by the breaker: refresh every ~60s while
+        // healthy (matching the cache TTL), retry every ~30s (the half-open
+        // probe) while the DB is down. Skipped entirely when there's no DB
+        // config — nothing to introspect and no outage to report.
         if has_config {
+            use laravel_lsp::database::{DB_CONNECT_TIMEOUT, DB_REFRESH_HEALTHY_INTERVAL};
             let db = self.database_schema.clone();
-            tokio::spawn(async move {
-                let start = std::time::Instant::now();
-                info!("🔥 Pre-warming database schema cache...");
-                let schema = {
-                    let guard = db.read().await;
-                    match guard.as_ref() {
-                        Some(provider) => provider.get_schema().await,
-                        None => None,
-                    }
-                };
-                match schema {
-                    Some(s) => info!(
-                        "🔥 Database schema cache warmed: {} tables in {:?}",
-                        s.tables.len(),
-                        start.elapsed()
-                    ),
-                    None => info!(
-                        "🔥 Database schema pre-warm failed ({:?}) — will retry on first completion",
-                        start.elapsed()
-                    ),
+            let refresh_handle = tokio::spawn(async move {
+                info!("🔥 Starting background database schema refresh loop...");
+                loop {
+                    // Hold the read guard only for the tick; drop it before
+                    // sleeping so a re-init can take the write lock. Multiple
+                    // concurrent readers (interactive requests) are fine.
+                    let sleep = {
+                        let guard = db.read().await;
+                        match guard.as_ref() {
+                            Some(provider) => {
+                                provider
+                                    .refresh_tick(DB_CONNECT_TIMEOUT, DB_REFRESH_HEALTHY_INTERVAL)
+                                    .await
+                            }
+                            // Provider gone (shutdown) — stop the loop.
+                            None => break,
+                        }
+                    };
+                    tokio::time::sleep(sleep).await;
                 }
             });
+            task_handles.push(refresh_handle);
         }
+
+        // Record the live tasks (still holding the guard) so a later
+        // same-root init no-ops and a different-root init aborts them.
+        *task_guard = Some((root_buf, task_handles));
     }
 
     /// Check if a file exists with async I/O and TTL caching
@@ -12565,17 +12651,13 @@ impl LaravelLanguageServer {
                     // Try to get tables (this triggers connection if not cached)
                     let tables = provider.get_tables().await;
 
-                    // If tables is empty and there was a connection error, publish diagnostic
+                    // If tables is empty and there was a connection error,
+                    // bail. No toast from here: the circuit-breaker channel
+                    // (wired in init_database_schema_provider) already
+                    // notified the user once when this outage began.
                     if tables.is_empty() {
                         if let Some(error) = provider.get_last_error().await {
                             info!("   ❌ Database connection error: {}", error.message);
-                            // Surface the unreachable-DB notification via the
-                            // single persistent toast. The previous inline
-                            // diagnostic at the rule position used the same
-                            // one-shot flag as the toast, so whichever fired
-                            // first hid the other. One channel = one signal,
-                            // and toast persists until the user dismisses it.
-                            self.maybe_notify_db_unreachable(&error.message).await;
                             // Return empty - no completions available
                             return Vec::new();
                         }
@@ -12745,15 +12827,12 @@ impl LaravelLanguageServer {
                         }
                     }
                 } else {
+                    // No provider means no database configuration was
+                    // discovered — scenario 0, a normal state for projects
+                    // without a DB. Deliberately silent (log only): toasting
+                    // "configure your database" at every exists:/unique:
+                    // completion would nag DB-less projects.
                     debug!("warn:  Database schema provider not initialized");
-                    // Same persistent-toast channel as the unreachable-DB
-                    // path above. "Provider not initialised" means no .env
-                    // (or no detection of one); say so explicitly.
-                    self.maybe_notify_db_unreachable(
-                        "Database not configured. Set DB_CONNECTION, DB_HOST, \
-                         DB_DATABASE, DB_USERNAME, DB_PASSWORD in .env.",
-                    )
-                    .await;
                     Vec::new()
                 }
             }
@@ -16891,7 +16970,7 @@ return [
             cached_validation_rule_names: self.cached_validation_rule_names.clone(),
             cached_directive_names: self.cached_directive_names.clone(),
             database_schema: self.database_schema.clone(),
-            database_diagnostic_shown: self.database_diagnostic_shown.clone(),
+            db_provider_task: self.db_provider_task.clone(),
             route_index: self.route_index.clone(),
             warm_complete: self.warm_complete.clone(),
             indexing_in_flight: self.indexing_in_flight.clone(),
@@ -17147,14 +17226,12 @@ return [
         }
 
         // Database-unreachable notifications go through the persistent
-        // toast (`maybe_notify_db_unreachable`) — driven from the chain
-        // completion handler when an LSP-completing path actually needs
-        // the DB and finds it unavailable. We deliberately don't publish
-        // a diagnostic from here: a 0:0 diagnostic on whatever file
-        // happened to be open is awkward, and emitting both a diagnostic
-        // AND a toast meant whichever fired first stole the
-        // `database_diagnostic_shown` flag and suppressed the other.
-        // Toast wins; diagnostic is gone.
+        // toast driven by the schema provider's circuit breaker (wired in
+        // `init_database_schema_provider`): one toast per outage episode,
+        // re-armed on reconnect. We deliberately don't publish a diagnostic
+        // from here: a 0:0 diagnostic on whatever file happened to be open
+        // is awkward, and a second channel for the same signal caused
+        // suppression races in the past. Toast wins; diagnostic is gone.
 
         // Get the Laravel config (checks memory cache first, then Salsa)
         let t_config = std::time::Instant::now();
@@ -17248,8 +17325,14 @@ return [
                         );
                     }
                     (_, Some(root)) => {
-                        let db_guard = self.database_schema.read().await;
-                        match db_guard.as_ref() {
+                        // Clone the provider handle (cheap — it's a bundle of
+                        // Arcs) out of the guard and drop the guard before the
+                        // await. chain_diagnostics' DB calls are now instant
+                        // in-memory cache reads (never connect), so this is no
+                        // longer a freeze risk — but not holding the outer lock
+                        // across an await keeps a re-init from blocking too.
+                        let db = self.database_schema.read().await.clone();
+                        match db {
                             None => info!(
                                 "🔗 chain_diagnostics: {} chains but DB schema provider not \
                                  initialised — column/relation diagnostics need a DB connection",
@@ -17259,7 +17342,7 @@ return [
                                 let t_chain = std::time::Instant::now();
                                 let chain_diags = laravel_lsp::query_chain::chain_diagnostics(
                                     &fresh_chains,
-                                    db,
+                                    &db,
                                     &root,
                                     source,
                                     severity,

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -21338,6 +21338,15 @@ impl LanguageServer for LaravelLanguageServer {
         // after disk-level changes. Saves no longer trigger this (#80);
         // external edits are the one remaining caller.
         if created_or_changed + deleted > 0 {
+            // Drop the FQCN→file resolution cache for this project so a
+            // watched create/delete is reflected immediately (a new class
+            // becomes resolvable, a removed one stops resolving). This covers
+            // the watched paths (controllers, views, livewire, vendor);
+            // unwatched app paths (e.g. `app/Models/`) rely on the locator's
+            // negative-entry TTL instead — see the Fork-2 note in class_locator.
+            if let Some(root) = self.initialized_root.read().await.clone() {
+                laravel_lsp::class_locator::invalidate_project(&root);
+            }
             self.schedule_magic_rebuild().await;
         }
     }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3118,21 +3118,22 @@ async fn build_magic_member_entries(
     // ── Pass 1: build the view-variable index ────────────────────────────
     // Scan non-vendor controllers (PHP with `view()` calls) for render sites,
     // resolving each passed variable's type so Blade accesses can be typed.
-    let view_targets: Vec<PathBuf> = pattern_cache
-        .iter()
-        .filter(|e| {
-            !e.key().components().any(|c| c.as_os_str() == "vendor")
-                && !e.key().to_string_lossy().ends_with(".blade.php")
-                && !e.value().1.views.is_empty()
-        })
-        .map(|e| e.key().clone())
-        .collect();
+    let view_targets: Vec<(PathBuf, Arc<laravel_lsp::salsa_impl::ParsedPatternsData>)> =
+        pattern_cache
+            .iter()
+            .filter(|e| {
+                !e.key().components().any(|c| c.as_os_str() == "vendor")
+                    && !e.key().to_string_lossy().ends_with(".blade.php")
+                    && !e.value().1.views.is_empty()
+            })
+            .map(|e| (e.key().clone(), e.value().1.clone()))
+            .collect();
     let mut view_var_index = laravel_lsp::view_var_index::ViewVarIndex::new();
     let mut view_renders: Vec<(PathBuf, Vec<laravel_lsp::view_var_index::ViewRender>)> = Vec::new();
     {
         let vv_sem = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
         let mut vv_handles = Vec::with_capacity(view_targets.len());
-        for path in view_targets {
+        for (path, data) in view_targets {
             let permit_owner = vv_sem.clone();
             let class_files = class_files.clone();
             let classviews = classviews.clone();
@@ -3140,13 +3141,31 @@ async fn build_magic_member_entries(
             vv_handles.push(tokio::spawn(async move {
                 let _permit = permit_owner.acquire_owned().await.ok()?;
                 tokio::task::spawn_blocking(move || {
-                    let source = std::fs::read_to_string(&path).ok()?;
-                    let renders = laravel_lsp::view_var_index::view_renders_in_file(
-                        &source,
-                        &*class_files,
-                        &classviews,
-                        &root,
-                    );
+                    // Evaluate the view-render plans captured at parse — no file
+                    // read. The resolver is the bare class→file map, exactly as
+                    // the tree path passed it (renders never consult the
+                    // container/facade snapshots).
+                    let renders = match data.member_context.as_ref() {
+                        Some(ctx) => laravel_lsp::view_var_index::evaluate_render_plans(
+                            &ctx.view_renders,
+                            &ctx.aliases,
+                            &*class_files,
+                            &classviews,
+                            &root,
+                        ),
+                        // Fallback — not expected for a non-vendor file post-v11
+                        // (capture always runs); re-read + re-parse to stay
+                        // correct if a context is ever absent.
+                        None => {
+                            let source = std::fs::read_to_string(&path).ok()?;
+                            laravel_lsp::view_var_index::view_renders_in_file(
+                                &source,
+                                &*class_files,
+                                &classviews,
+                                &root,
+                            )
+                        }
+                    };
                     (!renders.is_empty()).then_some((path, renders))
                 })
                 .await
@@ -3207,7 +3226,6 @@ async fn build_magic_member_entries(
         magic_handles.push(tokio::spawn(async move {
             let _permit = permit_owner.acquire_owned().await.ok()?;
             tokio::task::spawn_blocking(move || {
-                let source = std::fs::read_to_string(&path).ok()?;
                 let mut deps = HashSet::new();
                 let resolver = laravel_lsp::member_resolver::SnapshotResolver {
                     class_files,
@@ -3216,23 +3234,53 @@ async fn build_magic_member_entries(
                     macros,
                     implementers,
                 };
-                let mut entries = laravel_lsp::member_resolver::resolve_member_access_entries(
-                    &source,
-                    &data.member_access_refs,
-                    &resolver,
-                    &classviews,
-                    &root,
-                    Some(&mut deps),
-                );
-                // Volt SFC `.php` components: index `$this->member` reads under
-                // the component's synthetic key (no-op for plain/model .php).
-                entries.extend(
-                    laravel_lsp::view_var_index::resolve_component_member_accesses(
-                        &path,
-                        &source,
-                        &data.member_access_refs,
-                    ),
-                );
+                // Resolve from the context captured at parse — no file read.
+                let entries = match data.member_context.as_ref() {
+                    Some(ctx) => {
+                        let mut e =
+                            laravel_lsp::member_resolver::resolve_member_access_entries_with_context(
+                                ctx,
+                                &data.member_access_refs,
+                                &resolver,
+                                &classviews,
+                                &root,
+                                Some(&mut deps),
+                            );
+                        // Volt SFC `.php` components: index `$this->member`
+                        // reads under the captured synthetic key.
+                        if let Some(comp) = &ctx.component {
+                            e.extend(
+                                laravel_lsp::view_var_index::resolve_component_member_accesses_with_context(
+                                    comp,
+                                    &path,
+                                    &data.member_access_refs,
+                                ),
+                            );
+                        }
+                        e
+                    }
+                    // Fallback — not expected for a non-vendor file post-v11;
+                    // re-read + re-parse to stay correct if context is absent.
+                    None => {
+                        let source = std::fs::read_to_string(&path).ok()?;
+                        let mut e = laravel_lsp::member_resolver::resolve_member_access_entries(
+                            &source,
+                            &data.member_access_refs,
+                            &resolver,
+                            &classviews,
+                            &root,
+                            Some(&mut deps),
+                        );
+                        e.extend(
+                            laravel_lsp::view_var_index::resolve_component_member_accesses(
+                                &path,
+                                &source,
+                                &data.member_access_refs,
+                            ),
+                        );
+                        e
+                    }
+                };
                 // Keep dep-only files: a file whose every classification
                 // failed still *depends* on those classes — dropping it here
                 // would blind the incremental save flow to exactly the
@@ -3304,11 +3352,8 @@ async fn build_magic_member_entries(
                         macros,
                         implementers,
                     };
-                    // A Volt component (own front-matter, or an MFC template
-                    // referencing `$this->`) needs the file source — for property
-                    // typing AND for keying `$this->member` component references.
-                    // Files with no `$this->` (e.g. the ~58k published icon
-                    // templates) read nothing and resolve via the view-var index.
+                    // `$this->…` usage: same test as before (drives MFC prop
+                    // typing) but now off the captured refs, no file read.
                     let uses_this = data
                         .member_access_refs
                         .iter()
@@ -3317,69 +3362,149 @@ async fn build_magic_member_entries(
                             .blade_loops
                             .iter()
                             .any(|l| l.iterable.starts_with("$this->"));
-                    let source = if data.is_volt || uses_this {
-                        std::fs::read_to_string(&path).ok()
-                    } else {
-                        None
-                    };
-
-                    let volt_props = if data.is_volt {
-                        source.as_deref().map(|src| {
-                            laravel_lsp::view_var_index::volt_property_types(
-                                src,
-                                &resolver,
-                                &classviews,
-                                &root,
-                            )
-                        })
-                    } else if uses_this {
-                        laravel_lsp::view_var_index::mfc_volt_property_types(
-                            &path,
-                            &resolver,
-                            &classviews,
-                            &root,
-                        )
-                    } else {
-                        None
-                    };
 
                     let mut deps = HashSet::new();
-                    let mut entries = if let Some(prop_types) = volt_props {
-                        laravel_lsp::view_var_index::resolve_volt_member_accesses(
-                            &data.member_access_refs,
-                            &prop_types,
-                            &data.blade_loops,
-                            &resolver,
-                            &classviews,
-                            &root,
-                            Some(&mut deps),
-                        )
-                    } else {
-                        let view_name =
-                            laravel_lsp::view_var_index::view_name_for_path(&path, &view_paths)?;
-                        laravel_lsp::view_var_index::resolve_blade_member_accesses(
-                            &data.member_access_refs,
-                            &view_name,
-                            &view_var_index,
-                            &data.blade_loops,
-                            &resolver,
-                            &classviews,
-                            &root,
-                            Some(&mut deps),
-                        )
+                    // Resolve from captured context when present (the target Blade
+                    // file is NEVER read — only cross-file MFC sibling `.php`
+                    // reads remain, which the spec keeps at resolve). A missing
+                    // context is not expected for a non-vendor Blade file post-v11
+                    // (capture always runs), but — symmetric with Pass 1/2 — we
+                    // re-read + re-parse rather than silently drop the file.
+                    //
+                    // Routing (BOTH branches, mirroring the save-refresh path):
+                    //   is_volt  → ALWAYS the Volt resolver, with an empty prop
+                    //              map when there's no `<?php` front-matter. Never
+                    //              fall to the Blade resolver for an is_volt file:
+                    //              `is_volt` is a raw-byte needle scan, so a stray
+                    //              `computed(`/`form(` in a plain template with no
+                    //              PHP block would otherwise route to Blade here
+                    //              while the save path routes to Volt — and the
+                    //              Blade branch's `view_name_for_path?` could drop
+                    //              the whole file.
+                    //   uses_this→ MFC template: type from the sibling `.php`.
+                    //   else     → controller-rendered Blade (view-var index).
+                    let entries = match data.member_context.as_ref() {
+                        Some(ctx) => {
+                            let volt_props = if data.is_volt {
+                                Some(
+                                    ctx.volt_surface
+                                        .as_ref()
+                                        .map(|s| {
+                                            laravel_lsp::view_var_index::evaluate_volt_surface(
+                                                s,
+                                                &resolver,
+                                                &classviews,
+                                                &root,
+                                            )
+                                        })
+                                        .unwrap_or_default(),
+                                )
+                            } else if uses_this {
+                                laravel_lsp::view_var_index::mfc_volt_property_types(
+                                    &path,
+                                    &resolver,
+                                    &classviews,
+                                    &root,
+                                )
+                            } else {
+                                None
+                            };
+                            let mut e = if let Some(prop_types) = volt_props {
+                                laravel_lsp::view_var_index::resolve_volt_member_accesses_with_context(
+                                    ctx,
+                                    &data.member_access_refs,
+                                    &prop_types,
+                                    &data.blade_loops,
+                                    &resolver,
+                                    &classviews,
+                                    &root,
+                                    Some(&mut deps),
+                                )
+                            } else {
+                                let view_name = laravel_lsp::view_var_index::view_name_for_path(
+                                    &path,
+                                    &view_paths,
+                                )?;
+                                laravel_lsp::view_var_index::resolve_blade_member_accesses_with_context(
+                                    ctx,
+                                    &data.member_access_refs,
+                                    &view_name,
+                                    &view_var_index,
+                                    &data.blade_loops,
+                                    &resolver,
+                                    &classviews,
+                                    &root,
+                                    Some(&mut deps),
+                                )
+                            };
+                            // Component `$this->member` refs (SFC own class from
+                            // the captured members, or MFC sibling read). Additive.
+                            if let Some(comp) = &ctx.component {
+                                e.extend(
+                                    laravel_lsp::view_var_index::resolve_component_member_accesses_with_context(
+                                        comp,
+                                        &path,
+                                        &data.member_access_refs,
+                                    ),
+                                );
+                            }
+                            e
+                        }
+                        None => {
+                            let source = std::fs::read_to_string(&path).ok()?;
+                            let volt_props = if data.is_volt {
+                                Some(laravel_lsp::view_var_index::volt_property_types(
+                                    &source,
+                                    &resolver,
+                                    &classviews,
+                                    &root,
+                                ))
+                            } else if uses_this {
+                                laravel_lsp::view_var_index::mfc_volt_property_types(
+                                    &path,
+                                    &resolver,
+                                    &classviews,
+                                    &root,
+                                )
+                            } else {
+                                None
+                            };
+                            let mut e = if let Some(prop_types) = volt_props {
+                                laravel_lsp::view_var_index::resolve_volt_member_accesses(
+                                    &data.member_access_refs,
+                                    &prop_types,
+                                    &data.blade_loops,
+                                    &resolver,
+                                    &classviews,
+                                    &root,
+                                    Some(&mut deps),
+                                )
+                            } else {
+                                let view_name = laravel_lsp::view_var_index::view_name_for_path(
+                                    &path,
+                                    &view_paths,
+                                )?;
+                                laravel_lsp::view_var_index::resolve_blade_member_accesses(
+                                    &data.member_access_refs,
+                                    &view_name,
+                                    &view_var_index,
+                                    &data.blade_loops,
+                                    &resolver,
+                                    &classviews,
+                                    &root,
+                                    Some(&mut deps),
+                                )
+                            };
+                            e.extend(
+                                laravel_lsp::view_var_index::resolve_component_member_accesses(
+                                    &path,
+                                    &source,
+                                    &data.member_access_refs,
+                                ),
+                            );
+                            e
+                        }
                     };
-                    // Component `$this->member` references (SFC own class, or MFC
-                    // sibling). Additive — these are component-self refs, not
-                    // model/view-var resolutions.
-                    if let Some(src) = &source {
-                        entries.extend(
-                            laravel_lsp::view_var_index::resolve_component_member_accesses(
-                                &path,
-                                src,
-                                &data.member_access_refs,
-                            ),
-                        );
-                    }
                     // Dep-only files stay — see the pass-2 comment.
                     (!entries.is_empty() || !deps.is_empty()).then_some((path, entries, deps))
                 })
@@ -6245,12 +6370,24 @@ impl LaravelLanguageServer {
                 .unwrap_or(false);
             if !patterns.views.is_empty() || had_renders {
                 let classviews = laravel_lsp::member_resolver::ClassViewCache::new();
-                let renders = laravel_lsp::view_var_index::view_renders_in_file(
-                    content,
-                    &*class_files,
-                    &classviews,
-                    &root,
-                );
+                // Evaluate the captured render plans; fall back to a re-parse for
+                // a vendor save (no captured context) — see the resolution
+                // fallback below for the vendor rationale.
+                let renders = match patterns.member_context.as_ref() {
+                    Some(ctx) => laravel_lsp::view_var_index::evaluate_render_plans(
+                        &ctx.view_renders,
+                        &ctx.aliases,
+                        &*class_files,
+                        &classviews,
+                        &root,
+                    ),
+                    None => laravel_lsp::view_var_index::view_renders_in_file(
+                        content,
+                        &*class_files,
+                        &classviews,
+                        &root,
+                    ),
+                };
                 if let Ok(mut vv) = self.view_vars.write() {
                     let old = vv.renders_for(path).map(|r| r.to_vec()).unwrap_or_default();
                     if old != renders {
@@ -6308,67 +6445,149 @@ impl LaravelLanguageServer {
             macros,
             implementers,
         };
-        let mut entries = if is_volt {
-            let prop_types = laravel_lsp::view_var_index::volt_property_types(
-                content,
-                &resolver,
-                &classviews,
-                &root,
-            );
-            laravel_lsp::view_var_index::resolve_volt_member_accesses(
-                &patterns.member_access_refs,
-                &prop_types,
-                &patterns.blade_loops,
-                &resolver,
-                &classviews,
-                &root,
-                Some(&mut deps),
-            )
-        } else if is_blade {
-            // Controller-rendered Blade: resolve against the persistent
-            // view-var index. The read guard spans only this sync call —
-            // no awaits while held.
-            let view_paths = self
-                .cached_config
+        // Controller-rendered Blade needs the view paths (an await), fetched
+        // here at the async top level so both the captured-context and the
+        // vendor fallback branches below can use it without re-awaiting.
+        let view_paths = if is_blade && !is_volt {
+            self.cached_config
                 .read()
                 .await
                 .as_ref()
                 .map(|c| c.view_paths.clone())
-                .unwrap_or_default();
-            match laravel_lsp::view_var_index::view_name_for_path(path, &view_paths) {
-                Some(view_name) => match self.view_vars.read() {
-                    Ok(vv) => laravel_lsp::view_var_index::resolve_blade_member_accesses(
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        // Resolve from the context captured at parse when present. The ONLY
+        // no-context case is a VENDOR save: the build passes skip vendor, so
+        // vendor files carry no `member_context` — fall back to the original
+        // re-parse-over-`content` path so a vendor edit still refreshes
+        // correctly. (Both paths read the SAME `content` the patterns were
+        // parsed from, so per-file resolution is self-consistent — the
+        // build-path's former disk-vs-buffer skew doesn't apply here.)
+        let mut entries = match patterns.member_context.as_ref() {
+            Some(ctx) => {
+                if is_volt {
+                    let prop_types = ctx
+                        .volt_surface
+                        .as_ref()
+                        .map(|s| {
+                            laravel_lsp::view_var_index::evaluate_volt_surface(
+                                s,
+                                &resolver,
+                                &classviews,
+                                &root,
+                            )
+                        })
+                        .unwrap_or_default();
+                    laravel_lsp::view_var_index::resolve_volt_member_accesses_with_context(
+                        ctx,
                         &patterns.member_access_refs,
-                        &view_name,
-                        &vv,
+                        &prop_types,
                         &patterns.blade_loops,
                         &resolver,
                         &classviews,
                         &root,
                         Some(&mut deps),
-                    ),
-                    Err(_) => Vec::new(),
-                },
-                None => Vec::new(),
+                    )
+                } else if is_blade {
+                    match laravel_lsp::view_var_index::view_name_for_path(path, &view_paths) {
+                        Some(view_name) => match self.view_vars.read() {
+                            Ok(vv) => {
+                                laravel_lsp::view_var_index::resolve_blade_member_accesses_with_context(
+                                    ctx,
+                                    &patterns.member_access_refs,
+                                    &view_name,
+                                    &vv,
+                                    &patterns.blade_loops,
+                                    &resolver,
+                                    &classviews,
+                                    &root,
+                                    Some(&mut deps),
+                                )
+                            }
+                            Err(_) => Vec::new(),
+                        },
+                        None => Vec::new(),
+                    }
+                } else {
+                    laravel_lsp::member_resolver::resolve_member_access_entries_with_context(
+                        ctx,
+                        &patterns.member_access_refs,
+                        &resolver,
+                        &classviews,
+                        &root,
+                        Some(&mut deps),
+                    )
+                }
             }
-        } else {
-            laravel_lsp::member_resolver::resolve_member_access_entries(
-                content,
-                &patterns.member_access_refs,
-                &resolver,
-                &classviews,
-                &root,
-                Some(&mut deps),
-            )
+            None => {
+                if is_volt {
+                    let prop_types = laravel_lsp::view_var_index::volt_property_types(
+                        content,
+                        &resolver,
+                        &classviews,
+                        &root,
+                    );
+                    laravel_lsp::view_var_index::resolve_volt_member_accesses(
+                        &patterns.member_access_refs,
+                        &prop_types,
+                        &patterns.blade_loops,
+                        &resolver,
+                        &classviews,
+                        &root,
+                        Some(&mut deps),
+                    )
+                } else if is_blade {
+                    match laravel_lsp::view_var_index::view_name_for_path(path, &view_paths) {
+                        Some(view_name) => match self.view_vars.read() {
+                            Ok(vv) => laravel_lsp::view_var_index::resolve_blade_member_accesses(
+                                &patterns.member_access_refs,
+                                &view_name,
+                                &vv,
+                                &patterns.blade_loops,
+                                &resolver,
+                                &classviews,
+                                &root,
+                                Some(&mut deps),
+                            ),
+                            Err(_) => Vec::new(),
+                        },
+                        None => Vec::new(),
+                    }
+                } else {
+                    laravel_lsp::member_resolver::resolve_member_access_entries(
+                        content,
+                        &patterns.member_access_refs,
+                        &resolver,
+                        &classviews,
+                        &root,
+                        Some(&mut deps),
+                    )
+                }
+            }
         };
         // Component `$this->member` references (Volt SFC `.php` or Blade SFC).
-        entries.extend(
-            laravel_lsp::view_var_index::resolve_component_member_accesses(
-                path,
-                content,
-                &patterns.member_access_refs,
+        match patterns.member_context.as_ref() {
+            Some(ctx) => {
+                if let Some(comp) = &ctx.component {
+                    entries.extend(
+                        laravel_lsp::view_var_index::resolve_component_member_accesses_with_context(
+                            comp,
+                            path,
+                            &patterns.member_access_refs,
+                        ),
+                    );
+                }
+            }
+            None => entries.extend(
+                laravel_lsp::view_var_index::resolve_component_member_accesses(
+                    path,
+                    content,
+                    &patterns.member_access_refs,
+                ),
             ),
-        );
+        }
 
         if let Err(e) = self
             .salsa

--- a/laravel-lsp/src/member_capture.rs
+++ b/laravel-lsp/src/member_capture.rs
@@ -1,0 +1,148 @@
+//! M1 single-parse capture — orchestration.
+//!
+//! [`capture_member_context`] runs at PARSE time (in `pattern_indexer` and the
+//! actor's `handle_get_patterns`) and compiles everything the whole-project
+//! magic-member resolve passes need from a file's OWN source into an owned
+//! [`MemberContextData`]: per-site receiver recipes (`member_resolver`), the
+//! controller view-render plans + Volt front-matter surface + component member
+//! names (`view_var_index`). The resolve passes then finish the cross-file half
+//! against actor snapshots + memos, never re-reading or re-parsing the file.
+//!
+//! Returns `None` when there is nothing to resolve (icon Blade templates, plain
+//! files) — a single tag byte on `ParsedPatternsData`, honoring the
+//! zero-added-cost budget for pattern-free files. Only called for NON-vendor
+//! files: the three build passes all skip `vendor/`, so capturing there would
+//! be wasted memory (the incremental save path keeps a tree-based fallback for
+//! the rare vendor save).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tree_sitter::Tree;
+
+use crate::query_chain::use_aliases::extract_use_aliases;
+use crate::salsa_impl::{MemberAccessReferenceData, MemberContextData};
+
+/// Compile the file's own-source resolution context. `php_tree` is the
+/// full-file PHP parse for `.php` files (reused — no second tree-sitter pass);
+/// `None` for Blade (parsing a `.blade.php` as PHP is pathologically slow, so
+/// its receivers compile from per-site `<?php {receiver};` snippets instead).
+/// `is_volt` is the already-captured `source_contains_volt_signature`.
+pub fn capture_member_context(
+    path: &Path,
+    text: &str,
+    php_tree: Option<&Tree>,
+    refs: &[Arc<MemberAccessReferenceData>],
+    is_volt: bool,
+) -> Option<MemberContextData> {
+    let is_blade = path.to_string_lossy().ends_with(".blade.php");
+
+    let (aliases, sites, view_renders) = if let Some(tree) = php_tree {
+        // Full-file PHP: aliases + per-site recipes + view-render plans all off
+        // the one shared parse.
+        let aliases = extract_use_aliases(tree, text);
+        let sites = crate::member_resolver::capture_php_sites(text, tree, refs, &aliases);
+        let view_renders = crate::view_var_index::capture_render_plans(text, tree, &aliases);
+        (aliases, sites, view_renders)
+    } else {
+        // Blade: no full-file PHP tree. Each site's chain receiver compiles from
+        // its own `<?php {receiver};` snippet (bare `$var` / `$this->prop`
+        // receivers short-circuit to `Unresolvable` — they type from the
+        // view-var / Volt-prop maps by text, never the recipe). A Blade file
+        // has no controller view() renders and no file-level `use` aliases.
+        let sites = refs
+            .iter()
+            .map(|m| crate::member_resolver::compile_blade_site(m.receiver.trim()))
+            .collect();
+        (Default::default(), sites, Vec::new())
+    };
+
+    // Volt front-matter surface — only for a Volt single-file component.
+    let volt_surface = if is_blade && is_volt {
+        crate::view_var_index::capture_volt_surface(text)
+    } else {
+        None
+    };
+
+    // Component `$this->member` identity — captured only when the file actually
+    // reads `$this->…`. This gate is what keeps the ~58k published icon Blade
+    // templates (no member refs) from each paying a `mfc_sibling` filesystem
+    // stat: resolve_component_member_accesses yields entries ONLY for `$this`
+    // receivers, so with none present there is nothing to capture.
+    let has_this = refs.iter().any(|m| m.receiver.trim() == "$this");
+    let component = if has_this {
+        crate::view_var_index::capture_component(path, text, is_volt)
+    } else {
+        None
+    };
+
+    if sites.is_empty() && view_renders.is_empty() && volt_surface.is_none() && component.is_none()
+    {
+        return None;
+    }
+    Some(MemberContextData {
+        aliases,
+        sites,
+        view_renders,
+        volt_surface,
+        component,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse_php;
+    use std::path::Path;
+
+    #[test]
+    fn pattern_free_php_captures_nothing() {
+        // No member access, no view() render, not a component → `None`, so the
+        // field costs a single tag byte.
+        let src = "<?php\nnamespace App;\nclass Widget { public function noop() {} }\n";
+        let tree = parse_php(src).unwrap();
+        let ctx = capture_member_context(
+            Path::new("/proj/app/Widget.php"),
+            src,
+            Some(&tree),
+            &[],
+            false,
+        );
+        assert!(ctx.is_none(), "a pattern-free .php must capture no context");
+    }
+
+    #[test]
+    fn icon_blade_template_captures_nothing() {
+        // The ~58k published icon templates: no member refs, not Volt, no
+        // sibling `.php`. This is the zero-cost budget's key case.
+        let src = "<svg viewBox=\"0 0 24 24\"><path d=\"M0 0h24v24H0z\"/></svg>\n";
+        let ctx = capture_member_context(
+            Path::new("/proj/resources/views/icons/star.blade.php"),
+            src,
+            None,
+            &[],
+            false,
+        );
+        assert!(
+            ctx.is_none(),
+            "an icon Blade template must capture no context"
+        );
+    }
+
+    #[test]
+    fn controller_with_render_captures_context() {
+        // A controller that only PASSES a view var (no `->member` of its own)
+        // still captures — its render plan is what Blade typing needs.
+        let src = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+class C { public function show(User $u) { return view('users.show', ['user' => $u]); } }
+"#;
+        let tree = parse_php(src).unwrap();
+        let ctx =
+            capture_member_context(Path::new("/proj/app/C.php"), src, Some(&tree), &[], false)
+                .expect("controller with a render must capture context");
+        assert_eq!(ctx.view_renders.len(), 1);
+        assert_eq!(ctx.view_renders[0].view_name, "users.show");
+    }
+}

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -304,9 +304,31 @@ pub struct ResolvedMemberAccess {
 /// Per-FQCN [`ClassView`] memo so resolving a project's member-access firehose
 /// analyzes each model file once, not once per access site. Caches misses too
 /// (a `None`) so an unreadable / class-less file isn't re-analyzed repeatedly.
+///
+/// # Why interior mutability (`DashMap`) instead of `&mut HashMap`
+///
+/// The whole-project index build fans every referencing file out across
+/// `spawn_blocking` workers. Before, each worker built its *own* cache, so a
+/// class referenced from N files was analyzed N times — the O(n²) this type
+/// exists to kill. To share **one** cache across all those parallel workers it
+/// has to be `Send + Sync` and mutate through a shared `&` (a `&mut` can't be
+/// held by many threads at once). [`dashmap::DashMap`] gives exactly that: a
+/// sharded concurrent map whose `entry`/`get` take `&self`, so every method
+/// here takes `&self` and the build wraps the cache in one `Arc` cloned into
+/// each worker. Single-threaded callers (the live query paths) are unaffected —
+/// they just pay a negligible shard lock per lookup.
+///
+/// `ClassView` and everything it owns is plain data (`Send + Sync`), so
+/// `Arc<ClassView>` crosses the `spawn_blocking` boundary freely.
 #[derive(Default)]
 pub struct ClassViewCache {
-    cache: HashMap<String, Option<Arc<ClassView>>>,
+    cache: dashmap::DashMap<String, Option<Arc<ClassView>>>,
+    /// Instrumentation: cache hits and misses (a "miss" is a first-time build
+    /// of an FQCN, hit or fail). The magic-build log and the once-per-FQCN
+    /// regression test read these to prove the sharing actually collapses work.
+    /// `AtomicUsize` so they update through `&self` alongside the map.
+    hits: std::sync::atomic::AtomicUsize,
+    misses: std::sync::atomic::AtomicUsize,
 }
 
 impl ClassViewCache {
@@ -316,18 +338,42 @@ impl ClassViewCache {
 
     /// Return the cached `ClassView` for `fqcn`, building it from `file_path`
     /// on first request.
+    ///
+    /// Concurrency: `DashMap::entry` holds the FQCN's shard lock for the
+    /// duration of the build. That's intentional — it dedupes two workers
+    /// racing to build the *same* FQCN (the second waits and reuses the first's
+    /// result), which is precisely the redundant analysis we're removing.
+    /// `analyze` never re-enters this cache, so holding the shard lock across it
+    /// can't deadlock; other FQCNs live on other shards and proceed in parallel.
     pub fn get_or_build(
-        &mut self,
+        &self,
         fqcn: &str,
         file_path: &Path,
         project_root: &Path,
     ) -> Option<Arc<ClassView>> {
-        if let Some(cached) = self.cache.get(fqcn) {
-            return cached.clone();
+        use std::sync::atomic::Ordering::Relaxed;
+        match self.cache.entry(fqcn.to_string()) {
+            dashmap::mapref::entry::Entry::Occupied(e) => {
+                self.hits.fetch_add(1, Relaxed);
+                e.get().clone()
+            }
+            dashmap::mapref::entry::Entry::Vacant(slot) => {
+                self.misses.fetch_add(1, Relaxed);
+                let view = analyze(file_path, project_root).map(Arc::new);
+                slot.insert(view.clone());
+                view
+            }
         }
-        let view = analyze(file_path, project_root).map(Arc::new);
-        self.cache.insert(fqcn.to_string(), view.clone());
-        view
+    }
+
+    /// Number of lookups served from the cache without a rebuild. Test/log only.
+    pub fn hits(&self) -> usize {
+        self.hits.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Number of first-time builds (distinct FQCNs analyzed). Test/log only.
+    pub fn misses(&self) -> usize {
+        self.misses.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 
@@ -353,7 +399,7 @@ pub fn resolve_member_access_entries(
     source: &str,
     member_refs: &[Arc<MemberAccessReferenceData>],
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
     mut deps: Option<&mut HashSet<String>>,
 ) -> Vec<MagicMemberEntry> {
@@ -440,7 +486,7 @@ pub fn resolve_and_classify(
     bytes: &[u8],
     aliases: &UseAliases,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
     mut deps: Option<&mut HashSet<String>>,
 ) -> Option<ResolvedMemberAccess> {
@@ -572,7 +618,7 @@ fn classify_against(
     confidence: Confidence,
     via_facade: bool,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> Option<ResolvedMemberAccess> {
     // A class the index knows: classify against its real surfaces first.
@@ -658,7 +704,7 @@ fn resolve_call_chain_receiver(
     bytes: &[u8],
     aliases: &UseAliases,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> Option<(String, Confidence)> {
     let root = chain_root(receiver);
@@ -861,7 +907,7 @@ pub fn resolve_expression_type(
     bytes: &[u8],
     aliases: &UseAliases,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> Option<(String, Confidence)> {
     flow::resolve_expression(expr, bytes, aliases)
@@ -880,7 +926,7 @@ fn resolve_receiver(
     bytes: &[u8],
     aliases: &UseAliases,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> Option<(String, Confidence)> {
     // Auth-helper receivers (`auth()->user()`, `Auth::user()`, `request()->
@@ -1433,7 +1479,7 @@ fn resolve_method_return(
     bytes: &[u8],
     aliases: &UseAliases,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> Option<(String, Confidence)> {
     let object = call.child_by_field_name("object")?;

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -1915,5 +1915,731 @@ pub fn dynamic_finder_column(member: &str) -> Option<String> {
     Some(pascal_to_snake(rest))
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// M1 single-parse capture — compile (parse time) + eval (resolve time)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The functions below let the whole-project magic build stop re-reading and
+// re-parsing each target file. `capture_*` runs at PARSE (tree in hand) and
+// compiles each site's INTRA-file receiver resolution into a small owned
+// `ReceiverRecipeData`; `eval_*` / `resolve_member_access_entries_with_context`
+// run at RESOLVE and finish the CROSS-file half against snapshots + memos,
+// mirroring `resolve_and_classify` / `resolve_receiver` branch-for-branch so
+// the resolved entries + deps are byte-identical to the re-parse path. The
+// tree functions above stay the live-query path AND the equivalence baseline.
+
+use crate::salsa_impl::{
+    ChainRecipeData, ChainRootData, MemberContextData, ReceiverRecipeData, SiteContextData,
+    ValueExprPlanData,
+};
+use tree_sitter::Tree;
+
+// ─── Compile: PHP member-access sites ──────────────────────────────────────
+
+/// Compile every PHP member-access site into its captured [`SiteContextData`],
+/// positionally parallel to `refs`. Receivers are located by the SAME byte
+/// range the resolve pass uses, so node identity matches by construction.
+pub(crate) fn capture_php_sites(
+    source: &str,
+    tree: &Tree,
+    refs: &[Arc<MemberAccessReferenceData>],
+    aliases: &UseAliases,
+) -> Vec<SiteContextData> {
+    let bytes = source.as_bytes();
+    let root = tree.root_node();
+    refs.iter()
+        .map(|m| {
+            let Some(receiver) =
+                root.descendant_for_byte_range(m.receiver_byte_start, m.receiver_byte_end)
+            else {
+                return SiteContextData {
+                    recipe: ReceiverRecipeData::Unresolvable,
+                    chain: None,
+                    enclosing_class_fqcn: None,
+                    is_scope_param_receiver: false,
+                };
+            };
+            let recipe = compile_receiver(receiver, bytes, aliases);
+            // The builder-chain fallback + retry are call-form-only, so only
+            // call-form sites pay to capture them.
+            let (chain, enclosing, is_scope_param) = if m.form.is_call() {
+                (
+                    compile_chain(receiver, bytes, aliases),
+                    enclosing_class_fqcn(receiver, bytes),
+                    is_scope_param_receiver(receiver, bytes),
+                )
+            } else {
+                (None, None, false)
+            };
+            SiteContextData {
+                recipe,
+                chain,
+                enclosing_class_fqcn: enclosing,
+                is_scope_param_receiver: is_scope_param,
+            }
+        })
+        .collect()
+}
+
+/// Compile a Blade receiver expression (from its `<?php {receiver};` snippet)
+/// into a recipe — the parse-time form of `resolve_chain_receiver`'s
+/// `resolve_expression_type`. Bare `$var` / `$this->prop` receivers compile to
+/// `Unresolvable` (they resolve from the view-var / Volt-prop maps by text at
+/// eval, never through the recipe).
+pub(crate) fn compile_blade_site(receiver_text: &str) -> SiteContextData {
+    let recipe = compile_blade_receiver(receiver_text);
+    SiteContextData {
+        recipe,
+        chain: None,
+        enclosing_class_fqcn: None,
+        is_scope_param_receiver: false,
+    }
+}
+
+fn compile_blade_receiver(receiver_text: &str) -> ReceiverRecipeData {
+    let snippet = format!("<?php {receiver_text};");
+    let Ok(tree) = parse_php(&snippet) else {
+        return ReceiverRecipeData::Unresolvable;
+    };
+    let bytes = snippet.as_bytes();
+    let aliases = extract_use_aliases(&tree, &snippet);
+    let Some(expr) = first_snippet_expression(&tree) else {
+        return ReceiverRecipeData::Unresolvable;
+    };
+    // Mirror `resolve_expression_type`: flow classifier first, receiver second.
+    match flow::resolve_expression(expr, bytes, &aliases) {
+        Some((fqcn, confidence)) => ReceiverRecipeData::Resolved { fqcn, confidence },
+        None => compile_receiver(expr, bytes, &aliases),
+    }
+}
+
+/// The expression of the first `expression_statement` in a `<?php <expr>;`
+/// snippet — the receiver node. (Mirrors `view_var_index::first_expression`.)
+fn first_snippet_expression(tree: &Tree) -> Option<Node<'_>> {
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "expression_statement" {
+            let mut c = n.walk();
+            return n.named_children(&mut c).next();
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    None
+}
+
+/// Compile a value expression (a `view()`-data or Volt value) — the parse-time
+/// form of `resolve_expression_type`: flow classifier → `Resolved`, else the
+/// receiver recipe.
+pub(crate) fn compile_value_expr(
+    expr: Node,
+    bytes: &[u8],
+    aliases: &UseAliases,
+) -> ValueExprPlanData {
+    match flow::resolve_expression(expr, bytes, aliases) {
+        Some((fqcn, confidence)) => ValueExprPlanData::Resolved { fqcn, confidence },
+        None => ValueExprPlanData::Recipe(compile_receiver(expr, bytes, aliases)),
+    }
+}
+
+/// Compile a `flow::resolve`-typed value (the `compact('x')` case, which types
+/// purely intra-file) into a plan — always `Resolved` or omitted by the caller.
+pub(crate) fn compile_flow_var(
+    node: Node,
+    bytes: &[u8],
+    var: &str,
+    aliases: &UseAliases,
+) -> Option<ValueExprPlanData> {
+    flow::resolve_with_confidence(node, bytes, var, aliases)
+        .map(|(fqcn, confidence)| ValueExprPlanData::Resolved { fqcn, confidence })
+}
+
+/// Compile a receiver node into a recipe — the intra-file half of
+/// [`resolve_receiver`]. `resolve_and_classify` checks auth BEFORE the shape
+/// match, and an auth miss falls through to the rest of `resolve_receiver`, so
+/// the auth recipe carries that fallthrough as its `fallback`.
+fn compile_receiver(receiver: Node, bytes: &[u8], aliases: &UseAliases) -> ReceiverRecipeData {
+    if auth_user_receiver_shape(receiver, bytes) {
+        return ReceiverRecipeData::AuthUser {
+            fallback: Box::new(compile_receiver_after_auth(receiver, bytes, aliases)),
+        };
+    }
+    compile_receiver_after_auth(receiver, bytes, aliases)
+}
+
+/// The rest of [`resolve_receiver`] after the auth check: container → helper →
+/// the node-kind match.
+fn compile_receiver_after_auth(
+    receiver: Node,
+    bytes: &[u8],
+    aliases: &UseAliases,
+) -> ReceiverRecipeData {
+    if let Some(key) = container_receiver_key(receiver, bytes) {
+        return ReceiverRecipeData::ContainerKey(key);
+    }
+    if let Some(name) = helper_receiver_name(receiver, bytes) {
+        return ReceiverRecipeData::HelperBinding(name);
+    }
+    match receiver.kind() {
+        "variable_name" => {
+            let Ok(raw) = receiver.utf8_text(bytes) else {
+                return ReceiverRecipeData::Unresolvable;
+            };
+            let var = raw.trim_start_matches('$');
+            if var == "this" {
+                match enclosing_class_fqcn(receiver, bytes) {
+                    Some(fqcn) => ReceiverRecipeData::Resolved {
+                        fqcn,
+                        confidence: Confidence::High,
+                    },
+                    None => ReceiverRecipeData::Unresolvable,
+                }
+            } else if let Some((fqcn, confidence)) =
+                flow::resolve_with_confidence(receiver, bytes, var, aliases)
+                    .or_else(|| resolve_foreach_var(receiver, bytes, var, aliases))
+            {
+                ReceiverRecipeData::Resolved { fqcn, confidence }
+            } else if is_gate_closure_user_shape(receiver, bytes) {
+                ReceiverRecipeData::GateClosureUser
+            } else {
+                ReceiverRecipeData::Unresolvable
+            }
+        }
+        "member_access_expression" | "nullsafe_member_access_expression" => {
+            match resolve_typed_property(receiver, bytes, aliases) {
+                Some((fqcn, confidence)) => ReceiverRecipeData::Resolved { fqcn, confidence },
+                None => ReceiverRecipeData::Unresolvable,
+            }
+        }
+        "member_call_expression" | "nullsafe_member_call_expression" => {
+            // `resolve_method_return` requires a plain `name` method node.
+            let Some(name_node) = receiver.child_by_field_name("name") else {
+                return ReceiverRecipeData::Unresolvable;
+            };
+            if name_node.kind() != "name" {
+                return ReceiverRecipeData::Unresolvable;
+            }
+            let (Ok(method), Some(object)) = (
+                name_node.utf8_text(bytes),
+                receiver.child_by_field_name("object"),
+            ) else {
+                return ReceiverRecipeData::Unresolvable;
+            };
+            ReceiverRecipeData::MethodReturn {
+                object: Box::new(compile_receiver(object, bytes, aliases)),
+                method: method.to_string(),
+            }
+        }
+        "name" | "qualified_name" => {
+            let Ok(raw) = receiver.utf8_text(bytes) else {
+                return ReceiverRecipeData::Unresolvable;
+            };
+            ReceiverRecipeData::StaticName {
+                raw: raw.to_string(),
+                qualified: qualify_fqcn(resolve_class_name(raw, aliases), receiver, bytes),
+                is_namespaced: file_namespace(receiver, bytes).is_some(),
+            }
+        }
+        "relative_scope" | "self" | "static" | "parent" => {
+            let Ok(raw) = receiver.utf8_text(bytes) else {
+                return ReceiverRecipeData::Unresolvable;
+            };
+            match enclosing_class_fqcn(receiver, bytes) {
+                Some(fqcn) => match raw {
+                    "self" => ReceiverRecipeData::Resolved {
+                        fqcn,
+                        confidence: Confidence::High,
+                    },
+                    "static" => ReceiverRecipeData::Resolved {
+                        fqcn,
+                        confidence: Confidence::Medium,
+                    },
+                    _ => ReceiverRecipeData::Unresolvable,
+                },
+                None => ReceiverRecipeData::Unresolvable,
+            }
+        }
+        _ => ReceiverRecipeData::Unresolvable,
+    }
+}
+
+/// Compile the builder-chain fallback — the parse-time form of
+/// [`resolve_call_chain_receiver`]. `None` when the receiver roots in itself
+/// (no chain to walk).
+fn compile_chain(receiver: Node, bytes: &[u8], aliases: &UseAliases) -> Option<ChainRecipeData> {
+    let root = chain_root(receiver);
+    let links = chain_link_names(receiver, bytes);
+    if root.kind() == "scoped_call_expression" {
+        let scope = root.child_by_field_name("scope")?;
+        let (qualified, confidence) = match scope.kind() {
+            "name" | "qualified_name" => {
+                let raw = scope.utf8_text(bytes).ok()?;
+                (
+                    qualify_fqcn(resolve_class_name(raw, aliases), scope, bytes),
+                    Confidence::High,
+                )
+            }
+            "relative_scope" => {
+                let raw = scope.utf8_text(bytes).ok()?;
+                let fqcn = enclosing_class_fqcn(receiver, bytes)?;
+                match raw {
+                    "self" => (fqcn, Confidence::High),
+                    "static" => (fqcn, Confidence::Medium),
+                    _ => return None,
+                }
+            }
+            _ => return None,
+        };
+        let first_method = root
+            .child_by_field_name("name")
+            .and_then(|n| n.utf8_text(bytes).ok())?
+            .to_string();
+        return Some(ChainRecipeData {
+            root: ChainRootData::StaticScope {
+                qualified,
+                confidence,
+                first_method,
+            },
+            links,
+        });
+    }
+    if root.id() != receiver.id() {
+        return Some(ChainRecipeData {
+            root: ChainRootData::Var(Box::new(compile_receiver(root, bytes, aliases))),
+            links,
+        });
+    }
+    None
+}
+
+/// The member names walked from `receiver` toward (but not including) the chain
+/// root — the input to the relation-hop bail (see [`has_relationship_link`]).
+fn chain_link_names(receiver: Node, bytes: &[u8]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = receiver;
+    while matches!(
+        cur.kind(),
+        "member_call_expression"
+            | "nullsafe_member_call_expression"
+            | "member_access_expression"
+            | "nullsafe_member_access_expression"
+    ) {
+        if let Some(name) = cur.child_by_field_name("name") {
+            if let Ok(text) = name.utf8_text(bytes) {
+                out.push(text.to_string());
+            }
+        }
+        match cur.child_by_field_name("object") {
+            Some(o) => cur = o,
+            None => break,
+        }
+    }
+    out
+}
+
+// ─── Compile: intra-file SHAPE predicates ──────────────────────────────────
+// The shape half of the cross-file `resolve_*_receiver` functions — "does this
+// receiver look like X?" without doing the cross-file resolution. Kept in
+// lockstep with the resolvers they mirror.
+
+/// The shape of [`resolve_auth_user_receiver`] — `Auth::user()`,
+/// `auth()->user()`, `request()->user()` — without the auth-model lookup.
+fn auth_user_receiver_shape(receiver: Node, bytes: &[u8]) -> bool {
+    match receiver.kind() {
+        "scoped_call_expression" => {
+            let Some(name) = receiver
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(bytes).ok())
+            else {
+                return false;
+            };
+            if name != "user" {
+                return false;
+            }
+            receiver
+                .child_by_field_name("scope")
+                .and_then(|s| s.utf8_text(bytes).ok())
+                .map(|scope| scope.rsplit('\\').next().unwrap_or(scope) == "Auth")
+                .unwrap_or(false)
+        }
+        "member_call_expression" | "nullsafe_member_call_expression" => {
+            let Some(name) = receiver
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(bytes).ok())
+            else {
+                return false;
+            };
+            if name != "user" {
+                return false;
+            }
+            let Some(object) = receiver.child_by_field_name("object") else {
+                return false;
+            };
+            object.kind() == "function_call_expression"
+                && matches!(
+                    object
+                        .child_by_field_name("function")
+                        .and_then(|f| f.utf8_text(bytes).ok()),
+                    Some("auth") | Some("request")
+                )
+        }
+        _ => false,
+    }
+}
+
+/// The container-binding key of [`resolve_container_receiver`] — the `'key'` in
+/// `app('key')` / `resolve('key')`.
+fn container_receiver_key(receiver: Node, bytes: &[u8]) -> Option<String> {
+    if receiver.kind() != "function_call_expression" {
+        return None;
+    }
+    let func = receiver
+        .child_by_field_name("function")?
+        .utf8_text(bytes)
+        .ok()?
+        .trim_start_matches('\\');
+    if !matches!(func, "app" | "resolve") {
+        return None;
+    }
+    single_string_argument(receiver, bytes)
+}
+
+/// The helper name of [`resolve_helper_receiver`] — a zero-arg helper whose
+/// container binding we model (`view`, `cache`, …).
+fn helper_receiver_name(receiver: Node, bytes: &[u8]) -> Option<String> {
+    if receiver.kind() != "function_call_expression" {
+        return None;
+    }
+    let func = receiver
+        .child_by_field_name("function")?
+        .utf8_text(bytes)
+        .ok()?
+        .trim_start_matches('\\');
+    helper_binding_key(func).map(|_| func.to_string())
+}
+
+/// The shape of [`resolve_gate_closure_user`] — a variable that is a Gate
+/// ability closure's first parameter — without the auth-model lookup.
+fn is_gate_closure_user_shape(var_node: Node, bytes: &[u8]) -> bool {
+    let Ok(raw) = var_node.utf8_text(bytes) else {
+        return false;
+    };
+    let var = raw.trim_start_matches('$');
+    let Some(closure) = enclosing_closure(var_node) else {
+        return false;
+    };
+    is_first_param(closure, bytes, var) && is_gate_ability_closure(closure, bytes)
+}
+
+// ─── Eval: resolve captured context against snapshots ──────────────────────
+
+/// Pass-2 replacement: resolve captured PHP member sites without re-reading or
+/// re-parsing the target file. Byte-identical to
+/// [`resolve_member_access_entries`] for the same input.
+pub fn resolve_member_access_entries_with_context(
+    ctx: &MemberContextData,
+    member_refs: &[Arc<MemberAccessReferenceData>],
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+    mut deps: Option<&mut HashSet<String>>,
+) -> Vec<MagicMemberEntry> {
+    debug_assert_eq!(
+        ctx.sites.len(),
+        member_refs.len(),
+        "captured sites must be positionally parallel to member_access_refs"
+    );
+    let mut out = Vec::new();
+    for (m, site) in member_refs.iter().zip(ctx.sites.iter()) {
+        let Some(resolved) = resolve_recipe_and_classify(
+            site,
+            &ctx.aliases,
+            &m.member,
+            m.form,
+            resolver,
+            classviews,
+            project_root,
+            deps.as_deref_mut(),
+        ) else {
+            continue;
+        };
+        // find-references gate: HIGH + MEDIUM (mirrors the tree path).
+        if !matches!(resolved.confidence, Confidence::High | Confidence::Medium) {
+            continue;
+        }
+        if m.form.is_call()
+            && matches!(
+                resolved.kind,
+                MagicMemberKind::PlainMember | MagicMemberKind::FacadeMethod
+            )
+        {
+            continue;
+        }
+        out.push(MagicMemberEntry {
+            fqcn: resolved.declaring_fqcn,
+            member: m.member.clone(),
+            line: m.line,
+            column: m.column,
+            end_column: m.end_column,
+        });
+    }
+    out
+}
+
+/// The captured-context port of [`resolve_and_classify`], branch-for-branch.
+#[allow(clippy::too_many_arguments)]
+fn resolve_recipe_and_classify(
+    site: &SiteContextData,
+    aliases: &UseAliases,
+    member: &str,
+    form: AccessForm,
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+    mut deps: Option<&mut HashSet<String>>,
+) -> Option<ResolvedMemberAccess> {
+    // Outer facade interception — a static-name receiver only.
+    let facade_concrete = match &site.recipe {
+        ReceiverRecipeData::StaticName {
+            raw, is_namespaced, ..
+        } => eval_facade(raw, *is_namespaced, aliases, resolver, project_root),
+        _ => None,
+    };
+    // Outer helper interception, only when facade didn't fire.
+    let helper_concrete = if facade_concrete.is_none() {
+        match &site.recipe {
+            ReceiverRecipeData::HelperBinding(name) => eval_helper(name, resolver),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    let (fqcn, confidence, via_facade) = match facade_concrete.or(helper_concrete) {
+        Some((fqcn, confidence)) => (fqcn, confidence, true),
+        None => {
+            let (fqcn, confidence) =
+                match eval_receiver(&site.recipe, aliases, resolver, classviews, project_root) {
+                    Some(r) => r,
+                    None if form.is_call() => {
+                        let chain = site.chain.as_ref()?;
+                        eval_chain(chain, aliases, resolver, classviews, project_root)?
+                    }
+                    None => return None,
+                };
+            (fqcn, confidence, false)
+        }
+    };
+
+    if let Some(d) = deps.as_deref_mut() {
+        d.insert(fqcn.clone());
+    }
+
+    if let Some(resolved) = classify_against(
+        &fqcn,
+        member,
+        form,
+        confidence,
+        via_facade,
+        resolver,
+        classviews,
+        project_root,
+    ) {
+        return Some(resolved);
+    }
+
+    // Builder retry (see [`resolve_and_classify`]): captured `is_scope_param`
+    // gate + captured enclosing class.
+    if form.is_call() && is_eloquent_builder(&fqcn) && site.is_scope_param_receiver {
+        let model = site.enclosing_class_fqcn.clone()?;
+        if let Some(d) = deps {
+            d.insert(model.clone());
+        }
+        return classify_against(
+            &model,
+            member,
+            form,
+            Confidence::Medium,
+            false,
+            resolver,
+            classviews,
+            project_root,
+        );
+    }
+    None
+}
+
+/// The captured-context port of [`resolve_receiver`].
+pub(crate) fn eval_receiver(
+    recipe: &ReceiverRecipeData,
+    aliases: &UseAliases,
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+) -> Option<(String, Confidence)> {
+    match recipe {
+        ReceiverRecipeData::Resolved { fqcn, confidence } => Some((fqcn.clone(), *confidence)),
+        ReceiverRecipeData::AuthUser { fallback } => auth_model_fqcn(project_root)
+            .map(|m| (m, Confidence::High))
+            .or_else(|| eval_receiver(fallback, aliases, resolver, classviews, project_root)),
+        ReceiverRecipeData::GateClosureUser => {
+            auth_model_fqcn(project_root).map(|m| (m, Confidence::High))
+        }
+        ReceiverRecipeData::ContainerKey(key) => resolver
+            .binding_concrete(key)
+            .map(|c| (c, Confidence::High)),
+        ReceiverRecipeData::HelperBinding(name) => eval_helper(name, resolver),
+        ReceiverRecipeData::StaticName {
+            raw,
+            qualified,
+            is_namespaced,
+        } => eval_facade(raw, *is_namespaced, aliases, resolver, project_root).or_else(|| {
+            if resolver.class_file(qualified).is_some() || resolver.has_macro_host(qualified) {
+                Some((qualified.clone(), Confidence::High))
+            } else {
+                None
+            }
+        }),
+        ReceiverRecipeData::MethodReturn { object, method } => {
+            eval_method_return(object, method, aliases, resolver, classviews, project_root)
+        }
+        ReceiverRecipeData::Unresolvable => None,
+    }
+}
+
+/// Eval a [`ValueExprPlanData`] — the captured-context port of
+/// [`resolve_expression_type`].
+pub(crate) fn eval_value_expr(
+    plan: &ValueExprPlanData,
+    aliases: &UseAliases,
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+) -> Option<(String, Confidence)> {
+    match plan {
+        ValueExprPlanData::Resolved { fqcn, confidence } => Some((fqcn.clone(), *confidence)),
+        ValueExprPlanData::Recipe(recipe) => {
+            eval_receiver(recipe, aliases, resolver, classviews, project_root)
+        }
+    }
+}
+
+/// The captured-context port of [`resolve_facade_receiver`].
+fn eval_facade(
+    raw: &str,
+    is_namespaced: bool,
+    aliases: &UseAliases,
+    resolver: &impl ClassFileResolver,
+    project_root: &Path,
+) -> Option<(String, Confidence)> {
+    let facade_fqcn = crate::facade_resolver::resolve_facade_fqcn(
+        raw,
+        aliases,
+        &resolver.facade_aliases(),
+        is_namespaced,
+    )?;
+    let concrete = crate::facade_resolver::facade_accessor(&facade_fqcn, project_root)
+        .and_then(|accessor| resolver.binding_concrete(&accessor))?;
+    Some((concrete, Confidence::High))
+}
+
+/// The captured-context port of [`resolve_helper_receiver`]'s tail.
+fn eval_helper(name: &str, resolver: &impl ClassFileResolver) -> Option<(String, Confidence)> {
+    let key = helper_binding_key(name)?;
+    if key.contains('\\') {
+        resolve_interface_concrete(key, resolver).map(|c| (c, Confidence::High))
+    } else {
+        resolver
+            .binding_concrete(key)
+            .map(|c| (c, Confidence::High))
+    }
+}
+
+/// The captured-context port of [`resolve_call_chain_receiver`].
+fn eval_chain(
+    chain: &ChainRecipeData,
+    aliases: &UseAliases,
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+) -> Option<(String, Confidence)> {
+    match &chain.root {
+        ChainRootData::StaticScope {
+            qualified,
+            confidence,
+            first_method,
+        } => {
+            let file = resolver.class_file(qualified)?;
+            let view = classviews.get_or_build(qualified, &file, project_root)?;
+            let first_is_forwarding =
+                crate::query_chain::methods::is_eloquent_static_starter(first_method)
+                    || matches!(
+                        classify_call(&view, first_method).map(|c| c.kind),
+                        Some(MagicMemberKind::Scope) | Some(MagicMemberKind::DynamicFinder)
+                    );
+            if !first_is_forwarding {
+                return None;
+            }
+            if chain_links_hit_relationship(&chain.links, &view) {
+                return None;
+            }
+            Some((qualified.clone(), *confidence))
+        }
+        ChainRootData::Var(obj_recipe) => {
+            let (fqcn, confidence) =
+                eval_receiver(obj_recipe, aliases, resolver, classviews, project_root)?;
+            if let Some(file) = resolver.class_file(&fqcn) {
+                if let Some(view) = classviews.get_or_build(&fqcn, &file, project_root) {
+                    if chain_links_hit_relationship(&chain.links, &view) {
+                        return None;
+                    }
+                }
+            }
+            let capped = match confidence {
+                Confidence::High => Confidence::Medium,
+                other => other,
+            };
+            Some((fqcn, capped))
+        }
+    }
+}
+
+/// Does any captured chain link name a relationship on `view`? The
+/// captured-context form of [`has_relationship_link`].
+fn chain_links_hit_relationship(links: &[String], view: &ClassView) -> bool {
+    links
+        .iter()
+        .any(|l| view.relationships.iter().any(|r| r.method_name == *l))
+}
+
+/// The captured-context port of [`resolve_method_return`].
+fn eval_method_return(
+    object: &ReceiverRecipeData,
+    method: &str,
+    aliases: &UseAliases,
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+) -> Option<(String, Confidence)> {
+    let (obj_fqcn, _) = eval_receiver(object, aliases, resolver, classviews, project_root)?;
+    let file_path = resolver.class_file(&obj_fqcn)?;
+    let view = classviews.get_or_build(&obj_fqcn, &file_path, project_root)?;
+    let ret = method_return_type(&view, method)?;
+    let normalized = normalize_type(&ret)?;
+    if matches!(normalized.as_str(), "self" | "static") {
+        return Some((obj_fqcn, Confidence::Medium));
+    }
+    let candidate = qualify_return_type(&normalized, &view);
+    if let Some(concrete) = resolve_interface_concrete(&candidate, resolver) {
+        return Some((concrete, Confidence::Medium));
+    }
+    if resolver.class_file(&candidate).is_some() {
+        return Some((candidate, Confidence::Medium));
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests;

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -337,7 +337,7 @@ fn resolve_in(p: &Project, caller: &str, member: &str) -> Option<ResolvedMemberA
     let bytes = caller.as_bytes();
     let aliases = extract_use_aliases(&tree, caller);
     let receiver = receiver_of(&tree, bytes, member)?;
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     resolve_and_classify(
         receiver,
         member,
@@ -345,7 +345,7 @@ fn resolve_in(p: &Project, caller: &str, member: &str) -> Option<ResolvedMemberA
         bytes,
         &aliases,
         &p.index,
-        &mut cache,
+        &cache,
         &p.root,
         None,
     )
@@ -396,7 +396,7 @@ fn resolve_with(
     let bytes = caller.as_bytes();
     let aliases = extract_use_aliases(&tree, caller);
     let receiver = receiver_of(&tree, bytes, member)?;
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     resolve_and_classify(
         receiver,
         member,
@@ -404,7 +404,7 @@ fn resolve_with(
         bytes,
         &aliases,
         resolver,
-        &mut cache,
+        &cache,
         root,
         None,
     )
@@ -618,7 +618,7 @@ fn resolve_static_call(
             stack.push(ch);
         }
     }
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     resolve_and_classify(
         scope?,
         member,
@@ -626,7 +626,7 @@ fn resolve_static_call(
         bytes,
         &aliases,
         resolver,
-        &mut cache,
+        &cache,
         root,
         None,
     )
@@ -836,7 +836,7 @@ fn resolve_call_member(
     let bytes = caller.as_bytes();
     let aliases = extract_use_aliases(&tree, caller);
     let receiver = call_receiver_of(&tree, bytes, member)?;
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     resolve_and_classify(
         receiver,
         member,
@@ -844,7 +844,7 @@ fn resolve_call_member(
         bytes,
         &aliases,
         resolver,
-        &mut cache,
+        &cache,
         root,
         None,
     )
@@ -1288,7 +1288,7 @@ function show(User $user) {
 fn classview_cache_reuses_built_view() {
     // Two resolutions against the same FQCN must reuse one ClassView build.
     let p = project("app/Models/User.php", USER_MODEL);
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let node = p.index.get("App\\Models\\User").expect("indexed");
     let v1 = cache.get_or_build("App\\Models\\User", &node.file_path, &p.root);
     let v2 = cache.get_or_build("App\\Models\\User", &node.file_path, &p.root);
@@ -1697,7 +1697,7 @@ class C {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -1726,7 +1726,7 @@ function show($mystery) {
         caller,
         &member_refs_of(caller),
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -1753,7 +1753,7 @@ class C {
         caller,
         &member_refs_of(caller),
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -1764,7 +1764,7 @@ class C {
 fn population_empty_refs_is_empty() {
     let p = project("app/Models/User.php", USER_MODEL);
     let entries =
-        resolve_member_access_entries("", &[], &p.index, &mut ClassViewCache::new(), &p.root, None);
+        resolve_member_access_entries("", &[], &p.index, &ClassViewCache::new(), &p.root, None);
     assert!(entries.is_empty());
 }
 
@@ -1814,7 +1814,7 @@ class User extends Model {
         src,
         &data.member_access_refs,
         &snapshot,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         dir.path(),
         None,
     );
@@ -1893,7 +1893,7 @@ class User extends Authenticatable {
         src,
         &refs,
         &snapshot,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         dir.path(),
         None,
     );
@@ -1999,7 +1999,7 @@ fn resolve_auth_caller(
         caller,
         &refs,
         index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         dir.path(),
         None,
     )
@@ -2147,7 +2147,7 @@ class C {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2174,7 +2174,7 @@ class C {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2201,7 +2201,7 @@ class C {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2228,7 +2228,7 @@ class C {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2256,7 +2256,7 @@ class C {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2291,7 +2291,7 @@ class C {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2314,7 +2314,7 @@ $slug = Str::slug('Laravel');
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2340,7 +2340,7 @@ class Order extends Model {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2372,7 +2372,7 @@ class C {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2411,7 +2411,7 @@ class User extends Model {
         model,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2442,7 +2442,7 @@ class User extends Model {
         model,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2467,7 +2467,7 @@ $x = Str::of('laravel')->upper();
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2491,7 +2491,7 @@ class C {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2525,7 +2525,7 @@ class UserTest {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2556,7 +2556,7 @@ class User extends Model {
         model,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2595,7 +2595,7 @@ class User extends Model {
         model,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2636,7 +2636,7 @@ class C {
         caller,
         &refs,
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         None,
     );
@@ -2667,7 +2667,7 @@ class C {
         caller,
         &member_refs_of(caller),
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         Some(&mut deps),
     );
@@ -2694,7 +2694,7 @@ class C {
         caller,
         &member_refs_of(caller),
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         Some(&mut deps),
     );
@@ -2718,7 +2718,7 @@ function show($mystery) {
         caller,
         &member_refs_of(caller),
         &p.index,
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         &p.root,
         Some(&mut deps),
     );
@@ -2772,4 +2772,220 @@ class AppServiceProvider extends ServiceProvider {
     let r = resolve_with(&resolver, &p.root, caller, "logo").expect("resolves");
     assert_eq!(r.kind, MagicMemberKind::Accessor);
     assert_eq!(r.declaring_fqcn, "App\\Models\\Tenant");
+}
+
+// ─── Shared ClassViewCache: correctness + once-per-FQCN ───────────────────
+//
+// The whole-project build shares ONE `ClassViewCache` across every parallel
+// worker so each class is analyzed once total (not once per referencing file).
+// These prove the two invariants that keep that safe and worth it:
+//   1. equivalence — a cold cache-per-file run and a shared-cache run resolve
+//      byte-identical entries AND deps (sharing is pure memoization);
+//   2. once-per-FQCN — N files referencing the same model analyze it once.
+
+/// A project with a shared base model + shared trait and N caller files, each
+/// reading members off a typed receiver. Callers reuse a small model pool so
+/// the shared cache has something to collapse.
+struct SharedProject {
+    _dir: TempDir,
+    index: ClassHierarchyIndex,
+    root: PathBuf,
+    /// (source, captured refs) per caller — ready to feed into resolution.
+    callers: Vec<(String, Vec<Arc<MemberAccessReferenceData>>)>,
+}
+
+/// Build a shared-ancestor project: `BaseModel` (extends Eloquent Model, uses a
+/// trait) + `Auditable` trait + `pool` concrete models, and `n_callers` callers
+/// each targeting `Model{i % pool}`.
+fn shared_project(pool: usize, n_callers: usize) -> SharedProject {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    fs::write(
+        root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#,
+    )
+    .unwrap();
+    let mut index = ClassHierarchyIndex::default();
+
+    let write = |index: &mut ClassHierarchyIndex, rel: &str, body: &str| {
+        let path = root.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, body).unwrap();
+        index.insert_file(&path, classes_in_file(&path, body));
+    };
+
+    // Shared ancestors — the classes the sharing must analyze once, not N times.
+    write(
+        &mut index,
+        "app/Concerns/Auditable.php",
+        r#"<?php
+namespace App\Concerns;
+trait Auditable {
+    public function scopeAudited($query) { return $query; }
+    public function getAuditedAtAttribute() { return $this->updated_at; }
+}
+"#,
+    );
+    write(
+        &mut index,
+        "app/Models/BaseModel.php",
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+use App\Concerns\Auditable;
+class BaseModel extends Model {
+    use Auditable;
+    protected $fillable = ['id'];
+}
+"#,
+    );
+    for i in 0..pool {
+        write(
+            &mut index,
+            &format!("app/Models/Model{i}.php"),
+            &format!(
+                r#"<?php
+namespace App\Models;
+class Model{i} extends BaseModel {{
+    protected $fillable = ['name{i}'];
+    public function scopeActive{i}($query) {{ return $query; }}
+}}
+"#
+            ),
+        );
+    }
+
+    let callers = (0..n_callers)
+        .map(|c| {
+            let m = c % pool;
+            // Read one own column, one own scope, one inherited-trait accessor,
+            // and one inherited-trait scope — so the full receiver chain
+            // (Model{m} → BaseModel → Auditable) must be built to classify all.
+            let source = format!(
+                r#"<?php
+namespace App\Http\Controllers;
+use App\Models\Model{m};
+class Controller{c} {{
+    public function show(Model{m} $x) {{
+        $a = $x->name{m};
+        $b = $x->active{m}();
+        $d = $x->auditedAt;
+        $e = $x->audited();
+        return [$a, $b, $d, $e];
+    }}
+}}
+"#
+            );
+            let refs = member_refs_of(&source);
+            (source, refs)
+        })
+        .collect();
+
+    SharedProject {
+        _dir: dir,
+        index,
+        root,
+        callers,
+    }
+}
+
+/// Resolve every caller, sorting each file's entries so the comparison is order-
+/// independent (worker order differs between the two regimes). Also collects the
+/// per-file dep sets. `shared` picks one cache for all files vs a fresh one each.
+fn resolve_all(p: &SharedProject, shared: bool) -> (Vec<Vec<MagicMemberEntry>>, Vec<Vec<String>>) {
+    let one = ClassViewCache::new();
+    let mut all_entries = Vec::new();
+    let mut all_deps = Vec::new();
+    for (source, refs) in &p.callers {
+        let fresh = ClassViewCache::new();
+        let cache = if shared { &one } else { &fresh };
+        let mut deps = HashSet::new();
+        let mut entries =
+            resolve_member_access_entries(source, refs, &p.index, cache, &p.root, Some(&mut deps));
+        // Deterministic order for comparison — the resolver's output order can
+        // depend on capture order, which is stable, but sorting is belt-and-braces.
+        entries.sort_by(|a, b| {
+            (a.fqcn.as_str(), a.member.as_str(), a.line, a.column).cmp(&(
+                b.fqcn.as_str(),
+                b.member.as_str(),
+                b.line,
+                b.column,
+            ))
+        });
+        let mut dep_vec: Vec<String> = deps.into_iter().collect();
+        dep_vec.sort();
+        all_entries.push(entries);
+        all_deps.push(dep_vec);
+    }
+    (all_entries, all_deps)
+}
+
+#[test]
+fn shared_cache_resolves_identically_to_cold_cache() {
+    // The correctness gate: sharing one cache across all files must produce
+    // byte-identical resolved entries AND deps as a fresh-cache-per-file run.
+    let p = shared_project(4, 20);
+    let (cold_entries, cold_deps) = resolve_all(&p, false);
+    let (shared_entries, shared_deps) = resolve_all(&p, true);
+    assert_eq!(
+        cold_entries, shared_entries,
+        "shared-cache entries diverged from cold-cache — sharing must be pure memoization"
+    );
+    assert_eq!(
+        cold_deps, shared_deps,
+        "shared-cache deps diverged from cold-cache — sharing must be pure memoization"
+    );
+    // Sanity: the fixture actually resolved something (a green all-empty run
+    // would pass the equivalence trivially).
+    assert!(
+        cold_entries.iter().any(|e| !e.is_empty()),
+        "fixture resolved no entries — test would be vacuous"
+    );
+}
+
+#[test]
+fn shared_cache_analyzes_each_receiver_once() {
+    // 12 callers funnel through 3 distinct models. With ONE shared cache, each
+    // referenced FQCN is analyzed exactly once — misses == distinct classes,
+    // and the remaining lookups are all hits.
+    let p = shared_project(3, 12);
+    let cache = ClassViewCache::new();
+    for (source, refs) in &p.callers {
+        resolve_member_access_entries(source, refs, &p.index, &cache, &p.root, None);
+    }
+
+    // Only the 3 distinct Model FQCNs are analyzed — every other lookup for the
+    // same model across the 12 callers is a cache hit. (Ancestors BaseModel /
+    // Auditable are walked *inside* analyze(Model{i}), not keyed here, so the
+    // cache miss count is exactly the distinct receiver classes.)
+    assert_eq!(
+        cache.misses(),
+        3,
+        "expected 3 distinct receiver classes analyzed once each, got {} misses / {} hits",
+        cache.misses(),
+        cache.hits(),
+    );
+    // 12 callers × the same 3 models → 9 of them are repeat lookups (hits).
+    assert!(
+        cache.hits() >= 9,
+        "expected the repeated receivers to hit the cache, got {} hits",
+        cache.hits(),
+    );
+}
+
+#[test]
+fn shared_cache_single_receiver_analyzed_exactly_once() {
+    // The tightest statement of the win: N callers all referencing the SAME
+    // model analyze it exactly once total.
+    let p = shared_project(1, 25);
+    let cache = ClassViewCache::new();
+    for (source, refs) in &p.callers {
+        resolve_member_access_entries(source, refs, &p.index, &cache, &p.root, None);
+    }
+    assert_eq!(
+        cache.misses(),
+        1,
+        "one model referenced by 25 callers must analyze once, got {} misses",
+        cache.misses(),
+    );
 }

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -2989,3 +2989,398 @@ fn shared_cache_single_receiver_analyzed_exactly_once() {
         cache.misses(),
     );
 }
+
+// ─── M1 single-parse capture: capture-vs-live equivalence ─────────────────
+//
+// The hard M1 guarantee: resolving PHP member accesses from context captured at
+// parse must produce byte-identical entries AND deps to today's re-parse path,
+// on a fixture that exercises every receiver shape — aliased imports, `$this`,
+// typed + constructor-promoted props, multi-hop flow, foreach, `app('key')`
+// container bindings, `auth()->user()`, static + `::query()->…` chains,
+// self/static, and a multi-class file (per-site enclosing class).
+
+use crate::salsa_impl::MemberContextData;
+
+/// Build a `MemberContextData` for a `.php` file exactly as the parse-time
+/// capture does (aliases + per-site recipes off one parse).
+fn php_member_context(source: &str, refs: &[Arc<MemberAccessReferenceData>]) -> MemberContextData {
+    let tree = parse_php(source).expect("parse");
+    let aliases = extract_use_aliases(&tree, source);
+    let sites = super::capture_php_sites(source, &tree, refs, &aliases);
+    MemberContextData {
+        aliases,
+        sites,
+        view_renders: Vec::new(),
+        volt_surface: None,
+        component: None,
+    }
+}
+
+/// Resolve a caller's member accesses BOTH ways (tree path, captured-context
+/// path) against `resolver`/`root`, returning `(entries, deps)` sorted for an
+/// order-independent comparison.
+fn resolve_both_ways(
+    resolver: &impl ClassFileResolver,
+    root: &std::path::Path,
+    caller: &str,
+) -> (
+    (Vec<MagicMemberEntry>, Vec<String>),
+    (Vec<MagicMemberEntry>, Vec<String>),
+) {
+    let refs = member_refs_of(caller);
+
+    let sort_entries = |mut e: Vec<MagicMemberEntry>| {
+        e.sort_by(|a, b| {
+            (a.fqcn.as_str(), a.member.as_str(), a.line, a.column).cmp(&(
+                b.fqcn.as_str(),
+                b.member.as_str(),
+                b.line,
+                b.column,
+            ))
+        });
+        e
+    };
+    let sort_deps = |d: HashSet<String>| {
+        let mut v: Vec<String> = d.into_iter().collect();
+        v.sort();
+        v
+    };
+
+    let tree = {
+        let cache = ClassViewCache::new();
+        let mut deps = HashSet::new();
+        let e =
+            resolve_member_access_entries(caller, &refs, resolver, &cache, root, Some(&mut deps));
+        (sort_entries(e), sort_deps(deps))
+    };
+    let captured = {
+        let ctx = php_member_context(caller, &refs);
+        let cache = ClassViewCache::new();
+        let mut deps = HashSet::new();
+        let e = resolve_member_access_entries_with_context(
+            &ctx,
+            &refs,
+            resolver,
+            &cache,
+            root,
+            Some(&mut deps),
+        );
+        (sort_entries(e), sort_deps(deps))
+    };
+    (tree, captured)
+}
+
+/// A class index + auth-configured project root for the rich equivalence
+/// fixture. Each test builds its own `WithBindings` resolver borrowing the
+/// index (with a `tenant` container binding).
+fn rich_equivalence_project() -> (ClassHierarchyIndex, PathBuf, TempDir) {
+    let mut index = ClassHierarchyIndex::default();
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    fs::write(
+        root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#,
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("config")).unwrap();
+    fs::write(
+        root.join("config/auth.php"),
+        r#"<?php
+use App\Models\User;
+return ['providers' => ['users' => ['model' => User::class]]];
+"#,
+    )
+    .unwrap();
+
+    let write = |index: &mut ClassHierarchyIndex, rel: &str, body: &str| {
+        let path = root.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, body).unwrap();
+        index.insert_file(&path, classes_in_file(&path, body));
+    };
+    write(
+        &mut index,
+        "app/Models/User.php",
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+class User extends Model {
+    protected $fillable = ['email', 'name'];
+    public function scopeActive($query) { return $query->where('active', true); }
+    public function getFullNameAttribute(): string { return ''; }
+    public function posts(): HasMany { return $this->hasMany(Post::class); }
+}
+"#,
+    );
+    write(
+        &mut index,
+        "app/Models/Post.php",
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Post extends Model {
+    protected $fillable = ['title'];
+}
+"#,
+    );
+    write(
+        &mut index,
+        "app/Models/Tenant.php",
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Tenant extends Model {
+    protected $fillable = ['name'];
+    public function getLogoAttribute(): string { return ''; }
+}
+"#,
+    );
+
+    (index, root, dir)
+}
+
+/// A `WithBindings` resolver borrowing `index`, with a `tenant` container
+/// binding (matching the fixture's `app('tenant')`).
+fn rich_resolver(index: &ClassHierarchyIndex) -> WithBindings<'_> {
+    let mut bindings = HashMap::new();
+    bindings.insert("tenant".to_string(), "App\\Models\\Tenant".to_string());
+    WithBindings { index, bindings }
+}
+
+#[test]
+fn captured_context_resolves_identically_to_tree_path() {
+    let (index, root, _dir) = rich_equivalence_project();
+    let resolver = rich_resolver(&index);
+
+    // A controller-shaped caller exercising the receiver-shape zoo, plus a
+    // SECOND class in the same file so per-site enclosing-class capture is
+    // tested. Aliases: `User as U`, plain `Post`, `Tenant`.
+    let caller = r#"<?php
+namespace App\Http\Controllers;
+
+use App\Models\User as U;
+use App\Models\Post;
+use App\Models\Tenant;
+
+class ShowController {
+    private U $currentUser;
+
+    public function __construct(private Tenant $tenant) {}
+
+    public function show(U $u) {
+        $email = $u->email;            // typed param → column
+        $name = $u->fullName;          // accessor
+        $posts = $u->posts;            // relationship (property)
+        $scope = $u->active();         // scope (instance call)
+        $finder = $u->whereName('x');  // dynamic finder (instance call)
+
+        $mine = $this->currentUser->email;   // typed prop → column
+        $logo = $this->tenant->logo;         // promoted prop → accessor
+        $nope = $this->missingThing;         // $this = controller, no member → dropped
+
+        $s1 = U::active();                    // static scope
+        $s2 = U::query()->active();           // static builder chain
+        $s3 = U::whereEmail('a@b.c');         // static dynamic finder
+
+        $all = U::all();
+        foreach ($all as $one) {
+            $e2 = $one->email;                // foreach element → column
+        }
+
+        $auth = auth()->user()->email;        // auth model → column
+        $t = app('tenant')->name;             // container binding → column
+
+        return [$email, $name, $posts, $scope, $finder, $mine, $logo, $nope,
+                $s1, $s2, $s3, $e2, $auth, $t];
+    }
+}
+
+class Helper {
+    public function go(U $u) {
+        return $u->email;   // second class: per-site enclosing class
+    }
+}
+"#;
+
+    let (tree, captured) = resolve_both_ways(&resolver, &root, caller);
+    assert_eq!(
+        tree.0, captured.0,
+        "captured-context entries diverged from the tree path"
+    );
+    assert_eq!(
+        tree.1, captured.1,
+        "captured-context deps diverged from the tree path"
+    );
+    // Guard against a vacuous green: the fixture must resolve real entries.
+    assert!(
+        tree.0.len() >= 8,
+        "fixture under-resolved ({} entries) — equivalence would be near-vacuous",
+        tree.0.len()
+    );
+}
+
+#[test]
+fn captured_context_member_serde_round_trips() {
+    // The captured context must survive the bincode disk-cache round trip and
+    // re-resolve identically — the property the pattern-cache v11 bump relies on.
+    let (index, root, _dir) = rich_equivalence_project();
+    let resolver = rich_resolver(&index);
+    let caller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+class C {
+    public function show(User $u) {
+        $a = $u->email;
+        $b = $u->active();
+        $c = auth()->user()->email;
+        $d = app('tenant')->name;
+        return [$a, $b, $c, $d];
+    }
+}
+"#;
+    let refs = member_refs_of(caller);
+    let ctx = php_member_context(caller, &refs);
+
+    let bytes = bincode::serde::encode_to_vec(&ctx, bincode::config::standard()).unwrap();
+    let (decoded, _): (MemberContextData, _) =
+        bincode::serde::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+    assert_eq!(
+        ctx, decoded,
+        "context did not survive the bincode round trip"
+    );
+
+    let resolve = |c: &MemberContextData| {
+        let cache = ClassViewCache::new();
+        let mut deps = HashSet::new();
+        let mut e = resolve_member_access_entries_with_context(
+            c,
+            &refs,
+            &resolver,
+            &cache,
+            &root,
+            Some(&mut deps),
+        );
+        e.sort_by(|a, b| a.member.cmp(&b.member));
+        e
+    };
+    assert_eq!(
+        resolve(&ctx),
+        resolve(&decoded),
+        "re-resolving the decoded context diverged from the original"
+    );
+    assert!(!resolve(&ctx).is_empty(), "fixture resolved nothing");
+}
+
+/// A project exercising the four recipe/chain variants the first fixture left
+/// uncovered: `GateClosureUser`, `HelperBinding`-as-receiver, `MethodReturn`,
+/// and `ChainRootData::Var`. Auth model + a `cache` helper binding are set up.
+fn variant_project() -> (ClassHierarchyIndex, PathBuf, TempDir) {
+    let mut index = ClassHierarchyIndex::default();
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    fs::write(
+        root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#,
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("config")).unwrap();
+    fs::write(
+        root.join("config/auth.php"),
+        r#"<?php
+use App\Models\User;
+return ['providers' => ['users' => ['model' => User::class]]];
+"#,
+    )
+    .unwrap();
+    let write = |index: &mut ClassHierarchyIndex, rel: &str, body: &str| {
+        let path = root.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, body).unwrap();
+        index.insert_file(&path, classes_in_file(&path, body));
+    };
+    write(
+        &mut index,
+        "app/Models/User.php",
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    protected $fillable = ['email'];
+    public function scopeActive($query) { return $query->where('active', true); }
+}
+"#,
+    );
+    write(
+        &mut index,
+        "app/Repositories/Repo.php",
+        r#"<?php
+namespace App\Repositories;
+use App\Models\User;
+class Repo {
+    public function currentUser(): User { return new User(); }
+}
+"#,
+    );
+    write(
+        &mut index,
+        "app/Support/Cache.php",
+        r#"<?php
+namespace App\Support;
+class Cache {
+    public string $prefix = '';
+}
+"#,
+    );
+    (index, root, dir)
+}
+
+#[test]
+fn captured_context_covers_remaining_receiver_variants() {
+    let (index, root, _dir) = variant_project();
+    let mut bindings = HashMap::new();
+    bindings.insert("cache".to_string(), "App\\Support\\Cache".to_string());
+    let resolver = WithBindings {
+        index: &index,
+        bindings,
+    };
+
+    let caller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+use App\Repositories\Repo;
+class C {
+    public function show(User $u, Repo $repo) {
+        // ChainRootData::Var — $u->fresh() has no in-view return type, so the
+        // direct method-return fails and the chain fallback roots at the $u var.
+        $a = $u->fresh()->active();
+        // MethodReturn — currentUser(): User, then a column read on the result.
+        $b = $repo->currentUser()->email;
+        // HelperBinding as a receiver — cache() → the bound Cache concrete.
+        $c = cache()->prefix;
+        // GateClosureUser — the Gate ability closure's first param is the model.
+        \Gate::define('viewThing', function ($user) { return $user->email; });
+        return [$a, $b, $c];
+    }
+}
+"#;
+
+    let (tree, captured) = resolve_both_ways(&resolver, &root, caller);
+    assert_eq!(
+        tree.0, captured.0,
+        "captured-context entries diverged on the remaining variants"
+    );
+    assert_eq!(
+        tree.1, captured.1,
+        "captured-context deps diverged on the remaining variants"
+    );
+    // Each of the four variants must resolve a real entry (not just agree on
+    // dropping everything) — assert the members that only these paths produce.
+    let members: Vec<&str> = tree.0.iter().map(|e| e.member.as_str()).collect();
+    for expected in ["active", "email", "prefix"] {
+        assert!(
+            members.contains(&expected),
+            "variant fixture missing `{expected}` — got {members:?}"
+        );
+    }
+}

--- a/laravel-lsp/src/pattern_disk_cache.rs
+++ b/laravel-lsp/src/pattern_disk_cache.rs
@@ -31,12 +31,14 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use anyhow::{Context, Result};
 use dashmap::DashMap;
 use directories::ProjectDirs;
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -140,6 +142,19 @@ pub struct LoadResult {
     pub hierarchy: Vec<(PathBuf, Vec<ClassNode>)>,
 }
 
+/// Live counter the parallel freshness pass in [`load_into_reporting`]
+/// publishes into, so an async caller can render a moving progress bar
+/// during the (multi-second on a cold FS) 40k-entry load instead of one
+/// static message. `total` is `0` until the cache is decoded, then the
+/// entry count; `done` counts entries processed. Both are monotonic
+/// within a single load. All fields are atomics so the rayon workers and
+/// the async reporter can touch them concurrently without a lock.
+#[derive(Default)]
+pub struct LoadProgress {
+    pub done: AtomicUsize,
+    pub total: AtomicUsize,
+}
+
 /// Where the cache file for `project_root` lives on disk. Returns `None`
 /// only if the user's home directory can't be resolved — every modern
 /// OS we support has one, so this is effectively infallible in practice.
@@ -187,9 +202,33 @@ fn read_mtime(path: &Path) -> Option<(u64, u32)> {
 ///
 /// Errors silently degrade to "no cache available": the calling warming
 /// flow handles that fine — it just parses everything from scratch.
+///
+/// Thin wrapper over [`load_into_reporting`] with no progress plumbing —
+/// the entry point for callers (and tests) that don't render a bar.
 pub fn load_into(
     pattern_cache: &Arc<DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>,
     project_root: &Path,
+) -> LoadResult {
+    load_into_reporting(pattern_cache, project_root, None)
+}
+
+/// Same as [`load_into`], but publishes live per-entry counts into
+/// `progress` (when `Some`) so an async caller can render a moving bar
+/// during the freshness pass.
+///
+/// The pass is parallelized with rayon: on a large project the cache
+/// holds ~40k entries (source + vendor), and each one needs an
+/// independent mtime stat (a filesystem `metadata` call — the dominant
+/// cost on a cold FS cache) plus a position-index rebuild. Serially that
+/// was a multi-second startup stall; `into_par_iter` fans it across the
+/// rayon pool. The result is identical to a serial pass — DashMap inserts
+/// are lock-free, the counters are atomics, and the surfaced hierarchy is
+/// order-independent (the caller bulk-imports it as a set) — so the only
+/// observable change is that it finishes sooner.
+pub fn load_into_reporting(
+    pattern_cache: &Arc<DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>,
+    project_root: &Path,
+    progress: Option<&LoadProgress>,
 ) -> LoadResult {
     let Some(path) = cache_file_path(project_root) else {
         return LoadResult::default();
@@ -217,31 +256,57 @@ pub fn load_into(
         return LoadResult::default();
     }
 
-    let mut result = LoadResult::default();
-    for (path, entry) in cache.entries {
-        // Stat the file. If it's gone, or its mtime differs from the
-        // cached value, drop the entry — warming will re-parse it.
-        match read_mtime(&path) {
-            Some((s, n)) if s == entry.mtime_secs && n == entry.mtime_nanos => {
-                // Fresh: rebuild the position index (we skipped persisting
-                // it because it duplicates the Vec data) and insert.
-                let mut patterns = entry.patterns;
-                patterns.build_position_index();
-                // Surface the file's hierarchy nodes so the caller can
-                // re-import them — the index is otherwise empty on a warm
-                // start (no parse runs for disk-restored files).
-                if !entry.nodes.is_empty() {
-                    result.hierarchy.push((path.clone(), entry.nodes));
-                }
-                pattern_cache.insert(path, (0, Arc::new(patterns)));
-                result.restored += 1;
-            }
-            _ => {
-                result.dropped += 1;
-            }
-        }
+    // Publish the denominator now that the cache is decoded, so the async
+    // reporter can switch from an indeterminate message to "done of total"
+    // the moment the (fast) decode finishes and the (slow) stat pass runs.
+    if let Some(p) = progress {
+        p.total.store(cache.entries.len(), Ordering::Relaxed);
     }
-    result
+
+    // Freshness pass, parallelized. Each entry is validated, and fresh
+    // ones are rebuilt + inserted, independently; the closure surfaces the
+    // restored entry's hierarchy nodes (or `None`) and bumps the shared
+    // counters. `collect` gathers the hierarchy into a Vec whose order
+    // doesn't matter — it's imported as a set.
+    let restored = AtomicUsize::new(0);
+    let dropped = AtomicUsize::new(0);
+    let hierarchy: Vec<(PathBuf, Vec<ClassNode>)> = cache
+        .entries
+        .into_par_iter()
+        .filter_map(|(path, entry)| {
+            // Stat the file. If it's gone, or its mtime differs from the
+            // cached value, drop the entry — warming will re-parse it.
+            let node_entry = match read_mtime(&path) {
+                Some((s, n)) if s == entry.mtime_secs && n == entry.mtime_nanos => {
+                    // Fresh: rebuild the position index (we skipped persisting
+                    // it because it duplicates the Vec data) and insert.
+                    let mut patterns = entry.patterns;
+                    patterns.build_position_index();
+                    // Surface the file's hierarchy nodes so the caller can
+                    // re-import them — the index is otherwise empty on a warm
+                    // start (no parse runs for disk-restored files).
+                    let node_entry = (!entry.nodes.is_empty()).then(|| (path.clone(), entry.nodes));
+                    pattern_cache.insert(path, (0, Arc::new(patterns)));
+                    restored.fetch_add(1, Ordering::Relaxed);
+                    node_entry
+                }
+                _ => {
+                    dropped.fetch_add(1, Ordering::Relaxed);
+                    None
+                }
+            };
+            if let Some(p) = progress {
+                p.done.fetch_add(1, Ordering::Relaxed);
+            }
+            node_entry
+        })
+        .collect();
+
+    LoadResult {
+        restored: restored.into_inner(),
+        dropped: dropped.into_inner(),
+        hierarchy,
+    }
 }
 
 /// Persist every entry currently in `pattern_cache` to disk, stamped
@@ -300,10 +365,25 @@ pub fn save_from(
     if let Some(parent) = cache_path.parent() {
         std::fs::create_dir_all(parent).context("could not create cache directory")?;
     }
-    // Write to a temp file then rename — atomic on POSIX, so a crash
-    // mid-save leaves the previous cache intact rather than a truncated
-    // one we'd fail to decode on next load.
-    let tmp = cache_path.with_extension("bin.tmp");
+    // Write to a PER-CALL unique temp file, then atomically rename it onto
+    // the cache path. Atomic-rename-on-POSIX gives two guarantees at once:
+    //   1. Crash safety — a crash mid-write leaves the previous cache
+    //      intact rather than a truncated file we'd fail to decode.
+    //   2. Concurrent-save safety — the save now runs spawned/background
+    //      (see the warming path), so a reindex can start a second save
+    //      while a prior one is still writing. A SHARED tmp path would let
+    //      the two interleave their bytes into one file and corrupt it; a
+    //      unique suffix per call keeps them disjoint, and the two renames
+    //      simply race to last-writer-wins on a complete, valid file.
+    // The suffix combines the process id with a monotonic counter so it's
+    // unique across concurrent saves within this process.
+    static SAVE_SEQ: AtomicUsize = AtomicUsize::new(0);
+    let unique = format!(
+        "bin.tmp.{}.{}",
+        std::process::id(),
+        SAVE_SEQ.fetch_add(1, Ordering::Relaxed)
+    );
+    let tmp = cache_path.with_extension(unique);
     std::fs::write(&tmp, &encoded).context("write tmp cache file failed")?;
     std::fs::rename(&tmp, &cache_path).context("rename tmp cache file failed")?;
 

--- a/laravel-lsp/src/pattern_disk_cache.rs
+++ b/laravel-lsp/src/pattern_disk_cache.rs
@@ -91,7 +91,15 @@ use crate::salsa_impl::ParsedPatternsData;
 ///        re-parse. The envelope SHAPE didn't change — only the extraction
 ///        OUTPUT — which is exactly why an output-affecting change must
 ///        bump this even when serde would happily decode the old bytes.
-const SCHEMA_VERSION: u32 = 10;
+///   v11 — M1 single-parse capture: `ParsedPatternsData` grew a
+///        `member_context` (per-site receiver recipes + view-render plans +
+///        Volt surface), compiled at parse so the magic build stops re-reading
+///        target files. bincode is non-self-describing, so a v10 entry lacks
+///        those bytes entirely — stale slim entries must re-parse rather than
+///        mis-decode. The bump also guarantees every restored non-vendor entry
+///        carries context, so no "refs present but context missing" state can
+///        exist on the resolve path.
+const SCHEMA_VERSION: u32 = 11;
 
 const CACHE_FILENAME: &str = "pattern_cache.bin";
 

--- a/laravel-lsp/src/pattern_disk_cache/tests.rs
+++ b/laravel-lsp/src/pattern_disk_cache/tests.rs
@@ -200,6 +200,186 @@ fn hierarchy_nodes_survive_save_and_load() {
 }
 
 #[test]
+fn concurrent_saves_do_not_corrupt_the_cache() {
+    // The save now runs spawned/background, so a reindex can start a second
+    // `save_from` while a prior one is still writing. Each save must use a
+    // per-call unique temp file so the two can't interleave bytes into one
+    // file — they simply race to last-writer-wins on a complete, valid one.
+    // Two threads hammer the same project root; a shared temp path would
+    // intermittently leave a corrupt (undecodable) cache here.
+    let project = TempDir::new().unwrap();
+    let file = touch(project.path(), "shared.blade.php", "<x-foo/>");
+    let root = project.path().to_path_buf();
+
+    let handles: Vec<_> = (0..2)
+        .map(|k| {
+            let root = root.clone();
+            let file = file.clone();
+            std::thread::spawn(move || {
+                for _ in 0..50 {
+                    // Each save references the same real file, so the
+                    // restored count is a deterministic 1 whichever rename
+                    // wins; only the pattern payload differs between writers.
+                    let cache = Arc::new(DashMap::new());
+                    cache.insert(file.clone(), (0, Arc::new(fake_patterns(&format!("v{k}")))));
+                    save_from(&cache, &Default::default(), &root).unwrap();
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // The on-disk cache must be a complete, decodable file — never a
+    // truncated interleave of the two racing writers.
+    let restored_cache = Arc::new(DashMap::new());
+    let lr = load_into(&restored_cache, project.path());
+    assert_eq!(
+        lr.restored, 1,
+        "final cache decodes to the one shared entry"
+    );
+    assert_eq!(lr.dropped, 0);
+    assert!(restored_cache.contains_key(&file));
+}
+
+#[test]
+fn parallel_load_matches_serial_for_mixed_fixture() {
+    // The freshness pass is now parallel (rayon). It must produce the
+    // EXACT same outcome as the serial logic it replaced for a fixture
+    // mixing fresh (unchanged), stale (mtime-bumped), and missing
+    // (deleted) entries: same restored set, same restored/dropped counts,
+    // same surfaced hierarchy (order-independent).
+    let project = TempDir::new().unwrap();
+    let cache = Arc::new(DashMap::new());
+
+    // Enough entries that rayon actually splits the work across threads.
+    let fresh_src = |i: usize| format!("<?php\nnamespace App;\nclass Fresh{i} {{}}\n");
+    let fresh: Vec<PathBuf> = (0..50)
+        .map(|i| {
+            let p = touch(project.path(), &format!("Fresh{i}.php"), &fresh_src(i));
+            cache.insert(
+                p.clone(),
+                (0, Arc::new(fake_patterns(&format!("fresh{i}")))),
+            );
+            p
+        })
+        .collect();
+    let stale: Vec<PathBuf> = (0..20)
+        .map(|i| {
+            let p = touch(project.path(), &format!("Stale{i}.php"), "<?php class S {}");
+            cache.insert(
+                p.clone(),
+                (0, Arc::new(fake_patterns(&format!("stale{i}")))),
+            );
+            p
+        })
+        .collect();
+    let missing: Vec<PathBuf> = (0..10)
+        .map(|i| {
+            let p = touch(
+                project.path(),
+                &format!("Missing{i}.php"),
+                "<?php class M {}",
+            );
+            cache.insert(
+                p.clone(),
+                (0, Arc::new(fake_patterns(&format!("missing{i}")))),
+            );
+            p
+        })
+        .collect();
+
+    // Real hierarchy nodes for the fresh files, so we can assert they're
+    // surfaced — and only they are.
+    let mut hierarchy = std::collections::HashMap::new();
+    for (i, p) in fresh.iter().enumerate() {
+        hierarchy.insert(
+            p.clone(),
+            crate::class_hierarchy_index::classes_in_file(p, &fresh_src(i)),
+        );
+    }
+    save_from(&cache, &hierarchy, project.path()).unwrap();
+
+    // Invalidate: bump the stale files' mtime, delete the missing ones.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    for p in &stale {
+        std::fs::write(p, "<?php class S2 {}").unwrap();
+    }
+    for p in &missing {
+        std::fs::remove_file(p).unwrap();
+    }
+
+    let restored_cache = Arc::new(DashMap::new());
+    let lr = load_into(&restored_cache, project.path());
+
+    assert_eq!(lr.restored, fresh.len(), "all fresh entries restored");
+    assert_eq!(
+        lr.dropped,
+        stale.len() + missing.len(),
+        "stale + missing entries dropped"
+    );
+
+    // Exactly the fresh files landed in the live cache.
+    assert_eq!(restored_cache.len(), fresh.len());
+    for p in &fresh {
+        assert!(
+            restored_cache.contains_key(p),
+            "fresh file missing from cache: {p:?}"
+        );
+    }
+    for p in stale.iter().chain(&missing) {
+        assert!(
+            !restored_cache.contains_key(p),
+            "invalid file leaked into cache: {p:?}"
+        );
+    }
+
+    // Hierarchy surfaced for exactly the fresh files (set equality — the
+    // parallel collect gives no ordering guarantee, and none is needed).
+    let surfaced: std::collections::HashSet<PathBuf> =
+        lr.hierarchy.iter().map(|(p, _)| p.clone()).collect();
+    let expected: std::collections::HashSet<PathBuf> = fresh.iter().cloned().collect();
+    assert_eq!(
+        surfaced, expected,
+        "hierarchy surfaced for exactly the fresh files"
+    );
+}
+
+#[test]
+fn load_progress_counts_every_entry() {
+    use std::sync::atomic::Ordering;
+
+    let project = TempDir::new().unwrap();
+    let cache = Arc::new(DashMap::new());
+    for i in 0..30 {
+        let p = touch(project.path(), &format!("F{i}.php"), "<?php class F {}");
+        cache.insert(p, (0, Arc::new(fake_patterns(&format!("f{i}")))));
+    }
+    save_from(&cache, &Default::default(), project.path()).unwrap();
+
+    let progress = LoadProgress::default();
+    let restored_cache = Arc::new(DashMap::new());
+    let lr = load_into_reporting(&restored_cache, project.path(), Some(&progress));
+
+    assert_eq!(
+        progress.total.load(Ordering::Relaxed),
+        30,
+        "total = decoded entry count, published before the pass"
+    );
+    assert_eq!(
+        progress.done.load(Ordering::Relaxed),
+        30,
+        "every entry increments done exactly once"
+    );
+    assert_eq!(
+        progress.done.load(Ordering::Relaxed),
+        lr.restored + lr.dropped,
+        "done accounts for every entry as restored or dropped"
+    );
+}
+
+#[test]
 fn member_access_refs_survive_save_and_load() {
     // The real bug hunt: views round-trip through the disk cache, but do
     // member accesses? If this fails, bincode is dropping them and warm

--- a/laravel-lsp/src/pattern_indexer.rs
+++ b/laravel-lsp/src/pattern_indexer.rs
@@ -60,12 +60,12 @@ pub fn parse_owned_with_hierarchy(
         data.is_volt = crate::livewire_resolver::source_contains_volt_signature(text);
         // Capture `@foreach` loops so the magic build can type loop variables
         // (`{{ $user->email }}` in `@foreach($users as $user)`) without a read.
+        // The `@foreach`-iterable member accesses are pushed AFTER the embedded
+        // PHP regions below, so `member_access_refs` ends in the SAME order the
+        // actor's `handle_get_patterns` produces (region accesses, then
+        // iterable accesses) — otherwise a file's emitted entry order would
+        // depend on which constructor built it (warm build vs save-refresh).
         data.blade_loops = crate::salsa_impl::blade_loop_vars(text);
-        // Capture member accesses inside `@foreach` iterables (`$this->entities`)
-        // — directive args the `{{ }}`/PHP capture below would otherwise miss.
-        for m in crate::salsa_impl::blade_loop_iterable_accesses(text) {
-            data.member_access_refs.push(std::sync::Arc::new(m));
-        }
         let lang = language_blade();
         if let Ok(tree) = parse_blade(text) {
             if let Ok(bp) = extract_all_blade_patterns(&tree, text, &lang) {
@@ -129,6 +129,13 @@ pub fn parse_owned_with_hierarchy(
             };
             push_php_patterns(&snippet, &mut data, Some((region.row, region.column)));
         }
+
+        // Member accesses inside `@foreach` iterables (`$this->entities`) —
+        // directive args the `{{ }}`/PHP region capture above misses. Pushed
+        // LAST to match the actor constructor's order (see the blade_loops note).
+        for m in crate::salsa_impl::blade_loop_iterable_accesses(text) {
+            data.member_access_refs.push(std::sync::Arc::new(m));
+        }
     }
 
     // Full-file PHP parse. ONLY for .php files.
@@ -147,15 +154,39 @@ pub fn parse_owned_with_hierarchy(
     // All Blade-embedded PHP extraction happens above via
     // `extract_php_regions` + `<?php `-wrapped per-region parsing,
     // which is fast and accurate.
-    if !is_blade {
+    // Full-file PHP parse kept so the M1 capture below reuses it (no second
+    // tree-sitter pass). `None` for Blade — see the note above on why parsing a
+    // `.blade.php` as PHP is pathologically slow.
+    let php_tree = if !is_blade {
+        parse_php(text).ok()
+    } else {
+        None
+    };
+    if let Some(tree) = &php_tree {
         let lang_php = language_php();
-        if let Ok(tree) = parse_php(text) {
-            if let Ok(patterns) = extract_all_php_patterns(&tree, text, &lang_php) {
-                push_php_patterns(&patterns, &mut data, None);
-            }
-            // Class-hierarchy nodes share this same PHP parse.
-            nodes = classes_from_tree(path, &tree, text);
+        if let Ok(patterns) = extract_all_php_patterns(tree, text, &lang_php) {
+            push_php_patterns(&patterns, &mut data, None);
         }
+        // Class-hierarchy nodes share this same PHP parse.
+        nodes = classes_from_tree(path, tree, text);
+    }
+
+    // M1 single-parse capture: compile this file's own-source resolution
+    // context now (tree/source in hand) so the whole-project magic build never
+    // re-reads or re-parses it. Non-vendor only — the build passes all skip
+    // vendor, so capturing there would be wasted memory. Runs after the
+    // `member_access_refs` above are final so `sites` stays positionally
+    // parallel to them.
+    let is_vendor = path.components().any(|c| c.as_os_str() == "vendor");
+    if !is_vendor {
+        data.member_context = crate::member_capture::capture_member_context(
+            path,
+            text,
+            php_tree.as_ref(),
+            &data.member_access_refs,
+            data.is_volt,
+        )
+        .map(Box::new);
     }
 
     data.build_position_index();

--- a/laravel-lsp/src/pattern_indexer/tests.rs
+++ b/laravel-lsp/src/pattern_indexer/tests.rs
@@ -204,3 +204,51 @@ fn blade_directive_attribute_param_member_access_is_captured() {
         data.member_access_refs
     );
 }
+
+// ─── M1 single-parse capture: member_context gating via THIS constructor ──
+//
+// The vendor gate + zero-cost `None` behaviour must hold through the real
+// `parse_owned_with_hierarchy` path (the parallel warm constructor), not just
+// the `capture_member_context` helper. The v11 disk invariant depends on
+// vendor files carrying no context.
+
+#[test]
+fn parse_owned_captures_context_for_a_member_reader() {
+    let path = PathBuf::from("/proj/app/Http/Controllers/C.php");
+    let src = "<?php\nnamespace App;\nclass C { public function f(\\App\\Models\\User $u) { return $u->email; } }\n";
+    let (data, _) = parse_owned_with_hierarchy(&path, src);
+    let ctx = data
+        .member_context
+        .as_ref()
+        .expect("a non-vendor member reader must capture context");
+    assert_eq!(
+        ctx.sites.len(),
+        data.member_access_refs.len(),
+        "sites must stay positionally parallel to member_access_refs"
+    );
+}
+
+#[test]
+fn parse_owned_skips_capture_for_vendor() {
+    // Same source, under a `vendor/` path → NO context (the build passes skip
+    // vendor, so capturing there is wasted; the disk cache relies on this).
+    let path = PathBuf::from("/proj/vendor/acme/pkg/src/C.php");
+    let src = "<?php\nnamespace Acme;\nclass C { public function f(\\App\\Models\\User $u) { return $u->email; } }\n";
+    let (data, _) = parse_owned_with_hierarchy(&path, src);
+    assert!(
+        !data.member_access_refs.is_empty(),
+        "the file DOES have a member access (proving the gate, not the parse, drops context)"
+    );
+    assert!(
+        data.member_context.is_none(),
+        "a vendor file must capture no context"
+    );
+}
+
+#[test]
+fn parse_owned_no_context_for_pattern_free_file() {
+    let path = PathBuf::from("/proj/app/Widget.php");
+    let src = "<?php\nnamespace App;\nclass Widget { public function noop() {} }\n";
+    let (data, _) = parse_owned_with_hierarchy(&path, src);
+    assert!(data.member_context.is_none());
+}

--- a/laravel-lsp/src/reindex.rs
+++ b/laravel-lsp/src/reindex.rs
@@ -1,0 +1,170 @@
+//! The user-triggerable "Reindex project" surface (`laravel.reindexProject`).
+//!
+//! # Why a code action and not a command-palette command
+//!
+//! Zed extensions cannot register command-palette commands (verified against
+//! `zed_extension_api` 0.7.0 — the API has no such hook). The native mechanism
+//! an LSP server *does* have is a `source`-kind code action carrying a
+//! `workspace/executeCommand` command: Zed shows it in the code-actions menu
+//! (`cmd-.`) for any file the server is attached to, regardless of cursor
+//! position or diagnostics. So "Laravel: Reindex project" is offered as a
+//! global code action in every PHP/Blade file, and selecting it sends the
+//! `laravel.reindexProject` command back to us, which runs the full cold
+//! reindex (see `trigger_reindex` in `main.rs`).
+//!
+//! # Surviving the client's `only` filter
+//!
+//! A `textDocument/codeAction` request may carry `context.only`, a list of
+//! [`CodeActionKind`]s the client wants back. Kinds are hierarchical: per the
+//! LSP spec, a requested `"source"` matches our `"source.reindexProject"`
+//! (dotted-segment prefix), and an empty kind matches everything. We honor
+//! that filter in [`global_code_actions`] so an automated flow that requests a
+//! narrow kind (e.g. `source.fixAll` on save) never pulls in a reindex, while
+//! the manual code-actions menu — which requests actions without a kind filter
+//! — always gets it.
+//!
+//! One client-side caveat lives *above* this filter, in the editor UI and so
+//! not verifiable from this repo: VS Code (and editors that mirror its
+//! semantics) route pure `source.*` actions to a separate "Source Action…"
+//! command rather than the quick-fix (`cmd-.`) lightbulb. If Zed does the same,
+//! this action would be reachable but not from the `cmd-.` menu. That's a
+//! deliberate risk in the chosen `source.reindexProject` kind: the fallback, if
+//! a live Zed doesn't surface it in `cmd-.`, is to switch [`REINDEX_ACTION_KIND`]
+//! to `CodeActionKind::EMPTY` (no kind — always shown in the menu) or
+//! `refactor`. The `only`-filter logic here already admits every one of those
+//! kinds, so that swap is a one-line change with no other code impact.
+//!
+//! This module holds the pure, testable pieces: the command/action constants,
+//! the capability options, the `only`-filter logic, the action builder, and
+//! the [`IndexingFlightGuard`] that serializes indexing passes. The async
+//! orchestration (cache clearing + pipeline re-run) lives in `main.rs`.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, Command, ExecuteCommandOptions,
+    WorkDoneProgressOptions,
+};
+
+/// The `workspace/executeCommand` command id that triggers a full cold
+/// reindex. Declared in the server capabilities so clients know to route
+/// it back to us.
+pub const REINDEX_COMMAND: &str = "laravel.reindexProject";
+
+/// The kind of the reindex code action. A custom sub-kind of `source` —
+/// clients group `source.*` actions separately from quick-fixes, and the
+/// specific tail lets a client target exactly this action if it wants to.
+pub const REINDEX_ACTION_KIND: CodeActionKind = CodeActionKind::new("source.reindexProject");
+
+/// The user-visible menu label. Prefixed with "Laravel:" because Zed's
+/// code-actions menu mixes actions from every attached language server.
+pub const REINDEX_ACTION_TITLE: &str = "Laravel: Reindex project";
+
+/// The `execute_command_provider` server capability: the exact list of
+/// commands this server implements. Kept here (next to the command id)
+/// so the capability and the `execute_command` dispatch can't drift apart.
+pub fn execute_command_options() -> ExecuteCommandOptions {
+    ExecuteCommandOptions {
+        commands: vec![REINDEX_COMMAND.to_string()],
+        work_done_progress_options: WorkDoneProgressOptions::default(),
+    }
+}
+
+/// The always-available code actions for a `textDocument/codeAction` request.
+///
+/// Returns the "Laravel: Reindex project" action when the file is PHP/Blade
+/// and the request's `only` filter (if any) admits `source`-kind actions;
+/// otherwise an empty vec. Position within the file is deliberately ignored —
+/// the action is global by design, so it's reachable from anywhere.
+pub fn global_code_actions(
+    uri_path: &str,
+    only: Option<&[CodeActionKind]>,
+) -> Vec<CodeActionOrCommand> {
+    // `.ends_with(".php")` covers `.blade.php` too. Non-PHP files the LSP is
+    // attached to (`.env`, `phpunit.xml`, …) don't get the action: reindexing
+    // from them would work, but offering project-wide actions in a dotenv
+    // file reads as noise.
+    if !uri_path.ends_with(".php") || !reindex_action_allowed(only) {
+        return Vec::new();
+    }
+    vec![CodeActionOrCommand::CodeAction(CodeAction {
+        title: REINDEX_ACTION_TITLE.to_string(),
+        kind: Some(REINDEX_ACTION_KIND),
+        // No `edit`: the action's entire effect is the command round-trip.
+        // The client sends `workspace/executeCommand` with this command id
+        // when the user picks the action.
+        command: Some(Command {
+            title: REINDEX_ACTION_TITLE.to_string(),
+            command: REINDEX_COMMAND.to_string(),
+            arguments: None,
+        }),
+        diagnostics: None,
+        edit: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    })]
+}
+
+/// Does the request's `only` filter admit the reindex action?
+///
+/// `None` means "no filter — send everything". A non-empty list admits us
+/// when any requested kind hierarchically matches ours: exact match, an
+/// empty kind (matches all), or a dotted-segment prefix (`"source"` matches
+/// `"source.reindexProject"`, but `"sourcery"` must not — hence matching on
+/// `"{kind}."`, not a bare `starts_with`).
+fn reindex_action_allowed(only: Option<&[CodeActionKind]>) -> bool {
+    only.is_none_or(|kinds| {
+        kinds.iter().any(|kind| {
+            let kind = kind.as_str();
+            kind.is_empty()
+                || kind == REINDEX_ACTION_KIND.as_str()
+                || REINDEX_ACTION_KIND
+                    .as_str()
+                    .starts_with(&format!("{kind}."))
+        })
+    })
+}
+
+/// RAII guard serializing indexing passes: at most one may run at a time.
+///
+/// [`IndexingFlightGuard::try_acquire`] atomically flips the shared flag
+/// `false → true`; while the guard lives, every other `try_acquire` on the
+/// same flag fails, so a second `laravel.reindexProject` trigger (or a
+/// reindex racing the initial startup warm) no-ops instead of running two
+/// warming pipelines over the same shared caches.
+///
+/// The flag is released in `Drop` — a deliberate Rust idiom: whichever way
+/// the owning task ends (normal completion, early `return`, or a panic
+/// unwinding the stack), the guard is dropped and the flag clears. No code
+/// path can forget to release it, so a crashed warming task can never brick
+/// reindexing for the rest of the session.
+pub struct IndexingFlightGuard {
+    flag: Arc<AtomicBool>,
+}
+
+impl IndexingFlightGuard {
+    /// Try to claim the indexing slot. Returns `None` if another pass
+    /// already holds it.
+    ///
+    /// `compare_exchange(false, true, ..)` is the atomic "check and set in
+    /// one step": unlike a separate `load` + `store`, two concurrent callers
+    /// can't both observe `false` and both proceed. `SeqCst` is the
+    /// strongest (and simplest to reason about) memory ordering; the flag is
+    /// touched a handful of times per session, so its cost is irrelevant.
+    pub fn try_acquire(flag: Arc<AtomicBool>) -> Option<Self> {
+        flag.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+            .then_some(Self { flag })
+    }
+}
+
+impl Drop for IndexingFlightGuard {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/reindex/tests.rs
+++ b/laravel-lsp/src/reindex/tests.rs
@@ -1,0 +1,140 @@
+//! Tests for the reindex command surface: the declared capability, the
+//! global code action (file-type gate + `only`-filter semantics), and the
+//! concurrency guard. Each test targets a seam a regression would actually
+//! break: dropping the command from the capability, losing the action from
+//! the `cmd-.` menu, mis-matching hierarchical kinds, or letting two
+//! indexing passes run concurrently.
+
+use super::*;
+
+/// Unwrap the single expected reindex action or panic with context.
+fn only_action(actions: Vec<CodeActionOrCommand>) -> CodeAction {
+    assert_eq!(actions.len(), 1, "expected exactly one global action");
+    match actions.into_iter().next().unwrap() {
+        CodeActionOrCommand::CodeAction(action) => action,
+        CodeActionOrCommand::Command(_) => panic!("expected a CodeAction, got a bare Command"),
+    }
+}
+
+#[test]
+fn capability_declares_the_reindex_command() {
+    let options = execute_command_options();
+    assert_eq!(
+        options.commands,
+        vec![REINDEX_COMMAND.to_string()],
+        "server capability must declare exactly the reindex command"
+    );
+}
+
+#[test]
+fn php_file_gets_the_reindex_action() {
+    let action = only_action(global_code_actions("/app/Models/User.php", None));
+    assert_eq!(action.title, REINDEX_ACTION_TITLE);
+    assert_eq!(action.kind, Some(REINDEX_ACTION_KIND));
+    let command = action.command.expect("action must carry the command");
+    assert_eq!(command.command, REINDEX_COMMAND);
+    assert!(
+        action.edit.is_none(),
+        "the action's effect is the command round-trip, never an edit"
+    );
+}
+
+#[test]
+fn blade_file_gets_the_reindex_action() {
+    let action = only_action(global_code_actions(
+        "/resources/views/welcome.blade.php",
+        None,
+    ));
+    assert_eq!(action.title, REINDEX_ACTION_TITLE);
+}
+
+#[test]
+fn non_php_files_get_nothing() {
+    for path in [
+        "/project/.env",
+        "/project/phpunit.xml",
+        "/resources/js/app.js",
+    ] {
+        assert!(
+            global_code_actions(path, None).is_empty(),
+            "{path} must not get the reindex action"
+        );
+    }
+}
+
+#[test]
+fn only_filter_none_admits_the_action() {
+    // Zed's cmd-. menu sends no `only` filter — this is the case that must
+    // never break, or the action disappears from the menu entirely.
+    assert!(!global_code_actions("/app/User.php", None).is_empty());
+}
+
+#[test]
+fn only_filter_source_prefix_admits_the_action() {
+    // Hierarchical matching: the parent kind `source` admits our sub-kind.
+    for kinds in [
+        vec![CodeActionKind::SOURCE],
+        vec![REINDEX_ACTION_KIND],
+        vec![CodeActionKind::EMPTY], // empty kind matches everything
+        vec![CodeActionKind::QUICKFIX, CodeActionKind::SOURCE], // any match wins
+    ] {
+        assert!(
+            !global_code_actions("/app/User.php", Some(&kinds)).is_empty(),
+            "only={kinds:?} must admit the reindex action"
+        );
+    }
+}
+
+#[test]
+fn only_filter_without_source_hides_the_action() {
+    for kinds in [
+        vec![CodeActionKind::QUICKFIX],
+        vec![CodeActionKind::SOURCE_FIX_ALL], // sibling sub-kind, not a parent
+        vec![CodeActionKind::new("sourcery")], // prefix of the string, not of the segments
+    ] {
+        assert!(
+            global_code_actions("/app/User.php", Some(&kinds)).is_empty(),
+            "only={kinds:?} must hide the reindex action"
+        );
+    }
+}
+
+#[test]
+fn flight_guard_admits_one_pass_at_a_time() {
+    let flag = Arc::new(AtomicBool::new(false));
+
+    let first = IndexingFlightGuard::try_acquire(flag.clone());
+    assert!(first.is_some(), "first acquire must succeed");
+    assert!(flag.load(Ordering::SeqCst), "flag is raised while held");
+
+    // A concurrent trigger while the first pass runs must no-op.
+    assert!(
+        IndexingFlightGuard::try_acquire(flag.clone()).is_none(),
+        "second acquire while the first is held must fail"
+    );
+
+    drop(first);
+    assert!(!flag.load(Ordering::SeqCst), "drop must release the flag");
+    assert!(
+        IndexingFlightGuard::try_acquire(flag).is_some(),
+        "after release the slot is free again"
+    );
+}
+
+#[test]
+fn flight_guard_releases_on_panic() {
+    // The Drop-based release is what keeps a crashed warming task from
+    // bricking reindex for the rest of the session — prove it survives
+    // an unwind, not just a clean drop.
+    let flag = Arc::new(AtomicBool::new(false));
+    let flag_for_panic = flag.clone();
+    let result = std::panic::catch_unwind(move || {
+        let _guard = IndexingFlightGuard::try_acquire(flag_for_panic).unwrap();
+        panic!("warming task died");
+    });
+    assert!(result.is_err(), "the closure must actually panic");
+    assert!(
+        IndexingFlightGuard::try_acquire(flag).is_some(),
+        "the flag must be released by the unwinding drop"
+    );
+}

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -3377,6 +3377,204 @@ pub struct MemberAccessReferenceData {
     pub confidence: Confidence,
 }
 
+// ─── M1 single-parse capture: per-file resolution context ──────────────────
+//
+// Captured at PARSE time (tree in hand) so the whole-project magic-member
+// resolve passes never re-read or re-parse a target file. Each site's `recipe`
+// encodes the INTRA-file half of receiver resolution as a small owned value;
+// the cross-file half (class→file lookup, `ClassView` analysis, facade
+// accessor, container binding registry, auth model) is completed at resolve
+// against the actor snapshots + memos. The engine that consumes this lives in
+// `member_resolver` (PHP sites) and `view_var_index` (view renders + Volt); it
+// mirrors the tree engine's control flow branch-for-branch so the resolved
+// entries + deps stay byte-identical to the re-parse path.
+//
+// Grows `ParsedPatternsData`, so `pattern_disk_cache::SCHEMA_VERSION` is bumped
+// (10 → 11): the bincode envelope is non-self-describing, so stale slim entries
+// must re-parse rather than mis-decode.
+
+/// A receiver expression's compiled resolution recipe — the intra-file half of
+/// [`member_resolver`]'s `resolve_receiver`. Cross-file completion happens at
+/// eval; each variant names exactly what stays deferred.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ReceiverRecipeData {
+    /// Fully resolved intra-file: flow-tracked variable, `$this`, typed
+    /// `$this->prop`, `foreach` element, or `self`/`static`. The final answer —
+    /// no cross-file work remains.
+    Resolved {
+        fqcn: String,
+        confidence: Confidence,
+    },
+    /// `auth()->user()` / `Auth::user()` / `request()->user()`. Resolves to the
+    /// configured auth model at eval; `fallback` is what the tree resolver would
+    /// try next when no auth model is configured (auth is checked BEFORE the
+    /// shape match, so its miss falls through to the rest of `resolve_receiver`).
+    AuthUser { fallback: Box<ReceiverRecipeData> },
+    /// A Gate-ability closure's first parameter — resolves to the auth model at
+    /// eval, or `None` (terminal: the variable arm tries nothing else).
+    GateClosureUser,
+    /// `app('key')` / `resolve('key')` — the container binding key. Concrete
+    /// looked up in the binding registry at eval.
+    ContainerKey(String),
+    /// A zero-arg Laravel helper (`view()`, `cache()`, …) — the helper name.
+    /// Concrete looked up via the helper→binding map at eval.
+    HelperBinding(String),
+    /// A static class-name receiver (`User::…`, `Auth::…`). `qualified` is the
+    /// namespace-resolved FQCN (computed at parse from the file aliases +
+    /// namespace); at eval the facade interception runs first (needs the facade
+    /// alias snapshot), then the class-index / macro-host gate.
+    StaticName {
+        raw: String,
+        qualified: String,
+        is_namespaced: bool,
+    },
+    /// `$obj->method()` — resolve `object`, then the method's declared return
+    /// type (read from the DECLARING class's file at eval — legitimately
+    /// cross-file).
+    MethodReturn {
+        object: Box<ReceiverRecipeData>,
+        method: String,
+    },
+    /// Nothing resolvable intra-file (the tree resolver returned `None`).
+    Unresolvable,
+}
+
+/// Per-site captured context, positionally parallel to
+/// `ParsedPatternsData.member_access_refs`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SiteContextData {
+    /// The receiver's compiled recipe.
+    pub recipe: ReceiverRecipeData,
+    /// The call-form builder-chain fallback recipe, present only when the direct
+    /// recipe might fail and the receiver roots in a resolvable chain
+    /// (`User::query()->active()`, `$user->posts()->active()`).
+    pub chain: Option<ChainRecipeData>,
+    /// The lexically enclosing class FQCN — per SITE (a file may hold several
+    /// classes, or an anonymous Volt class). Feeds the builder→enclosing-model
+    /// retry.
+    pub enclosing_class_fqcn: Option<String>,
+    /// Whether this receiver roots in the enclosing `scope*` method's parameter
+    /// — the gate for the builder retry.
+    pub is_scope_param_receiver: bool,
+}
+
+/// A call-form receiver's builder-chain fallback — the compiled form of
+/// `resolve_call_chain_receiver`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ChainRecipeData {
+    pub root: ChainRootData,
+    /// Member names walked from the receiver toward the root — checked against
+    /// the resolved class's relationships at eval for the relation-hop bail.
+    pub links: Vec<String>,
+}
+
+/// The root of a builder chain: an explicit static scope, or a nested receiver
+/// recipe for a variable/other root.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ChainRootData {
+    StaticScope {
+        qualified: String,
+        confidence: Confidence,
+        first_method: String,
+    },
+    Var(Box<ReceiverRecipeData>),
+}
+
+/// A `view()`-data value expression's compiled typing — either resolved
+/// intra-file (flow classifier hit) or a recipe to finish cross-file.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ValueExprPlanData {
+    /// The flow expression classifier resolved it (pure intra-file) — final.
+    Resolved {
+        fqcn: String,
+        confidence: Confidence,
+    },
+    /// Flow missed; the receiver resolver finishes it at eval.
+    Recipe(ReceiverRecipeData),
+}
+
+/// One `view('name', […])` render site's compiled plan (pass 1). `items` are in
+/// traversal order so the resolve replay reproduces last-wins map semantics.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ViewRenderPlanData {
+    pub view_name: String,
+    pub items: Vec<(String, ValueExprPlanData)>,
+}
+
+/// A Volt front-matter property plan, replayed in declaration order.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum VoltPropPlanData {
+    /// Typed public property — authoritative, overwrites (`insert`).
+    TypedProp { name: String, fqcn: String },
+    /// A single direct `or_insert` value (a `mount()` `$this->prop = $param`
+    /// assignment, or a `$x = computed(...)` binding). Writes straight into the
+    /// surface with `or_insert` — first write per key wins, both within and
+    /// across these items (the tree engine's `out.entry(k).or_insert(...)`).
+    OrInsert {
+        name: String,
+        plan: ValueExprPlanData,
+    },
+    /// ONE `with()`/`state()`/`render()` HANDLER's ordered value items. The tree
+    /// engine resolves each into a temp map with `insert` — so WITHIN the
+    /// handler it is last-RESOLVING-wins (an unresolvable later value does NOT
+    /// overwrite an earlier resolved one) — then folds the temp into the surface
+    /// with `or_insert` (first-HANDLER-wins). Because resolvability is cross-file
+    /// (eval-time only), the items are kept in ORDER here and gated at eval; they
+    /// are NOT pre-deduped at capture.
+    OrInsertGroup(Vec<(String, ValueExprPlanData)>),
+    /// `#[Computed]` method — prefer the body-inferred type, else the declared
+    /// return type; `or_insert`.
+    Computed {
+        name: String,
+        body: Option<ValueExprPlanData>,
+        declared: Option<String>,
+    },
+}
+
+/// The Volt component's compiled front-matter surface (item 8).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VoltSurfaceData {
+    pub items: Vec<VoltPropPlanData>,
+    /// The front-matter block's own `use` aliases — the surface's value recipes
+    /// resolve facades against THESE (not the file-level, empty-for-Blade map).
+    pub aliases: HashMap<String, String>,
+}
+
+/// A Livewire/Volt component's identity + declared member names, when both are
+/// capturable intra-file. `members` is `None` for a multi-file-component Blade
+/// TEMPLATE, whose class lives in a sibling `.php` (read at eval — legitimately
+/// cross-file).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ComponentContextData {
+    pub key: String,
+    pub members: Option<Vec<String>>,
+}
+
+/// Everything the resolve passes need from a file's own source, captured once at
+/// parse. `None` on `ParsedPatternsData` for files with nothing to resolve
+/// (icon Blade templates, vendor files) — a single tag byte, honoring the
+/// zero-added-cost budget for pattern-free files.
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct MemberContextData {
+    /// File `use`-alias map (alias → FQCN), persisted once instead of the two
+    /// per-file re-derivations the resolve + hierarchy passes did. Empty for
+    /// Blade files (their chain receivers compile from `use`-less snippets).
+    /// The only eval-time consumer is facade resolution on a `StaticName`
+    /// recipe; namespace-qualification is baked into each recipe at compile (so
+    /// the file's `namespace …;` needs no separate field — it survives as each
+    /// `StaticName`'s `qualified` + `is_namespaced`).
+    pub aliases: HashMap<String, String>,
+    /// One entry per `member_access_refs` element, in the SAME order — the
+    /// positionally-parallel invariant the resolve pass relies on.
+    pub sites: Vec<SiteContextData>,
+    /// `view('name', […])` render structure per controller (pass 1).
+    pub view_renders: Vec<ViewRenderPlanData>,
+    /// Volt front-matter surface (item 8).
+    pub volt_surface: Option<VoltSurfaceData>,
+    /// Livewire/Volt component identity + member names (item 8).
+    pub component: Option<ComponentContextData>,
+}
+
 /// Hover payload for a resolved magic member (M6). Crosses the Salsa async
 /// boundary, so it owns plain data (no lifetimes / borrows). `decl_file` /
 /// `decl_line` locate the declaration for a source link — `None` when the
@@ -4273,6 +4471,18 @@ pub struct ParsedPatternsData {
     /// (source in hand). Empty for `.php` files.
     #[serde(default)]
     pub blade_loops: Vec<BladeLoopVar>,
+    /// M1 single-parse capture: the file's own-source resolution context —
+    /// per-site receiver recipes, view-render plans, and the Volt surface —
+    /// compiled once at parse so the magic-member resolve passes never re-read
+    /// or re-parse this file. `None` for files with nothing to resolve (icon
+    /// Blade templates, vendor files): a single tag byte, so pattern-free files
+    /// pay ~zero. `member_context.sites` is positionally parallel to
+    /// `member_access_refs` when present. `#[serde(default)]` keeps older
+    /// disk-cache entries decodable in principle, but the growth of this struct
+    /// is guarded by the `pattern_disk_cache` SCHEMA_VERSION bump (10 → 11) —
+    /// bincode is non-self-describing, so stale slim entries re-parse.
+    #[serde(default)]
+    pub member_context: Option<Box<MemberContextData>>,
     /// Sorted index of all patterns by (line, column) for O(log n) lookup.
     /// Skipped during (de)serialization — when loading from the on-disk
     /// cache, the caller must invoke `build_position_index()` to rebuild
@@ -7332,11 +7542,20 @@ impl SalsaActor {
             .path(&self.db)
             .to_string_lossy()
             .ends_with(".blade.php");
-        if !path_is_blade {
-            if let Ok(tree) = parse_php(text) {
+        // Parse the full-file PHP tree ONCE and keep it — the M1 capture below
+        // reuses it (no second tree-sitter pass) to compile per-site receiver
+        // recipes. `None` for Blade (parsing a `.blade.php` as PHP is
+        // pathologically slow — see `pattern_indexer`).
+        let php_tree = if !path_is_blade {
+            parse_php(text).ok()
+        } else {
+            None
+        };
+        if let Some(tree) = &php_tree {
+            {
                 let lang = language_php();
 
-                if let Ok(php_patterns) = extract_all_php_patterns(&tree, text, &lang) {
+                if let Ok(php_patterns) = extract_all_php_patterns(tree, text, &lang) {
                     for r in php_patterns.route_calls {
                         route_refs.push(Arc::new(RouteReferenceData {
                             name: r.route_name.to_string(),
@@ -7419,7 +7638,7 @@ impl SalsaActor {
                 // Extract Eloquent / DB query builder chains from the same
                 // parsed tree. No second parse — we reuse the `tree` already
                 // produced above for route/url/action/feature extraction.
-                for chain in crate::query_chain::extract_chains(&tree, text) {
+                for chain in crate::query_chain::extract_chains(tree, text) {
                     chains.push(Arc::new(chain));
                 }
 
@@ -7429,7 +7648,7 @@ impl SalsaActor {
                 // already cached — without this, an open/edited model's own
                 // class is absent from the hierarchy, so magic-member
                 // resolution (`$this->email` → its declaring class) fails.
-                let nodes = crate::class_hierarchy_index::classes_from_tree(path, &tree, text);
+                let nodes = crate::class_hierarchy_index::classes_from_tree(path, tree, text);
                 // Invalidate the cached class→file snapshot only when this
                 // file's set of declared FQCNs actually changed — a method-body
                 // edit leaves it intact, keeping the next snapshot O(1).
@@ -7442,7 +7661,7 @@ impl SalsaActor {
                     self.class_files_snapshot = None;
                 }
             }
-        } // end if !path_is_blade
+        } // end if let Some(tree) = &php_tree  (non-Blade full-file PHP)
 
         // Blade-embedded PHP: extract route/url/action/feature from every
         // `{{ }}` / `{!! !!}` / `@php` region. Mirrors the Salsa-cached
@@ -7672,8 +7891,29 @@ impl SalsaActor {
             } else {
                 Vec::new()
             },
+            // Populated below once `data` is in hand — capture needs the final
+            // `member_access_refs` (parallel `sites`) and reuses the PHP tree.
+            member_context: None,
             sorted_positions: Vec::new(),
         };
+
+        // M1 single-parse capture: compile this file's own-source resolution
+        // context now, while the tree/source are in hand, so the whole-project
+        // magic build never re-reads or re-parses it. Non-vendor only — the
+        // build passes all skip vendor, so capturing there would be wasted
+        // memory. `.php` reuses `php_tree`; Blade compiles from receiver-text
+        // snippets + front-matter (there's no full-file PHP tree for Blade).
+        let is_vendor = path.components().any(|c| c.as_os_str() == "vendor");
+        if !is_vendor {
+            data.member_context = crate::member_capture::capture_member_context(
+                path,
+                text,
+                php_tree.as_ref(),
+                &data.member_access_refs,
+                data.is_volt,
+            )
+            .map(Box::new);
+        }
 
         // Build the sorted position index for O(log n) lookups
         data.build_position_index();

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -4589,6 +4589,11 @@ pub enum SalsaRequest {
     /// handlers, processed lazily on next query.
     BuildSymbolIndex { reply: oneshot::Sender<usize> },
 
+    /// Wipe every in-memory reference index for a cold reindex (pattern
+    /// cache, symbol index, class hierarchy, per-file LRU caches, class-files
+    /// snapshot). See `SalsaHandle::clear_reindex_state`.
+    ClearReindexState { reply: oneshot::Sender<()> },
+
     // === Config Management ===
     /// Register configuration files for the project
     RegisterConfigFiles {
@@ -5097,6 +5102,26 @@ impl SalsaHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(SalsaRequest::BuildSymbolIndex { reply: reply_tx })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Wipe every in-memory reference index in one actor turn, for the
+    /// `laravel.reindexProject` cold rebuild. Clears the pattern cache, the
+    /// inverted symbol index, the class-hierarchy index, the per-file LRU
+    /// caches, and the class-files snapshot. Doing it in a single message
+    /// keeps the wipe atomic against concurrent actor reads, and emptying the
+    /// pattern cache is what forces the following warming pass to re-parse
+    /// every file instead of reusing a stale cached entry. The categorized
+    /// file lists are left alone — `register_project_files` re-walks and
+    /// replaces them next.
+    pub async fn clear_reindex_state(&self) -> Result<(), &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::ClearReindexState { reply: reply_tx })
             .await
             .map_err(|_| "Salsa actor disconnected")?;
         reply_rx
@@ -6509,6 +6534,22 @@ impl SalsaActor {
                     }
                     let count = self.symbol_index.entry_count();
                     let _ = reply.send(count);
+                }
+
+                SalsaRequest::ClearReindexState { reply } => {
+                    // Cold-reindex wipe. Emptying pattern_cache is the load-
+                    // bearing part: the warming pass skips any path already in
+                    // it, so a stale entry would otherwise never be re-parsed.
+                    // The rest are dropped so no since-deleted file's symbols,
+                    // hierarchy node, or cached parse can survive the rebuild.
+                    self.pattern_cache.clear();
+                    self.symbol_index.clear();
+                    self.class_hierarchy_index.clear();
+                    self.loop_blocks_cache.clear();
+                    self.php_assignments_cache.clear();
+                    self.document_symbols_cache.clear();
+                    self.class_files_snapshot = None;
+                    let _ = reply.send(());
                 }
 
                 // === Config Handlers ===

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2642,13 +2642,13 @@ fn resolve_closure_concrete(
     };
 
     let resolver = ProviderBindingResolver { root };
-    let mut classviews = crate::member_resolver::ClassViewCache::new();
+    let classviews = crate::member_resolver::ClassViewCache::new();
     let (fqcn, confidence) = crate::member_resolver::resolve_expression_type(
         expr,
         bytes,
         aliases,
         &resolver,
-        &mut classviews,
+        &classviews,
         root,
     )?;
     if !matches!(confidence, Confidence::High | Confidence::Medium) {
@@ -8300,7 +8300,7 @@ impl SalsaActor {
         // that. Needs the receiver node (located by byte range — valid for PHP;
         // Blade-embedded refs may not locate, which is fine — the component
         // fallback below is text-based).
-        let mut classviews = crate::member_resolver::ClassViewCache::new();
+        let classviews = crate::member_resolver::ClassViewCache::new();
         let resolver = self.container_aware_resolver();
         if let Some(receiver) = tree
             .root_node()
@@ -8313,7 +8313,7 @@ impl SalsaActor {
                 bytes,
                 &aliases,
                 &resolver,
-                &mut classviews,
+                &classviews,
                 &project_root,
                 None, // query-time path — no dependency recording
             ) {
@@ -8370,7 +8370,7 @@ impl SalsaActor {
         let bytes = text.as_bytes();
         let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, &text);
 
-        let mut classviews = crate::member_resolver::ClassViewCache::new();
+        let classviews = crate::member_resolver::ClassViewCache::new();
         let resolver = self.container_aware_resolver();
         let receiver = tree.root_node().descendant_for_byte_range(
             member_ref.receiver_byte_start,
@@ -8389,7 +8389,7 @@ impl SalsaActor {
                 bytes,
                 &aliases,
                 &resolver,
-                &mut classviews,
+                &classviews,
                 &project_root,
                 None, // query-time path — no dependency recording
             ) {
@@ -8406,7 +8406,7 @@ impl SalsaActor {
                         bytes,
                         &aliases,
                         &resolver,
-                        &mut classviews,
+                        &classviews,
                         &project_root,
                     )?;
                     if !matches!(confidence, Confidence::High | Confidence::Medium) {
@@ -8604,7 +8604,7 @@ impl SalsaActor {
         let bytes = text.as_bytes();
         let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, &text);
 
-        let mut classviews = crate::member_resolver::ClassViewCache::new();
+        let classviews = crate::member_resolver::ClassViewCache::new();
         let resolver = self.container_aware_resolver();
         let receiver = tree.root_node().descendant_for_byte_range(
             member_ref.receiver_byte_start,
@@ -8617,7 +8617,7 @@ impl SalsaActor {
             bytes,
             &aliases,
             &resolver,
-            &mut classviews,
+            &classviews,
             &project_root,
             None, // query-time path — no dependency recording
         )?;

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -4509,3 +4509,46 @@ class AppServiceProvider extends ServiceProvider {
         "the removed macro must be GONE after re-registration"
     );
 }
+
+// ─── M1 single-parse capture: member_context gating via the ACTOR ─────────
+//
+// The vendor gate + zero-cost `None` must also hold through the actor's
+// `handle_get_patterns` (the on-demand / save-refresh constructor), so warm
+// build and save-refresh agree on which files carry context.
+
+#[tokio::test]
+async fn handle_get_patterns_captures_context_non_vendor() {
+    let handle = SalsaActor::spawn();
+    let path = std::path::PathBuf::from("/proj/app/Http/Controllers/C.php");
+    let src = "<?php\nnamespace App;\nclass C { public function f(\\App\\Models\\User $u) { return $u->email; } }\n";
+    handle
+        .update_file(path.clone(), 1, src.to_string())
+        .await
+        .unwrap();
+    let data = handle.get_patterns(path).await.unwrap().expect("patterns");
+    let ctx = data
+        .member_context
+        .as_ref()
+        .expect("a non-vendor member reader must capture context");
+    assert_eq!(ctx.sites.len(), data.member_access_refs.len());
+}
+
+#[tokio::test]
+async fn handle_get_patterns_skips_capture_for_vendor() {
+    let handle = SalsaActor::spawn();
+    let path = std::path::PathBuf::from("/proj/vendor/acme/pkg/src/C.php");
+    let src = "<?php\nnamespace Acme;\nclass C { public function f(\\App\\Models\\User $u) { return $u->email; } }\n";
+    handle
+        .update_file(path.clone(), 1, src.to_string())
+        .await
+        .unwrap();
+    let data = handle.get_patterns(path).await.unwrap().expect("patterns");
+    assert!(
+        !data.member_access_refs.is_empty(),
+        "the file DOES have a member access (proving the gate drops context)"
+    );
+    assert!(
+        data.member_context.is_none(),
+        "a vendor file must capture no context through the actor either"
+    );
+}

--- a/laravel-lsp/src/tests/db_provider_init_idempotency.rs
+++ b/laravel-lsp/src/tests/db_provider_init_idempotency.rs
@@ -1,0 +1,100 @@
+//! Idempotency of `init_database_schema_provider`.
+//!
+//! The method is called from two startup sites (the config-discovery flow
+//! and the `initialized` background task). Before the guard, each call spun
+//! up its own provider + refresh loop + channel listener + breaker, and two
+//! fresh breakers (each starting Closed) each fired a Closed→Open toast on
+//! the first failure — the user saw DUPLICATE "can't reach the database"
+//! warnings, and the first loop leaked (both kept probing every 30s).
+//!
+//! These tests assert the guard collapses that to exactly one live set of
+//! tasks: a second init for the SAME root is a no-op, and a different root
+//! aborts the old tasks and replaces them. No live DB is involved — a temp
+//! dir has no `config/database.php`, so the refresh loop is never spawned
+//! (only the always-on channel listener), and nothing connects.
+
+use crate::LaravelLanguageServer;
+use tempfile::TempDir;
+use tower_lsp::LspService;
+
+/// Build a backend for handler-level tests: `LspService::new` wires up a
+/// real `Client`, and `inner().clone()` hands back the
+/// `LaravelLanguageServer` so we can call its private methods. Mirrors the
+/// `minimal_backend()` harness in `blade_var_rename_handler.rs`.
+fn backend() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// The task `Id`s currently stored in the idempotency guard (one per live
+/// background task). Fails if no tasks have been stored yet.
+async fn stored_task_ids(b: &LaravelLanguageServer) -> Vec<tokio::task::Id> {
+    let guard = b.db_provider_task.lock().await;
+    let (_root, handles) = guard.as_ref().expect("init should have stored tasks");
+    handles.iter().map(|h| h.id()).collect()
+}
+
+#[tokio::test]
+async fn init_twice_same_root_is_a_noop() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let backend = backend();
+
+    backend.init_database_schema_provider(&root).await;
+    let first_ids = stored_task_ids(&backend).await;
+    // No config/database.php in a temp dir → no refresh loop, only the
+    // always-on channel listener.
+    assert_eq!(
+        first_ids.len(),
+        1,
+        "without a DB config only the listener task should run"
+    );
+    assert!(
+        backend.database_schema.read().await.is_some(),
+        "the single provider is stored"
+    );
+
+    // Second init for the same root: must NOT spawn a second provider/loop/
+    // listener/breaker — the stored task set is byte-for-byte the same.
+    backend.init_database_schema_provider(&root).await;
+    let second_ids = stored_task_ids(&backend).await;
+    assert_eq!(
+        first_ids, second_ids,
+        "a same-root re-init must be a no-op (no new tasks) — this is the \
+         duplicate-toast fix"
+    );
+}
+
+#[tokio::test]
+async fn init_different_root_aborts_old_tasks_and_replaces() {
+    let dir1 = TempDir::new().unwrap();
+    let dir2 = TempDir::new().unwrap();
+    let backend = backend();
+
+    backend.init_database_schema_provider(dir1.path()).await;
+    let first_ids = stored_task_ids(&backend).await;
+
+    // Re-init for a DIFFERENT root: the guard aborts the old tasks and
+    // starts a fresh set, so the stored root and task Ids both change and
+    // the task set doesn't accumulate.
+    backend.init_database_schema_provider(dir2.path()).await;
+    let (second_root, second_ids) = {
+        let guard = backend.db_provider_task.lock().await;
+        let (root, handles) = guard.as_ref().expect("tasks stored");
+        (
+            root.clone(),
+            handles.iter().map(|h| h.id()).collect::<Vec<_>>(),
+        )
+    };
+
+    assert_eq!(second_root, dir2.path(), "the stored root is replaced");
+    assert_ne!(
+        first_ids, second_ids,
+        "a different-root re-init spawns fresh tasks (the old ones are aborted)"
+    );
+    assert_eq!(
+        second_ids.len(),
+        1,
+        "the replacement is clean — tasks don't accumulate across root changes"
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -45,4 +45,5 @@ mod translation_namespace_navigation;
 mod view_diagnostic_containment;
 mod view_navigation_containment;
 mod vite_completion_context;
+mod warm_parse_progress;
 mod watched_files_magic;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod component_file_navigation_containment;
 mod component_navigation_containment;
 mod composer_autoload_containment;
 mod controllers_dir_containment;
+mod db_provider_init_idempotency;
 mod diagnostic_severity;
 mod directive_navigation_containment;
 mod dynamic_where_sparseness;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -45,3 +45,4 @@ mod translation_namespace_navigation;
 mod view_diagnostic_containment;
 mod view_navigation_containment;
 mod vite_completion_context;
+mod watched_files_magic;

--- a/laravel-lsp/src/tests/warm_parse_progress.rs
+++ b/laravel-lsp/src/tests/warm_parse_progress.rs
@@ -1,0 +1,60 @@
+//! Regression: the warm parse loop must advance its progress count in task
+//! COMPLETION order, not spawn order.
+//!
+//! The warming pass spawns one parse task per file and drains them with a
+//! `tokio::task::JoinSet` via `join_next`, which yields each task as it
+//! finishes. Previously it awaited the spawned handles in SPAWN order
+//! (`for h in handles { h.await }`): a single slow file (this project has
+//! 6–23 MB seeder files that parse for seconds) blocked the loop on that
+//! one handle, freezing the progress count (~23%) while every fast file
+//! finished invisibly in the background — then the backlog drained at once
+//! and the bar blasted to done.
+//!
+//! This test models the drain: one slow task spawned FIRST, then many
+//! instant tasks. With completion-order draining, all the fast tasks are
+//! observed before the slow one, so the count climbs smoothly. With the
+//! old spawn-order await, the slow task (spawned first) would gate the
+//! whole drain and `before_slow` would be 0.
+
+use std::time::Duration;
+
+#[tokio::test]
+async fn parse_progress_advances_on_completion_not_spawn_order() {
+    let mut set = tokio::task::JoinSet::new();
+
+    // Spawn the SLOW task first: with an in-spawn-order await it would
+    // block the drain before any fast task could be counted.
+    set.spawn(async {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        "slow"
+    });
+    let fast = 20;
+    for _ in 0..fast {
+        set.spawn(async { "fast" });
+    }
+
+    // Drain in completion order, mirroring the warm parse loop.
+    let mut completed = 0usize;
+    let mut before_slow = 0usize;
+    let mut saw_slow = false;
+    while let Some(res) = set.join_next().await {
+        completed += 1;
+        if res.unwrap() == "slow" {
+            saw_slow = true;
+        } else if !saw_slow {
+            before_slow += 1;
+        }
+    }
+
+    assert_eq!(completed, fast + 1, "every task is drained");
+    assert!(saw_slow, "the slow task is eventually drained");
+    // The instant tasks finish long before the 300 ms sleeper, so their
+    // completions are ALL observed first — the count reaches `fast` while
+    // the slow task is still sleeping, exactly the smooth advance the bar
+    // needs. In-spawn-order draining would force this to 0 (the slow task,
+    // spawned first, would be awaited before any fast one).
+    assert_eq!(
+        before_slow, fast,
+        "all fast completions observed before the slow one (completion order)"
+    );
+}

--- a/laravel-lsp/src/tests/watched_files_magic.rs
+++ b/laravel-lsp/src/tests/watched_files_magic.rs
@@ -25,6 +25,13 @@
 //! feeding synthesized watched-file events through the real notification
 //! handler. The batch is awaited via its `JoinHandle` (which M2 keeps alive and
 //! awaitable precisely so a test can observe convergence deterministically).
+//!
+//! Also here (same harness, same fixtures): the M4 **on-open vendor** lazy
+//! indexing tests at the bottom — `did_open` of a `vendor/` file resolves THAT
+//! file's own magic-member usages into the reverse index (the eager build
+//! skips vendor files as usage sites, so their occurrence lines were missing
+//! from find-references), bounded by `vendor_open_magic_lru` so a session's
+//! vendor browsing can't grow the index monotonically.
 
 use crate::{LaravelLanguageServer, PendingWatchedChange};
 use laravel_lsp::salsa_impl::ParsedPatternsData;
@@ -33,7 +40,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tempfile::TempDir;
-use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent, Url};
+use tower_lsp::lsp_types::{
+    DidChangeWatchedFilesParams, DidOpenTextDocumentParams, FileChangeType, FileEvent,
+    TextDocumentItem, Url,
+};
 use tower_lsp::{LanguageServer, LspService};
 
 const COMPOSER: &str = r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#;
@@ -503,5 +513,232 @@ async fn drain_treats_present_flagged_but_missing_file_as_delete() {
     assert!(
         !magic_deps_has(&backend, &post),
         "the gone file's dep contribution must be purged, not leaked"
+    );
+}
+
+// === M4: on-open vendor lazy indexing =======================================
+
+/// A vendor consumer reading `$post->headline` off a typed `Post` param —
+/// the same resolution shape as [`CONSUMER`], but under `vendor/`, so the
+/// eager build never resolves it as a usage site.
+const VENDOR_CONSUMER: &str = r#"<?php
+namespace Acme\Blog;
+use App\Models\Post;
+class PostPresenter {
+    public function present(Post $post) {
+        return $post->headline;
+    }
+}
+"#;
+
+/// 0-based (line, column) of a cursor inside `headline` in [`VENDOR_CONSUMER`].
+const VENDOR_USAGE: (u32, u32) = (5, 23);
+/// 0-based (line, column) of a cursor inside `headline` in [`CONSUMER`].
+const APP_USAGE: (u32, u32) = (5, 24);
+
+/// Drive the **real** `did_open` handler for `path` with `src` as the buffer.
+async fn open(backend: &LaravelLanguageServer, path: &Path, src: &str) {
+    backend
+        .did_open(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: Url::from_file_path(path).unwrap(),
+                language_id: "php".to_string(),
+                version: 1,
+                text: src.to_string(),
+            },
+        })
+        .await;
+}
+
+/// Seed the shared app-side fixture — a `Post` model declaring the `headline`
+/// accessor plus an app consumer reading it — both eagerly indexed the way
+/// the build/save paths would. Returns `(post, consumer)` paths.
+async fn seed_app_fixture(backend: &LaravelLanguageServer, root: &Path) -> (PathBuf, PathBuf) {
+    write_file(root, "composer.json", COMPOSER);
+    let post_src = post_with_accessors(&["Headline"]);
+    let post = write_file(root, "app/Models/Post.php", &post_src);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    seed(backend, &post, &post_src).await;
+    seed(backend, &consumer, CONSUMER).await;
+    (post, consumer)
+}
+
+#[tokio::test]
+async fn opening_a_vendor_file_indexes_its_own_usages() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    let (_post, consumer) = seed_app_fixture(&backend, root).await;
+
+    let vendor = write_file(
+        root,
+        "vendor/acme/blog/src/PostPresenter.php",
+        VENDOR_CONSUMER,
+    );
+    // Mirror the eager build's end state: the vendor file is registered in
+    // Salsa (patterns/literals exist) but its usages were never resolved into
+    // the reverse index — vendor is skipped as a usage site.
+    backend
+        .salsa
+        .update_file(vendor.clone(), 1, VENDOR_CONSUMER.to_string())
+        .await
+        .unwrap();
+
+    // THE GAP: before the open, the reference set omits the vendor file's own
+    // occurrence — from a cursor inside the vendor file and from the app
+    // usage site alike.
+    let from_vendor = backend
+        .salsa
+        .find_member_references(vendor.clone(), VENDOR_USAGE.0, VENDOR_USAGE.1)
+        .await
+        .unwrap();
+    assert!(
+        from_vendor.iter().all(|r| r.file_path != vendor),
+        "pre-open: no vendor self-reference; got {from_vendor:?}"
+    );
+    let from_app = backend
+        .salsa
+        .find_member_references(consumer.clone(), APP_USAGE.0, APP_USAGE.1)
+        .await
+        .unwrap();
+    assert!(
+        from_app.iter().any(|r| r.file_path == consumer),
+        "sanity: the app usage itself is indexed; got {from_app:?}"
+    );
+    assert!(
+        from_app.iter().all(|r| r.file_path != vendor),
+        "pre-open: app-site references omit the vendor occurrence"
+    );
+    assert!(
+        member_names(&backend, &vendor).await.is_empty(),
+        "pre-open: the vendor file holds no magic entries"
+    );
+
+    open(&backend, &vendor, VENDOR_CONSUMER).await;
+
+    assert!(
+        member_names(&backend, &vendor).await.contains("headline"),
+        "post-open: the vendor file's own usage is resolved into the index"
+    );
+    let from_app = backend
+        .salsa
+        .find_member_references(consumer.clone(), APP_USAGE.0, APP_USAGE.1)
+        .await
+        .unwrap();
+    assert!(
+        from_app
+            .iter()
+            .any(|r| r.file_path == vendor && r.line == VENDOR_USAGE.0),
+        "post-open: the vendor file's own occurrence line joins the reference set; got {from_app:?}"
+    );
+    assert_eq!(
+        backend.vendor_open_magic_lru.lock().unwrap().len(),
+        1,
+        "the on-open path records the vendor file in the session LRU"
+    );
+}
+
+#[tokio::test]
+async fn reopening_a_vendor_file_replaces_not_duplicates() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    seed_app_fixture(&backend, root).await;
+
+    let vendor = write_file(
+        root,
+        "vendor/acme/blog/src/PostPresenter.php",
+        VENDOR_CONSUMER,
+    );
+    open(&backend, &vendor, VENDOR_CONSUMER).await;
+    let entry_count =
+        |members: &HashMap<PathBuf, Vec<_>>| members.get(&vendor).map(|e| e.len()).unwrap_or(0);
+    let first = entry_count(&backend.salsa.export_magic_members().await.unwrap());
+    assert!(first > 0, "first open indexes the vendor usage");
+
+    // Re-open (references multibuffer, tab churn): the actor's remove-then-
+    // insert must REPLACE the file's entries, never append duplicates — and
+    // the LRU `push` of the same key is a recency touch, not an eviction.
+    open(&backend, &vendor, VENDOR_CONSUMER).await;
+    let second = entry_count(&backend.salsa.export_magic_members().await.unwrap());
+    assert_eq!(first, second, "re-open must replace, not duplicate");
+    assert!(
+        member_names(&backend, &vendor).await.contains("headline"),
+        "re-open keeps the entries alive (same-key push must not evict)"
+    );
+}
+
+#[tokio::test]
+async fn vendor_open_lru_evicts_oldest_contributions_only() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    let (_post, consumer) = seed_app_fixture(&backend, root).await;
+
+    let oldest = write_file(
+        root,
+        "vendor/acme/blog/src/PostPresenter.php",
+        VENDOR_CONSUMER,
+    );
+    open(&backend, &oldest, VENDOR_CONSUMER).await;
+    assert!(
+        member_names(&backend, &oldest).await.contains("headline"),
+        "seed: the oldest vendor open is indexed"
+    );
+    assert!(magic_deps_has(&backend, &oldest), "seed: and records deps");
+
+    // Fill the LRU to capacity with trivial vendor opens (they occupy slots
+    // regardless of whether resolution produced entries)…
+    for i in 0..crate::VENDOR_OPEN_MAGIC_LRU_CAP - 1 {
+        let filler = write_file(root, &format!("vendor/acme/blog/src/F{i}.php"), "<?php\n");
+        open(&backend, &filler, "<?php\n").await;
+    }
+    // …then one more real vendor open pushes past the cap: the oldest evicts.
+    let newest_src = VENDOR_CONSUMER.replace("PostPresenter", "PostSummary");
+    let newest = write_file(root, "vendor/acme/blog/src/PostSummary.php", &newest_src);
+    open(&backend, &newest, &newest_src).await;
+
+    assert!(
+        member_names(&backend, &oldest).await.is_empty(),
+        "overflow evicts the OLDEST opened vendor file's entries"
+    );
+    assert!(
+        !magic_deps_has(&backend, &oldest),
+        "…and purges its recorded receiver deps"
+    );
+    assert!(
+        member_names(&backend, &newest).await.contains("headline"),
+        "a recently opened vendor file's entries survive"
+    );
+    assert!(
+        member_names(&backend, &consumer).await.contains("headline"),
+        "eager app-file entries are never LRU-tracked, so never evicted"
+    );
+}
+
+#[tokio::test]
+async fn app_file_open_does_not_trigger_vendor_refresh() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    // The model exists and is seeded, so resolution WOULD succeed if the
+    // on-open refresh (wrongly) ran for app files.
+    let post_src = post_with_accessors(&["Headline"]);
+    let post = write_file(root, "app/Models/Post.php", &post_src);
+    seed(&backend, &post, &post_src).await;
+
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    open(&backend, &consumer, CONSUMER).await;
+
+    assert!(
+        member_names(&backend, &consumer).await.is_empty(),
+        "did_open must not magic-index app files — the eager build owns those"
+    );
+    assert_eq!(
+        backend.vendor_open_magic_lru.lock().unwrap().len(),
+        0,
+        "an app open must not occupy a vendor-LRU slot"
     );
 }

--- a/laravel-lsp/src/tests/watched_files_magic.rs
+++ b/laravel-lsp/src/tests/watched_files_magic.rs
@@ -1,0 +1,507 @@
+//! Handler-level coverage for the external-edit magic-member convergence
+//! introduced by M2: `did_change_watched_files` → the debounced incremental
+//! batch → dependent re-resolution.
+//!
+//! Before M2, an external `.php` change (a `git pull`, a formatter run outside
+//! Zed, a branch switch) only updated Salsa inputs and then scheduled a
+//! project-wide reconverge that was SIZE-GATED OFF above 15,000 files — so on a
+//! large project the magic-member index silently went stale after any disk-side
+//! change. M2 routes the watched path through the same dependency-tracked
+//! pre/post surface diff `did_save` uses, scaling with the *change*, not the
+//! project, and drops the gate entirely.
+//!
+//! Lower layers are already covered elsewhere: the surface diff in
+//! `class_hierarchy_index/tests.rs`, the dependency index in
+//! `magic_dependency_index.rs`, receiver/member resolution in
+//! `member_resolver/tests.rs`. What was NOT covered is the *handler* wiring:
+//! that a synthesized `DidChangeWatchedFilesParams` actually converges a
+//! previously-indexed dependent across create / change / delete, purges a
+//! deleted file's dependency + view-render contributions, and runs regardless
+//! of project size.
+//!
+//! These drive the **real** `Backend` on the `LspService::new` harness (same
+//! seam as `inertia_handler.rs` / `macro_goto_def_handler.rs`), priming only
+//! `root_path` — the one piece of state `refresh_file_magic` reads — and then
+//! feeding synthesized watched-file events through the real notification
+//! handler. The batch is awaited via its `JoinHandle` (which M2 keeps alive and
+//! awaitable precisely so a test can observe convergence deterministically).
+
+use crate::{LaravelLanguageServer, PendingWatchedChange};
+use laravel_lsp::salsa_impl::ParsedPatternsData;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent, Url};
+use tower_lsp::{LanguageServer, LspService};
+
+const COMPOSER: &str = r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#;
+
+/// A backend with `root_path` primed to `root` — the only state the watched
+/// magic batch reads (`refresh_file_magic` resolves against it).
+async fn backend_for(root: &Path) -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    let backend = service.inner().clone();
+    *backend.root_path.write().await = Some(root.to_path_buf());
+    backend
+}
+
+/// Write a `.php` file (creating parent dirs) and return its absolute path.
+fn write_file(root: &Path, rel: &str, src: &str) -> PathBuf {
+    let path = root.join(rel);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, src).unwrap();
+    path
+}
+
+/// Register a file in Salsa and run the per-file magic refresh — exactly what
+/// the save path does, so the file's entries + receiver deps + render sites
+/// land in the live indexes.
+async fn seed(backend: &LaravelLanguageServer, path: &Path, src: &str) {
+    backend
+        .salsa
+        .update_file(path.to_path_buf(), 1, src.to_string())
+        .await
+        .unwrap();
+    backend.refresh_file_magic(path, src).await;
+}
+
+/// The resolved magic-member *member names* the index currently holds for
+/// `path` (empty if the file has no entries).
+async fn member_names(backend: &LaravelLanguageServer, path: &Path) -> HashSet<String> {
+    backend
+        .salsa
+        .export_magic_members()
+        .await
+        .unwrap()
+        .get(path)
+        .map(|entries| entries.iter().map(|e| e.member.clone()).collect())
+        .unwrap_or_default()
+}
+
+/// Does the magic-dependency index still hold a `by_file` entry for `path`?
+fn magic_deps_has(backend: &LaravelLanguageServer, path: &Path) -> bool {
+    backend
+        .magic_deps
+        .read()
+        .unwrap()
+        .export()
+        .iter()
+        .any(|(p, _)| p == path)
+}
+
+/// One watched-file event for `path`.
+fn watched(path: &Path, typ: FileChangeType) -> DidChangeWatchedFilesParams {
+    DidChangeWatchedFilesParams {
+        changes: vec![FileEvent {
+            uri: Url::from_file_path(path).unwrap(),
+            typ,
+        }],
+    }
+}
+
+/// Await the in-flight watched-files batch to completion (M2 keeps the handle
+/// alive and awaitable for exactly this).
+async fn drain_batch(backend: &LaravelLanguageServer) {
+    let handle = backend.magic_rebuild_handle.write().await.take();
+    if let Some(h) = handle {
+        let _ = h.await;
+    }
+}
+
+fn post_with_accessors(accessors: &[&str]) -> String {
+    let methods: String = accessors
+        .iter()
+        .map(|a| format!("    public function get{a}Attribute(): string {{ return ''; }}\n"))
+        .collect();
+    format!(
+        "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Post extends Model {{\n{methods}}}\n"
+    )
+}
+
+/// A controller reading `$post->headline` and `$post->summary` off a typed
+/// `Post` param — `headline`/`summary` resolve only when `Post` declares the
+/// matching accessor, which is what makes it a dependent of `App\Models\Post`.
+const CONSUMER: &str = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\Post;
+class PostController {
+    public function show(Post $post) {
+        return [$post->headline, $post->summary];
+    }
+}
+"#;
+
+#[tokio::test]
+async fn changed_dependency_converges_dependent() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    let post_v1 = post_with_accessors(&["Headline"]);
+    let post = write_file(root, "app/Models/Post.php", &post_v1);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+
+    seed(&backend, &post, &post_v1).await;
+    seed(&backend, &consumer, CONSUMER).await;
+
+    let before = member_names(&backend, &consumer).await;
+    assert!(
+        before.contains("headline"),
+        "seed: headline must resolve; got {before:?}"
+    );
+    assert!(
+        !before.contains("summary"),
+        "seed: summary must NOT resolve before Post declares it; got {before:?}"
+    );
+
+    // External edit adds a `summary` accessor — a surface change.
+    let post_v2 = post_with_accessors(&["Headline", "Summary"]);
+    fs::write(&post, &post_v2).unwrap();
+    backend
+        .did_change_watched_files(watched(&post, FileChangeType::CHANGED))
+        .await;
+    drain_batch(&backend).await;
+
+    let after = member_names(&backend, &consumer).await;
+    assert!(
+        after.contains("headline") && after.contains("summary"),
+        "dependent must converge to BOTH accessors after the external change; got {after:?}"
+    );
+}
+
+#[tokio::test]
+async fn created_dependency_converges_pre_existing_dependent() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    // The consumer references App\Models\Post BEFORE the model exists. A typed
+    // param records the receiver dep syntactically (before classification), so
+    // the dependent is discoverable the moment Post lands on disk.
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    seed(&backend, &consumer, CONSUMER).await;
+    assert!(
+        member_names(&backend, &consumer).await.is_empty(),
+        "seed: nothing resolves while Post is absent"
+    );
+
+    // Post is created on disk (git pull, scaffolding tool).
+    let post_src = post_with_accessors(&["Headline"]);
+    let post = write_file(root, "app/Models/Post.php", &post_src);
+    backend
+        .did_change_watched_files(watched(&post, FileChangeType::CREATED))
+        .await;
+    drain_batch(&backend).await;
+
+    let after = member_names(&backend, &consumer).await;
+    assert!(
+        after.contains("headline"),
+        "creating the dependency must ripple to the pre-existing dependent; got {after:?}"
+    );
+}
+
+#[tokio::test]
+async fn deleted_dependency_converges_dependent_and_purges_deps() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    // Post both declares an accessor AND reads it via `$this->headline`, so it
+    // has its own magic-dependency contribution (a self-dep on App\Models\Post)
+    // that the delete must purge — the leak M2 closes.
+    let post_src = "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Post extends Model {\n    public function getHeadlineAttribute(): string { return ''; }\n    public function describe(): string { return $this->headline; }\n}\n";
+    let post = write_file(root, "app/Models/Post.php", post_src);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+
+    seed(&backend, &post, post_src).await;
+    seed(&backend, &consumer, CONSUMER).await;
+
+    assert!(
+        member_names(&backend, &consumer).await.contains("headline"),
+        "seed: consumer resolves headline"
+    );
+    assert!(
+        magic_deps_has(&backend, &post),
+        "seed: Post has its own magic-dependency contribution"
+    );
+
+    // Post is deleted on disk.
+    fs::remove_file(&post).unwrap();
+    backend
+        .did_change_watched_files(watched(&post, FileChangeType::DELETED))
+        .await;
+    drain_batch(&backend).await;
+
+    assert!(
+        member_names(&backend, &consumer).await.is_empty(),
+        "dependent must converge — Post gone, its accessors no longer resolve"
+    );
+    assert!(
+        member_names(&backend, &post).await.is_empty(),
+        "the deleted file's own entries are evicted"
+    );
+    assert!(
+        !magic_deps_has(&backend, &post),
+        "the deleted file's magic-dependency contribution must be purged"
+    );
+}
+
+#[tokio::test]
+async fn deleted_controller_purges_view_renders() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    // A model to give the render var a resolvable type, and a controller that
+    // renders a view — so the controller has a view-render contribution.
+    let post_src = post_with_accessors(&["Headline"]);
+    let post = write_file(root, "app/Models/Post.php", &post_src);
+    let controller_src = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\Post;
+class ReportController {
+    public function show(Post $post) {
+        return view('reports.show', ['post' => $post]);
+    }
+}
+"#;
+    let controller = write_file(
+        root,
+        "app/Http/Controllers/ReportController.php",
+        controller_src,
+    );
+
+    seed(&backend, &post, &post_src).await;
+    seed(&backend, &controller, controller_src).await;
+    assert!(
+        backend
+            .view_vars
+            .read()
+            .unwrap()
+            .renders_for(&controller)
+            .is_some(),
+        "seed: controller has a recorded view-render contribution"
+    );
+
+    fs::remove_file(&controller).unwrap();
+    backend
+        .did_change_watched_files(watched(&controller, FileChangeType::DELETED))
+        .await;
+    drain_batch(&backend).await;
+
+    assert!(
+        backend
+            .view_vars
+            .read()
+            .unwrap()
+            .renders_for(&controller)
+            .is_none(),
+        "the deleted controller's view-render contribution must be purged"
+    );
+}
+
+#[tokio::test]
+async fn incremental_batch_runs_regardless_of_project_size() {
+    // Prove the 15k size gate is gone: inflate the pattern cache past the old
+    // MAX_FULL_REBUILD_FILES ceiling with cheap dummy entries, then run the
+    // change flow. Convergence still happens because the batch scales with the
+    // change set, not the project — the old gated full rebuild would have
+    // skipped entirely at this size.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    let post_v1 = post_with_accessors(&["Headline"]);
+    let post = write_file(root, "app/Models/Post.php", &post_v1);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    seed(&backend, &post, &post_v1).await;
+    seed(&backend, &consumer, CONSUMER).await;
+
+    // Inflate the pattern cache past the retired 15,000-file gate with cheap
+    // empty entries (no parsing — direct DashMap inserts).
+    let cache = backend.salsa.pattern_cache();
+    for i in 0..15_001 {
+        cache.insert(
+            root.join(format!("app/Filler/F{i}.php")),
+            (0, Arc::new(ParsedPatternsData::default())),
+        );
+    }
+    assert!(cache.len() > 15_000, "cache must exceed the retired gate");
+
+    let post_v2 = post_with_accessors(&["Headline", "Summary"]);
+    fs::write(&post, &post_v2).unwrap();
+    backend
+        .did_change_watched_files(watched(&post, FileChangeType::CHANGED))
+        .await;
+    drain_batch(&backend).await;
+
+    let after = member_names(&backend, &consumer).await;
+    assert!(
+        after.contains("summary"),
+        "incremental convergence must run even above the old 15k gate; got {after:?}"
+    );
+}
+
+#[tokio::test]
+async fn record_watched_change_is_first_event_wins() {
+    // Two events for one path in a burst collapse to ONE pending entry: the
+    // pre-change surface is captured on the FIRST event and never overwritten
+    // (an interleaved re-parse would otherwise poison it), while the `deleted`
+    // flag tracks the file's final existence (last-event-wins).
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    let post_src = post_with_accessors(&["Headline"]);
+    let post = write_file(root, "app/Models/Post.php", &post_src);
+    seed(&backend, &post, &post_src).await;
+
+    // First event captures Post's live surface.
+    backend.record_watched_change(&post, false).await;
+
+    // Now tear Post's hierarchy node down — a *fresh* snapshot here would come
+    // back empty. First-event-wins means the second event must NOT re-snapshot.
+    backend.salsa.remove_file(post.clone()).await.unwrap();
+    backend.record_watched_change(&post, true).await;
+
+    let state = backend.magic_batch_state.lock().await;
+    assert_eq!(
+        state.pending.len(),
+        1,
+        "two events for one path collapse to one entry"
+    );
+    let entry: &PendingWatchedChange = state.pending.get(&post).unwrap();
+    assert!(
+        entry.deleted,
+        "the `deleted` flag tracks the final event (last-event-wins)"
+    );
+    assert!(
+        entry
+            .old_surfaces
+            .keys()
+            .any(|fqcn| fqcn == "App\\Models\\Post"),
+        "the ORIGINAL pre-change surface is kept, not the now-empty re-snapshot; got {:?}",
+        entry.old_surfaces
+    );
+}
+
+#[tokio::test]
+async fn scheduler_respawns_after_batch_exit_for_a_lone_event() {
+    // FIX 1 (lost-wakeup race): once a batch drains and the task exits, it must
+    // relinquish liveness under the state lock so a SINGLE subsequent event —
+    // with no second unrelated event to un-stick it — spawns a fresh task and
+    // converges. If the exit and the spawn-decision weren't serialized on one
+    // lock (the old `is_finished` split), the second lone event could be
+    // stranded with no task to drain it.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    let post_v1 = post_with_accessors(&["Headline"]);
+    let post = write_file(root, "app/Models/Post.php", &post_v1);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    seed(&backend, &post, &post_v1).await;
+    seed(&backend, &consumer, CONSUMER).await;
+
+    // Batch 1 drains fully and the task exits.
+    let post_v2 = post_with_accessors(&["Headline", "Summary"]);
+    fs::write(&post, &post_v2).unwrap();
+    backend
+        .did_change_watched_files(watched(&post, FileChangeType::CHANGED))
+        .await;
+    drain_batch(&backend).await;
+    assert!(member_names(&backend, &consumer).await.contains("summary"));
+
+    // Liveness must have been relinquished under the state lock, map emptied.
+    {
+        let state = backend.magic_batch_state.lock().await;
+        assert!(
+            !state.running,
+            "task must clear `running` on its empty-exit"
+        );
+        assert!(state.pending.is_empty(), "map drained");
+    }
+
+    // A LONE follow-up event (no second nudge) must spawn a fresh task and
+    // converge — proving liveness was correctly relinquished. Drop the Summary
+    // accessor this time: a surface change the consumer observes as `summary`
+    // ceasing to resolve.
+    let post_v3 = post_with_accessors(&["Headline"]);
+    fs::write(&post, &post_v3).unwrap();
+    backend
+        .did_change_watched_files(watched(&post, FileChangeType::CHANGED))
+        .await;
+    drain_batch(&backend).await;
+
+    let after = member_names(&backend, &consumer).await;
+    assert!(
+        after.contains("headline") && !after.contains("summary"),
+        "a lone event after batch exit must converge on its own; got {after:?}"
+    );
+}
+
+#[tokio::test]
+async fn drain_treats_present_flagged_but_missing_file_as_delete() {
+    // FIX 2 (flag-race): existence is authoritative AT DRAIN, from re-reading
+    // the file — not the recorded `deleted` flag. Simulate the outcome of two
+    // overlapping notifications leaving `deleted == false` on a file that is
+    // actually gone (its Salsa/hierarchy state already removed), and assert the
+    // batch converges it as a DELETE: the dependent drops, and the gone file's
+    // dep/render contributions are purged rather than leaked.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    // Post reads its own accessor (`$this->headline`) so it holds a magic-dep
+    // contribution that the purge must drop.
+    let post_src = "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Post extends Model {\n    public function getHeadlineAttribute(): string { return ''; }\n    public function describe(): string { return $this->headline; }\n}\n";
+    let post = write_file(root, "app/Models/Post.php", post_src);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    seed(&backend, &post, post_src).await;
+    seed(&backend, &consumer, CONSUMER).await;
+    assert!(member_names(&backend, &consumer).await.contains("headline"));
+    assert!(magic_deps_has(&backend, &post));
+
+    // Snapshot Post's live surface (what the FIRST, present-flagged notification
+    // would have captured), then make Post actually gone — file removed AND its
+    // Salsa/hierarchy state removed (the DELETE notification's index effect that
+    // the flag race lost track of).
+    let old_surfaces = backend
+        .salsa
+        .file_class_surfaces(post.clone())
+        .await
+        .unwrap();
+    fs::remove_file(&post).unwrap();
+    backend.salsa.remove_file(post.clone()).await.unwrap();
+
+    // Hand the batch a stale present-flagged entry for the now-gone file.
+    let mut batch = HashMap::new();
+    batch.insert(
+        post.clone(),
+        PendingWatchedChange {
+            old_surfaces,
+            old_render_views: Vec::new(),
+            deleted: false, // WRONG on purpose — the flag race
+        },
+    );
+    backend.run_magic_batch_once(batch).await;
+
+    assert!(
+        member_names(&backend, &consumer).await.is_empty(),
+        "a present-flagged-but-missing file must converge the dependent as a delete"
+    );
+    assert!(
+        !magic_deps_has(&backend, &post),
+        "the gone file's dep contribution must be purged, not leaked"
+    );
+}

--- a/laravel-lsp/src/view_var_index.rs
+++ b/laravel-lsp/src/view_var_index.rs
@@ -201,7 +201,7 @@ pub fn resolve_blade_member_accesses(
     view_index: &ViewVarIndex,
     blade_loops: &[BladeLoopVar],
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
     mut deps: Option<&mut HashSet<String>>,
 ) -> Vec<MagicMemberEntry> {
@@ -302,7 +302,7 @@ fn classify_fqcn_member(
     member: &str,
     form: AccessForm,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> Option<ClassifiedMember> {
     let file = resolver.class_file(fqcn)?;
@@ -320,7 +320,7 @@ fn resolve_chain_receiver(
     member: &str,
     form: AccessForm,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
     deps: Option<&mut HashSet<String>>,
 ) -> Option<ClassifiedMember> {
@@ -518,7 +518,7 @@ pub fn resolve_component_member_accesses(
 pub fn volt_property_types(
     source: &str,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> HashMap<String, String> {
     let Some(front) = volt_frontmatter(source) else {
@@ -680,7 +680,7 @@ fn computed_assignment(
     bytes: &[u8],
     aliases: &UseAliases,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> Option<(String, String)> {
     let var = plain_variable_name(assign.child_by_field_name("left")?, bytes)?;
@@ -711,7 +711,7 @@ fn render_method_vars(
     bytes: &[u8],
     aliases: &UseAliases,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> HashMap<String, String> {
     let Some(ret) = function_return_expr(method) else {
@@ -787,7 +787,7 @@ fn function_return_expr(func: Node) -> Option<Node> {
 pub fn mfc_volt_property_types(
     blade_path: &Path,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> Option<HashMap<String, String>> {
     let sibling = crate::livewire_resolver::mfc_sibling(blade_path)?;
@@ -810,7 +810,7 @@ pub fn resolve_volt_member_accesses(
     prop_types: &HashMap<String, String>,
     blade_loops: &[BladeLoopVar],
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
     mut deps: Option<&mut HashSet<String>>,
 ) -> Vec<MagicMemberEntry> {
@@ -1094,7 +1094,7 @@ fn clean_type(raw: &str) -> Option<String> {
 pub fn view_renders_in_file(
     source: &str,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> Vec<ViewRender> {
     let Ok(tree) = parse_php(source) else {
@@ -1129,7 +1129,7 @@ fn render_from_view_call(
     bytes: &[u8],
     aliases: &crate::query_chain::use_aliases::UseAliases,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
 ) -> Option<ViewRender> {
     let args = call.child_by_field_name("arguments")?;
@@ -1172,7 +1172,7 @@ fn collect_vars(
     bytes: &[u8],
     aliases: &crate::query_chain::use_aliases::UseAliases,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
     vars: &mut HashMap<String, String>,
 ) {
@@ -1229,7 +1229,7 @@ fn collect_with_chain(
     bytes: &[u8],
     aliases: &crate::query_chain::use_aliases::UseAliases,
     resolver: &impl ClassFileResolver,
-    classviews: &mut ClassViewCache,
+    classviews: &ClassViewCache,
     project_root: &Path,
     vars: &mut HashMap<String, String>,
 ) {

--- a/laravel-lsp/src/view_var_index.rs
+++ b/laravel-lsp/src/view_var_index.rs
@@ -1324,5 +1324,755 @@ fn string_literal_value(node: Node, bytes: &[u8]) -> Option<String> {
     )
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// M1 single-parse capture — view-render + Volt-surface + component capture/eval
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// These COMPILE the intra-file structure at parse (view() renders, Volt
+// front-matter surface, component member names) and EVAL it at resolve against
+// snapshots, so the magic build never re-reads/re-parses the file. Each capture
+// function mirrors its live counterpart's traversal exactly, emitting a plan
+// instead of resolving; each eval replays the plan, applying insert vs
+// or_insert precedence identically. The live functions above stay untouched —
+// the equivalence baseline.
+
+use crate::salsa_impl::{
+    ComponentContextData, MemberContextData, ReceiverRecipeData, ValueExprPlanData,
+    ViewRenderPlanData, VoltPropPlanData, VoltSurfaceData,
+};
+use tree_sitter::Tree;
+
+// ─── Capture: controller view() renders (pass 1) ───────────────────────────
+
+/// Compile every `view('name', […])` render site into a [`ViewRenderPlanData`]
+/// — the parse-time form of [`view_renders_in_file`].
+pub(crate) fn capture_render_plans(
+    source: &str,
+    tree: &Tree,
+    aliases: &UseAliases,
+) -> Vec<ViewRenderPlanData> {
+    let bytes = source.as_bytes();
+    let mut out = Vec::new();
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "function_call_expression" && call_function_name(n, bytes) == Some("view") {
+            if let Some(plan) = render_plan_from_view_call(n, bytes, aliases) {
+                out.push(plan);
+            }
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    out
+}
+
+/// The plan form of [`render_from_view_call`].
+fn render_plan_from_view_call(
+    call: Node,
+    bytes: &[u8],
+    aliases: &UseAliases,
+) -> Option<ViewRenderPlanData> {
+    let args = call.child_by_field_name("arguments")?;
+    let arg_exprs = positional_args(args);
+    let view_name = string_literal_value(*arg_exprs.first()?, bytes)?;
+
+    let mut items = Vec::new();
+    if let Some(data) = arg_exprs.get(1) {
+        items.extend(collect_var_plan_items(*data, bytes, aliases));
+    }
+    collect_with_chain_plans(call, bytes, aliases, &mut items);
+    Some(ViewRenderPlanData { view_name, items })
+}
+
+/// The plan form of [`collect_vars`]: `(key, plan)` pairs in traversal order.
+/// For the array form every key is emitted (eval gates on the value resolving,
+/// preserving last-wins); for `compact` only intra-file-typed vars are emitted
+/// (mirrors `flow::resolve` skipping the untypable).
+fn collect_var_plan_items(
+    data: Node,
+    bytes: &[u8],
+    aliases: &UseAliases,
+) -> Vec<(String, ValueExprPlanData)> {
+    let mut items = Vec::new();
+    match data.kind() {
+        "array_creation_expression" => {
+            let mut c = data.walk();
+            for el in data.named_children(&mut c) {
+                if el.kind() != "array_element_initializer" {
+                    continue;
+                }
+                let mut ec = el.walk();
+                let kids: Vec<_> = el.named_children(&mut ec).collect();
+                if kids.len() != 2 {
+                    continue;
+                }
+                let Some(key) = string_literal_value(kids[0], bytes) else {
+                    continue;
+                };
+                items.push((
+                    key,
+                    crate::member_resolver::compile_value_expr(kids[1], bytes, aliases),
+                ));
+            }
+        }
+        "function_call_expression" if call_function_name(data, bytes) == Some("compact") => {
+            if let Some(args) = data.child_by_field_name("arguments") {
+                for arg in positional_args(args) {
+                    let Some(name) = string_literal_value(arg, bytes) else {
+                        continue;
+                    };
+                    if let Some(plan) =
+                        crate::member_resolver::compile_flow_var(arg, bytes, &name, aliases)
+                    {
+                        items.push((name, plan));
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    items
+}
+
+/// The plan form of [`collect_with_chain`].
+fn collect_with_chain_plans(
+    view_call: Node,
+    bytes: &[u8],
+    aliases: &UseAliases,
+    items: &mut Vec<(String, ValueExprPlanData)>,
+) {
+    let mut node = view_call;
+    while let Some(parent) = node.parent() {
+        if parent.kind() != "member_call_expression"
+            || parent.child_by_field_name("object").map(|o| o.id()) != Some(node.id())
+        {
+            break;
+        }
+        if parent
+            .child_by_field_name("name")
+            .and_then(|n| n.utf8_text(bytes).ok())
+            == Some("with")
+        {
+            if let Some(args) = parent.child_by_field_name("arguments") {
+                let exprs = positional_args(args);
+                match exprs.as_slice() {
+                    [key, value] => {
+                        if let Some(name) = string_literal_value(*key, bytes) {
+                            items.push((
+                                name,
+                                crate::member_resolver::compile_value_expr(*value, bytes, aliases),
+                            ));
+                        }
+                    }
+                    [data] => items.extend(collect_var_plan_items(*data, bytes, aliases)),
+                    _ => {}
+                }
+            }
+        }
+        node = parent;
+    }
+}
+
+/// Pass-1 replacement: build [`ViewRender`]s from captured plans without
+/// re-reading/re-parsing the controller.
+pub fn evaluate_render_plans(
+    plans: &[ViewRenderPlanData],
+    aliases: &UseAliases,
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+) -> Vec<ViewRender> {
+    plans
+        .iter()
+        .map(|plan| ViewRender {
+            view_name: plan.view_name.clone(),
+            // Resolve-gated last-wins over the site's items (an unresolvable
+            // later value never overwrites an earlier resolved one).
+            vars: eval_value_items(&plan.items, aliases, resolver, classviews, project_root),
+        })
+        .collect()
+}
+
+// ─── Capture: Volt front-matter surface (item 8) ───────────────────────────
+
+/// Compile a Volt SFC's front-matter surface into an ordered plan — the
+/// parse-time form of [`volt_property_types`]. Items are emitted in the SAME
+/// DFS order the live typer applies them, so the eval replay reproduces the
+/// insert (typed prop, overwrites) vs or_insert (inferred, first-wins)
+/// precedence exactly.
+pub(crate) fn capture_volt_surface(source: &str) -> Option<VoltSurfaceData> {
+    let front = volt_frontmatter(source)?;
+    let tree = parse_php(front).ok()?;
+    let bytes = front.as_bytes();
+    let aliases = extract_use_aliases(&tree, front);
+    let mut items: Vec<VoltPropPlanData> = Vec::new();
+
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        match n.kind() {
+            "property_declaration" if is_public(n, bytes) => {
+                if let (Some(ty), Some(name)) = (
+                    n.child_by_field_name("type"),
+                    property_element_name(n, bytes),
+                ) {
+                    if let Some(fqcn) = clean_type(ty.utf8_text(bytes).unwrap_or("")) {
+                        items.push(VoltPropPlanData::TypedProp {
+                            name,
+                            fqcn: resolve_class_name(&fqcn, &aliases),
+                        });
+                    }
+                }
+            }
+            "method_declaration" if method_name_is(n, bytes, "mount") => {
+                collect_mount_assignment_plans(n, bytes, &aliases, &mut items);
+            }
+            "method_declaration" if method_name_is(n, bytes, "with") => {
+                if let Some(ret) = function_return_expr(n) {
+                    items.push(VoltPropPlanData::OrInsertGroup(collect_var_plan_items(
+                        ret, bytes, &aliases,
+                    )));
+                }
+            }
+            "method_declaration" if method_name_is(n, bytes, "render") => {
+                if let Some(ret) = function_return_expr(n) {
+                    if let Some(view_call) = find_view_call(ret, bytes) {
+                        if let Some(plan) = render_plan_from_view_call(view_call, bytes, &aliases) {
+                            items.push(VoltPropPlanData::OrInsertGroup(plan.items));
+                        }
+                    }
+                }
+            }
+            "method_declaration" if method_has_attribute(n, bytes, "Computed") => {
+                if let Some(name) = n
+                    .child_by_field_name("name")
+                    .and_then(|nm| nm.utf8_text(bytes).ok())
+                {
+                    let body = function_return_expr(n).map(|ret| {
+                        crate::member_resolver::compile_value_expr(ret, bytes, &aliases)
+                    });
+                    let declared = n
+                        .child_by_field_name("return_type")
+                        .and_then(|rt| clean_type(rt.utf8_text(bytes).ok()?))
+                        .map(|t| resolve_class_name(&t, &aliases));
+                    items.push(VoltPropPlanData::Computed {
+                        name: name.to_string(),
+                        body,
+                        declared,
+                    });
+                }
+            }
+            "function_call_expression" if call_function_name(n, bytes) == Some("mount") => {
+                if let Some(closure) = first_closure_arg(n) {
+                    collect_mount_assignment_plans(closure, bytes, &aliases, &mut items);
+                }
+            }
+            "function_call_expression" if call_function_name(n, bytes) == Some("state") => {
+                if let Some(args) = n.child_by_field_name("arguments") {
+                    if let Some(data) = positional_args(args).first() {
+                        items.push(VoltPropPlanData::OrInsertGroup(collect_var_plan_items(
+                            *data, bytes, &aliases,
+                        )));
+                    }
+                }
+            }
+            "function_call_expression" if call_function_name(n, bytes) == Some("with") => {
+                if let Some(closure) = first_closure_arg(n) {
+                    if let Some(ret) = function_return_expr(closure) {
+                        items.push(VoltPropPlanData::OrInsertGroup(collect_var_plan_items(
+                            ret, bytes, &aliases,
+                        )));
+                    }
+                }
+            }
+            "assignment_expression" => {
+                if let Some((var, plan)) = compile_computed_assignment(n, bytes, &aliases) {
+                    items.push(VoltPropPlanData::OrInsert { name: var, plan });
+                }
+            }
+            _ => {}
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    Some(VoltSurfaceData { items, aliases })
+}
+
+/// Resolve a handler's ordered `(name, plan)` items into a `var → FQCN` map,
+/// gating each on the value resolving — the exact analog of the tree engine's
+/// `collect_vars` (`if let Some((fqcn, _)) = resolve_expression_type(..) {
+/// vars.insert(key, fqcn); }`). A later value overwrites an earlier one ONLY
+/// when it resolves, so within a handler it is last-RESOLVING-wins. Shared by
+/// [`evaluate_render_plans`] (returns the map directly) and
+/// [`evaluate_volt_surface`]'s `OrInsertGroup` fold.
+fn eval_value_items(
+    items: &[(String, ValueExprPlanData)],
+    aliases: &UseAliases,
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+) -> HashMap<String, String> {
+    let mut vars = HashMap::new();
+    for (key, value_plan) in items {
+        if let Some((fqcn, _)) = crate::member_resolver::eval_value_expr(
+            value_plan,
+            aliases,
+            resolver,
+            classviews,
+            project_root,
+        ) {
+            vars.insert(key.clone(), fqcn);
+        }
+    }
+    vars
+}
+
+/// The plan form of [`collect_mount_assignments`] — each `$this->prop = $param`
+/// becomes an `OrInsert` of the param's (pure, declared) type.
+fn collect_mount_assignment_plans(
+    func: Node,
+    bytes: &[u8],
+    aliases: &UseAliases,
+    items: &mut Vec<VoltPropPlanData>,
+) {
+    let mut param_types: HashMap<String, String> = HashMap::new();
+    if let Some(params) = func.child_by_field_name("parameters") {
+        let mut c = params.walk();
+        for p in params.named_children(&mut c) {
+            if p.kind() != "simple_parameter" {
+                continue;
+            }
+            let (Some(ty), Some(nm)) =
+                (p.child_by_field_name("type"), p.child_by_field_name("name"))
+            else {
+                continue;
+            };
+            let Some(fqcn) = clean_type(ty.utf8_text(bytes).unwrap_or("")) else {
+                continue;
+            };
+            if let Ok(name) = nm.utf8_text(bytes) {
+                param_types.insert(
+                    name.trim_start_matches('$').to_string(),
+                    resolve_class_name(&fqcn, aliases),
+                );
+            }
+        }
+    }
+    if param_types.is_empty() {
+        return;
+    }
+    let Some(body) = func.child_by_field_name("body") else {
+        return;
+    };
+    let mut stack = vec![body];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "assignment_expression" {
+            if let (Some(left), Some(right)) = (
+                n.child_by_field_name("left"),
+                n.child_by_field_name("right"),
+            ) {
+                if let (Some(prop), Some(param)) = (
+                    this_property_name(left, bytes),
+                    plain_variable_name(right, bytes),
+                ) {
+                    if let Some(fqcn) = param_types.get(&param) {
+                        items.push(VoltPropPlanData::OrInsert {
+                            name: prop,
+                            plan: ValueExprPlanData::Resolved {
+                                fqcn: fqcn.clone(),
+                                confidence: Confidence::High,
+                            },
+                        });
+                    }
+                }
+            }
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+}
+
+/// The plan form of [`computed_assignment`].
+fn compile_computed_assignment(
+    assign: Node,
+    bytes: &[u8],
+    aliases: &UseAliases,
+) -> Option<(String, ValueExprPlanData)> {
+    let var = plain_variable_name(assign.child_by_field_name("left")?, bytes)?;
+    let right = assign.child_by_field_name("right")?;
+    if right.kind() != "function_call_expression"
+        || call_function_name(right, bytes) != Some("computed")
+    {
+        return None;
+    }
+    let closure = first_closure_arg(right)?;
+    if let Some(rt) = closure.child_by_field_name("return_type") {
+        if let Some(t) = rt.utf8_text(bytes).ok().and_then(clean_type) {
+            return Some((
+                var,
+                ValueExprPlanData::Resolved {
+                    fqcn: resolve_class_name(&t, aliases),
+                    confidence: Confidence::High,
+                },
+            ));
+        }
+    }
+    let ret = function_return_expr(closure)?;
+    Some((
+        var,
+        crate::member_resolver::compile_value_expr(ret, bytes, aliases),
+    ))
+}
+
+/// Volt-props replacement: evaluate a captured surface into `prop → FQCN`
+/// without re-reading/re-parsing the component. Byte-identical to
+/// [`volt_property_types`] for the same source.
+pub fn evaluate_volt_surface(
+    surface: &VoltSurfaceData,
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+) -> HashMap<String, String> {
+    let mut out: HashMap<String, String> = HashMap::new();
+    for item in &surface.items {
+        match item {
+            VoltPropPlanData::TypedProp { name, fqcn } => {
+                out.insert(name.clone(), fqcn.clone());
+            }
+            VoltPropPlanData::OrInsert { name, plan } => {
+                if let Some((fqcn, _)) = crate::member_resolver::eval_value_expr(
+                    plan,
+                    &surface.aliases,
+                    resolver,
+                    classviews,
+                    project_root,
+                ) {
+                    out.entry(name.clone()).or_insert(fqcn);
+                }
+            }
+            VoltPropPlanData::OrInsertGroup(group) => {
+                // Two-stage precedence (the tree's temp-map then fold_or_insert):
+                //   1. WITHIN the handler — resolve-gated last-wins into a temp
+                //      map (a later unresolvable value never clobbers an earlier
+                //      resolved one).
+                //   2. ACROSS handlers — or_insert the temp into the surface, so
+                //      the FIRST handler to set a key wins. (temp's keys are
+                //      distinct, so its iteration order is immaterial here.)
+                let temp =
+                    eval_value_items(group, &surface.aliases, resolver, classviews, project_root);
+                for (k, v) in temp {
+                    out.entry(k).or_insert(v);
+                }
+            }
+            VoltPropPlanData::Computed {
+                name,
+                body,
+                declared,
+            } => {
+                let fqcn = body
+                    .as_ref()
+                    .and_then(|b| {
+                        crate::member_resolver::eval_value_expr(
+                            b,
+                            &surface.aliases,
+                            resolver,
+                            classviews,
+                            project_root,
+                        )
+                        .map(|(f, _)| f)
+                    })
+                    .or_else(|| declared.clone());
+                if let Some(fqcn) = fqcn {
+                    out.entry(name.clone()).or_insert(fqcn);
+                }
+            }
+        }
+    }
+    out
+}
+
+// ─── Capture: component identity + member names (item 8) ───────────────────
+
+/// Capture a Livewire/Volt component's synthetic key + declared member names,
+/// when both are intra-file. `members` is `None` for a multi-file-component
+/// TEMPLATE (its class lives in a sibling `.php`, read at eval). `is_volt` is
+/// the already-captured `source_contains_volt_signature` for Blade files.
+pub(crate) fn capture_component(
+    path: &Path,
+    source: &str,
+    is_volt: bool,
+) -> Option<ComponentContextData> {
+    let is_blade = path.to_string_lossy().ends_with(".blade.php");
+    if is_blade {
+        if is_volt {
+            // Single-file Volt component: members come from the front-matter.
+            let members = volt_frontmatter(source)
+                .map(volt_component_member_names)
+                .unwrap_or_default();
+            Some(ComponentContextData {
+                key: format!("volt::{}", path.display()),
+                members: Some(sorted_members(members)),
+            })
+        } else {
+            // MFC template: identity is the sibling `.php`; its member names are
+            // read from that sibling at eval (a cross-file read kept at resolve).
+            let sib = crate::livewire_resolver::mfc_sibling(path)?;
+            Some(ComponentContextData {
+                key: format!("volt::{}", sib.display()),
+                members: None,
+            })
+        }
+    } else if crate::php_class::detect_inline_livewire_class(source) {
+        Some(ComponentContextData {
+            key: format!("volt::{}", path.display()),
+            members: Some(sorted_members(volt_component_member_names(source))),
+        })
+    } else {
+        None
+    }
+}
+
+fn sorted_members(names: HashSet<String>) -> Vec<String> {
+    let mut v: Vec<String> = names.into_iter().collect();
+    v.sort();
+    v
+}
+
+/// Component-refs replacement: index `$this->member` reads under the captured
+/// key without re-reading/re-parsing this file. For a multi-file-component
+/// template (`members == None`) the sibling `.php` is read here — the one
+/// cross-file read the spec keeps at resolve.
+pub fn resolve_component_member_accesses_with_context(
+    component: &ComponentContextData,
+    path: &Path,
+    member_refs: &[Arc<MemberAccessReferenceData>],
+) -> Vec<MagicMemberEntry> {
+    let members: HashSet<String> = match &component.members {
+        Some(m) => m.iter().cloned().collect(),
+        None => {
+            let Some(sib) = crate::livewire_resolver::mfc_sibling(path) else {
+                return Vec::new();
+            };
+            let src = std::fs::read_to_string(&sib).unwrap_or_default();
+            if src.is_empty() {
+                return Vec::new();
+            }
+            volt_component_member_names(&src)
+        }
+    };
+    if members.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    let mut seen: HashSet<(u32, u32)> = HashSet::new();
+    for m in member_refs {
+        if m.receiver.trim() != "$this" || !members.contains(&m.member) {
+            continue;
+        }
+        if seen.insert((m.line, m.column)) {
+            out.push(MagicMemberEntry {
+                fqcn: component.key.clone(),
+                member: m.member.clone(),
+                line: m.line,
+                column: m.column,
+                end_column: m.end_column,
+            });
+        }
+    }
+    out
+}
+
+// ─── Eval: Blade / Volt member accesses from captured recipes ──────────────
+
+/// Pass-3 replacement (controller-rendered Blade): identical to
+/// [`resolve_blade_member_accesses`] except the non-variable (chain) receiver
+/// resolves through its captured recipe instead of a re-parsed snippet.
+/// `ctx.sites` is positionally parallel to `member_refs`.
+#[allow(clippy::too_many_arguments)]
+pub fn resolve_blade_member_accesses_with_context(
+    ctx: &MemberContextData,
+    member_refs: &[Arc<MemberAccessReferenceData>],
+    view_name: &str,
+    view_index: &ViewVarIndex,
+    blade_loops: &[BladeLoopVar],
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+    mut deps: Option<&mut HashSet<String>>,
+) -> Vec<MagicMemberEntry> {
+    debug_assert_eq!(ctx.sites.len(), member_refs.len());
+    let mut out: Vec<MagicMemberEntry> = Vec::new();
+    let mut seen: HashSet<(String, u32, u32)> = HashSet::new();
+
+    let var_types = |var: &str, line: u32| -> Vec<String> {
+        let direct = view_index.var_types(view_name, var);
+        if !direct.is_empty() {
+            return direct;
+        }
+        match enclosing_loop_iterable(blade_loops, var, line) {
+            Some(iter) => bare_variable(iter)
+                .map(|iv| view_index.var_types(view_name, iv))
+                .unwrap_or_default(),
+            None => Vec::new(),
+        }
+    };
+
+    for (m, site) in member_refs.iter().zip(ctx.sites.iter()) {
+        let receiver = m.receiver.trim();
+
+        let declaring: Vec<String> = if let Some(var) = bare_variable(receiver) {
+            var_types(var, m.line)
+                .into_iter()
+                .filter_map(|fqcn| {
+                    if let Some(d) = deps.as_deref_mut() {
+                        d.insert(fqcn.clone());
+                    }
+                    classify_fqcn_member(
+                        &fqcn,
+                        &m.member,
+                        m.form,
+                        resolver,
+                        classviews,
+                        project_root,
+                    )
+                    .map(|c| c.declaring_fqcn)
+                })
+                .collect()
+        } else {
+            resolve_recipe_chain_receiver(
+                &site.recipe,
+                &ctx.aliases,
+                &m.member,
+                m.form,
+                resolver,
+                classviews,
+                project_root,
+                deps.as_deref_mut(),
+            )
+            .map(|c| vec![c.declaring_fqcn])
+            .unwrap_or_default()
+        };
+
+        for fqcn in declaring {
+            if seen.insert((fqcn.clone(), m.line, m.column)) {
+                out.push(MagicMemberEntry {
+                    fqcn,
+                    member: m.member.clone(),
+                    line: m.line,
+                    column: m.column,
+                    end_column: m.end_column,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Pass-3 replacement (Volt): identical to [`resolve_volt_member_accesses`]
+/// except the non-prop (chain) receiver resolves through its captured recipe.
+#[allow(clippy::too_many_arguments)]
+pub fn resolve_volt_member_accesses_with_context(
+    ctx: &MemberContextData,
+    member_refs: &[Arc<MemberAccessReferenceData>],
+    prop_types: &HashMap<String, String>,
+    blade_loops: &[BladeLoopVar],
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+    mut deps: Option<&mut HashSet<String>>,
+) -> Vec<MagicMemberEntry> {
+    debug_assert_eq!(ctx.sites.len(), member_refs.len());
+    let mut out: Vec<MagicMemberEntry> = Vec::new();
+    let mut seen: HashSet<(String, u32, u32)> = HashSet::new();
+
+    for (m, site) in member_refs.iter().zip(ctx.sites.iter()) {
+        let receiver = m.receiver.trim();
+        let declaring: Option<String> = if let Some(prop) = volt_base_prop(receiver) {
+            let direct = prop_types.get(prop).and_then(|fqcn| {
+                if let Some(d) = deps.as_deref_mut() {
+                    d.insert(fqcn.clone());
+                }
+                classify_fqcn_member(fqcn, &m.member, m.form, resolver, classviews, project_root)
+                    .map(|c| c.declaring_fqcn)
+            });
+            direct.or_else(|| {
+                let var = bare_variable(receiver)?;
+                let iter = enclosing_loop_iterable(blade_loops, var, m.line)?;
+                let iter_prop = volt_base_prop(iter)?;
+                prop_types.get(iter_prop).and_then(|fqcn| {
+                    if let Some(d) = deps.as_deref_mut() {
+                        d.insert(fqcn.clone());
+                    }
+                    classify_fqcn_member(
+                        fqcn,
+                        &m.member,
+                        m.form,
+                        resolver,
+                        classviews,
+                        project_root,
+                    )
+                    .map(|c| c.declaring_fqcn)
+                })
+            })
+        } else {
+            resolve_recipe_chain_receiver(
+                &site.recipe,
+                &ctx.aliases,
+                &m.member,
+                m.form,
+                resolver,
+                classviews,
+                project_root,
+                deps.as_deref_mut(),
+            )
+            .map(|c| c.declaring_fqcn)
+        };
+
+        if let Some(fqcn) = declaring {
+            if seen.insert((fqcn.clone(), m.line, m.column)) {
+                out.push(MagicMemberEntry {
+                    fqcn,
+                    member: m.member.clone(),
+                    line: m.line,
+                    column: m.column,
+                    end_column: m.end_column,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// The captured-context form of [`resolve_chain_receiver`]: resolve a
+/// non-variable Blade/Volt receiver through its recipe, gate to HIGH/MEDIUM,
+/// record the dep, then classify.
+#[allow(clippy::too_many_arguments)]
+fn resolve_recipe_chain_receiver(
+    recipe: &ReceiverRecipeData,
+    aliases: &UseAliases,
+    member: &str,
+    form: AccessForm,
+    resolver: &impl ClassFileResolver,
+    classviews: &ClassViewCache,
+    project_root: &Path,
+    deps: Option<&mut HashSet<String>>,
+) -> Option<ClassifiedMember> {
+    let (fqcn, confidence) =
+        crate::member_resolver::eval_receiver(recipe, aliases, resolver, classviews, project_root)?;
+    if !matches!(confidence, Confidence::High | Confidence::Medium) {
+        return None;
+    }
+    if let Some(d) = deps {
+        d.insert(fqcn.clone());
+    }
+    classify_fqcn_member(&fqcn, member, form, resolver, classviews, project_root)
+}
+
 #[cfg(test)]
 mod tests;

--- a/laravel-lsp/src/view_var_index/tests.rs
+++ b/laravel-lsp/src/view_var_index/tests.rs
@@ -12,7 +12,7 @@ fn renders(controller: &str) -> Vec<ViewRender> {
     view_renders_in_file(
         controller,
         &ClassHierarchyIndex::default(),
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         Path::new("/proj"),
     )
 }
@@ -296,14 +296,14 @@ fn blade_var_resolves_via_view_index() {
 
     // `{{ $user->email }}` captured at line 3, col 15.
     let refs = vec![member_ref("$user", "email", 3, 15)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let entries = resolve_blade_member_accesses(
         &refs,
         "users.show",
         &idx,
         &[],
         &p.index,
-        &mut cache,
+        &cache,
         &p.root,
         None,
     );
@@ -325,14 +325,14 @@ fn blade_unknown_member_is_dropped() {
     );
     // `nope` is not a column/accessor/relationship/property on User → dropped.
     let refs = vec![member_ref("$user", "nope", 1, 0)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let entries = resolve_blade_member_accesses(
         &refs,
         "users.show",
         &idx,
         &[],
         &p.index,
-        &mut cache,
+        &cache,
         &p.root,
         None,
     );
@@ -344,14 +344,14 @@ fn blade_var_with_no_inferred_type_is_dropped() {
     let p = blade_project();
     let idx = ViewVarIndex::new(); // empty — nothing rendered this view
     let refs = vec![member_ref("$user", "email", 1, 0)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let entries = resolve_blade_member_accesses(
         &refs,
         "users.show",
         &idx,
         &[],
         &p.index,
-        &mut cache,
+        &cache,
         &p.root,
         None,
     );
@@ -385,14 +385,14 @@ fn blade_container_binding_receiver_resolves() {
     let idx = ViewVarIndex::new(); // no controller render — type comes from the binding
     let resolver = user_bound_resolver(&p, "currentUser");
     let refs = vec![member_ref("app('currentUser')", "email", 5, 12)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let entries = resolve_blade_member_accesses(
         &refs,
         "users.show",
         &idx,
         &[],
         &resolver,
-        &mut cache,
+        &cache,
         &p.root,
         None,
     );
@@ -410,14 +410,14 @@ fn blade_container_binding_unknown_key_is_dropped() {
     let idx = ViewVarIndex::new();
     let resolver = user_bound_resolver(&p, "someOtherKey");
     let refs = vec![member_ref("app('currentUser')", "email", 1, 0)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let entries = resolve_blade_member_accesses(
         &refs,
         "users.show",
         &idx,
         &[],
         &resolver,
-        &mut cache,
+        &cache,
         &p.root,
         None,
     );
@@ -434,14 +434,14 @@ fn blade_relationship_resolves() {
     );
     // `{{ $user->posts }}` — relationship read as a property.
     let refs = vec![member_ref("$user", "posts", 2, 4)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let entries = resolve_blade_member_accesses(
         &refs,
         "users.show",
         &idx,
         &[],
         &p.index,
-        &mut cache,
+        &cache,
         &p.root,
         None,
     );
@@ -459,7 +459,7 @@ fn volt_types(src: &str) -> HashMap<String, String> {
     volt_property_types(
         src,
         &ClassHierarchyIndex::default(),
-        &mut ClassViewCache::new(),
+        &ClassViewCache::new(),
         Path::new("/proj"),
     )
 }
@@ -650,9 +650,8 @@ fn volt_resolves_this_property_access() {
 
     // `{{ $this->user->email }}` — receiver captured as `$this->user`.
     let refs = vec![member_ref("$this->user", "email", 5, 18)];
-    let mut cache = ClassViewCache::new();
-    let entries =
-        resolve_volt_member_accesses(&refs, &types, &[], &p.index, &mut cache, &p.root, None);
+    let cache = ClassViewCache::new();
+    let entries = resolve_volt_member_accesses(&refs, &types, &[], &p.index, &cache, &p.root, None);
     assert_eq!(entries.len(), 1, "got {entries:?}");
     assert_eq!(entries[0].fqcn, "App\\Models\\User");
     assert_eq!(entries[0].member, "email");
@@ -666,9 +665,8 @@ fn volt_resolves_bare_public_property_access() {
 
     // Public properties are also readable bare in the template: `{{ $user->email }}`.
     let refs = vec![member_ref("$user", "email", 1, 0)];
-    let mut cache = ClassViewCache::new();
-    let entries =
-        resolve_volt_member_accesses(&refs, &types, &[], &p.index, &mut cache, &p.root, None);
+    let cache = ClassViewCache::new();
+    let entries = resolve_volt_member_accesses(&refs, &types, &[], &p.index, &cache, &p.root, None);
     assert_eq!(entries.len(), 1, "got {entries:?}");
     assert_eq!(entries[0].fqcn, "App\\Models\\User");
 }
@@ -678,9 +676,8 @@ fn volt_unknown_property_is_dropped() {
     let p = blade_project();
     let types = HashMap::new(); // nothing inferred
     let refs = vec![member_ref("$this->user", "email", 1, 0)];
-    let mut cache = ClassViewCache::new();
-    let entries =
-        resolve_volt_member_accesses(&refs, &types, &[], &p.index, &mut cache, &p.root, None);
+    let cache = ClassViewCache::new();
+    let entries = resolve_volt_member_accesses(&refs, &types, &[], &p.index, &cache, &p.root, None);
     assert!(entries.is_empty(), "got {entries:?}");
 }
 
@@ -724,9 +721,9 @@ fn volt_foreach_loop_var_resolves_from_this_computed() {
         end_line: 20,
     }];
     let refs = vec![member_ref("$user", "email", 7, 40)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let entries =
-        resolve_volt_member_accesses(&refs, &types, &loops, &p.index, &mut cache, &p.root, None);
+        resolve_volt_member_accesses(&refs, &types, &loops, &p.index, &cache, &p.root, None);
     assert_eq!(entries.len(), 1, "got {entries:?}");
     assert_eq!(entries[0].fqcn, "App\\Models\\User");
     assert_eq!(entries[0].member, "email");
@@ -749,14 +746,14 @@ fn blade_foreach_loop_var_resolves_from_view_var() {
         end_line: 10,
     }];
     let refs = vec![member_ref("$user", "email", 4, 12)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let entries = resolve_blade_member_accesses(
         &refs,
         "users.index",
         &idx,
         &loops,
         &p.index,
-        &mut cache,
+        &cache,
         &p.root,
         None,
     );
@@ -777,9 +774,9 @@ fn loop_var_outside_loop_range_is_dropped() {
     }];
     // Access on line 30 — outside the loop body → no resolution.
     let refs = vec![member_ref("$user", "email", 30, 0)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let entries =
-        resolve_volt_member_accesses(&refs, &types, &loops, &p.index, &mut cache, &p.root, None);
+        resolve_volt_member_accesses(&refs, &types, &loops, &p.index, &cache, &p.root, None);
     assert!(entries.is_empty(), "got {entries:?}");
 }
 
@@ -870,7 +867,7 @@ fn blade_deps_record_attempted_var_types_even_on_unknown_member() {
 
     // `notAColumn` doesn't classify — the dependency must still register.
     let refs = vec![member_ref("$user", "notAColumn", 3, 15)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let mut deps = HashSet::new();
     let entries = resolve_blade_member_accesses(
         &refs,
@@ -878,7 +875,7 @@ fn blade_deps_record_attempted_var_types_even_on_unknown_member() {
         &idx,
         &[],
         &p.index,
-        &mut cache,
+        &cache,
         &p.root,
         Some(&mut deps),
     );
@@ -893,14 +890,14 @@ fn volt_deps_record_attempted_prop_types_even_on_unknown_member() {
     types.insert("user".to_string(), "App\\Models\\User".to_string());
 
     let refs = vec![member_ref("$this->user", "notAColumn", 1, 0)];
-    let mut cache = ClassViewCache::new();
+    let cache = ClassViewCache::new();
     let mut deps = HashSet::new();
     let entries = resolve_volt_member_accesses(
         &refs,
         &types,
         &[],
         &p.index,
-        &mut cache,
+        &cache,
         &p.root,
         Some(&mut deps),
     );

--- a/laravel-lsp/src/view_var_index/tests.rs
+++ b/laravel-lsp/src/view_var_index/tests.rs
@@ -936,3 +936,444 @@ fn renders_for_returns_current_contribution() {
     idx.insert_file(a.clone(), std::slice::from_ref(&r));
     assert_eq!(idx.renders_for(&a), Some(std::slice::from_ref(&r)));
 }
+
+// ─── M1 single-parse capture: view-render + Volt-surface equivalence ──────
+//
+// Evaluating captured plans must be byte-identical to the live re-parse path,
+// across every render/Volt-surface shape the fixtures exercise.
+
+/// Resolve a controller's view() renders BOTH ways (live `view_renders_in_file`
+/// vs captured `evaluate_render_plans`), sorted for an order-independent
+/// comparison.
+fn render_both_ways(
+    resolver: &impl ClassFileResolver,
+    root: &Path,
+    controller: &str,
+) -> (Vec<ViewRender>, Vec<ViewRender>) {
+    let sort = |mut v: Vec<ViewRender>| {
+        v.sort_by(|a, b| a.view_name.cmp(&b.view_name));
+        v
+    };
+    let live = view_renders_in_file(controller, resolver, &ClassViewCache::new(), root);
+    let tree = crate::parser::parse_php(controller).unwrap();
+    let aliases = crate::query_chain::use_aliases::extract_use_aliases(&tree, controller);
+    let plans = capture_render_plans(controller, &tree, &aliases);
+    let captured = evaluate_render_plans(&plans, &aliases, resolver, &ClassViewCache::new(), root);
+    (sort(live), sort(captured))
+}
+
+#[test]
+fn captured_render_plans_match_live_across_shapes() {
+    let p = blade_project();
+    let controller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+class C {
+    public function show(User $user) {
+        $u2 = User::first();
+        view('a.array', ['user' => $user, 'other' => 42]);   // array (one typed, one not)
+        view('a.compact', compact('user'));                  // compact
+        view('a.with')->with('user', $u2);                   // ->with(k, v)
+        view('a.witharr')->with(['user' => $user]);          // ->with([...])
+        view('a.dynamic', ['x' => $undefinedVar]);           // value that won't type
+        view($dynamicName, ['user' => $user]);               // dynamic view name → skipped by both
+    }
+}
+"#;
+    let (live, captured) = render_both_ways(&p.index, &p.root, controller);
+    assert_eq!(live, captured, "captured render plans diverged from live");
+    assert!(
+        live.iter().any(|r| r.vars.contains_key("user")),
+        "fixture typed no view vars — comparison would be near-vacuous"
+    );
+}
+
+/// Type a Volt SFC's front-matter BOTH ways (live `volt_property_types` vs
+/// captured `evaluate_volt_surface`).
+fn volt_both_ways(
+    resolver: &impl ClassFileResolver,
+    root: &Path,
+    src: &str,
+) -> (HashMap<String, String>, HashMap<String, String>) {
+    let live = volt_property_types(src, resolver, &ClassViewCache::new(), root);
+    let surface = capture_volt_surface(src).expect("volt surface captured");
+    let captured = evaluate_volt_surface(&surface, resolver, &ClassViewCache::new(), root);
+    (live, captured)
+}
+
+#[test]
+fn captured_volt_surface_matches_live_across_shapes() {
+    // Typed prop (authoritative), computed (body-inferred), state, with,
+    // mount-assignment, and `$x = computed(...)` — the whole surface zoo.
+    let src = r#"<?php
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Livewire\Volt\Component;
+use function Livewire\Volt\{state, computed, mount, with};
+
+new class extends Component {
+    public User $user;               // typed prop — authoritative
+    public int $count = 0;           // non-class, dropped
+
+    public function mount(User $injected) {
+        $this->user = $injected;     // or_insert, loses to the typed prop
+    }
+
+    #[Computed]
+    public function latest(): Collection { return User::query()->latest()->get(); }
+
+    public function with(): array {
+        return ['viaWith' => User::first()];
+    }
+};
+
+$posts = computed(fn (): User => User::first());
+state(['seed' => User::first()]);
+?>
+<div>{{ $this->user->email }}</div>
+"#;
+    let (live, captured) = volt_both_ways(&ClassHierarchyIndex::default(), Path::new("/proj"), src);
+    assert_eq!(live, captured, "captured Volt surface diverged from live");
+    assert_eq!(
+        live.get("user").map(String::as_str),
+        Some("App\\Models\\User"),
+        "typed prop must stay authoritative"
+    );
+}
+
+/// Build a Blade `MemberContextData` as the parse-time capture does (per-site
+/// recipes from receiver-text snippets; empty file-level aliases).
+fn blade_context(refs: &[Arc<MemberAccessReferenceData>]) -> crate::salsa_impl::MemberContextData {
+    let sites = refs
+        .iter()
+        .map(|m| crate::member_resolver::compile_blade_site(m.receiver.trim()))
+        .collect();
+    crate::salsa_impl::MemberContextData {
+        aliases: Default::default(),
+        sites,
+        view_renders: Vec::new(),
+        volt_surface: None,
+        component: None,
+    }
+}
+
+#[test]
+fn captured_blade_member_accesses_match_live() {
+    // A bare `$user` (view-var path — recipe unused) and a chain receiver
+    // `app('currentUser')->email` (recipe path) resolved both ways.
+    let p = blade_project();
+    let mut idx = ViewVarIndex::new();
+    idx.insert_file(
+        p.root.join("C.php"),
+        &[render("users.show", &[("user", "App\\Models\\User")])],
+    );
+    let resolver = user_bound_resolver(&p, "currentUser");
+    let refs = vec![
+        member_ref("$user", "posts", 2, 4),
+        member_ref("app('currentUser')", "email", 3, 8),
+    ];
+
+    let live = resolve_blade_member_accesses(
+        &refs,
+        "users.show",
+        &idx,
+        &[],
+        &resolver,
+        &ClassViewCache::new(),
+        &p.root,
+        None,
+    );
+    let ctx = blade_context(&refs);
+    let captured = resolve_blade_member_accesses_with_context(
+        &ctx,
+        &refs,
+        "users.show",
+        &idx,
+        &[],
+        &resolver,
+        &ClassViewCache::new(),
+        &p.root,
+        None,
+    );
+    assert_eq!(live, captured, "captured Blade accesses diverged from live");
+    assert_eq!(captured.len(), 2, "both sites should resolve: {captured:?}");
+}
+
+// ─── M1 review follow-ups: Bug 1 & Bug 2 regressions + coverage ───────────
+
+#[test]
+fn captured_volt_duplicate_key_within_handler_is_last_wins() {
+    // Bug 1: within ONE render() handler the tree engine merges the array data
+    // and the chained ->with into a single temp map with `insert` (LAST-wins),
+    // then or_inserts across handlers. A flat first-wins replay wrongly kept the
+    // array value. Trigger: array `account => User` shadowed by `->with('account',
+    // Admin)` in the same handler → must be Admin, with the Admin dep.
+    let src = r#"<?php
+use App\Models\User;
+use App\Models\Admin;
+use Livewire\Volt\Component;
+new class extends Component {
+    public function render() {
+        return view('x', ['account' => User::first()])->with('account', Admin::first());
+    }
+};
+?>
+<div>{{ $this->account->id }}</div>
+"#;
+    let (live, captured) = volt_both_ways(&ClassHierarchyIndex::default(), Path::new("/proj"), src);
+    assert_eq!(
+        live, captured,
+        "duplicate-key-within-handler diverged from live"
+    );
+    assert_eq!(
+        live.get("account").map(String::as_str),
+        Some("App\\Models\\Admin"),
+        "within-handler last-wins: ->with('account', Admin) must beat the array value"
+    );
+}
+
+#[test]
+fn captured_volt_first_handler_wins_across_handlers() {
+    // The other half of the precedence: across DISTINCT handlers a key is
+    // FIRST-VISITED-handler-wins (`fold_or_insert` → `or_insert`). BOTH engines
+    // walk the front-matter with the SAME stack DFS, which pops sibling
+    // statements last-to-first — so of two top-level handlers the SOURCE-LAST one
+    // (`with` here) is visited first and wins. The point of this test is that
+    // live == captured for the cross-handler fold AND the winner is a specific,
+    // non-empty value (so it can't pass vacuously) — not the source position.
+    let src = r#"<?php
+use App\Models\User;
+use App\Models\Admin;
+use Livewire\Volt\Component;
+use function Livewire\Volt\{state, with};
+new class extends Component {};
+state(['a' => User::first()]);
+with(fn () => ['a' => Admin::first()]);
+?>
+<div>{{ $this->a }}</div>
+"#;
+    let (live, captured) = volt_both_ways(&ClassHierarchyIndex::default(), Path::new("/proj"), src);
+    assert_eq!(
+        live, captured,
+        "cross-handler precedence diverged from live"
+    );
+    // First-VISITED handler wins: the DFS reaches `with` (source-last) before
+    // `state`, so `a = Admin` in both engines.
+    assert_eq!(
+        live.get("a").map(String::as_str),
+        Some("App\\Models\\Admin"),
+        "cross-handler or_insert: the first-VISITED handler (with) must win"
+    );
+    assert!(
+        !live.is_empty(),
+        "surface resolved nothing — test would be vacuous"
+    );
+}
+
+#[test]
+fn captured_volt_within_handler_earlier_resolved_beats_unresolvable_later() {
+    // The precise over-correction guard for Bug 1's fix: WITHIN one handler the
+    // tree engine inserts ONLY when the value resolves (resolvability is
+    // cross-file / eval-time), so a LATER UNRESOLVABLE duplicate must NOT clobber
+    // an EARLIER resolved one. A capture-time last-occurrence dedup would wrongly
+    // keep the unresolvable later value and drop `account` entirely. (`$mystery`
+    // is an undefined local → unresolvable at eval.) Both the array-literal
+    // duplicate and the view([...])->with('same', $mystery) chain form.
+    let array_form = r#"<?php
+use App\Models\User;
+use Livewire\Volt\Component;
+use function Livewire\Volt\with;
+new class extends Component {};
+with(fn () => ['account' => User::first(), 'account' => $mystery]);
+?>
+<div>{{ $this->account }}</div>
+"#;
+    let chain_form = r#"<?php
+use App\Models\User;
+use Livewire\Volt\Component;
+new class extends Component {
+    public function render() {
+        return view('x', ['account' => User::first()])->with('account', $mystery);
+    }
+};
+?>
+<div>{{ $this->account }}</div>
+"#;
+    for src in [array_form, chain_form] {
+        let (live, captured) =
+            volt_both_ways(&ClassHierarchyIndex::default(), Path::new("/proj"), src);
+        assert_eq!(
+            live, captured,
+            "earlier-resolved-vs-later-unresolvable diverged from live:\n{src}"
+        );
+        assert_eq!(
+            live.get("account").map(String::as_str),
+            Some("App\\Models\\User"),
+            "earlier RESOLVED value must win over a later unresolvable one:\n{src}"
+        );
+    }
+}
+
+#[test]
+fn is_volt_needle_without_frontmatter_routes_to_volt_not_blade() {
+    // Bug 2: `source_contains_volt_signature` is a raw-byte needle scan (no
+    // `<?php` required), so a plain template with a stray `computed(` and no
+    // front-matter is is_volt=true / volt_surface=None. The OLD engine and the
+    // save-refresh route such a file to the VOLT resolver (empty props); the
+    // build path must too — never to the Blade resolver, whose view-var index
+    // would resolve `$user->email` and whose `view_name_for_path?` could drop
+    // the whole file.
+    let p = blade_project();
+    let mut idx = ViewVarIndex::new();
+    idx.insert_file(
+        p.root.join("C.php"),
+        &[render("users.show", &[("user", "App\\Models\\User")])],
+    );
+
+    let source = "<div x-data=\"{ get computed() { return 1 } }\">{{ $user->email }}</div>\n";
+    assert!(
+        crate::livewire_resolver::source_contains_volt_signature(source),
+        "test needs the volt needle to fire — signature function changed?"
+    );
+    let path = p.root.join("resources/views/users/show.blade.php");
+    let refs = vec![member_ref("$user", "email", 0, 20)];
+    let ctx = crate::member_capture::capture_member_context(&path, source, None, &refs, true)
+        .expect("is_volt file with refs captures context");
+    assert!(
+        ctx.volt_surface.is_none(),
+        "a needle without a <?php block must have no captured Volt surface"
+    );
+
+    // What BOTH build and save now call: the Volt resolver with an empty prop
+    // map. It must match the OLD tree Volt path (also an empty map).
+    let volt_ctx = resolve_volt_member_accesses_with_context(
+        &ctx,
+        &refs,
+        &HashMap::new(),
+        &[],
+        &p.index,
+        &ClassViewCache::new(),
+        &p.root,
+        None,
+    );
+    let volt_tree = resolve_volt_member_accesses(
+        &refs,
+        &volt_property_types(source, &p.index, &ClassViewCache::new(), &p.root),
+        &[],
+        &p.index,
+        &ClassViewCache::new(),
+        &p.root,
+        None,
+    );
+    assert_eq!(
+        volt_ctx, volt_tree,
+        "Volt build path diverged from Volt save/old"
+    );
+
+    // And the routing genuinely matters: the Blade path WOULD resolve
+    // `$user->email` via the view-var index — the bug's misroute. The fix picks
+    // Volt (empty), so the two paths differ.
+    let blade = resolve_blade_member_accesses(
+        &refs,
+        "users.show",
+        &idx,
+        &[],
+        &p.index,
+        &ClassViewCache::new(),
+        &p.root,
+        None,
+    );
+    assert_ne!(
+        volt_ctx, blade,
+        "Volt vs Blade must differ here, else the routing fix is untested"
+    );
+    assert!(volt_ctx.is_empty() && !blade.is_empty());
+}
+
+#[test]
+fn captured_render_multiple_sites_same_view_name() {
+    // Two `view('x', …)` sites for the SAME view name must both survive in
+    // order, and match live (the view-var index unions them downstream).
+    let p = blade_project();
+    let controller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+class C {
+    public function a(User $user) { view('shared', ['user' => $user]); }
+    public function b(User $user) { view('shared', ['also' => $user]); }
+}
+"#;
+    let (live, captured) = render_both_ways(&p.index, &p.root, controller);
+    assert_eq!(live, captured, "multi-site same-name renders diverged");
+    assert_eq!(
+        live.iter().filter(|r| r.view_name == "shared").count(),
+        2,
+        "both same-name render sites must be present: {live:?}"
+    );
+}
+
+#[test]
+fn captured_render_duplicate_array_key_last_wins() {
+    // A duplicate key inside ONE `view()` array is last-wins (the tree's
+    // `vars.insert`); the controller render path already uses `insert`, so
+    // capture must agree.
+    let p = blade_project();
+    let controller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+use App\Models\Admin;
+class C {
+    public function show(User $user, Admin $admin) {
+        view('x', ['who' => $user, 'who' => $admin]);
+    }
+}
+"#;
+    let (live, captured) = render_both_ways(&p.index, &p.root, controller);
+    assert_eq!(live, captured, "duplicate array key diverged");
+    assert_eq!(
+        live[0].vars.get("who").map(String::as_str),
+        Some("App\\Models\\Admin"),
+        "last array entry wins"
+    );
+}
+
+#[test]
+fn captured_component_member_accesses_match_live() {
+    // resolve_component_member_accesses_with_context (captured member names for
+    // a Volt SFC) must match the live re-parse for the component's `$this->…`
+    // reads.
+    let p = blade_project();
+    let source = r#"<?php
+use App\Models\User;
+use Livewire\Volt\Component;
+new class extends Component {
+    public User $user;
+    public int $count = 0;
+    public function increment() { $this->count++; }
+};
+?>
+<div>{{ $this->user }} {{ $this->count }}</div>
+"#;
+    let path = p.root.join("resources/views/livewire/counter.blade.php");
+    let refs = vec![
+        member_ref("$this", "user", 10, 4),
+        member_ref("$this", "count", 10, 20),
+        member_ref("$this", "increment", 11, 4),
+        member_ref("$this", "notAMember", 12, 4),
+    ];
+
+    let live = resolve_component_member_accesses(&path, source, &refs);
+    let comp = capture_component(&path, source, true).expect("volt SFC → component context");
+    let captured = resolve_component_member_accesses_with_context(&comp, &path, &refs);
+
+    assert_eq!(
+        live, captured,
+        "component member accesses diverged from live"
+    );
+    assert_eq!(
+        captured.len(),
+        3,
+        "user/count/increment index; notAMember drops"
+    );
+    assert!(captured.iter().all(|e| e.fqcn.starts_with("volt::")));
+}


### PR DESCRIPTION
## Indexing performance overhaul

Rebuilds the `laravel-lsp` initial-index pipeline. On a 47k-file project the cold index went from extrapolating to **2+ hours** to **~54 seconds of visible work**, and warm reloads are near-instant.

### The O(n²) fix
Initial-index magic-member resolution was O(files × ancestors): a fresh `ClassViewCache` per file re-analyzed shared ancestors (Eloquent `Model`, base controllers, traits) once per referencing file, amplified by full-directory re-walks and repeated parent re-reads.

- `9de58d6` — magic-member resolution benchmark (per-optimization isolation)
- `44a8885` — share one concurrent `ClassViewCache` across all build workers
- `c475c72` — memoize the class-locator WalkDir fallback (app-over-vendor precedence + `path_within_root` containment preserved)
- `3148d03` — memoize parsed class-file structures in the chain walker (`mtime+size` revalidated, LRU-bounded)

### Features & architecture
- `1851a74` — **"Reindex project" global code action** (`cmd-.` in any PHP/Blade file → full cold rebuild)
- `5621cf9` — **M1: single-parse capture** — resolve magic members from context captured at parse time, eliminating the per-target-file re-read + re-parse the resolve passes did (~5× faster resolve; proven byte-identical to the tree path by equivalence tests)
- `c0d244a` — **M2: external-edit convergence** — route watched `.php` edits (git pull, formatters, branch switch) through the precise dependency-tracked incremental path, and widen the watcher to composer PSR-4 source roots. Removes a 15k-file size gate that silently skipped magic-index convergence on large projects, and closes a `magic_deps`/`view_vars` leak on watched deletes.
- `d07b4db` + `0d0f147` — **M3: honest progress bar** — one monotonic 0→100% bar (no reset); parse reporting in completion order (a slow file can't stall the count); the ~42s cache save moved off the critical path; the cache-load freshness pass parallelized with `rayon` and animated.
- `b85b104` — **M4: lazy vendor indexing** — index a vendor file's own magic-member usages on `did_open` (LRU-bounded), so find-references includes vendor occurrences without the eager 31k-file cost.

### Verification
Each milestone: investigation → design (options + decision) → implementation → adversarial multi-agent review → remediation → test. **2,635 tests pass; `clippy --all-targets -D warnings` clean; `cargo fmt` clean.** Correctness invariants held under review: byte-identical resolution equivalence (M1), save-path parity (M2), monotonic progress + concurrent-save safety (M3), parallel-load result-equivalence (M3).

### Follow-ups (tracked separately)
- Quiet the DB schema pre-warm when the database is unreachable (currently retries a down MySQL with 5s timeouts).
- Shrink the on-disk pattern cache — M1's captured context inflated each entry, which is why the background save is large.
