### PR TITLE
Harden release.yml `sed` version substitutions against metacharacter breakage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,17 @@ jobs:
           fi
           # Remove 'v' prefix if present (e.g., v1.2.3 -> 1.2.3)
           VERSION="${TAG#v}"
+          # Fail fast unless VERSION is a strict semver (with optional
+          # pre-release suffix). Every downstream consumer — the three sed
+          # version substitutions, the commit message, and the tag/release
+          # curl calls — uses this value or the tag it derives from, so this
+          # single guard keeps sed metacharacters (/, &, \) and anything else
+          # surprising out of all of them.
+          SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$'
+          if [[ ! "$VERSION" =~ $SEMVER_RE ]]; then
+            echo "::error::Tag '${TAG}' does not yield a valid semver version (got '${VERSION}')"
+            exit 1
+          fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "Extracted version: ${VERSION}"
 

--- a/laravel-lsp/src/livewire_resolver.rs
+++ b/laravel-lsp/src/livewire_resolver.rs
@@ -207,10 +207,7 @@ pub fn resolve_component(
     let sub = parents_to_path(parents);
 
     let base_dirs: Vec<&PathBuf> = match namespace {
-        Some(ns) => match config.component_namespaces.get(ns) {
-            Some(p) => vec![p],
-            None => return None,
-        },
+        Some(ns) => vec![config.component_namespaces.get(ns)?],
         None => config.component_locations.iter().collect(),
     };
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -8163,39 +8163,36 @@ impl LaravelLanguageServer {
             if !has_middleware_context {
                 // Check previous lines (up to 20 lines back) for middleware array context
                 // We need to find an opening pattern without a matching close
-                if let Some(prev_lines) = previous_lines {
-                    let mut found_in_previous = false;
-                    let mut bracket_depth = 0i32;
+                let prev_lines = previous_lines?;
+                let mut found_in_previous = false;
+                let mut bracket_depth = 0i32;
 
-                    // Scan backwards through previous lines
-                    for prev_line in prev_lines.iter().rev().take(20) {
-                        // Count brackets to track nesting
-                        for ch in prev_line.chars() {
-                            match ch {
-                                '[' => bracket_depth += 1,
-                                ']' => bracket_depth -= 1,
-                                _ => {}
-                            }
-                        }
-
-                        // Check if this line has a middleware indicator
-                        if middleware_indicators
-                            .iter()
-                            .any(|ind| prev_line.contains(ind))
-                        {
-                            // Found middleware context, and we should still be inside it
-                            // (bracket_depth > 0 means we haven't closed the array yet)
-                            if bracket_depth > 0 {
-                                found_in_previous = true;
-                                break;
-                            }
+                // Scan backwards through previous lines
+                for prev_line in prev_lines.iter().rev().take(20) {
+                    // Count brackets to track nesting
+                    for ch in prev_line.chars() {
+                        match ch {
+                            '[' => bracket_depth += 1,
+                            ']' => bracket_depth -= 1,
+                            _ => {}
                         }
                     }
 
-                    if !found_in_previous {
-                        return None;
+                    // Check if this line has a middleware indicator
+                    if middleware_indicators
+                        .iter()
+                        .any(|ind| prev_line.contains(ind))
+                    {
+                        // Found middleware context, and we should still be inside it
+                        // (bracket_depth > 0 means we haven't closed the array yet)
+                        if bracket_depth > 0 {
+                            found_in_previous = true;
+                            break;
+                        }
                     }
-                } else {
+                }
+
+                if !found_in_previous {
                     return None;
                 }
             }

--- a/laravel-lsp/src/query_chain/cursor.rs
+++ b/laravel-lsp/src/query_chain/cursor.rs
@@ -390,15 +390,12 @@ fn initial_receiver_context(
                         (BuilderMode::BaseBuilder, None, None, None)
                     }
                 },
-                _ => match php_type {
-                    Some(class) => (
-                        BuilderMode::EloquentBuilder,
-                        None,
-                        Some(class.clone()),
-                        None,
-                    ),
-                    None => return None,
-                },
+                _ => (
+                    BuilderMode::EloquentBuilder,
+                    None,
+                    Some(php_type.clone()?),
+                    None,
+                ),
             }
         }
         // `$user->competitions->where(...)` — start at the base variable's


### PR DESCRIPTION
## Summary
Implements #243 — defense-in-depth follow-up from the review of #240 (PR #242). The "Update versions and lock files" step embedded `$VERSION` (tag-derived) unescaped into three `sed` substitution expressions; a tag containing `sed` metacharacters (`/`, `&`, `\`) would break them.

## Changes
- Add a fail-fast semver guard in the `extract_version` step of `.github/workflows/release.yml`, immediately after `VERSION="${TAG#v}"` and **before** the `$GITHUB_OUTPUT` write (so a hostile `workflow_dispatch` tag can't inject step outputs either).
- Guard regex is exactly the one specified in the AC: `^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$` — permits only digits, dots, and `[-.][0-9A-Za-z.-]` suffixes, so no `sed` metacharacter, quote, space, or newline can pass.
- All three `sed` call-sites inherit the guarantee from the single guard — no per-site escaping needed.
- **CI unblock (unrelated to #243's subject but required for a green gate):** clippy 1.97 (current stable on CI runners) newly flags three `clippy::question_mark` sites on `main` (`livewire_resolver.rs:210`, `query_chain/cursor.rs:393`, `main.rs:8166`), and CI runs `clippy --all-targets -- -D warnings`, so every PR was red. Replaced the three match/if-let blocks with the equivalent `?` expressions — behavior unchanged, two atomic `style` commits.

## Acceptance Criteria
- [x] `release.yml` — `Cargo.toml` `sed`: $VERSION substitution safe (strict semver validation up front)
- [x] `release.yml` — `extension.toml` `sed`: same hardening
- [x] `release.yml` — `laravel-lsp/Cargo.toml` `sed`: same hardening
- [x] Single up-front guard: $VERSION validated against `^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$` immediately after `VERSION="${TAG#v}"`, step fails on mismatch, all three call-sites inherit the guarantee
- [x] Confirmed no other unescaped interpolation of tag-derived values into shell tools remains: `TAG_NAME` in the "Update tag and release" `curl` calls runs in the same job **after** the guard step (guard failure kills the job first), and a guarded `VERSION` constrains the tag itself to `v?` + `[0-9A-Za-z.-]` — no `/`, `&`, `\`, or `"` can reach the URL or JSON body. `matrix.*`/`runner.os` are workflow constants; the `softprops` `tag_name:` is an action input, not shell interpolation.

## Test Plan
- [x] Regex matrix (local bash, same `[[ =~ ]]` semantics as the runner): accepts `1.2.3`, `0.6.0`, `1.2.3-beta.1`, `1.2.3.4`, `10.20.30-rc-2`; rejects `1.2`, `v1.2.3`, `1.2.3/x`, `1.2.3&`, `1.2.3\1e`, `1.2.3"; curl evil`, trailing space, empty string, newline-injection payload
- [x] Full step simulation under `bash -e`: benign tags (`v0.6.1`, `v1.2.3-beta.1`) → rc=0, `version=` output written; hostile tags (`v1.2.3/&\`, `v1.2.3"; curl evil`) → rc=1, `::error::` emitted, **nothing** written to `$GITHUB_OUTPUT`
- [x] YAML parses cleanly (ruby `YAML.load_file`)
- [x] Clippy fixes verified locally on clippy 1.97 with `--all-targets -- -D warnings` (same invocation as CI); `cargo fmt --check` clean; all 2553 LSP tests pass
- [x] CI green

Fixes #243