### PR TITLE
Linter hover shows warning, but does not indicate squiggly underline.

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -19527,11 +19527,26 @@ return [
 
     /// Route — detail line (verb + URI + action) + the route registration
     /// line from source + link to the `->name(` callsite.
+    ///
+    /// Mirrors the guards in [`Self::route_not_found_diagnostics`] (issue #247):
+    /// an absent or empty index means every route would look missing (the
+    /// startup false-positive), and wildcard names (`players.*`) reference a
+    /// *family* of routes that never appears verbatim in the index (issue
+    /// #209) — all three suppress the hover card entirely (empty string → no
+    /// card) rather than render a false "not found" trailer.
     async fn hover_for_route(&self, name: &str) -> String {
         use laravel_lsp::hover;
+        if name.contains('*') {
+            return String::new();
+        }
         let idx_guard = self.route_index.read().await;
-        let def = idx_guard.as_ref().and_then(|idx| idx.get(name));
-        let Some(def) = def else {
+        let Some(idx) = idx_guard.as_ref() else {
+            return String::new();
+        };
+        if idx.is_empty() {
+            return String::new();
+        }
+        let Some(def) = idx.get(name) else {
             return hover::render(&hover::HoverContent {
                 trailer: Some("*(route not found in index)*"),
                 ..Default::default()

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -37,6 +37,7 @@ mod query_chain_completion_handler;
 mod rename_integration;
 mod route_binding_resolution;
 mod route_diagnostics;
+mod route_hover;
 mod routes_dir_gate;
 mod scan_dir_containment;
 mod slot_navigation_containment;

--- a/laravel-lsp/src/tests/route_hover.rs
+++ b/laravel-lsp/src/tests/route_hover.rs
@@ -1,0 +1,115 @@
+//! Coverage for `LaravelLanguageServer::hover_for_route` guard parity with
+//! `route_not_found_diagnostics` (issue #247).
+//!
+//! The diagnostic path learned three guards — absent index, empty (cold-start)
+//! index, wildcard name (issue #209) — but the hover path kept rendering a
+//! "route not found in index" trailer in all three situations, so hover
+//! disagreed with the (silent) squiggly. These tests drive the real private
+//! `hover_for_route` on a live server instance (repo `test_server()` pattern)
+//! with the route index primed directly, and pin down:
+//!   (a) absent index      → empty string, no card
+//!   (b) empty index       → empty string, no card
+//!   (c) wildcard name     → empty string, no card (even against a non-empty index)
+//!   (d) genuine miss      → "route not found in index" trailer, unchanged
+//!   (e) found route       → full detail card, unchanged
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::route_discovery::{RouteDefinition, RouteIndex};
+use std::path::PathBuf;
+use tower_lsp::LspService;
+
+/// Build a server instance for testing. `LspService::new` wires up a real
+/// `Client`; `inner()` hands back the `LaravelLanguageServer` so we can prime
+/// its private `route_index` and call its private `hover_for_route`.
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// An index holding `home` with full detail metadata, so the found-route card
+/// renders the verb + URI + action line. Mirrors `index_with` in
+/// `route_diagnostics.rs`, plus the optional detail fields.
+fn index_with_home() -> RouteIndex {
+    let mut idx = RouteIndex::new();
+    idx.insert(
+        "home".to_string(),
+        RouteDefinition {
+            file: PathBuf::from("routes/web.php"),
+            line: 0,
+            column: 0,
+            end_column: 0,
+            priority: 0,
+            method: Some("get".to_string()),
+            uri: Some("/".to_string()),
+            action: Some("HomeController@index".to_string()),
+        },
+    );
+    idx
+}
+
+/// Prime the server's route index and render the hover for `name`.
+async fn hover_with_index(index: Option<RouteIndex>, name: &str) -> String {
+    let server = test_server();
+    *server.route_index.write().await = index;
+    server.hover_for_route(name).await
+}
+
+#[tokio::test]
+async fn absent_index_renders_nothing() {
+    // Before the index is built, every route would look missing — same guard
+    // as `route_not_found_diagnostics`.
+    let rendered = hover_with_index(None, "home").await;
+    assert!(
+        rendered.is_empty(),
+        "absent index must suppress the hover card, got: {rendered:?}"
+    );
+}
+
+#[tokio::test]
+async fn empty_index_renders_nothing() {
+    // Cold-start guard: an index that exists but holds nothing yet must not
+    // make every route look missing.
+    let rendered = hover_with_index(Some(RouteIndex::new()), "home").await;
+    assert!(
+        rendered.is_empty(),
+        "empty index must suppress the hover card, got: {rendered:?}"
+    );
+}
+
+#[tokio::test]
+async fn wildcard_name_renders_nothing() {
+    // Wildcard patterns (`players.*`) reference a family of routes and never
+    // appear verbatim in the index (issue #209) — no not-found trailer, even
+    // against a non-empty index.
+    let rendered = hover_with_index(Some(index_with_home()), "players.*").await;
+    assert!(
+        rendered.is_empty(),
+        "wildcard route names must suppress the hover card, got: {rendered:?}"
+    );
+}
+
+#[tokio::test]
+async fn genuine_miss_renders_not_found_trailer() {
+    let rendered = hover_with_index(Some(index_with_home()), "does.not.exist").await;
+    assert!(
+        rendered.contains("route not found in index"),
+        "a genuine miss must keep the not-found trailer, got: {rendered:?}"
+    );
+}
+
+#[tokio::test]
+async fn found_route_renders_detail_card() {
+    let rendered = hover_with_index(Some(index_with_home()), "home").await;
+    assert!(
+        !rendered.is_empty(),
+        "a found route must render the detail card"
+    );
+    assert!(
+        !rendered.contains("not found"),
+        "a found route must not carry a not-found trailer, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("GET"),
+        "the detail card must carry the HTTP verb, got: {rendered:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Implements #247

Hover over a `route('…')` reference rendered a *(route not found in index)* trailer even in situations where the diagnostics path stays silent — absent index (startup), empty index (cold start), and wildcard names (`players.*`, issue #209). `hover_for_route` now mirrors the exact guards of `route_not_found_diagnostics`, so hover and squiggly always agree.

## Changes
- `hover_for_route` returns an empty string (no hover card) when the route index is absent, when it is present but empty, or when the route name contains `*` — the same three guards `route_not_found_diagnostics` applies
- Genuine-miss behaviour unchanged: non-wildcard name absent from a non-empty index still renders the *(route not found in index)* trailer
- Found-route behaviour unchanged: full detail card (verb + URI + action + source link)
- New test module `laravel-lsp/src/tests/route_hover.rs` driving the real private `hover_for_route` on a live server instance (repo `test_server()` pattern)

## Acceptance Criteria
- [x] `hover_for_route` returns an empty string (no hover card rendered) when `self.route_index` is `None` — same absent-index guard already applied in `route_not_found_diagnostics`
- [x] `hover_for_route` returns an empty string when the index is present but `is_empty()` — same cold-start guard as `route_not_found_diagnostics`
- [x] `hover_for_route` returns an empty string when the route name contains `*` — same wildcard suppression added to `route_not_found_diagnostics` for issue #209
- [x] `hover_for_route` continues to render `*(route not found in index)*` when the name is a genuine miss: non-wildcard, non-empty, non-absent index, route absent from it
- [x] `hover_for_route` continues to render the full detail card (HTTP verb + URI + controller action + source link) when the route IS found — existing happy-path behaviour is unchanged
- [x] A new test module `laravel-lsp/src/tests/route_hover.rs` is added covering: (a) absent index → empty string, (b) empty index → empty string, (c) wildcard name against a non-empty index → empty string, (d) genuine miss against a non-empty index → string contains "route not found in index", (e) found route → string is non-empty and does not contain "not found"
- [x] No existing tests in `route_diagnostics.rs` are broken — the diagnostic path is not changed

## Test Plan
- [x] All existing tests pass — full `cargo test`: 2703 passed, 0 failed (includes all `route_diagnostics` tests)
- [x] New tests cover the changes — 5 tests in `tests/route_hover.rs`, all passing
- [x] `cargo fmt` + `cargo clippy --tests` clean

Fixes #247