### PR TITLE
fix: registry reverse-index lag on provider-body edits + nondeterministic equal-priority merge

### DIFF
--- a/laravel-lsp/src/magic_dependency_index.rs
+++ b/laravel-lsp/src/magic_dependency_index.rs
@@ -21,6 +21,16 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+/// Key-space prefix for a *container-binding attempt* dependency: a site whose
+/// receiver is a string-keyed container resolution (`app('key')`,
+/// `resolve('key')`, or a mapped zero-arg helper like `view()`) records
+/// `binding:<key>` — resolved or not. The colon keeps the space disjoint from
+/// FQCNs (`:` can't appear in a PHP class name), and recording the *abstract*
+/// key is what lets a brand-new binding ripple to its call sites on the
+/// provider save (#255): those sites resolved to nothing before, so they hold
+/// no concrete-FQCN dependency the registration diff could otherwise reach.
+pub const BINDING_DEP_PREFIX: &str = "binding:";
+
 #[derive(Default, Debug)]
 pub struct MagicDependencyIndex {
     /// fqcn → files that resolved a receiver against it.

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -38,11 +38,11 @@ use laravel_lsp::route_discovery::{
 
 // Salsa 0.25 database - integrated via actor pattern for async compatibility
 use laravel_lsp::salsa_impl::{
-    ActionReferenceData, AssetReferenceData, BindingReferenceData, ComponentReferenceData,
-    ConfigReferenceData, DirectiveReferenceData, EnvReferenceData, FeatureReferenceData,
-    LaravelConfigData, LivewireReferenceData, MiddlewareReferenceData, PatternAtPosition,
-    ReferenceLocationData, RouteReferenceData, SalsaActor, SalsaHandle, TranslationReferenceData,
-    UrlReferenceData, ViewReferenceData,
+    registration_ripple_keys, ActionReferenceData, AssetReferenceData, BindingReferenceData,
+    ComponentReferenceData, ConfigReferenceData, DirectiveReferenceData, EnvReferenceData,
+    FeatureReferenceData, LaravelConfigData, LivewireReferenceData, MiddlewareReferenceData,
+    PatternAtPosition, ReferenceLocationData, RouteReferenceData, SalsaActor, SalsaHandle,
+    TranslationReferenceData, UrlReferenceData, ViewReferenceData,
 };
 
 // The Linux release binaries are static musl builds; musl's default
@@ -6390,13 +6390,16 @@ impl LaravelLanguageServer {
     /// no magic work). The flow (#80):
     ///
     /// 1. Snapshot the file's pre-save class surfaces (the hierarchy still
-    ///    holds them — nothing has re-parsed yet).
+    ///    holds them — nothing has re-parsed yet) and, for a provider, its
+    ///    registration contribution (macros / bindings / facade aliases).
     /// 2. Push the saved buffer into Salsa, run the instant per-file refresh
     ///    (which re-parses, updates the hierarchy, records receiver deps, and
     ///    updates the file's view-render contribution).
-    /// 3. Diff pre/post surfaces and view renders. A body-only edit — the
-    ///    overwhelming majority of saves — diffs empty and stops here: no
-    ///    other file's resolution can have changed.
+    /// 3. Diff pre/post surfaces, registrations, and view renders. An edit
+    ///    that changes none of them — the overwhelming majority of saves —
+    ///    diffs empty and stops here: no other file's resolution can have
+    ///    changed. (Registration diffs are what catch a `boot()`/`register()`
+    ///    body edit whose surface diff is empty, #255.)
     /// 4. Otherwise re-resolve only the actual blast radius (dependents of
     ///    the changed classes + their descendants, plus Blade files of views
     ///    whose variable types changed) in the background, at bounded
@@ -6419,6 +6422,18 @@ impl LaravelLanguageServer {
             .await
             .unwrap_or_default();
 
+        // Pre-save registration snapshot (#255) — a provider's macros /
+        // bindings / facade aliases live in `boot()`/`register()` BODIES, so
+        // a registration edit leaves the class-surface diff below empty and
+        // would never ripple to dependent call sites. Cheap for the
+        // non-provider majority: a path the actor doesn't track yields the
+        // empty default.
+        let old_registrations = self
+            .salsa
+            .file_provider_registrations(path.clone(), None)
+            .await
+            .unwrap_or_default();
+
         // Ensure Salsa reflects the saved buffer before resolving — a pending
         // did_change debounce may not have fired yet. Use the buffer's version
         // so this doesn't regress against a newer in-flight update.
@@ -6437,6 +6452,17 @@ impl LaravelLanguageServer {
             debug!("Failed to update Salsa on save for {}: {}", path_str, e);
         }
 
+        // Post-save registration snapshot (#255). `Some(text)` re-registers
+        // the provider source first — the App rescan a provider save queues is
+        // asynchronous, so without it this would still read the pre-save
+        // text. Taken before the per-file refresh so that pass already sees
+        // the fresh registries.
+        let new_registrations = self
+            .salsa
+            .file_provider_registrations(path.clone(), Some(text.to_string()))
+            .await
+            .unwrap_or_default();
+
         let changed_views = self.refresh_file_magic(&path, text).await;
 
         let new_surfaces = self
@@ -6444,15 +6470,27 @@ impl LaravelLanguageServer {
             .file_class_surfaces(path.clone())
             .await
             .unwrap_or_default();
-        let changed_classes =
+        let mut changed_classes =
             laravel_lsp::class_hierarchy_index::surface_map_diff(&old_surfaces, &new_surfaces);
+        // A body-only registration edit ripples through the same blast radius
+        // as a surface change: the emitted keys are what dependent call sites
+        // recorded in the reverse index (macro host FQCNs, binding/alias
+        // concretes, the provider's own path), and expand_class_descendants
+        // passes unknown seeds through unchanged into dependents_of (#255).
+        changed_classes.extend(registration_ripple_keys(
+            &old_registrations,
+            &new_registrations,
+            &path,
+        ));
 
         // The per-file refresh above already mutated the live indexes —
         // keep the disk cache converging regardless of ripple size.
         self.schedule_magic_cache_save().await;
 
         if changed_classes.is_empty() && changed_views.is_empty() {
-            return; // body-only edit — nothing beyond this file can change
+            // No surface, render, or registration change — nothing beyond
+            // this file can have changed.
+            return;
         }
 
         // The ripple runs in the background so did_save returns promptly. The

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -1911,6 +1911,11 @@ struct LaravelLanguageServer {
     /// formatter, branch switch) into one dependency-tracked incremental
     /// reconverge; a batch already draining is never aborted.
     magic_rebuild_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
+    /// Handle for the save-path dependent-ripple task
+    /// ([`Self::refresh_magic_on_save`]'s background `refresh_magic_dependents`
+    /// spawn), kept solely so tests can await the ripple deterministically
+    /// (#255) — the production path never joins or aborts it.
+    magic_ripple_handle: Arc<RwLock<Option<tokio::task::JoinHandle<()>>>>,
     /// Accumulated external `.php` changes + the batch task's liveness flag,
     /// under one mutex (see [`WatchedBatchState`]). Producer:
     /// `did_change_watched_files` records events and spawns a task iff none is
@@ -4320,6 +4325,7 @@ impl LaravelLanguageServer {
             pending_rescans: Arc::new(RwLock::new(HashSet::new())),
             rescan_debounce_handle: Arc::new(RwLock::new(None)),
             magic_rebuild_handle: Arc::new(RwLock::new(None)),
+            magic_ripple_handle: Arc::new(RwLock::new(None)),
             magic_batch_state: Arc::new(tokio::sync::Mutex::new(WatchedBatchState::default())),
             file_exists_cache: Arc::new(RwLock::new(HashMap::new())),
             cached_config: Arc::new(RwLock::new(None)),
@@ -6494,11 +6500,14 @@ impl LaravelLanguageServer {
         let server = self.clone_for_spawn();
         let mut already_refreshed = HashSet::new();
         already_refreshed.insert(path.clone());
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             server
                 .refresh_magic_dependents(&already_refreshed, changed_classes, changed_views)
                 .await;
         });
+        // Kept awaitable for the save-path regression tests (#255) — mirrors
+        // `magic_rebuild_handle` on the watched-files batch.
+        *self.magic_ripple_handle.write().await = Some(handle);
     }
 
     /// Re-resolve the blast radius of a surface or render change: dependents
@@ -16985,6 +16994,7 @@ return [
             pending_rescans: self.pending_rescans.clone(),
             rescan_debounce_handle: self.rescan_debounce_handle.clone(),
             magic_rebuild_handle: self.magic_rebuild_handle.clone(),
+            magic_ripple_handle: self.magic_ripple_handle.clone(),
             magic_batch_state: self.magic_batch_state.clone(),
             file_exists_cache: self.file_exists_cache.clone(),
             cached_config: self.cached_config.clone(),

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -6422,18 +6422,6 @@ impl LaravelLanguageServer {
             .await
             .unwrap_or_default();
 
-        // Pre-save registration snapshot (#255) — a provider's macros /
-        // bindings / facade aliases live in `boot()`/`register()` BODIES, so
-        // a registration edit leaves the class-surface diff below empty and
-        // would never ripple to dependent call sites. Cheap for the
-        // non-provider majority: a path the actor doesn't track yields the
-        // empty default.
-        let old_registrations = self
-            .salsa
-            .file_provider_registrations(path.clone(), None)
-            .await
-            .unwrap_or_default();
-
         // Ensure Salsa reflects the saved buffer before resolving — a pending
         // did_change debounce may not have fired yet. Use the buffer's version
         // so this doesn't regress against a newer in-flight update.
@@ -6452,12 +6440,19 @@ impl LaravelLanguageServer {
             debug!("Failed to update Salsa on save for {}: {}", path_str, e);
         }
 
-        // Post-save registration snapshot (#255). `Some(text)` re-registers
-        // the provider source first — the App rescan a provider save queues is
-        // asynchronous, so without it this would still read the pre-save
-        // text. Taken before the per-file refresh so that pass already sees
-        // the fresh registries.
-        let new_registrations = self
+        // Registration snapshot pair (#255) — a provider's macros / bindings /
+        // facade aliases live in `boot()`/`register()` BODIES, so a
+        // registration edit leaves the class-surface diff below empty and
+        // would never ripple to dependent call sites. One transactional call:
+        // `before` is the actor-kept baseline (last save), NOT the live
+        // inputs — the did_change debounce eagerly overwrites those on every
+        // typing pause, so a pre-save read here would already see the edited
+        // text and diff empty. `Some(text)` re-registers the saved buffer
+        // (provider input, or config/app.php's config input) before `after`
+        // is read, and advances the baseline. Taken before the per-file
+        // refresh so that pass already sees the fresh registries. Cheap for
+        // the non-provider majority: an untracked path yields empty defaults.
+        let (old_registrations, new_registrations) = self
             .salsa
             .file_provider_registrations(path.clone(), Some(text.to_string()))
             .await

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -490,6 +490,21 @@ pub fn resolve_and_classify(
     project_root: &Path,
     mut deps: Option<&mut HashSet<String>>,
 ) -> Option<ResolvedMemberAccess> {
+    // A container-resolution receiver records its *abstract* binding key as an
+    // attempt dependency BEFORE any resolution — an `app('key')` site whose key
+    // has no registration yet resolves to nothing and would otherwise record no
+    // dependency at all, so the provider save that later ADDS the binding could
+    // never ripple to it (#255). Mirrored branch-for-branch in
+    // [`resolve_recipe_and_classify`].
+    if let Some(d) = deps.as_deref_mut() {
+        if let Some(key) = container_attempt_key(receiver, bytes) {
+            d.insert(format!(
+                "{}{key}",
+                crate::magic_dependency_index::BINDING_DEP_PREFIX
+            ));
+        }
+    }
+
     // Facade interception, checked first for a static-call name receiver —
     // `Auth::check()` — so the "resolved via facade" signal threads cleanly into
     // classification. A `Some` here means the concrete came through the facade
@@ -2345,6 +2360,32 @@ fn helper_receiver_name(receiver: Node, bytes: &[u8]) -> Option<String> {
     helper_binding_key(func).map(|_| func.to_string())
 }
 
+/// The registry-shaped container-binding key a receiver *attempts* — the
+/// `'key'` in `app('key')` / `resolve('key')` ([`container_receiver_key`]) or a
+/// mapped zero-arg helper's binding key ([`helper_binding_key`]) — independent
+/// of whether the key resolves. Contract-shaped helper keys (`response`'s
+/// `Illuminate\Contracts\…` — they carry a `\`) are excluded: the string-keyed
+/// binding registry never holds them, so a registration diff never emits them.
+/// Facade-accessor indirection (`Auth::…` → accessor key) is deliberately NOT
+/// covered: extracting the accessor requires parsing the facade class even on
+/// failed resolutions, and a facade site that resolved records the concrete
+/// FQCN the diff already emits.
+fn container_attempt_key(receiver: Node, bytes: &[u8]) -> Option<String> {
+    container_receiver_key(receiver, bytes).or_else(|| {
+        if receiver.kind() != "function_call_expression" {
+            return None;
+        }
+        let func = receiver
+            .child_by_field_name("function")?
+            .utf8_text(bytes)
+            .ok()?
+            .trim_start_matches('\\');
+        helper_binding_key(func)
+            .filter(|key| !key.contains('\\'))
+            .map(str::to_string)
+    })
+}
+
 /// The shape of [`resolve_gate_closure_user`] — a variable that is a Gate
 /// ability closure's first parameter — without the auth-model lookup.
 fn is_gate_closure_user_shape(var_node: Node, bytes: &[u8]) -> bool {
@@ -2425,6 +2466,25 @@ fn resolve_recipe_and_classify(
     project_root: &Path,
     mut deps: Option<&mut HashSet<String>>,
 ) -> Option<ResolvedMemberAccess> {
+    // Container-binding attempt dependency (see [`resolve_and_classify`]'s
+    // mirror): the abstract key is recorded resolved-or-not, so a provider
+    // save that ADDS the binding ripples to this site (#255).
+    if let Some(d) = deps.as_deref_mut() {
+        let key = match &site.recipe {
+            ReceiverRecipeData::ContainerKey(key) => Some(key.as_str()),
+            ReceiverRecipeData::HelperBinding(name) => {
+                helper_binding_key(name).filter(|key| !key.contains('\\'))
+            }
+            _ => None,
+        };
+        if let Some(key) = key {
+            d.insert(format!(
+                "{}{key}",
+                crate::magic_dependency_index::BINDING_DEP_PREFIX
+            ));
+        }
+    }
+
     // Outer facade interception — a static-name receiver only.
     let facade_concrete = match &site.recipe {
         ReceiverRecipeData::StaticName {

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -566,6 +566,7 @@ pub fn resolve_and_classify(
         classviews,
         project_root,
     ) {
+        record_macro_decl_dep(&resolved, &fqcn, member, resolver, deps.as_deref_mut());
         return Some(resolved);
     }
 
@@ -582,7 +583,7 @@ pub fn resolve_and_classify(
     // the actual safety here.
     if form.is_call() && is_eloquent_builder(&fqcn) && is_scope_param_receiver(receiver, bytes) {
         let model = enclosing_class_fqcn(receiver, bytes)?;
-        if let Some(d) = deps {
+        if let Some(d) = deps.as_deref_mut() {
             d.insert(model.clone());
         }
         let resolved = classify_against(
@@ -595,9 +596,33 @@ pub fn resolve_and_classify(
             classviews,
             project_root,
         )?;
+        record_macro_decl_dep(&resolved, &model, member, resolver, deps);
         return Some(resolved);
     }
     None
+}
+
+/// Record a macro's declaration file as a reverse-index dependency for a
+/// site that classified as [`MagicMemberKind::Macro`] (#255). For an inline
+/// `::macro()` registration that file IS the registering service provider,
+/// so a provider-body edit's save ripple (`registration_ripple_keys`, keyed
+/// on the provider path among others) reaches the site directly; the host
+/// FQCN recorded by the resolution above covers the added/removed-key
+/// directions. No-op for every other kind, or when the registry has no
+/// entry (the classification just proved it does).
+fn record_macro_decl_dep(
+    resolved: &ResolvedMemberAccess,
+    fqcn: &str,
+    member: &str,
+    resolver: &impl ClassFileResolver,
+    deps: Option<&mut HashSet<String>>,
+) {
+    if resolved.kind != MagicMemberKind::Macro {
+        return;
+    }
+    if let (Some(d), Some((decl_file, _))) = (deps, resolver.macro_target(fqcn, member)) {
+        d.insert(decl_file.to_string_lossy().into_owned());
+    }
 }
 
 /// Classify `member` against `fqcn`'s resolved surfaces — the shared tail of
@@ -2447,6 +2472,7 @@ fn resolve_recipe_and_classify(
         classviews,
         project_root,
     ) {
+        record_macro_decl_dep(&resolved, &fqcn, member, resolver, deps.as_deref_mut());
         return Some(resolved);
     }
 
@@ -2454,10 +2480,10 @@ fn resolve_recipe_and_classify(
     // gate + captured enclosing class.
     if form.is_call() && is_eloquent_builder(&fqcn) && site.is_scope_param_receiver {
         let model = site.enclosing_class_fqcn.clone()?;
-        if let Some(d) = deps {
+        if let Some(d) = deps.as_deref_mut() {
             d.insert(model.clone());
         }
-        return classify_against(
+        let resolved = classify_against(
             &model,
             member,
             form,
@@ -2466,7 +2492,9 @@ fn resolve_recipe_and_classify(
             resolver,
             classviews,
             project_root,
-        );
+        )?;
+        record_macro_decl_dep(&resolved, &model, member, resolver, deps);
+        return Some(resolved);
     }
     None
 }

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -2725,6 +2725,67 @@ function show($mystery) {
     assert!(deps.is_empty(), "{deps:?}");
 }
 
+#[test]
+fn deps_record_macro_decl_file_on_macro_classification() {
+    // #255: a site that classifies as a Macro records the macro's declaration
+    // file — the registering provider for an inline `::macro()` — so the
+    // provider-path ripple key emitted by a provider-body save reaches it.
+    // Both resolution paths (live re-parse and captured recipe) must record
+    // identically; `resolve_both_ways` drives both chokepoints.
+    let dir = TempDir::new().unwrap();
+    let provider = dir.path().join("app/Providers/AppServiceProvider.php");
+    let resolver = macros_resolver("Illuminate\\Support\\Str", "uuid7", (provider.clone(), 17));
+    let caller = r#"<?php
+use Illuminate\Support\Str;
+class Ids {
+    public function make(): string { return Str::uuid7(); }
+}
+"#;
+    let ((tree_entries, tree_deps), (recipe_entries, recipe_deps)) =
+        resolve_both_ways(&resolver, dir.path(), caller);
+    let provider_dep = provider.to_string_lossy().into_owned();
+    assert!(
+        !tree_entries.is_empty() && !recipe_entries.is_empty(),
+        "the macro call site must classify on both paths",
+    );
+    assert!(
+        tree_deps.contains(&provider_dep),
+        "live path must record the macro decl file (the provider); got {tree_deps:?}",
+    );
+    assert!(
+        recipe_deps.contains(&provider_dep),
+        "captured-recipe path must record the macro decl file (the provider); got {recipe_deps:?}",
+    );
+}
+
+#[test]
+fn deps_record_binding_attempt_key_even_when_unresolved() {
+    // #255: a string-keyed container site records `binding:<key>` resolved or
+    // not — a brand-new binding's call sites resolved to NOTHING before the
+    // provider save, so this attempt key is the only dependency the
+    // registration diff can reach them through. Both paths must record it.
+    let dir = TempDir::new().unwrap();
+    let resolver = macros_resolver(
+        "Illuminate\\Support\\Str",
+        "unused",
+        (dir.path().join("p.php"), 1),
+    );
+    let caller = r#"<?php
+function f() {
+    return app('tenant')->name;
+}
+"#;
+    let ((_, tree_deps), (_, recipe_deps)) = resolve_both_ways(&resolver, dir.path(), caller);
+    assert!(
+        tree_deps.contains(&"binding:tenant".to_string()),
+        "live path must record the binding attempt key; got {tree_deps:?}",
+    );
+    assert!(
+        recipe_deps.contains(&"binding:tenant".to_string()),
+        "captured-recipe path must record the binding attempt key; got {recipe_deps:?}",
+    );
+}
+
 // ─── End-to-end: a closure-bound key resolves app('key')->member ───────────
 //
 // Proves the new tree-sitter binding walker feeds the SAME `concrete_class`

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -4284,6 +4284,72 @@ pub struct MacroRegistrationData {
     pub priority: u8,
 }
 
+/// One provider file's own registration contribution — the macros, bindings,
+/// and facade aliases parsed from exactly that file — in sorted, comparable
+/// form. The save path snapshots this before and after a provider save: a
+/// non-empty diff with an empty class-surface diff is the body-only
+/// registration edit that previously never rippled to dependent call sites
+/// (#255).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProviderRegistrationsData {
+    /// `(receiver host FQCN, macro name)` pairs, sorted.
+    pub macros: Vec<(String, String)>,
+    /// `(abstract name, concrete FQCN)` pairs, sorted.
+    pub bindings: Vec<(String, String)>,
+    /// `(alias token, target FQCN)` pairs, sorted. Only `bootstrap/app.php`
+    /// (`withAliases`) and `config/app.php` (`aliases`) contribute here.
+    pub aliases: Vec<(String, String)>,
+}
+
+/// The reverse-index keys whose dependents a provider registration diff must
+/// re-resolve — the save path feeds these into the same blast radius a class
+/// surface change uses (#255). Empty when nothing changed.
+///
+/// Emitted per changed (added/removed/retargeted) entry, keyed on what the
+/// dependent call sites actually recorded in `MagicDependencyIndex`:
+///
+/// - **macro**: the receiver host FQCN (`Illuminate\Support\Str`) — every
+///   call site records the resolved receiver as an attempt, so this finds
+///   sites in both directions (macro added: the previously-failed sites;
+///   macro removed/renamed: the previously-resolved sites).
+/// - **binding / facade alias**: the concrete/target FQCN from both sides of
+///   the diff — a site that resolved through a binding (helper, `app('key')`,
+///   facade accessor) recorded the *concrete* it resolved to, so the old
+///   concrete finds the now-stale sites and the new one finds direct
+///   references. (A site that never resolved — `app('key')` before the key
+///   existed — recorded nothing and converges on the next full pass; it holds
+///   no stale classification either.)
+/// - **the provider's own path**: macro classifications record the macro's
+///   declaration file as a dependency ([`crate::member_resolver`]), which for
+///   inline `::macro()` registrations is the registering provider itself.
+pub fn registration_ripple_keys(
+    before: &ProviderRegistrationsData,
+    after: &ProviderRegistrationsData,
+    provider_path: &Path,
+) -> Vec<String> {
+    fn changed<'a>(
+        a: &'a [(String, String)],
+        b: &'a [(String, String)],
+    ) -> impl Iterator<Item = &'a (String, String)> {
+        let sa: std::collections::HashSet<&(String, String)> = a.iter().collect();
+        let sb: std::collections::HashSet<&(String, String)> = b.iter().collect();
+        sa.symmetric_difference(&sb)
+            .map(|e| *e)
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    let mut keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+    keys.extend(changed(&before.macros, &after.macros).map(|(host, _)| host.clone()));
+    keys.extend(changed(&before.bindings, &after.bindings).map(|(_, concrete)| concrete.clone()));
+    keys.extend(changed(&before.aliases, &after.aliases).map(|(_, target)| target.clone()));
+    if keys.is_empty() {
+        return Vec::new();
+    }
+    keys.insert(provider_path.to_string_lossy().into_owned());
+    keys.into_iter().collect()
+}
+
 /// Pairs the class-hierarchy index (FQCN → file) with the in-actor container
 /// binding registry (binding key → concrete FQCN) behind the
 /// [`crate::member_resolver::ClassFileResolver`] seam, so the live query path
@@ -4977,6 +5043,16 @@ pub enum SalsaRequest {
     /// it does on the live query path. Mirrors [`Self::SnapshotBindings`].
     SnapshotMacros {
         reply: oneshot::Sender<Arc<std::collections::HashMap<(String, String), (PathBuf, u32)>>>,
+    },
+    /// One provider file's registration contribution (macros / bindings /
+    /// facade aliases), for the save path's pre/post registration diff (#255).
+    /// `fresh_text`, when given, re-registers the provider source first — the
+    /// App rescan a provider save queues is asynchronous, so without this the
+    /// post-save snapshot would still read the pre-save text.
+    FileProviderRegistrations {
+        path: PathBuf,
+        fresh_text: Option<String>,
+        reply: oneshot::Sender<ProviderRegistrationsData>,
     },
     /// Snapshot the interface→implementors reverse map — `interface FQCN` →
     /// directly implementing class FQCNs — for the same out-of-actor build, so a
@@ -5749,6 +5825,29 @@ impl SalsaHandle {
         self.sender
             .send(SalsaRequest::FileClassSurfaces {
                 path,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// One provider file's registration contribution (macros / bindings /
+    /// facade aliases), for the save path's pre/post registration diff (#255).
+    /// Pass `fresh_text` on the post-save call so the snapshot reads the saved
+    /// buffer rather than the stale provider input (the App rescan is async).
+    pub async fn file_provider_registrations(
+        &self,
+        path: PathBuf,
+        fresh_text: Option<String>,
+    ) -> Result<ProviderRegistrationsData, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::FileProviderRegistrations {
+                path,
+                fresh_text,
                 reply: reply_tx,
             })
             .await
@@ -6985,6 +7084,28 @@ impl SalsaActor {
                         map.insert(key.clone(), (data.decl_file.clone(), data.decl_line));
                     }
                     let _ = reply.send(Arc::new(map));
+                }
+                SalsaRequest::FileProviderRegistrations {
+                    path,
+                    fresh_text,
+                    reply,
+                } => {
+                    if let Some(text) = fresh_text {
+                        // Only re-register a provider the actor already knows —
+                        // a brand-new provider file is the App rescan's job.
+                        if let Some(sp_file) = self.salsa_sp_files.get(&path) {
+                            let priority = sp_file.priority(&self.db);
+                            if let Some(root) = self.salsa_sp_root.clone() {
+                                self.handle_register_service_provider_source(
+                                    path.clone(),
+                                    text,
+                                    priority,
+                                    root,
+                                );
+                            }
+                        }
+                    }
+                    let _ = reply.send(self.handle_file_provider_registrations(&path));
                 }
                 SalsaRequest::SnapshotImplementers { reply } => {
                     // A cheap clone of the interface→implementors reverse map the
@@ -9136,19 +9257,38 @@ impl SalsaActor {
         Arc::new(map)
     }
 
+    /// The Salsa-parsed provider files in lexicographic path order — the
+    /// deterministic merge order for the registry builders. `salsa_sp_files`
+    /// is a `HashMap` with unspecified iteration order; merging in that order
+    /// made an equal-priority key collision resolve to whichever provider the
+    /// map happened to yield first, flipping across LSP restarts (#255).
+    /// Combined with the builders' keep-first rule on equal priority, sorting
+    /// here makes the winner the provider with the lexicographically smallest
+    /// path — stable across restarts.
+    fn sorted_sp_files(&self) -> Vec<ServiceProviderFile> {
+        let mut entries: Vec<(&PathBuf, &ServiceProviderFile)> =
+            self.salsa_sp_files.iter().collect();
+        entries.sort_unstable_by_key(|(path, _)| *path);
+        entries.into_iter().map(|(_, file)| *file).collect()
+    }
+
     /// Build the macro registry — `(receiver_fqcn, macro_name)` → registration —
     /// by merging every Salsa-parsed service provider's `macros`, highest
     /// priority winning on key collision (framework=0 < package=1 < app=2). Built
     /// fresh each call from the tracked-query outputs (mirrors
     /// [`Self::build_facade_alias_snapshot`]); macros number in the dozens-to-
     /// hundreds, with no cache to invalidate on a provider edit.
+    ///
+    /// Providers merge in lexicographic path order ([`Self::sorted_sp_files`]),
+    /// so an equal-priority key collision deterministically resolves to the
+    /// provider with the smallest path (#255).
     fn build_macro_registry(&self) -> Arc<HashMap<(String, String), MacroRegistrationData>> {
         let mut map: HashMap<(String, String), MacroRegistrationData> = HashMap::new();
         let Some(root) = self.salsa_sp_root.as_ref() else {
             return Arc::new(map);
         };
-        for sp_file in self.salsa_sp_files.values() {
-            let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+        for sp_file in self.sorted_sp_files() {
+            let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
             for m in parsed.macros(&self.db) {
                 let key = (
                     m.receiver_fqcn(&self.db).name(&self.db).clone(),
@@ -9170,6 +9310,55 @@ impl SalsaActor {
             }
         }
         Arc::new(map)
+    }
+
+    /// One provider file's own registration contribution, sorted for the
+    /// save path's pre/post diff (#255). Uniform across the three registries:
+    /// macros and bindings parse from the file's `ServiceProviderFile` input;
+    /// the facade-alias sources are `bootstrap/app.php` (`withAliases`, also a
+    /// provider input) and `config/app.php` (`aliases`, a config input).
+    /// A path the actor doesn't know yields the empty (default) contribution.
+    fn handle_file_provider_registrations(&self, path: &Path) -> ProviderRegistrationsData {
+        let mut out = ProviderRegistrationsData::default();
+        if let (Some(root), Some(sp_file)) = (
+            self.salsa_sp_root.as_ref(),
+            self.salsa_sp_files.get(path).copied(),
+        ) {
+            let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
+            for m in parsed.macros(&self.db) {
+                out.macros.push((
+                    m.receiver_fqcn(&self.db).name(&self.db).clone(),
+                    m.macro_name(&self.db).name(&self.db).clone(),
+                ));
+            }
+            for binding in parsed.bindings(&self.db) {
+                out.bindings.push((
+                    binding.abstract_name(&self.db).name(&self.db).clone(),
+                    binding
+                        .concrete_class(&self.db)
+                        .trim_start_matches('\\')
+                        .to_string(),
+                ));
+            }
+            if *path == root.join("bootstrap/app.php") {
+                let text = sp_file.text(&self.db);
+                if let Ok(tree) = parse_php(text) {
+                    out.aliases.extend(extract_with_aliases(&tree, text));
+                }
+            }
+        }
+        if let Some(root) = self.config_root.as_ref() {
+            if *path == root.join("config/app.php") {
+                if let Some(file) = self.config_files.get(path) {
+                    out.aliases
+                        .extend(crate::config::parse_facade_aliases(file.text(&self.db)));
+                }
+            }
+        }
+        out.macros.sort_unstable();
+        out.bindings.sort_unstable();
+        out.aliases.sort_unstable();
+        out
     }
 
     // === Service Provider Handlers ===
@@ -9654,6 +9843,11 @@ impl SalsaActor {
     }
 
     /// Handle getting all parsed bindings from Salsa
+    ///
+    /// Providers merge in lexicographic path order ([`Self::sorted_sp_files`]),
+    /// so an equal-priority key collision deterministically resolves to the
+    /// provider with the smallest path (#255) — mirrors
+    /// [`Self::build_macro_registry`].
     fn handle_get_all_parsed_bindings(&self) -> Vec<ParsedBindingData> {
         let root = match self.salsa_sp_root.as_ref() {
             Some(r) => r,
@@ -9662,8 +9856,8 @@ impl SalsaActor {
 
         let mut merged: HashMap<String, ParsedBindingData> = HashMap::new();
 
-        for sp_file in self.salsa_sp_files.values() {
-            let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+        for sp_file in self.sorted_sp_files() {
+            let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
             for binding in parsed.bindings(&self.db) {
                 let name = binding.abstract_name(&self.db).name(&self.db).clone();
                 let data = ParsedBindingData {

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -4346,8 +4346,8 @@ pub fn registration_ripple_keys(
 
     let mut keys: std::collections::HashSet<String> = std::collections::HashSet::new();
     keys.extend(changed(&before.macros, &after.macros).map(|(host, _)| host.clone()));
-    keys.extend(
-        changed(&before.bindings, &after.bindings).flat_map(|(abstract_name, concrete)| {
+    keys.extend(changed(&before.bindings, &after.bindings).flat_map(
+        |(abstract_name, concrete)| {
             [
                 format!(
                     "{}{abstract_name}",
@@ -4355,8 +4355,8 @@ pub fn registration_ripple_keys(
                 ),
                 concrete.clone(),
             ]
-        }),
-    );
+        },
+    ));
     keys.extend(changed(&before.aliases, &after.aliases).map(|(_, target)| target.clone()));
     if keys.is_empty() {
         return Vec::new();
@@ -8296,8 +8296,10 @@ impl SalsaActor {
         let mut class_component_files: HashMap<String, (u8, PathBuf)> = HashMap::new();
 
         if let Some(sp_root) = self.salsa_sp_root.as_ref() {
-            for sp_file in self.salsa_sp_files.values() {
-                let parsed = parse_service_provider_source(&self.db, *sp_file, sp_root.clone());
+            // Lexicographic provider order (`sorted_sp_files`) so the
+            // first-wins / priority tiebreaks below are deterministic (#255).
+            for sp_file in self.sorted_sp_files() {
+                let parsed = parse_service_provider_source(&self.db, sp_file, sp_root.clone());
 
                 // Collect view namespaces
                 for vn in parsed.view_namespaces(&self.db) {
@@ -9484,8 +9486,9 @@ impl SalsaActor {
         let root = self.salsa_sp_root.as_ref()?;
         let mut best: Option<ViewNamespaceData> = None;
 
-        for sp_file in self.salsa_sp_files.values() {
-            let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+        // Lexicographic provider order — deterministic equal-priority winner (#255).
+        for sp_file in self.sorted_sp_files() {
+            let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
             for vn in parsed.view_namespaces(&self.db) {
                 if vn.namespace(&self.db).namespace(&self.db) == namespace {
                     let data = ViewNamespaceData {
@@ -9511,8 +9514,10 @@ impl SalsaActor {
         let mut merged: HashMap<String, ViewNamespaceData> = self.sp_view_namespaces.clone();
 
         if let Some(root) = self.salsa_sp_root.as_ref() {
-            for sp_file in self.salsa_sp_files.values() {
-                let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+            // Lexicographic provider order — deterministic equal-priority
+            // winner per key (#255); output order stays map-arbitrary.
+            for sp_file in self.sorted_sp_files() {
+                let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
                 for vn in parsed.view_namespaces(&self.db) {
                     let ns = vn.namespace(&self.db).namespace(&self.db).clone();
                     let data = ViewNamespaceData {
@@ -9547,8 +9552,9 @@ impl SalsaActor {
         let root = self.salsa_sp_root.as_ref()?;
         let mut best: Option<BladeComponentRegData> = None;
 
-        for sp_file in self.salsa_sp_files.values() {
-            let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+        // Lexicographic provider order — deterministic equal-priority winner (#255).
+        for sp_file in self.sorted_sp_files() {
+            let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
             for bc in parsed.blade_components(&self.db) {
                 if bc.tag_name(&self.db).name(&self.db) == tag_name {
                     let data = BladeComponentRegData {
@@ -9575,8 +9581,10 @@ impl SalsaActor {
         let mut merged: HashMap<String, BladeComponentRegData> = self.sp_blade_components.clone();
 
         if let Some(root) = self.salsa_sp_root.as_ref() {
-            for sp_file in self.salsa_sp_files.values() {
-                let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+            // Lexicographic provider order — deterministic equal-priority
+            // winner per key (#255); output order stays map-arbitrary.
+            for sp_file in self.sorted_sp_files() {
+                let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
                 for bc in parsed.blade_components(&self.db) {
                     let tag = bc.tag_name(&self.db).name(&self.db).clone();
                     let data = BladeComponentRegData {
@@ -9612,8 +9620,9 @@ impl SalsaActor {
         let root = self.salsa_sp_root.as_ref()?;
         let mut best: Option<ComponentNamespaceData> = None;
 
-        for sp_file in self.salsa_sp_files.values() {
-            let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+        // Lexicographic provider order — deterministic equal-priority winner (#255).
+        for sp_file in self.sorted_sp_files() {
+            let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
             for cn in parsed.component_namespaces(&self.db) {
                 if cn.prefix(&self.db).namespace(&self.db) == prefix {
                     let data = ComponentNamespaceData {
@@ -9640,8 +9649,10 @@ impl SalsaActor {
             self.sp_component_namespaces.clone();
 
         if let Some(root) = self.salsa_sp_root.as_ref() {
-            for sp_file in self.salsa_sp_files.values() {
-                let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+            // Lexicographic provider order — deterministic equal-priority
+            // winner per key (#255); output order stays map-arbitrary.
+            for sp_file in self.sorted_sp_files() {
+                let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
                 for cn in parsed.component_namespaces(&self.db) {
                     let pfx = cn.prefix(&self.db).namespace(&self.db).clone();
                     let data = ComponentNamespaceData {
@@ -9823,8 +9834,9 @@ impl SalsaActor {
         let root = self.salsa_sp_root.as_ref()?;
         let mut best: Option<ParsedMiddlewareData> = None;
 
-        for sp_file in self.salsa_sp_files.values() {
-            let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+        // Lexicographic provider order — deterministic equal-priority winner (#255).
+        for sp_file in self.sorted_sp_files() {
+            let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
             for mw in parsed.middleware(&self.db) {
                 if mw.alias(&self.db).name(&self.db) == base_alias {
                     let data = ParsedMiddlewareData {
@@ -9856,8 +9868,10 @@ impl SalsaActor {
 
         let mut merged: HashMap<String, ParsedMiddlewareData> = HashMap::new();
 
-        for sp_file in self.salsa_sp_files.values() {
-            let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+        // Lexicographic provider order — deterministic equal-priority
+        // winner per key (#255); output order stays map-arbitrary.
+        for sp_file in self.sorted_sp_files() {
+            let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
             for mw in parsed.middleware(&self.db) {
                 let alias = mw.alias(&self.db).name(&self.db).clone();
                 let data = ParsedMiddlewareData {
@@ -9886,8 +9900,10 @@ impl SalsaActor {
         let root = self.salsa_sp_root.as_ref()?;
         let mut best: Option<ParsedBindingData> = None;
 
-        for sp_file in self.salsa_sp_files.values() {
-            let parsed = parse_service_provider_source(&self.db, *sp_file, root.clone());
+        // Lexicographic provider order — deterministic equal-priority winner
+        // (#255); mirrors [`Self::handle_get_all_parsed_bindings`].
+        for sp_file in self.sorted_sp_files() {
+            let parsed = parse_service_provider_source(&self.db, sp_file, root.clone());
             for binding in parsed.bindings(&self.db) {
                 if binding.abstract_name(&self.db).name(&self.db) == name {
                     let data = ParsedBindingData {

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -4334,7 +4334,7 @@ pub fn registration_ripple_keys(
         let sa: std::collections::HashSet<&(String, String)> = a.iter().collect();
         let sb: std::collections::HashSet<&(String, String)> = b.iter().collect();
         sa.symmetric_difference(&sb)
-            .map(|e| *e)
+            .copied()
             .collect::<Vec<_>>()
             .into_iter()
     }

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -4312,12 +4312,17 @@ pub struct ProviderRegistrationsData {
 ///   call site records the resolved receiver as an attempt, so this finds
 ///   sites in both directions (macro added: the previously-failed sites;
 ///   macro removed/renamed: the previously-resolved sites).
-/// - **binding / facade alias**: the concrete/target FQCN from both sides of
-///   the diff — a site that resolved through a binding (helper, `app('key')`,
-///   facade accessor) recorded the *concrete* it resolved to, so the old
-///   concrete finds the now-stale sites and the new one finds direct
-///   references. (A site that never resolved — `app('key')` before the key
-///   existed — recorded nothing and converges on the next full pass; it holds
+/// - **binding**: the `binding:<abstract>` attempt key
+///   ([`crate::magic_dependency_index::BINDING_DEP_PREFIX`]) from both sides
+///   of the diff — every string-keyed container site (`app('key')`, mapped
+///   zero-arg helpers) records it resolved-or-not, so a BRAND-NEW binding
+///   reaches the sites that previously resolved to nothing — plus the
+///   concrete FQCN from both sides, which finds sites already referencing
+///   the target directly.
+/// - **facade alias**: the target FQCN from both sides of the diff — a site
+///   that resolved through an alias recorded the concrete it landed on, so
+///   the old target finds the now-stale sites. (An alias site that never
+///   resolved recorded nothing and converges on the next full pass; it holds
 ///   no stale classification either.)
 /// - **the provider's own path**: macro classifications record the macro's
 ///   declaration file as a dependency ([`crate::member_resolver`]), which for
@@ -4341,7 +4346,17 @@ pub fn registration_ripple_keys(
 
     let mut keys: std::collections::HashSet<String> = std::collections::HashSet::new();
     keys.extend(changed(&before.macros, &after.macros).map(|(host, _)| host.clone()));
-    keys.extend(changed(&before.bindings, &after.bindings).map(|(_, concrete)| concrete.clone()));
+    keys.extend(
+        changed(&before.bindings, &after.bindings).flat_map(|(abstract_name, concrete)| {
+            [
+                format!(
+                    "{}{abstract_name}",
+                    crate::magic_dependency_index::BINDING_DEP_PREFIX
+                ),
+                concrete.clone(),
+            ]
+        }),
+    );
     keys.extend(changed(&before.aliases, &after.aliases).map(|(_, target)| target.clone()));
     if keys.is_empty() {
         return Vec::new();
@@ -5044,15 +5059,24 @@ pub enum SalsaRequest {
     SnapshotMacros {
         reply: oneshot::Sender<Arc<std::collections::HashMap<(String, String), (PathBuf, u32)>>>,
     },
-    /// One provider file's registration contribution (macros / bindings /
-    /// facade aliases), for the save path's pre/post registration diff (#255).
-    /// `fresh_text`, when given, re-registers the provider source first — the
-    /// App rescan a provider save queues is asynchronous, so without this the
-    /// post-save snapshot would still read the pre-save text.
+    /// One provider file's `(before, after)` registration contribution
+    /// (macros / bindings / facade aliases), for the save path's registration
+    /// diff (#255). `before` is the actor-kept BASELINE — the contribution as
+    /// of the last save transaction — NOT the live inputs: the did_change
+    /// debounce eagerly overwrites `salsa_sp_files` / `config_files` on every
+    /// typing pause, so a snapshot of the live inputs taken at save time
+    /// already holds the edited text and would diff empty. A path with no
+    /// baseline yields the empty default (the first save of a session
+    /// over-ripples that provider's keys once — the fail-safe direction).
+    /// `fresh_text`, when given, marks a save transaction: the saved buffer is
+    /// re-registered first (the App rescan a provider save queues is
+    /// asynchronous), `after` reads the fresh registration, and the baseline
+    /// advances to it. Without `fresh_text` this is a pure read — the
+    /// baseline does not advance.
     FileProviderRegistrations {
         path: PathBuf,
         fresh_text: Option<String>,
-        reply: oneshot::Sender<ProviderRegistrationsData>,
+        reply: oneshot::Sender<(ProviderRegistrationsData, ProviderRegistrationsData)>,
     },
     /// Snapshot the interface→implementors reverse map — `interface FQCN` →
     /// directly implementing class FQCNs — for the same out-of-actor build, so a
@@ -5835,14 +5859,17 @@ impl SalsaHandle {
     }
 
     /// One provider file's registration contribution (macros / bindings /
-    /// facade aliases), for the save path's pre/post registration diff (#255).
-    /// Pass `fresh_text` on the post-save call so the snapshot reads the saved
-    /// buffer rather than the stale provider input (the App rescan is async).
+    /// facade aliases), as `(before, after)` for the save path's registration
+    /// diff (#255). `before` is the actor-kept baseline (last save
+    /// transaction), insulated from the did_change debounce's eager input
+    /// overwrite; `after` reads the current registration. Pass `fresh_text`
+    /// on the save call: it re-registers the saved buffer first and advances
+    /// the baseline. See [`SalsaRequest::FileProviderRegistrations`].
     pub async fn file_provider_registrations(
         &self,
         path: PathBuf,
         fresh_text: Option<String>,
-    ) -> Result<ProviderRegistrationsData, &'static str> {
+    ) -> Result<(ProviderRegistrationsData, ProviderRegistrationsData), &'static str> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(SalsaRequest::FileProviderRegistrations {
@@ -6680,6 +6707,14 @@ pub struct SalsaActor {
     config_version: i32,
     /// Cached Laravel config data (version, data)
     config_cache: Option<(i32, LaravelConfigData)>,
+    /// Per-path registration BASELINE for the save path's diff (#255): the
+    /// contribution as of the last save transaction
+    /// ([`SalsaRequest::FileProviderRegistrations`] with `fresh_text`).
+    /// Deliberately NOT updated by the did_change debounce's eager
+    /// re-registration — that insulation is what keeps the pre-save side of
+    /// the diff pre-edit. Missing entry = empty default (first save
+    /// over-ripples once; fail-safe).
+    registration_baselines: HashMap<PathBuf, ProviderRegistrationsData>,
 
     // === Reference Finding ===
     /// Project files input for reference finding
@@ -6799,6 +6834,7 @@ impl SalsaActor {
                 config_files: HashMap::with_capacity(4),
                 config_version: 0,
                 config_cache: None,
+                registration_baselines: HashMap::new(),
                 // Reference finding
                 project_files: None,
                 project_files_version: 0,
@@ -7090,11 +7126,22 @@ impl SalsaActor {
                     fresh_text,
                     reply,
                 } => {
+                    // `before` comes from the baseline, never the live inputs
+                    // — the did_change debounce has usually already overwritten
+                    // those with the edited text by the time a save runs, which
+                    // would diff empty and leave dependents stale (#255).
+                    let before = self
+                        .registration_baselines
+                        .get(&path)
+                        .cloned()
+                        .unwrap_or_default();
+                    let is_save = fresh_text.is_some();
                     if let Some(text) = fresh_text {
-                        // Only re-register a provider the actor already knows —
-                        // a brand-new provider file is the App rescan's job.
-                        if let Some(sp_file) = self.salsa_sp_files.get(&path) {
-                            let priority = sp_file.priority(&self.db);
+                        if self.salsa_sp_files.contains_key(&path) {
+                            // Only re-register a provider the actor already
+                            // knows — a brand-new provider file is the App
+                            // rescan's job.
+                            let priority = self.salsa_sp_files[&path].priority(&self.db);
                             if let Some(root) = self.salsa_sp_root.clone() {
                                 self.handle_register_service_provider_source(
                                     path.clone(),
@@ -7103,9 +7150,31 @@ impl SalsaActor {
                                     root,
                                 );
                             }
+                        } else if self
+                            .config_root
+                            .as_ref()
+                            .is_some_and(|root| path == root.join("config/app.php"))
+                        {
+                            // config/app.php `aliases` live in the SEPARATE
+                            // `config_files` input the provider re-registration
+                            // above never touches — without this the post-save
+                            // alias snapshot reads the same entry as the
+                            // baseline and an alias edit never ripples (#255).
+                            self.handle_update_config_file(path.clone(), text);
                         }
                     }
-                    let _ = reply.send(self.handle_file_provider_registrations(&path));
+                    let after = self.handle_file_provider_registrations(&path);
+                    // Advance the baseline only on a save transaction, and only
+                    // for paths that carry (or carried) a contribution — every
+                    // .php save lands here, and the untracked majority must not
+                    // grow the map.
+                    if is_save
+                        && (after != ProviderRegistrationsData::default()
+                            || self.registration_baselines.contains_key(&path))
+                    {
+                        self.registration_baselines.insert(path, after.clone());
+                    }
+                    let _ = reply.send((before, after));
                 }
                 SalsaRequest::SnapshotImplementers { reply } => {
                     // A cheap clone of the interface→implementors reverse map the

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -3796,28 +3796,29 @@ class ZzServiceProvider extends ServiceProvider {
         .await
         .unwrap();
 
-    // Stable across repeated builds: the smallest path wins, both registries.
-    for _ in 0..3 {
-        let macros = handle.snapshot_macros().await.unwrap();
-        let (decl_file, _) = macros
-            .get(&("Illuminate\\Support\\Str".to_string(), "shared".to_string()))
-            .expect("colliding macro key must still resolve");
-        assert_eq!(
-            decl_file, &first,
-            "equal-priority macro collision must resolve to the lexicographically smallest provider path",
-        );
+    // The reversed registration order above is the actual nondeterminism
+    // guard: an insertion-ordered merge would pick Zz, and an unsorted
+    // HashMap merge could. (Re-querying an unmutated map can't change its
+    // iteration order, so repeating the assertions would prove nothing.)
+    let macros = handle.snapshot_macros().await.unwrap();
+    let (decl_file, _) = macros
+        .get(&("Illuminate\\Support\\Str".to_string(), "shared".to_string()))
+        .expect("colliding macro key must still resolve");
+    assert_eq!(
+        decl_file, &first,
+        "equal-priority macro collision must resolve to the lexicographically smallest provider path",
+    );
 
-        let bindings = handle.get_all_parsed_bindings().await.unwrap();
-        let svc = bindings
-            .iter()
-            .find(|b| b.abstract_name == "svc")
-            .expect("colliding binding key must still resolve");
-        assert_eq!(
-            svc.concrete_class.trim_start_matches('\\'),
-            "App\\Services\\AaImpl",
-            "equal-priority binding collision must resolve to the lexicographically smallest provider path",
-        );
-    }
+    let bindings = handle.get_all_parsed_bindings().await.unwrap();
+    let svc = bindings
+        .iter()
+        .find(|b| b.abstract_name == "svc")
+        .expect("colliding binding key must still resolve");
+    assert_eq!(
+        svc.concrete_class.trim_start_matches('\\'),
+        "App\\Services\\AaImpl",
+        "equal-priority binding collision must resolve to the lexicographically smallest provider path",
+    );
 }
 
 #[tokio::test]
@@ -3924,6 +3925,78 @@ fn registration_ripple_keys_binding_retarget_emits_both_concretes() {
     assert!(
         keys.contains(&"/prov.php".to_string()),
         "a non-empty diff must include the provider's own path",
+    );
+}
+
+#[test]
+fn registration_ripple_keys_alias_retarget_emits_both_targets() {
+    // A facade-alias retarget must emit BOTH sides of the diff: the old
+    // target finds sites holding the now-stale classification; the new one
+    // finds direct references (mirrors the binding-retarget case).
+    let before = ProviderRegistrationsData {
+        aliases: vec![("Str".to_string(), "Illuminate\\Support\\Str".to_string())],
+        ..Default::default()
+    };
+    let after = ProviderRegistrationsData {
+        aliases: vec![("Str".to_string(), "App\\Support\\MyStr".to_string())],
+        ..Default::default()
+    };
+    let keys = registration_ripple_keys(&before, &after, Path::new("/prov.php"));
+    assert!(keys.contains(&"Illuminate\\Support\\Str".to_string()));
+    assert!(keys.contains(&"App\\Support\\MyStr".to_string()));
+}
+
+#[tokio::test]
+async fn config_app_alias_edit_ripples_through_save_transaction() {
+    // #255 Bug A regression (config/app.php): the legacy `aliases` array
+    // lives in the `config_files` input — a SEPARATE map from
+    // `salsa_sp_files` — so the save transaction must route the fresh text
+    // through the config input, or the post-save alias snapshot reads the
+    // same entry as the baseline and an alias edit never ripples.
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+    let cfg = root.join("config/app.php");
+    let v1 = r#"<?php
+return [
+    'aliases' => [
+        'Str' => Illuminate\Support\Str::class,
+    ],
+];
+"#;
+    let v2 = v1.replace("Illuminate\\Support\\Str", "App\\Support\\MyStr");
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+
+    // First save transaction establishes the baseline at v1.
+    let (_, after1) = handle
+        .file_provider_registrations(cfg.clone(), Some(v1.to_string()))
+        .await
+        .unwrap();
+    assert_eq!(
+        after1.aliases,
+        vec![("Str".to_string(), "Illuminate\\Support\\Str".to_string())],
+        "save transaction must register config/app.php's aliases",
+    );
+
+    // Second save retargets the alias: before = v1 baseline, after = v2.
+    let (before2, after2) = handle
+        .file_provider_registrations(cfg.clone(), Some(v2))
+        .await
+        .unwrap();
+    assert_eq!(
+        before2.aliases, after1.aliases,
+        "baseline must be the last-saved contribution"
+    );
+    let keys = registration_ripple_keys(&before2, &after2, &cfg);
+    assert!(
+        keys.contains(&"Illuminate\\Support\\Str".to_string())
+            && keys.contains(&"App\\Support\\MyStr".to_string()),
+        "a config/app.php alias retarget must ripple both targets; got {keys:?}",
     );
 }
 

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -3743,6 +3743,189 @@ class AppServiceProvider extends ServiceProvider {
 }
 
 #[tokio::test]
+async fn equal_priority_collision_resolves_to_smallest_provider_path() {
+    // #255 Bug B regression: two providers at the SAME priority register the
+    // same macro key and the same binding key. `salsa_sp_files` is a HashMap
+    // (unspecified iteration order), so before the sorted merge the winner
+    // was whichever provider the map happened to yield first — flipping
+    // across LSP restarts. The documented rule: the lexicographically
+    // smallest provider path wins on an equal-priority collision, in BOTH
+    // registries (`sorted_sp_files`).
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+
+    let first = root.join("app/Providers/AaServiceProvider.php");
+    let first_src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AaServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('shared', fn () => 'aa');
+        $this->app->singleton('svc', \App\Services\AaImpl::class);
+    }
+}
+"#;
+    let second = root.join("app/Providers/ZzServiceProvider.php");
+    let second_src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class ZzServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('shared', fn () => 'zz');
+        $this->app->singleton('svc', \App\Services\ZzImpl::class);
+    }
+}
+"#;
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    // Registration order is deliberately the REVERSE of the documented
+    // winner's, so an insertion-ordered merge would fail this test too.
+    handle
+        .register_service_provider_source(second.clone(), second_src.to_string(), 2, root.clone())
+        .await
+        .unwrap();
+    handle
+        .register_service_provider_source(first.clone(), first_src.to_string(), 2, root.clone())
+        .await
+        .unwrap();
+
+    // Stable across repeated builds: the smallest path wins, both registries.
+    for _ in 0..3 {
+        let macros = handle.snapshot_macros().await.unwrap();
+        let (decl_file, _) = macros
+            .get(&("Illuminate\\Support\\Str".to_string(), "shared".to_string()))
+            .expect("colliding macro key must still resolve");
+        assert_eq!(
+            decl_file, &first,
+            "equal-priority macro collision must resolve to the lexicographically smallest provider path",
+        );
+
+        let bindings = handle.get_all_parsed_bindings().await.unwrap();
+        let svc = bindings
+            .iter()
+            .find(|b| b.abstract_name == "svc")
+            .expect("colliding binding key must still resolve");
+        assert_eq!(
+            svc.concrete_class.trim_start_matches('\\'),
+            "App\\Services\\AaImpl",
+            "equal-priority binding collision must resolve to the lexicographically smallest provider path",
+        );
+    }
+}
+
+#[tokio::test]
+async fn provider_registration_snapshot_diffs_body_only_macro_rename() {
+    // #255 Bug A regression: a macro rename inside `boot()` — a body-only
+    // edit whose class-surface diff is EMPTY — must still yield ripple keys,
+    // so the save path re-resolves dependent call sites without a restart.
+    // The pre/post snapshots come from `file_provider_registrations`; the
+    // post-save call passes the fresh text because the App rescan a provider
+    // save queues is asynchronous (the provider input would otherwise still
+    // hold the pre-save source).
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    let root = dir.path().to_path_buf();
+
+    let provider = root.join("app/Providers/AppServiceProvider.php");
+    let before_src = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('before', fn () => 'x');
+    }
+}
+"#;
+    let after_src = before_src.replace("'before'", "'after'");
+
+    let handle = SalsaActor::spawn();
+    handle
+        .register_config_files(root.clone(), None, None, None)
+        .await
+        .unwrap();
+    handle
+        .register_service_provider_source(provider.clone(), before_src.to_string(), 2, root.clone())
+        .await
+        .unwrap();
+
+    let before = handle
+        .file_provider_registrations(provider.clone(), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        before.macros,
+        vec![("Illuminate\\Support\\Str".to_string(), "before".to_string())],
+        "pre-save snapshot must carry the provider's registered macro",
+    );
+
+    let after = handle
+        .file_provider_registrations(provider.clone(), Some(after_src))
+        .await
+        .unwrap();
+    assert_eq!(
+        after.macros,
+        vec![("Illuminate\\Support\\Str".to_string(), "after".to_string())],
+        "fresh_text must re-register the provider before the post-save snapshot",
+    );
+
+    let keys = registration_ripple_keys(&before, &after, &provider);
+    assert!(
+        keys.contains(&"Illuminate\\Support\\Str".to_string()),
+        "ripple keys must carry the macro host FQCN dependent call sites recorded",
+    );
+    assert!(
+        keys.contains(&provider.to_string_lossy().into_owned()),
+        "ripple keys must carry the registering provider's own path (macro decl-file deps)",
+    );
+}
+
+#[test]
+fn registration_ripple_keys_empty_diff_yields_no_keys() {
+    // The overwhelming majority of saves change no registrations — the diff
+    // must be empty (no provider-path key either), so the save path's
+    // early-return still stops body-only NON-registration edits.
+    let snap = ProviderRegistrationsData {
+        macros: vec![("Illuminate\\Support\\Str".to_string(), "uuid7".to_string())],
+        bindings: vec![("svc".to_string(), "App\\Services\\Impl".to_string())],
+        aliases: vec![("Str".to_string(), "Illuminate\\Support\\Str".to_string())],
+    };
+    assert!(
+        registration_ripple_keys(&snap, &snap, Path::new("/prov.php")).is_empty(),
+        "an unchanged registration set must not ripple",
+    );
+}
+
+#[test]
+fn registration_ripple_keys_binding_retarget_emits_both_concretes() {
+    // A binding retarget must emit BOTH sides of the diff: the old concrete
+    // finds sites holding the now-stale classification; the new concrete
+    // finds sites already referencing the target directly.
+    let before = ProviderRegistrationsData {
+        bindings: vec![("svc".to_string(), "App\\Old".to_string())],
+        ..Default::default()
+    };
+    let after = ProviderRegistrationsData {
+        bindings: vec![("svc".to_string(), "App\\New".to_string())],
+        ..Default::default()
+    };
+    let keys = registration_ripple_keys(&before, &after, Path::new("/prov.php"));
+    assert!(keys.contains(&"App\\Old".to_string()));
+    assert!(keys.contains(&"App\\New".to_string()));
+    assert!(
+        keys.contains(&"/prov.php".to_string()),
+        "a non-empty diff must include the provider's own path",
+    );
+}
+
+#[tokio::test]
 async fn resolve_magic_member_at_classifies_macro_call() {
     // The headline feature, end-to-end through the actor: register a provider
     // declaring `Str::macro('uuid7', fn () => …)`, then resolve a `Str::uuid7()`

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -3856,7 +3856,9 @@ class AppServiceProvider extends ServiceProvider {
         .await
         .unwrap();
 
-    let before = handle
+    // Pure read: `after` side carries the current contribution (baseline is
+    // empty until a save transaction).
+    let (_, before) = handle
         .file_provider_registrations(provider.clone(), None)
         .await
         .unwrap();
@@ -3866,7 +3868,7 @@ class AppServiceProvider extends ServiceProvider {
         "pre-save snapshot must carry the provider's registered macro",
     );
 
-    let after = handle
+    let (_, after) = handle
         .file_provider_registrations(provider.clone(), Some(after_src))
         .await
         .unwrap();

--- a/laravel-lsp/src/tests/watched_files_magic.rs
+++ b/laravel-lsp/src/tests/watched_files_magic.rs
@@ -120,6 +120,95 @@ async fn drain_batch(backend: &LaravelLanguageServer) {
     }
 }
 
+/// Await the in-flight save-path dependent ripple (#255 keeps the handle
+/// alive and awaitable for exactly this — mirrors `drain_batch`).
+async fn drain_ripple(backend: &LaravelLanguageServer) {
+    let handle = backend.magic_ripple_handle.write().await.take();
+    if let Some(h) = handle {
+        let _ = h.await;
+    }
+}
+
+/// #255 Bug A end-to-end regression, through the REAL save path: a macro
+/// rename inside a provider's `boot()` body — an edit whose class-surface
+/// diff is empty — must re-resolve dependent call sites in other files.
+/// Crucially, the edit is delivered through `execute_salsa_update` (the
+/// did_change debounce body) BEFORE the save, exactly like a real
+/// "type → pause → save" flow: the debounce eagerly overwrites the live
+/// provider input, so a pre-save snapshot of the live inputs would diff
+/// empty and never ripple — the actor-kept baseline is what keeps the
+/// `before` side pre-edit.
+#[tokio::test]
+async fn provider_body_macro_rename_converges_dependent_on_save() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    let provider_v1 = r#"<?php
+namespace App\Providers;
+use Illuminate\Support\Str;
+use Illuminate\Support\ServiceProvider;
+class AppServiceProvider extends ServiceProvider {
+    public function boot(): void {
+        Str::macro('slugify', fn () => 'x');
+    }
+}
+"#;
+    let provider = write_file(root, "app/Providers/AppServiceProvider.php", provider_v1);
+    backend
+        .salsa
+        .register_config_files(root.to_path_buf(), None, None, None)
+        .await
+        .unwrap();
+    backend
+        .salsa
+        .register_service_provider_source(
+            provider.clone(),
+            provider_v1.to_string(),
+            2,
+            root.to_path_buf(),
+        )
+        .await
+        .unwrap();
+
+    // The dependent call site, in ANOTHER file.
+    let consumer_src = r#"<?php
+namespace App\Support;
+use Illuminate\Support\Str;
+class Ids {
+    public function make(): string { return Str::slugify(); }
+}
+"#;
+    let consumer = write_file(root, "app/Support/Ids.php", consumer_src);
+    seed(&backend, &consumer, consumer_src).await;
+    assert!(
+        member_names(&backend, &consumer).await.contains("slugify"),
+        "seed: the consumer's macro call must classify while the macro exists",
+    );
+
+    // Save #1 establishes the provider's registration baseline.
+    let uri = Url::from_file_path(&provider).unwrap();
+    backend.refresh_magic_on_save(&uri, provider_v1).await;
+    drain_ripple(&backend).await;
+
+    // The user types the rename; the did_change debounce fires and eagerly
+    // re-registers the provider input with the EDITED text — pre-save.
+    let provider_v2 = provider_v1.replace("'slugify'", "'sluggish'");
+    backend.execute_salsa_update(&uri, &provider_v2, 2).await;
+
+    // Then saves. The registration diff must come from the baseline, not the
+    // (already-edited) live input, for the ripple to fire at all.
+    backend.refresh_magic_on_save(&uri, &provider_v2).await;
+    drain_ripple(&backend).await;
+
+    let after = member_names(&backend, &consumer).await;
+    assert!(
+        !after.contains("slugify"),
+        "the dependent's stale macro classification must clear on the provider save; got {after:?}"
+    );
+}
+
 fn post_with_accessors(accessors: &[&str]) -> String {
     let methods: String = accessors
         .iter()


### PR DESCRIPTION
## Summary
Implements #255 — fixes two inherited defects in the shared provider-registry model (bindings / facade aliases / macros):

- **Bug A** — the reverse find-references index lagged an in-editor provider-body edit: a `boot()`/`register()` registration change produces an empty class-surface diff, so `refresh_magic_dependents` was never spawned and call sites in other files kept stale classifications until an unrelated reconverge.
- **Bug B** — an equal-priority same-key collision (two providers registering the same macro/binding key) resolved nondeterministically because the merge iterated a `HashMap`, flipping the goto target across LSP restarts.

## Changes
- **Bug B:** `sorted_sp_files()` merges providers in lexicographic path order in `build_macro_registry` **and** `handle_get_all_parsed_bindings` — on an equal-priority collision the provider with the smallest path deterministically wins (documented in both builders).
- **Bug A:** `ProviderRegistrationsData` + pure `registration_ripple_keys(before, after, provider_path)` + the `FileProviderRegistrations` actor request. Uniform across macro, binding, and facade-alias registries (`bootstrap/app.php` `withAliases` + `config/app.php` `aliases` included).
- **Bug A baseline (review round):** the pre-save "before" snapshot comes from an actor-kept `registration_baselines` map advanced only by save transactions (`fresh_text`), so it is **insulated from the `did_change` debounce's eager re-registration** — the ripple fires on the realistic edit → pause → save flow, not just inside the debounce window.
- **Bug A config path (review round):** the save transaction routes `config/app.php` through `handle_update_config_file`, so the legacy `aliases`-array diff reads fresh text and ripples like the other two sources.
- **Bug A wiring:** `refresh_magic_on_save` snapshots the file's registration contribution pre/post save and folds the ripple keys (macro host FQCNs, binding/alias concretes from both diff sides, the provider's own path) into the `changed_classes` blast radius and its early-return check. Keys pass through `expand_class_descendants` (seeds included) into `dependents_of` unchanged.
- **Bug A deps:** `member_resolver` records a `Macro` classification's declaration file (= the registering provider for inline `::macro()`) as a reverse-index dependency at all four classify exits, in both the live re-parse path and the captured-recipe path; binding call sites record a `binding:<key>` **attempt** dependency even when unresolved, so brand-new bindings ripple on the provider save too.
- **Ripple observability:** new `magic_ripple_handle` (mirrors `magic_rebuild_handle`) makes the spawned ripple awaitable — used by the e2e regression test.
- **Determinism sweep (review follow-up, this PR):** zero `salsa_sp_files.values()` merges remain — 12 sites now iterate `sorted_sp_files()`, including the view/blade/component namespace resolvers (single **and** `_all_` variants — their per-key priority tiebreaks resolve winners, so sorting fixes real nondeterminism; output order of collected maps stays arbitrary), `handle_get_parsed_binding`, `handle_get_parsed_middleware` / `handle_get_all_parsed_middleware`, and the `handle_get_laravel_config` build loop. `build_facade_alias_snapshot` audited: it merges two fixed-path sources with no map iteration — already deterministic.
- Non-provider saves stay cheap: an untracked path yields the empty default contribution, and an empty diff adds no keys, preserving the body-only early return.

## Acceptance Criteria
- [x] **[Bug A — provider-body refresh]** Modifying a macro/binding registration in a provider `boot()`/`register()` body (without changing the class surface) causes the ripple to re-resolve call sites in other open files — no LSP restart required, including when the `did_change` debounce fired before the save (debounce-insulated baseline).
- [x] **[Bug A]** The reverse-index records the registering provider's path as a dependency for each macro key it registers (macro decl-file deps at every classify exit); binding sites record a `binding:<key>` attempt dependency (resolved or not), so both retargets **and brand-new keys** ripple on a provider save even when `surface_map_diff` is empty.
- [x] **[Bug A]** The provider-body invalidation path is applied uniformly to all three registries: macro, binding, and facade-alias — including the legacy `config/app.php` alias source, routed through the save transaction.
- [x] **[Bug B — deterministic merge]** Equal-priority same-key registrations resolve deterministically: lexicographically smallest provider path wins, stable across restarts, documented in the builders.
- [x] **[Bug B]** The tiebreak is applied in both `build_macro_registry` and `handle_get_all_parsed_bindings` (and swept across every remaining provider-map merge).
- [x] **[Test — Bug A]** End-to-end: `provider_body_macro_rename_converges_dependent_on_save` drives the real backend through the exact poisoned flow — `execute_salsa_update` (debounce) runs with the edited text *before* `refresh_magic_on_save` — and asserts the dependent file's stale classification clears. Plus `config_app_alias_edit_ripples_through_save_transaction` (alias source), unit coverage of `registration_ripple_keys` (empty diff → no keys; binding retarget → both concretes; alias retarget → both targets), and deps-recording tests for both macro decl files and binding attempt keys on both resolution paths.
- [x] **[Test — Bug B]** `equal_priority_collision_resolves_to_smallest_provider_path`: two equal-priority providers register the same macro + binding keys (registration order reversed on purpose — the construction that makes the assertion meaningful); the winner is the lexicographically smallest path in both registries.
- [x] **[Scope]** Live hover / goto-definition / rename are untouched — they re-derive from Salsa per call; every query-time `resolve_and_classify` call site passes `None` for the deps sink, so nothing is recorded on those paths.

## Test Plan
- [x] Full suite green: 2165 + 467 tests pass (`cargo test`)
- [x] CI green on head `8e6b69c` (LSP test/fmt/clippy, extension wasm check, CodeQL)
- [x] New regression tests cover both bugs end-to-end (see Test — Bug A / Bug B above)
- [x] `cargo clippy --all-targets` clean, `cargo fmt` applied

Fixes #255
