### PR TITLE
Harden residual tag-derived values in release.yml to consume the validated version output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,22 @@ jobs:
           # surprising out of all of them.
           SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$'
           if [[ ! "$VERSION" =~ $SEMVER_RE ]]; then
-            echo "::error::Tag '${TAG}' does not yield a valid semver version (got '${VERSION}')"
+            # Strip CR/LF before interpolating the (unvalidated) values into
+            # the workflow command, so a newline in a workflow_dispatch tag
+            # input can't split the ::error:: annotation and forge an
+            # additional workflow command.
+            SAFE_TAG="${TAG//[$'\n\r']/ }"
+            SAFE_VERSION="${VERSION//[$'\n\r']/ }"
+            echo "::error::Tag '${SAFE_TAG}' does not yield a valid semver version (got '${SAFE_VERSION}')"
             exit 1
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          # Past the guard, TAG is structurally either VERSION or v${VERSION}
+          # (the '#v' strip removes at most one leading 'v'), so this output is
+          # guard-validated too. Downstream steps consume it instead of the raw
+          # event value, making their injection-safety independent of step
+          # ordering (defense-in-depth follow-up from #243 / PR #261 → #262).
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "Extracted version: ${VERSION}"
 
       - name: Update versions and lock files
@@ -133,7 +145,13 @@ jobs:
       - name: Update tag and release
         if: github.event_name == 'release' && steps.commit_changes.outputs.new_commit_sha != ''
         env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          # Consume the guard-validated tag (safe-by-construction) rather than
+          # the raw event value (safe only by same-job step ordering). On a
+          # release event both hold the same string, but this keeps the curl
+          # URL/JSON interpolations hardened even if steps get reordered or
+          # split across jobs. Closes the residual follow-up from Holmes's
+          # review of #243 (PR #261): #262.
+          TAG_NAME: ${{ steps.extract_version.outputs.tag }}
         run: |
           RELEASE_ID="${{ github.event.release.id }}"
           FINAL_COMMIT_SHA="${{ steps.commit_changes.outputs.new_commit_sha }}"


### PR DESCRIPTION
## Summary
Implements #262 — closes out the residual defense-in-depth follow-up from Holmes's review of #243 (PR #261). Both remaining tag-derived-value surfaces in `release.yml` are now **safe-by-construction** instead of safe-by-ordering.

## Changes
- The semver guard step (`extract_version`) now exports the tag as a step output **after** the guard passes — at that point `TAG` is structurally `VERSION` or `v${VERSION}`, so the output is guard-validated.
- The "Update tag and release" step's `TAG_NAME` env now consumes `steps.extract_version.outputs.tag` instead of raw `github.event.release.tag_name`, so the curl URL/JSON interpolations no longer depend on same-job step ordering for their injection-safety.
- The guard's `::error::` echo strips CR/LF from the raw tag/version (`${TAG//[$'\n\r']/ }`) before interpolation, so a newline in a `workflow_dispatch` `tag` input can't split the annotation and forge an additional workflow command.

## Acceptance Criteria
- [x] "Update tag and release" step no longer interpolates raw `${TAG_NAME}` into the curl URL and JSON `-d` bodies; it consumes the guard-validated value, so injection-safety no longer depends on same-job step ordering
- [x] Guard's error echo strips/neutralizes CR/LF from the raw `${TAG}` (and derived `${VERSION}`) before interpolation
- [x] Both changes confined to `release.yml`; no behavior change to the semver guard's pass/fail logic, the sed substitutions, or the commit step
- [x] Workflow YAML parses/lints cleanly (YAML parse + `bash -n` on every `run:` block; actionlint unavailable on the build host)
- [x] PR description and inline comments note this closes the residual follow-up from Holmes's review of #243/PR #261 — both surfaces are now safe-by-construction

## Test Plan
- [x] YAML parses cleanly; `bash -n` passes on every `run:` block in the workflow
- [x] Functional harness on the extracted guard logic (10/10 passing):
  - newline-injection tag (`v1.2.3\n::error::forged`) rejected with a single-line, non-forgeable error annotation; no outputs written on failure
  - CR-injection tag neutralized
  - `v1.2.3` → `version=1.2.3`, `tag=v1.2.3`; bare `2.0.0-beta.1` → `tag`/`version` identical
  - metacharacter tag (`v1.2.3/&\evil`) still rejected — guard pass/fail behavior unchanged

Fixes #262