### PR TITLE
feat: factory chain navigation and custom collection/pivot resolution

### DIFF
--- a/docs/autocomplete.md
+++ b/docs/autocomplete.md
@@ -76,6 +76,8 @@ $user->
 
 Works with type-hinted variables, PHPDoc annotations, and static chains like `User::find(1)->`.
 
+To-many relationships honor the related model's custom collection — when `Post` declares `protected $collectionClass = PostCollection::class;` (or a `newCollection()` override), `posts` completes as `PostCollection<Post>` instead of the default `Collection<Post>`.
+
 ## 🔗 Eloquent Query Chains
 
 Type a string literal inside a query-builder method and the extension completes it from your schema and model definitions — **columns** inside `where`, `orderBy`, `whereIn`, `pluck`, `select`, … and **relations** inside `with`, `whereHas`, `withCount`, `load`, `has`, …:

--- a/docs/go-to-definition.md
+++ b/docs/go-to-definition.md
@@ -65,7 +65,16 @@ $user->email;
 
 User::whereEmail($value);
 //   ^^^^^^^^^^ dynamic finder → the email column's migration line
+
+User::factory()->suspended()->create();
+//    ^^^^^^^ → database/factories/UserFactory.php  (class UserFactory)
+//               ^^^^^^^^^ → database/factories/UserFactory.php  (public function suspended())
+
+$user->pivot;
+//     ^^^^^ → app/Models/Pivots/Membership.php  (when the model declares $pivotClass)
 ```
+
+`Model::factory()` resolves the model to its factory class — a `newFactory()` override when the model declares one, else Laravel's `Database\Factories\…Factory` convention — and chained calls the factory actually declares (custom states, `state`, …) jump to their declaration in the factory file. `->pivot` jumps to a custom pivot class only when the model declares `protected $pivotClass = …::class;` (the framework default `Pivot` is left alone).
 
 Resolution is inheritance- and trait-aware — a member declared in a trait or a parent model jumps to the file that declares it — and chain-aware: `User::query()->active()`, `self::` / `static::` calls, and `$query->active()` inside scope bodies all resolve. Plain properties and plain method calls are left to your PHP language server (no duplicate results), and factory states sharing a scope's name (`User::factory()->active()`) are correctly NOT treated as scopes. Dynamic finders classify against the model's source-visible column surface (`$casts`, `$fillable`, timestamps) — a `$guarded = []` model that declares neither won't resolve its finders. Not resolved (conservatively dropped rather than guessed): `parent::` receivers, `(new User)->active()`, and relation-hopped chains (`$user->posts()->active()` — that's Post's scope).
 

--- a/laravel-lsp/src/factory_resolver.rs
+++ b/laravel-lsp/src/factory_resolver.rs
@@ -1,0 +1,223 @@
+//! Model → factory resolution (issue #30, item 3).
+//!
+//! `User::factory()` is `HasFactory::factory()` at runtime — a vendor trait
+//! method no PHP LSP can see through without ide-helper output. This module
+//! answers "which factory class does this model's `factory()` return?" from
+//! project structure alone, mirroring Laravel's own resolution order:
+//!
+//! 1. An explicit `newFactory()` override on the model names the factory
+//!    directly (`UserFactory::new()`, `new UserFactory`, `UserFactory::class`).
+//! 2. Convention (`Illuminate\Database\Eloquent\Factories\Factory::resolveFactoryName`):
+//!    the model's FQCN relative to `App\Models\` (or `App\`) maps into
+//!    `Database\Factories\…Factory` — `App\Models\Admin\User` →
+//!    `Database\Factories\Admin\UserFactory`. Where that namespace lives on
+//!    disk is composer's business: the conventional candidate only resolves
+//!    when the [`ClassFileResolver`] (PSR-4 aware, `autoload-dev` included)
+//!    actually locates its file, so a project that remaps the factories path
+//!    in `composer.json` still resolves and a model with no factory yields
+//!    `None` instead of a dead goto target.
+
+use crate::laravel_introspector::chain::ClassView;
+use crate::member_resolver::ClassFileResolver;
+use crate::parser::parse_php;
+use crate::query_chain::use_aliases::extract_use_aliases;
+
+/// The factory FQCN `view`'s `factory()` call resolves to, or `None` when the
+/// model has no override and no conventional factory file exists.
+pub fn factory_fqcn_for_model(
+    view: &ClassView,
+    resolver: &impl ClassFileResolver,
+) -> Option<String> {
+    // 1. `newFactory()` override — declared anywhere in the hierarchy; parse
+    //    the DECLARING file (a parent/trait may carry it) for the class it
+    //    names. Only models that actually declare one pay the file read.
+    if let Some(m) = view
+        .all_methods
+        .iter()
+        .find(|m| m.value.name == "newFactory")
+    {
+        if let Some(file) = resolver.class_file(&m.source_class) {
+            if let Some(fqcn) = std::fs::read_to_string(&file)
+                .ok()
+                .and_then(|src| factory_from_new_factory(&src))
+            {
+                return Some(fqcn);
+            }
+        }
+    }
+    // 2. Convention, gated on the factory class actually existing.
+    let candidate = conventional_factory_fqcn(&view.fqcn);
+    resolver.class_file(&candidate).map(|_| candidate)
+}
+
+/// Laravel's conventional factory name for a model FQCN: the model path
+/// relative to the application namespace (`App\Models\` first, bare `App\`
+/// second, the basename as a last resort) prefixed with `Database\Factories\`
+/// and suffixed `Factory`.
+pub fn conventional_factory_fqcn(model_fqcn: &str) -> String {
+    let relative = model_fqcn
+        .strip_prefix("App\\Models\\")
+        .or_else(|| model_fqcn.strip_prefix("App\\"))
+        .unwrap_or_else(|| model_fqcn.rsplit('\\').next().unwrap_or(model_fqcn));
+    format!("Database\\Factories\\{relative}Factory")
+}
+
+/// Extract the factory FQCN named inside a `newFactory()` method body:
+/// `UserFactory::new()`, `UserFactory::class`, or `new UserFactory(...)`.
+/// The short name resolves through the file's own `use` aliases + namespace.
+fn factory_from_new_factory(src: &str) -> Option<String> {
+    let tree = parse_php(src).ok()?;
+    let bytes = src.as_bytes();
+    let aliases = extract_use_aliases(&tree, src);
+    let namespace = file_namespace(tree.root_node(), bytes);
+
+    let method = find_method(tree.root_node(), bytes, "newFactory")?;
+    let raw = first_class_token(method, bytes)?;
+    Some(
+        crate::laravel_introspector::model_metadata::resolve_to_fqcn(
+            &raw,
+            namespace.as_deref(),
+            &aliases,
+        ),
+    )
+}
+
+/// The file's `namespace X;` declaration, if any.
+fn file_namespace(root: tree_sitter::Node, bytes: &[u8]) -> Option<String> {
+    let mut cursor = root.walk();
+    for child in root.children(&mut cursor) {
+        if child.kind() == "namespace_definition" {
+            return child
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(bytes).ok())
+                .map(str::to_string);
+        }
+    }
+    None
+}
+
+/// Depth-first search for a `method_declaration` named `name`.
+fn find_method<'t>(
+    node: tree_sitter::Node<'t>,
+    bytes: &[u8],
+    name: &str,
+) -> Option<tree_sitter::Node<'t>> {
+    let mut stack = vec![node];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "method_declaration"
+            && n.child_by_field_name("name")
+                .and_then(|c| c.utf8_text(bytes).ok())
+                == Some(name)
+        {
+            return Some(n);
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    None
+}
+
+/// The first class name referenced inside `node` as `X::…` (scoped call /
+/// `::class` constant) or `new X(…)`.
+fn first_class_token(node: tree_sitter::Node, bytes: &[u8]) -> Option<String> {
+    let mut stack = vec![node];
+    while let Some(n) = stack.pop() {
+        let class_node = match n.kind() {
+            "scoped_call_expression" | "class_constant_access_expression" => {
+                n.child_by_field_name("scope").or_else(|| n.child(0))
+            }
+            "object_creation_expression" => n
+                .named_children(&mut n.walk())
+                .find(|c| matches!(c.kind(), "name" | "qualified_name")),
+            _ => None,
+        };
+        if let Some(c) = class_node {
+            if matches!(c.kind(), "name" | "qualified_name") {
+                if let Ok(text) = c.utf8_text(bytes) {
+                    return Some(text.to_string());
+                }
+            }
+        }
+        let mut cursor = n.walk();
+        for ch in n.children(&mut cursor) {
+            stack.push(ch);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conventional_name_strips_app_models() {
+        assert_eq!(
+            conventional_factory_fqcn("App\\Models\\User"),
+            "Database\\Factories\\UserFactory"
+        );
+    }
+
+    #[test]
+    fn conventional_name_keeps_model_subdirectories() {
+        assert_eq!(
+            conventional_factory_fqcn("App\\Models\\Admin\\User"),
+            "Database\\Factories\\Admin\\UserFactory"
+        );
+    }
+
+    #[test]
+    fn conventional_name_handles_bare_app_namespace() {
+        assert_eq!(
+            conventional_factory_fqcn("App\\User"),
+            "Database\\Factories\\UserFactory"
+        );
+    }
+
+    #[test]
+    fn conventional_name_falls_back_to_basename() {
+        assert_eq!(
+            conventional_factory_fqcn("Modules\\Blog\\Models\\Post"),
+            "Database\\Factories\\PostFactory"
+        );
+    }
+
+    #[test]
+    fn new_factory_static_new_resolves_through_aliases() {
+        let src = r#"<?php
+namespace App\Models;
+use Database\Factories\Custom\UserFactory;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    protected static function newFactory() { return UserFactory::new(); }
+}
+"#;
+        assert_eq!(
+            factory_from_new_factory(src).as_deref(),
+            Some("Database\\Factories\\Custom\\UserFactory")
+        );
+    }
+
+    #[test]
+    fn new_factory_object_creation_resolves() {
+        let src = r#"<?php
+namespace App\Models;
+use Database\Factories\UserFactory;
+class User {
+    protected static function newFactory() { return new UserFactory(); }
+}
+"#;
+        assert_eq!(
+            factory_from_new_factory(src).as_deref(),
+            Some("Database\\Factories\\UserFactory")
+        );
+    }
+
+    #[test]
+    fn no_new_factory_method_yields_none() {
+        let src = "<?php namespace App\\Models; class User {}";
+        assert_eq!(factory_from_new_factory(src), None);
+    }
+}

--- a/laravel-lsp/src/factory_resolver.rs
+++ b/laravel-lsp/src/factory_resolver.rs
@@ -41,7 +41,11 @@ pub fn factory_fqcn_for_model(
                 .ok()
                 .and_then(|src| factory_from_new_factory(&src))
             {
-                return Some(fqcn);
+                // The declared override is authoritative — no convention
+                // fallback — but it honors the same gate as the convention
+                // branch: a named class with no file on disk is a dead
+                // target (goto AND hover), so it yields `None`.
+                return resolver.class_file(&fqcn).map(|_| fqcn);
             }
         }
     }
@@ -119,8 +123,8 @@ fn find_method<'t>(
     None
 }
 
-/// The first class name referenced inside `node` as `X::…` (scoped call /
-/// `::class` constant) or `new X(…)`.
+/// The first class name referenced inside `node` — in document order — as
+/// `X::…` (scoped call / `::class` constant) or `new X(…)`.
 fn first_class_token(node: tree_sitter::Node, bytes: &[u8]) -> Option<String> {
     let mut stack = vec![node];
     while let Some(n) = stack.pop() {
@@ -140,8 +144,12 @@ fn first_class_token(node: tree_sitter::Node, bytes: &[u8]) -> Option<String> {
                 }
             }
         }
+        // Push children REVERSED so the LIFO stack pops siblings
+        // left-to-right — a plain forward push would visit them in
+        // reverse and return the LAST reference for multi-branch bodies.
         let mut cursor = n.walk();
-        for ch in n.children(&mut cursor) {
+        let children: Vec<_> = n.children(&mut cursor).collect();
+        for ch in children.into_iter().rev() {
             stack.push(ch);
         }
     }
@@ -219,5 +227,29 @@ class User {
     fn no_new_factory_method_yields_none() {
         let src = "<?php namespace App\\Models; class User {}";
         assert_eq!(factory_from_new_factory(src), None);
+    }
+
+    #[test]
+    fn new_factory_multi_reference_body_yields_first_in_document_order() {
+        // A conditional override references two factories; the FIRST in
+        // source order wins (regression: the DFS used to pop siblings
+        // right-to-left and returned the last).
+        let src = r#"<?php
+namespace App\Models;
+use Database\Factories\FirstFactory;
+use Database\Factories\SecondFactory;
+class User {
+    protected static function newFactory() {
+        if (app()->environment('testing')) {
+            return FirstFactory::new();
+        }
+        return SecondFactory::new();
+    }
+}
+"#;
+        assert_eq!(
+            factory_from_new_factory(src).as_deref(),
+            Some("Database\\Factories\\FirstFactory")
+        );
     }
 }

--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -253,6 +253,12 @@ pub fn magic_member_card(
         // concrete the facade forwards to. Worth a card precisely because
         // Intelephense can't see through the proxy.
         MagicMemberKind::FacadeMethod => "Facade method",
+        // `Model::factory()` — declaring_fqcn is the resolved factory class.
+        MagicMemberKind::Factory => "Model factory",
+        // A method on a factory-rooted chain (custom state, vendor `state`).
+        MagicMemberKind::FactoryMethod => "Factory method",
+        // `->pivot` on a model with a custom `$pivotClass`.
+        MagicMemberKind::Pivot => "Pivot model",
         // Generic property — Intelephense already covers it. Don't duplicate.
         MagicMemberKind::PlainMember => return String::new(),
     };

--- a/laravel-lsp/src/hover/tests.rs
+++ b/laravel-lsp/src/hover/tests.rs
@@ -264,6 +264,9 @@ fn magic_member_card_labels_each_kind() {
     assert_eq!(label(MagicMemberKind::Accessor), "**Eloquent accessor**");
     assert_eq!(label(MagicMemberKind::Column), "**Database column**");
     assert_eq!(label(MagicMemberKind::DynamicFinder), "**Dynamic finder**");
+    assert_eq!(label(MagicMemberKind::Factory), "**Model factory**");
+    assert_eq!(label(MagicMemberKind::FactoryMethod), "**Factory method**");
+    assert_eq!(label(MagicMemberKind::Pivot), "**Pivot model**");
 }
 
 #[test]

--- a/laravel-lsp/src/laravel_introspector.rs
+++ b/laravel-lsp/src/laravel_introspector.rs
@@ -55,6 +55,7 @@ pub use chain::{
 pub use model_metadata::{
     extract_namespace, extract_use_aliases, map_cast_to_php_type, parse_array_keys_public,
     parse_cast_array, parse_string_array, pascal_to_snake, relationship_to_php_type,
+    relationship_to_php_type_with_collection,
     resolve_to_fqcn, snake_to_studly, ModelMetadata,
 };
 // Compatibility re-exports of the historical `AccessorInfo` /

--- a/laravel-lsp/src/laravel_introspector.rs
+++ b/laravel-lsp/src/laravel_introspector.rs
@@ -55,8 +55,7 @@ pub use chain::{
 pub use model_metadata::{
     extract_namespace, extract_use_aliases, map_cast_to_php_type, parse_array_keys_public,
     parse_cast_array, parse_string_array, pascal_to_snake, relationship_to_php_type,
-    relationship_to_php_type_with_collection,
-    resolve_to_fqcn, snake_to_studly, ModelMetadata,
+    relationship_to_php_type_with_collection, resolve_to_fqcn, snake_to_studly, ModelMetadata,
 };
 // Compatibility re-exports of the historical `AccessorInfo` /
 // `RelationshipInfo` shapes that some call sites import from this

--- a/laravel-lsp/src/laravel_introspector/chain.rs
+++ b/laravel-lsp/src/laravel_introspector/chain.rs
@@ -413,6 +413,16 @@ pub struct ClassView {
     /// for Eloquent Builder and Query Builder; empty for everything
     /// else.
     pub callstatic_surface: Vec<BuilderMethod>,
+
+    /// Custom Eloquent collection FQCN the model hydrates into —
+    /// `protected $collectionClass = UserCollection::class;` or a
+    /// `newCollection()` override (issue #30 item 4). `None` = the
+    /// framework default `Illuminate\Database\Eloquent\Collection`.
+    pub collection_class: Option<String>,
+    /// Custom pivot FQCN for the model's many-to-many rows —
+    /// `protected $pivotClass = MembershipPivot::class;`. `None` = the
+    /// framework default `Relations\Pivot`.
+    pub pivot_class: Option<String>,
 }
 
 /// Single-file analysis: parse `content` and compute every Laravel
@@ -497,6 +507,13 @@ fn analyze_from_prefixed(content: &str) -> Option<ClassView> {
         table_name: compute_table_name(&all_properties),
         column_surface,
         callstatic_surface: Vec::new(),
+        collection_class: compute_collection_class(
+            &all_methods,
+            &all_properties,
+            &aliases,
+            namespace.as_deref(),
+        ),
+        pivot_class: compute_pivot_class(&all_properties, &aliases, namespace.as_deref()),
         all_methods,
         all_properties,
     })
@@ -566,6 +583,9 @@ pub fn analyze(file_path: &Path, project_root: &Path) -> Option<ClassView> {
     let casts = compute_casts(&all_methods, &all_properties);
     let table_name = compute_table_name(&all_properties);
     let column_surface = compute_column_surface(&all_methods, &all_properties, &casts);
+    let collection_class =
+        compute_collection_class(&all_methods, &all_properties, aliases, namespace.as_deref());
+    let pivot_class = compute_pivot_class(&all_properties, aliases, namespace.as_deref());
     let callstatic_surface = match kind {
         LaravelClassKind::EloquentBuilder | LaravelClassKind::QueryBuilder => {
             compute_callstatic_surface(&all_methods, &fqcn)
@@ -589,6 +609,8 @@ pub fn analyze(file_path: &Path, project_root: &Path) -> Option<ClassView> {
         table_name,
         column_surface,
         callstatic_surface,
+        collection_class,
+        pivot_class,
     })
 }
 
@@ -1222,6 +1244,102 @@ fn compute_table_name(properties: &[ResolvedMember<PhpPropertyInfo>]) -> Option<
     let prop = properties.iter().find(|p| p.value.name == "table")?;
     let default = prop.value.default_value.as_deref()?;
     unquote_string_literal(default)
+}
+
+// ---- Custom collection / pivot overrides (issue #30 item 4) -------------
+
+/// The model's custom Eloquent collection FQCN: a `$collectionClass`
+/// property default first (child-first ordering — first match wins, same
+/// as PHP), else a `newCollection()` override's declared return type or
+/// its `new X(...)` body. `None` when the model uses the framework default.
+fn compute_collection_class(
+    methods: &[ResolvedMember<PhpMethodInfo>],
+    properties: &[ResolvedMember<PhpPropertyInfo>],
+    aliases: &HashMap<String, String>,
+    file_namespace: Option<&str>,
+) -> Option<String> {
+    class_property_override(properties, "collectionClass", aliases, file_namespace).or_else(|| {
+        let m = methods.iter().find(|m| m.value.name == "newCollection")?;
+        let raw = m
+            .value
+            .return_type_raw
+            .as_deref()
+            .filter(|t| {
+                // A bare `Collection` return type is the framework default,
+                // not an override worth surfacing.
+                t.trim_start_matches('?').rsplit('\\').next() != Some("Collection")
+            })
+            .map(str::to_string)
+            .or_else(|| m.value.body_source.as_deref().and_then(first_new_class))?;
+        Some(
+            crate::laravel_introspector::model_metadata::resolve_to_fqcn(
+                raw.trim_start_matches('?'),
+                file_namespace,
+                aliases,
+            ),
+        )
+    })
+}
+
+/// The model's custom pivot FQCN (`protected $pivotClass = X::class;`).
+fn compute_pivot_class(
+    properties: &[ResolvedMember<PhpPropertyInfo>],
+    aliases: &HashMap<String, String>,
+    file_namespace: Option<&str>,
+) -> Option<String> {
+    class_property_override(properties, "pivotClass", aliases, file_namespace)
+}
+
+/// The custom collection FQCN `model_fqcn` hydrates into, if the model (or
+/// an ancestor) declares one. Resolves the model's file through composer
+/// autoload and runs the memoized analysis — the lookup the completion call
+/// sites use per relationship's RELATED model.
+pub fn collection_class_for(model_fqcn: &str, project_root: &Path) -> Option<String> {
+    let path =
+        crate::class_locator::find_php_class_file_in_app_or_vendor(model_fqcn, project_root)?;
+    analyze(&path, project_root)?.collection_class
+}
+
+/// Resolve a `protected $name = X::class;` (or `'App\\…\\X'` string) property
+/// default to an FQCN. Uses the ENTRY file's aliases — the same convention
+/// `compute_relationships` applies to inherited members.
+fn class_property_override(
+    properties: &[ResolvedMember<PhpPropertyInfo>],
+    name: &str,
+    aliases: &HashMap<String, String>,
+    file_namespace: Option<&str>,
+) -> Option<String> {
+    let default = properties
+        .iter()
+        .find(|p| p.value.name == name)?
+        .value
+        .default_value
+        .as_deref()?
+        .trim()
+        .to_string();
+    if let Some(class_ref) = default.strip_suffix("::class") {
+        return Some(
+            crate::laravel_introspector::model_metadata::resolve_to_fqcn(
+                class_ref.trim(),
+                file_namespace,
+                aliases,
+            ),
+        );
+    }
+    // Quoted-string form carries a full class path already.
+    unquote_string_literal(&default).map(|s| s.trim_start_matches('\\').to_string())
+}
+
+/// The class named by the first `new X(...)` in a method body — the
+/// body-strategy counterpart of a declared return type (same `contains`-level
+/// heuristic `compute_relationships` uses for relationship bodies).
+fn first_new_class(body: &str) -> Option<String> {
+    let idx = body.find("new ")?;
+    let token: String = body[idx + 4..]
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '\\')
+        .collect();
+    (!token.is_empty()).then_some(token)
 }
 
 // ---- __callStatic surface (Builder) ------------------------------------

--- a/laravel-lsp/src/laravel_introspector/chain.rs
+++ b/laravel-lsp/src/laravel_introspector/chain.rs
@@ -1264,20 +1264,16 @@ fn compute_collection_class(
             .value
             .return_type_raw
             .as_deref()
-            .filter(|t| {
-                // A bare `Collection` return type is the framework default,
-                // not an override worth surfacing.
-                t.trim_start_matches('?').rsplit('\\').next() != Some("Collection")
-            })
             .map(str::to_string)
             .or_else(|| m.value.body_source.as_deref().and_then(first_new_class))?;
-        Some(
-            crate::laravel_introspector::model_metadata::resolve_to_fqcn(
-                raw.trim_start_matches('?'),
-                file_namespace,
-                aliases,
-            ),
-        )
+        let fqcn = crate::laravel_introspector::model_metadata::resolve_to_fqcn(
+            raw.trim_start_matches('?'),
+            file_namespace,
+            aliases,
+        );
+        // Restating the framework default — whether in the return type or
+        // the `new X(...)` body — is not an override worth surfacing.
+        (fqcn != "Illuminate\\Database\\Eloquent\\Collection").then_some(fqcn)
     })
 }
 

--- a/laravel-lsp/src/laravel_introspector/chain.rs
+++ b/laravel-lsp/src/laravel_introspector/chain.rs
@@ -1258,32 +1258,39 @@ fn compute_collection_class(
     aliases: &HashMap<String, String>,
     file_namespace: Option<&str>,
 ) -> Option<String> {
-    class_property_override(properties, "collectionClass", aliases, file_namespace).or_else(|| {
-        let m = methods.iter().find(|m| m.value.name == "newCollection")?;
-        let raw = m
-            .value
-            .return_type_raw
-            .as_deref()
-            .map(str::to_string)
-            .or_else(|| m.value.body_source.as_deref().and_then(first_new_class))?;
-        let fqcn = crate::laravel_introspector::model_metadata::resolve_to_fqcn(
-            raw.trim_start_matches('?'),
-            file_namespace,
-            aliases,
-        );
-        // Restating the framework default — whether in the return type or
-        // the `new X(...)` body — is not an override worth surfacing.
-        (fqcn != "Illuminate\\Database\\Eloquent\\Collection").then_some(fqcn)
-    })
+    class_property_override(properties, "collectionClass", aliases, file_namespace)
+        .or_else(|| {
+            let m = methods.iter().find(|m| m.value.name == "newCollection")?;
+            let raw = m
+                .value
+                .return_type_raw
+                .as_deref()
+                .map(str::to_string)
+                .or_else(|| m.value.body_source.as_deref().and_then(first_new_class))?;
+            Some(
+                crate::laravel_introspector::model_metadata::resolve_to_fqcn(
+                    raw.trim_start_matches('?'),
+                    file_namespace,
+                    aliases,
+                ),
+            )
+        })
+        // Restating the framework default — in the property, the return
+        // type, or the `new X(...)` body — is not an override worth
+        // surfacing; the filter sits outside both paths so they share it.
+        .filter(|fqcn| fqcn != "Illuminate\\Database\\Eloquent\\Collection")
 }
 
 /// The model's custom pivot FQCN (`protected $pivotClass = X::class;`).
+/// `None` when the model uses the framework default — a restated default
+/// is filtered the same way as the collection path above.
 fn compute_pivot_class(
     properties: &[ResolvedMember<PhpPropertyInfo>],
     aliases: &HashMap<String, String>,
     file_namespace: Option<&str>,
 ) -> Option<String> {
     class_property_override(properties, "pivotClass", aliases, file_namespace)
+        .filter(|fqcn| fqcn != "Illuminate\\Database\\Eloquent\\Relations\\Pivot")
 }
 
 /// The custom collection FQCN `model_fqcn` hydrates into, if the model (or

--- a/laravel-lsp/src/laravel_introspector/chain/tests.rs
+++ b/laravel-lsp/src/laravel_introspector/chain/tests.rs
@@ -222,6 +222,127 @@ class Portfolio extends Model {
     assert_eq!(view.table_name.as_deref(), Some("user_portfolios"));
 }
 
+// ---- Custom collection / pivot overrides (issue #30 item 4) -------------
+
+#[test]
+fn extracts_collection_class_from_property() {
+    let (dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+use App\Support\PortfolioCollection;
+use Illuminate\Database\Eloquent\Model;
+class Portfolio extends Model {
+    protected $collectionClass = PortfolioCollection::class;
+}
+"#,
+    );
+    let view = analyze(&path, dir.path()).unwrap();
+    assert_eq!(
+        view.collection_class.as_deref(),
+        Some("App\\Support\\PortfolioCollection")
+    );
+}
+
+#[test]
+fn extracts_collection_class_from_new_collection_return_type() {
+    let (dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+use App\Support\PortfolioCollection;
+use Illuminate\Database\Eloquent\Model;
+class Portfolio extends Model {
+    public function newCollection(array $models = []): PortfolioCollection {
+        return new PortfolioCollection($models);
+    }
+}
+"#,
+    );
+    let view = analyze(&path, dir.path()).unwrap();
+    assert_eq!(
+        view.collection_class.as_deref(),
+        Some("App\\Support\\PortfolioCollection")
+    );
+}
+
+#[test]
+fn extracts_collection_class_from_untyped_new_collection_body() {
+    // No declared return type — the body's `new X(…)` names the collection.
+    let (dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+use App\Support\PortfolioCollection;
+use Illuminate\Database\Eloquent\Model;
+class Portfolio extends Model {
+    public function newCollection(array $models = []) {
+        return new PortfolioCollection($models);
+    }
+}
+"#,
+    );
+    let view = analyze(&path, dir.path()).unwrap();
+    assert_eq!(
+        view.collection_class.as_deref(),
+        Some("App\\Support\\PortfolioCollection")
+    );
+}
+
+#[test]
+fn bare_collection_return_type_is_not_an_override() {
+    // `newCollection(): Collection` restates the framework default — no
+    // override to surface.
+    let (dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+class Portfolio extends Model {
+    public function newCollection(array $models = []): Collection {
+        return new Collection($models);
+    }
+}
+"#,
+    );
+    let view = analyze(&path, dir.path()).unwrap();
+    assert_eq!(view.collection_class, None);
+}
+
+#[test]
+fn extracts_pivot_class_from_property() {
+    let (dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+use App\Models\Pivots\Membership;
+use Illuminate\Database\Eloquent\Model;
+class Portfolio extends Model {
+    protected $pivotClass = Membership::class;
+}
+"#,
+    );
+    let view = analyze(&path, dir.path()).unwrap();
+    assert_eq!(
+        view.pivot_class.as_deref(),
+        Some("App\\Models\\Pivots\\Membership")
+    );
+}
+
+#[test]
+fn models_without_overrides_default_collection_and_pivot_to_none() {
+    // The common case: no `$collectionClass`, no `newCollection()`, no
+    // `$pivotClass` — both stay `None` so consumers keep default behavior.
+    let (dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Portfolio extends Model {
+    protected $fillable = ['title'];
+}
+"#,
+    );
+    let view = analyze(&path, dir.path()).unwrap();
+    assert_eq!(view.collection_class, None);
+    assert_eq!(view.pivot_class, None);
+}
+
 #[test]
 fn detects_relationships() {
     let (dir, path) = fixture(

--- a/laravel-lsp/src/laravel_introspector/chain/tests.rs
+++ b/laravel-lsp/src/laravel_introspector/chain/tests.rs
@@ -326,6 +326,42 @@ class Portfolio extends Model {
 }
 
 #[test]
+fn restated_default_collection_property_is_not_an_override() {
+    // `$collectionClass = \Illuminate\…\Collection::class;` restates the
+    // framework default — the property path honors the same no-override
+    // contract as the `newCollection()` return-type path.
+    let (dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Portfolio extends Model {
+    protected $collectionClass = \Illuminate\Database\Eloquent\Collection::class;
+}
+"#,
+    );
+    let view = analyze(&path, dir.path()).unwrap();
+    assert_eq!(view.collection_class, None);
+}
+
+#[test]
+fn restated_default_pivot_property_is_not_an_override() {
+    // Same contract for `$pivotClass = Pivot::class;` — a restated default
+    // must not surface a "custom" pivot pointing into vendor code.
+    let (dir, path) = fixture(
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Model;
+class Portfolio extends Model {
+    protected $pivotClass = Pivot::class;
+}
+"#,
+    );
+    let view = analyze(&path, dir.path()).unwrap();
+    assert_eq!(view.pivot_class, None);
+}
+
+#[test]
 fn models_without_overrides_default_collection_and_pivot_to_none() {
     // The common case: no `$collectionClass`, no `newCollection()`, no
     // `$pivotClass` — both stay `None` so consumers keep default behavior.

--- a/laravel-lsp/src/laravel_introspector/model_metadata.rs
+++ b/laravel-lsp/src/laravel_introspector/model_metadata.rs
@@ -72,6 +72,11 @@ pub struct ModelMetadata {
     pub accessors: Vec<AccessorInfo>,
     /// Relationships found in the model
     pub relationships: Vec<RelationshipInfo>,
+    /// Custom Eloquent collection FQCN (`$collectionClass` /
+    /// `newCollection()` override); `None` = framework default.
+    pub collection_class: Option<String>,
+    /// Custom pivot FQCN (`$pivotClass`); `None` = framework default.
+    pub pivot_class: Option<String>,
 }
 
 impl ModelMetadata {
@@ -120,6 +125,8 @@ impl ModelMetadata {
                     related_model: r.related_model.clone(),
                 })
                 .collect(),
+            collection_class: view.collection_class.clone(),
+            pivot_class: view.pivot_class.clone(),
         }
     }
 
@@ -545,6 +552,19 @@ pub fn map_cast_to_php_type(cast: &str) -> String {
 /// completion details should be short, and the model's namespace
 /// rarely adds value at a glance.
 pub fn relationship_to_php_type(rel_type: &str, related_model: Option<&str>) -> String {
+    relationship_to_php_type_with_collection(rel_type, related_model, None)
+}
+
+/// [`relationship_to_php_type`] with the related model's custom collection
+/// class (issue #30 item 4): a to-many result hydrates into the RELATED
+/// model's `newCollection()` / `$collectionClass`, so `collection_class`
+/// (when `Some`) replaces the default `Collection` label. Simple names for
+/// both, same display rule as the model.
+pub fn relationship_to_php_type_with_collection(
+    rel_type: &str,
+    related_model: Option<&str>,
+    collection_class: Option<&str>,
+) -> String {
     let model_full = related_model.unwrap_or("Model");
     let model = model_full.rsplit('\\').next().unwrap_or(model_full);
 
@@ -556,7 +576,10 @@ pub fn relationship_to_php_type(rel_type: &str, related_model: Option<&str>) -> 
         // Collection relationships
         "hasMany" | "belongsToMany" | "morphMany" | "morphToMany" | "morphedByMany"
         | "hasManyThrough" => {
-            format!("Collection<{}>", model)
+            let collection = collection_class
+                .map(|c| c.rsplit('\\').next().unwrap_or(c))
+                .unwrap_or("Collection");
+            format!("{}<{}>", collection, model)
         }
         _ => "mixed".to_string(),
     }

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -37,6 +37,7 @@ pub mod database;
 pub mod document_symbols;
 pub mod env_key_locator;
 pub mod facade_resolver;
+pub mod factory_resolver;
 pub mod file_watcher;
 pub mod folio_discovery;
 pub mod hover;

--- a/laravel-lsp/src/magic_disk_cache.rs
+++ b/laravel-lsp/src/magic_disk_cache.rs
@@ -69,7 +69,7 @@ use crate::view_var_index::ViewRender;
 /// path), so a warm v3 cache is discarded and the project re-indexed with the
 /// corrected resolver rather than trusting stale entries. Parsing did not
 /// change, so the pattern/config disk caches are intentionally NOT bumped.
-const SCHEMA_VERSION: u32 = 4;
+const SCHEMA_VERSION: u32 = 5;
 
 const CACHE_FILENAME: &str = "magic_cache.bin";
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13916,7 +13916,7 @@ impl LaravelLanguageServer {
     /// Forms, DTOs, value objects — any class with public properties.
     async fn get_class_properties(&self, class_name: &str) -> Vec<ModelPropertyCompletion> {
         use laravel_lsp::laravel_introspector::{
-            map_cast_to_php_type, relationship_to_php_type, ModelMetadata,
+            map_cast_to_php_type, relationship_to_php_type_with_collection, ModelMetadata,
         };
 
         // Synthetic Blade types — short-circuit before any filesystem lookup so they
@@ -14036,8 +14036,16 @@ impl LaravelLanguageServer {
         //    the trailing `()` so the completion handler picks it up
         //    as the method shape without an extra flag on the struct.
         for rel in &metadata.relationships {
-            let result_type =
-                relationship_to_php_type(&rel.relationship_type, rel.related_model.as_deref());
+            // A to-many result hydrates into the RELATED model's custom
+            // collection when it declares one (issue #30 item 4).
+            let collection_class = rel.related_model.as_deref().and_then(|related| {
+                laravel_lsp::laravel_introspector::chain::collection_class_for(related, &root)
+            });
+            let result_type = relationship_to_php_type_with_collection(
+                &rel.relationship_type,
+                rel.related_model.as_deref(),
+                collection_class.as_deref(),
+            );
             let relation_type = format!(
                 "{}<{}>",
                 rel.relationship_type,
@@ -18856,6 +18864,15 @@ return [
         // method-name token to narrow to on the Macroable host (it's vendor), so
         // jump to the definition's start with a zero-width caret.
         if matches!(data.kind, MagicMemberKind::Macro) {
+            let decl_file = data.decl_file?;
+            return Self::goto_link(&decl_file, data.decl_line.unwrap_or(0), 0, 0);
+        }
+
+        // A model factory (`User::factory()`) or custom pivot (`->pivot`)
+        // resolves to its CLASS — there's no member-named method to narrow to
+        // (the member is vendor-trait / runtime magic). The Salsa side already
+        // located the class line in `decl_file`/`decl_line`.
+        if matches!(data.kind, MagicMemberKind::Factory | MagicMemberKind::Pivot) {
             let decl_file = data.decl_file?;
             return Self::goto_link(&decl_file, data.decl_line.unwrap_or(0), 0, 0);
         }

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -2575,18 +2575,16 @@ fn resolve_recipe_and_classify(
 
     let (fqcn, confidence, via_facade, via_factory) = match facade_concrete.or(helper_concrete) {
         Some((fqcn, confidence)) => (fqcn, confidence, true, false),
-        None => {
-            match eval_receiver(&site.recipe, aliases, resolver, classviews, project_root) {
-                Some((fqcn, confidence)) => (fqcn, confidence, false, false),
-                None if form.is_call() => {
-                    let chain = site.chain.as_ref()?;
-                    let (fqcn, confidence, via_factory) =
-                        eval_chain(chain, aliases, resolver, classviews, project_root)?;
-                    (fqcn, confidence, false, via_factory)
-                }
-                None => return None,
+        None => match eval_receiver(&site.recipe, aliases, resolver, classviews, project_root) {
+            Some((fqcn, confidence)) => (fqcn, confidence, false, false),
+            None if form.is_call() => {
+                let chain = site.chain.as_ref()?;
+                let (fqcn, confidence, via_factory) =
+                    eval_chain(chain, aliases, resolver, classviews, project_root)?;
+                (fqcn, confidence, false, via_factory)
             }
-        }
+            None => return None,
+        },
     };
 
     if let Some(d) = deps.as_deref_mut() {

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -17,7 +17,7 @@
 //! rename/lens can attribute every inheriting model correctly.
 
 use crate::class_hierarchy_index::ClassHierarchyIndex;
-use crate::laravel_introspector::chain::{analyze, ClassView};
+use crate::laravel_introspector::chain::{analyze, ClassView, LaravelClassKind};
 use crate::laravel_introspector::model_metadata::pascal_to_snake;
 use crate::parser::parse_php;
 use crate::query_chain::flow;
@@ -243,6 +243,18 @@ fn classify_property(view: &ClassView, member: &str) -> Option<ClassifiedMember>
             kind: MagicMemberKind::Relationship,
         });
     }
+    // Many-to-many `->pivot` on a model declaring a custom pivot class
+    // (`protected $pivotClass = MembershipPivot::class;`, issue #30 item 4).
+    // Models without the override fall through — the default
+    // `Relations\Pivot` is vendor territory, not worth a card or a goto.
+    if member == "pivot" && view.kind == LaravelClassKind::Model {
+        if let Some(pivot) = &view.pivot_class {
+            return Some(ClassifiedMember {
+                declaring_fqcn: pivot.clone(),
+                kind: MagicMemberKind::Pivot,
+            });
+        }
+    }
     // Database column surfaced as a model attribute.
     if view.column_surface.iter().any(|c| c.name == member) {
         return Some(ClassifiedMember {
@@ -443,11 +455,16 @@ pub fn resolve_member_access_entries(
         // Property-form plain members stay (bounded: declared properties on
         // resolved classes). Facade methods (`Auth::check()`) are likewise
         // unbounded across a codebase; they're a goto/hover surface, not a
-        // find-references one, so they don't index here either.
+        // find-references one, so they don't index here either. Factory
+        // resolutions (`Model::factory()` + chained factory methods) follow
+        // the facade precedent: goto/hover only, no reverse-index entries.
         if m.form.is_call()
             && matches!(
                 resolved.kind,
-                MagicMemberKind::PlainMember | MagicMemberKind::FacadeMethod
+                MagicMemberKind::PlainMember
+                    | MagicMemberKind::FacadeMethod
+                    | MagicMemberKind::Factory
+                    | MagicMemberKind::FactoryMethod
             )
         {
             continue;
@@ -534,18 +551,11 @@ pub fn resolve_and_classify(
         None
     };
 
-    let (fqcn, confidence, via_facade) = match facade_concrete.or(helper_concrete) {
-        Some((fqcn, confidence)) => (fqcn, confidence, true),
+    let (fqcn, confidence, via_facade, via_factory) = match facade_concrete.or(helper_concrete) {
+        Some((fqcn, confidence)) => (fqcn, confidence, true, false),
         None => {
-            let (fqcn, confidence) = match resolve_receiver(
-                receiver,
-                bytes,
-                aliases,
-                resolver,
-                classviews,
-                project_root,
-            ) {
-                Some(r) => r,
+            match resolve_receiver(receiver, bytes, aliases, resolver, classviews, project_root) {
+                Some((fqcn, confidence)) => (fqcn, confidence, false, false),
                 // Call-form receivers are frequently builder CHAINS
                 // (`User::query()->active()`, `User::where(…)->active()`) whose
                 // links the direct resolver can't type. The chain's subject is its
@@ -553,17 +563,19 @@ pub fn resolve_and_classify(
                 // (`User::first()->full_name`) deliberately stay chain-blind: the
                 // column surface makes property terminals a far bigger
                 // false-positive net than the call surfaces gated below.
-                None if form.is_call() => resolve_call_chain_receiver(
-                    receiver,
-                    bytes,
-                    aliases,
-                    resolver,
-                    classviews,
-                    project_root,
-                )?,
+                None if form.is_call() => {
+                    let (fqcn, confidence, via_factory) = resolve_call_chain_receiver(
+                        receiver,
+                        bytes,
+                        aliases,
+                        resolver,
+                        classviews,
+                        project_root,
+                    )?;
+                    (fqcn, confidence, false, via_factory)
+                }
                 None => return None,
-            };
-            (fqcn, confidence, false)
+            }
         }
     };
 
@@ -577,6 +589,7 @@ pub fn resolve_and_classify(
         form,
         confidence,
         via_facade,
+        via_factory,
         resolver,
         classviews,
         project_root,
@@ -607,6 +620,7 @@ pub fn resolve_and_classify(
             form,
             Confidence::Medium,
             false, // a builder retry never comes through a facade
+            false, // …nor through a factory chain
             resolver,
             classviews,
             project_root,
@@ -650,6 +664,15 @@ fn record_macro_decl_dep(
 /// the way a plain `$obj->method()` is. (Magic kinds — scope / accessor /
 /// relationship / finder — still win over the facade tag: those are the
 /// concrete's own Eloquent surfaces and resolve more precisely.)
+///
+/// `via_factory` is the chain analogue for a factory-rooted subject
+/// (`User::factory()->…`, issue #30 item 3): `fqcn` is the resolved factory
+/// class, and a member the factory hierarchy declares (a custom state, the
+/// vendor `state`/`create`) re-tags [`MagicMemberKind::FactoryMethod`] so the
+/// goto/hover consumers own it instead of dropping it as a plain method.
+/// Unlike the facade signal it never degrades an undeclared member to the
+/// class line — factories forward the remainder to the model/builder, and a
+/// wrong-class target is worse than none.
 #[allow(clippy::too_many_arguments)]
 fn classify_against(
     fqcn: &str,
@@ -657,6 +680,7 @@ fn classify_against(
     form: AccessForm,
     confidence: Confidence,
     via_facade: bool,
+    via_factory: bool,
     resolver: &impl ClassFileResolver,
     classviews: &ClassViewCache,
     project_root: &Path,
@@ -664,7 +688,36 @@ fn classify_against(
     // A class the index knows: classify against its real surfaces first.
     if let Some(file_path) = resolver.class_file(fqcn) {
         if let Some(view) = classviews.get_or_build(fqcn, &file_path, project_root) {
+            // `Model::factory()` (issue #30 item 3): the method is vendor
+            // `HasFactory` magic, so classifying it against the model's own
+            // surfaces would at best yield a droppable PlainMember. Resolve
+            // the model → factory FQCN instead (`newFactory()` override or
+            // convention); no resolvable factory falls through to the normal
+            // surfaces. Checked first: a real `factory()` declaration wins
+            // over `__callStatic` magic in PHP, and Eloquent's own dispatch
+            // still lands on the trait method, never a `scopeFactory`.
+            if form.is_call() && member == "factory" && view.kind == LaravelClassKind::Model {
+                if let Some(factory) =
+                    crate::factory_resolver::factory_fqcn_for_model(&view, resolver)
+                {
+                    return Some(ResolvedMemberAccess {
+                        declaring_fqcn: factory,
+                        kind: MagicMemberKind::Factory,
+                        confidence,
+                    });
+                }
+            }
             if let Some(classified) = classify_member(&view, member, form) {
+                // A factory-chain member the factory hierarchy declares
+                // (`->suspended()`, `->state()`) — a real target Intelephense
+                // can't type without ide-helper. Re-tag so consumers keep it.
+                if via_factory && classified.kind == MagicMemberKind::PlainMember {
+                    return Some(ResolvedMemberAccess {
+                        declaring_fqcn: classified.declaring_fqcn,
+                        kind: MagicMemberKind::FactoryMethod,
+                        confidence,
+                    });
+                }
                 // A facade call whose member is just a plain method on the
                 // concrete (`Auth::check()` → `AuthManager::check()`) is a real
                 // goto target — tag it `FacadeMethod` so the consumers don't drop
@@ -739,6 +792,13 @@ fn classify_against(
 /// root re-enters the direct resolver capped at MEDIUM — informational
 /// (consumer gates accept High|Medium alike); the gates above plus
 /// classification are the real safety.
+///
+/// A `Model::factory()` root (issue #30 item 3) is the one deliberate
+/// exception to the first-link gate: instead of refusing, the chain's subject
+/// RE-TARGETS to the model's resolved factory class, and the returned
+/// `via_factory` flag tells [`classify_against`] to tag its declared members
+/// [`MagicMemberKind::FactoryMethod`]. Scope classification on the *model* is
+/// still refused for factory chains — that's what the gate protects.
 fn resolve_call_chain_receiver(
     receiver: Node,
     bytes: &[u8],
@@ -746,7 +806,7 @@ fn resolve_call_chain_receiver(
     resolver: &impl ClassFileResolver,
     classviews: &ClassViewCache,
     project_root: &Path,
-) -> Option<(String, Confidence)> {
+) -> Option<(String, Confidence, bool)> {
     let root = chain_root(receiver);
     if root.kind() == "scoped_call_expression" {
         let scope = root.child_by_field_name("scope")?;
@@ -779,6 +839,14 @@ fn resolve_call_chain_receiver(
         let first = root
             .child_by_field_name("name")
             .and_then(|n| n.utf8_text(bytes).ok())?;
+        // `Model::factory()->…` — the chain's subject is the FACTORY, not the
+        // model. Re-target before the forwarding gate; the model-relationship
+        // bail below doesn't apply (the links are factory members). A model
+        // with no resolvable factory keeps the original refusal.
+        if first == "factory" && view.kind == LaravelClassKind::Model {
+            let factory = crate::factory_resolver::factory_fqcn_for_model(&view, resolver)?;
+            return Some((factory, confidence, true));
+        }
         let first_is_forwarding = crate::query_chain::methods::is_eloquent_static_starter(first)
             || matches!(
                 classify_call(&view, first).map(|c| c.kind),
@@ -790,7 +858,7 @@ fn resolve_call_chain_receiver(
         if has_relationship_link(receiver, bytes, &view) {
             return None;
         }
-        return Some((fqcn, confidence));
+        return Some((fqcn, confidence, false));
     }
     if root.id() != receiver.id() {
         let (fqcn, confidence) =
@@ -809,7 +877,7 @@ fn resolve_call_chain_receiver(
             Confidence::High => Confidence::Medium,
             other => other,
         };
-        return Some((fqcn, capped));
+        return Some((fqcn, capped, false));
     }
     None
 }
@@ -2438,7 +2506,10 @@ pub fn resolve_member_access_entries_with_context(
         if m.form.is_call()
             && matches!(
                 resolved.kind,
-                MagicMemberKind::PlainMember | MagicMemberKind::FacadeMethod
+                MagicMemberKind::PlainMember
+                    | MagicMemberKind::FacadeMethod
+                    | MagicMemberKind::Factory
+                    | MagicMemberKind::FactoryMethod
             )
         {
             continue;
@@ -2502,19 +2573,19 @@ fn resolve_recipe_and_classify(
         None
     };
 
-    let (fqcn, confidence, via_facade) = match facade_concrete.or(helper_concrete) {
-        Some((fqcn, confidence)) => (fqcn, confidence, true),
+    let (fqcn, confidence, via_facade, via_factory) = match facade_concrete.or(helper_concrete) {
+        Some((fqcn, confidence)) => (fqcn, confidence, true, false),
         None => {
-            let (fqcn, confidence) =
-                match eval_receiver(&site.recipe, aliases, resolver, classviews, project_root) {
-                    Some(r) => r,
-                    None if form.is_call() => {
-                        let chain = site.chain.as_ref()?;
-                        eval_chain(chain, aliases, resolver, classviews, project_root)?
-                    }
-                    None => return None,
-                };
-            (fqcn, confidence, false)
+            match eval_receiver(&site.recipe, aliases, resolver, classviews, project_root) {
+                Some((fqcn, confidence)) => (fqcn, confidence, false, false),
+                None if form.is_call() => {
+                    let chain = site.chain.as_ref()?;
+                    let (fqcn, confidence, via_factory) =
+                        eval_chain(chain, aliases, resolver, classviews, project_root)?;
+                    (fqcn, confidence, false, via_factory)
+                }
+                None => return None,
+            }
         }
     };
 
@@ -2528,6 +2599,7 @@ fn resolve_recipe_and_classify(
         form,
         confidence,
         via_facade,
+        via_factory,
         resolver,
         classviews,
         project_root,
@@ -2548,6 +2620,7 @@ fn resolve_recipe_and_classify(
             member,
             form,
             Confidence::Medium,
+            false,
             false,
             resolver,
             classviews,
@@ -2652,7 +2725,7 @@ fn eval_chain(
     resolver: &impl ClassFileResolver,
     classviews: &ClassViewCache,
     project_root: &Path,
-) -> Option<(String, Confidence)> {
+) -> Option<(String, Confidence, bool)> {
     match &chain.root {
         ChainRootData::StaticScope {
             qualified,
@@ -2661,6 +2734,12 @@ fn eval_chain(
         } => {
             let file = resolver.class_file(qualified)?;
             let view = classviews.get_or_build(qualified, &file, project_root)?;
+            // `Model::factory()->…` re-targets to the factory (see
+            // [`resolve_call_chain_receiver`]'s static branch).
+            if first_method == "factory" && view.kind == LaravelClassKind::Model {
+                let factory = crate::factory_resolver::factory_fqcn_for_model(&view, resolver)?;
+                return Some((factory, *confidence, true));
+            }
             let first_is_forwarding =
                 crate::query_chain::methods::is_eloquent_static_starter(first_method)
                     || matches!(
@@ -2673,7 +2752,7 @@ fn eval_chain(
             if chain_links_hit_relationship(&chain.links, &view) {
                 return None;
             }
-            Some((qualified.clone(), *confidence))
+            Some((qualified.clone(), *confidence, false))
         }
         ChainRootData::Var(obj_recipe) => {
             let (fqcn, confidence) =
@@ -2689,7 +2768,7 @@ fn eval_chain(
                 Confidence::High => Confidence::Medium,
                 other => other,
             };
-            Some((fqcn, capped))
+            Some((fqcn, capped, false))
         }
     }
 }

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -3445,3 +3445,217 @@ class C {
         );
     }
 }
+
+// ─── Factory resolution: `Model::factory()` + factory chains (#30) ─────────
+
+const FACTORY_USER_MODEL: &str = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    protected $fillable = ['email'];
+}
+"#;
+
+const USER_FACTORY_SRC: &str = r#"<?php
+namespace Database\Factories;
+use Illuminate\Database\Eloquent\Factories\Factory;
+class UserFactory extends Factory {
+    public function suspended(): static { return $this->state(['active' => false]); }
+}
+"#;
+
+const FACTORY_CALLER: &str = r#"<?php
+namespace Tests\Feature;
+use App\Models\User;
+class UserTest {
+    public function seed() { return User::factory(); }
+}
+"#;
+
+/// Resolve an instance call `…->{member}()` in `caller` against `resolver` —
+/// the chain-link counterpart of [`resolve_static_call`].
+fn resolve_instance_call(
+    resolver: &impl ClassFileResolver,
+    root: &std::path::Path,
+    caller: &str,
+    member: &str,
+) -> Option<ResolvedMemberAccess> {
+    let tree = parse_php(caller).expect("parse caller");
+    let bytes = caller.as_bytes();
+    let aliases = extract_use_aliases(&tree, caller);
+    let mut stack = vec![tree.root_node()];
+    let mut object = None;
+    while let Some(n) = stack.pop() {
+        if n.kind() == "member_call_expression"
+            && n.child_by_field_name("name")
+                .and_then(|nm| nm.utf8_text(bytes).ok())
+                == Some(member)
+        {
+            object = n.child_by_field_name("object");
+            break;
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    let cache = ClassViewCache::new();
+    resolve_and_classify(
+        object?,
+        member,
+        AccessForm::InstanceCall,
+        bytes,
+        &aliases,
+        resolver,
+        &cache,
+        root,
+        None,
+    )
+}
+
+#[test]
+fn factory_call_resolves_to_conventional_factory() {
+    // `User::factory()` → `Database\Factories\UserFactory` by Laravel's
+    // convention, gated on the factory class actually resolving.
+    let p = project_files(&[
+        ("app/Models/User.php", FACTORY_USER_MODEL),
+        ("database/factories/UserFactory.php", USER_FACTORY_SRC),
+    ]);
+    let r = resolve_static_call(&p.index, &p.root, FACTORY_CALLER, "factory").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::Factory);
+    assert_eq!(r.declaring_fqcn, "Database\\Factories\\UserFactory");
+}
+
+#[test]
+fn factory_call_with_fully_qualified_receiver_resolves() {
+    // `\App\Models\User::factory()` — no `use` import; the written-out
+    // receiver must resolve identically (AC: FQ receiver form).
+    let p = project_files(&[
+        ("app/Models/User.php", FACTORY_USER_MODEL),
+        ("database/factories/UserFactory.php", USER_FACTORY_SRC),
+    ]);
+    let caller = "<?php \\App\\Models\\User::factory();";
+    let r = resolve_static_call(&p.index, &p.root, caller, "factory").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::Factory);
+    assert_eq!(r.declaring_fqcn, "Database\\Factories\\UserFactory");
+}
+
+#[test]
+fn factory_call_honors_new_factory_override() {
+    // A declared `newFactory()` names the factory directly and beats the
+    // conventional candidate.
+    let override_model = r#"<?php
+namespace App\Models;
+use Database\Factories\Custom\AdminFactory;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    protected static function newFactory(): AdminFactory { return AdminFactory::new(); }
+}
+"#;
+    let admin_factory = r#"<?php
+namespace Database\Factories\Custom;
+use Illuminate\Database\Eloquent\Factories\Factory;
+class AdminFactory extends Factory {}
+"#;
+    let p = project_files(&[
+        ("app/Models/User.php", override_model),
+        ("database/factories/Custom/AdminFactory.php", admin_factory),
+    ]);
+    let r = resolve_static_call(&p.index, &p.root, FACTORY_CALLER, "factory").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::Factory);
+    assert_eq!(
+        r.declaring_fqcn,
+        "Database\\Factories\\Custom\\AdminFactory"
+    );
+}
+
+#[test]
+fn factory_call_without_factory_file_does_not_classify() {
+    // No factory class resolves → no Factory tag, and nothing else on the
+    // model claims `factory` — a dead goto target is worse than none.
+    let p = project_files(&[("app/Models/User.php", FACTORY_USER_MODEL)]);
+    let r = resolve_static_call(&p.index, &p.root, FACTORY_CALLER, "factory");
+    assert!(
+        r.is_none(),
+        "a model with no resolvable factory must not classify; got {r:?}"
+    );
+}
+
+#[test]
+fn factory_chain_declared_state_classifies_as_factory_method() {
+    // `User::factory()->suspended()` — the chain's subject re-targets to the
+    // factory, and a state the factory DECLARES tags FactoryMethod (not a
+    // droppable PlainMember).
+    let p = project_files(&[
+        ("app/Models/User.php", FACTORY_USER_MODEL),
+        ("database/factories/UserFactory.php", USER_FACTORY_SRC),
+    ]);
+    let caller = r#"<?php
+namespace Tests\Feature;
+use App\Models\User;
+class UserTest {
+    public function t() { return User::factory()->suspended(); }
+}
+"#;
+    let r = resolve_instance_call(&p.index, &p.root, caller, "suspended").expect("resolves");
+    assert_eq!(r.kind, MagicMemberKind::FactoryMethod);
+    assert_eq!(r.declaring_fqcn, "Database\\Factories\\UserFactory");
+}
+
+#[test]
+fn factory_chain_undeclared_member_never_degrades_to_class_line() {
+    // `User::factory()->create()` — `create` lives on the vendor base the
+    // index can't see. Unlike the facade signal, a factory chain never
+    // degrades an undeclared member to the class line: no target beats a
+    // wrong-class target.
+    let p = project_files(&[
+        ("app/Models/User.php", FACTORY_USER_MODEL),
+        ("database/factories/UserFactory.php", USER_FACTORY_SRC),
+    ]);
+    let caller = r#"<?php
+namespace Tests\Feature;
+use App\Models\User;
+class UserTest {
+    public function t() { return User::factory()->create(); }
+}
+"#;
+    let r = resolve_instance_call(&p.index, &p.root, caller, "create");
+    assert!(
+        r.is_none(),
+        "an undeclared factory-chain member must not classify; got {r:?}"
+    );
+}
+
+// ─── Custom pivot classification: `->pivot` (#30 item 4) ───────────────────
+
+#[test]
+fn classifies_pivot_property_with_declared_pivot_class() {
+    let (_d, view) = model(
+        r#"<?php
+namespace App\Models;
+use App\Models\Pivots\Membership;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    protected $pivotClass = Membership::class;
+}
+"#,
+    );
+    let c = classify_member(&view, "pivot", AccessForm::Property).expect("pivot");
+    assert_eq!(c.kind, MagicMemberKind::Pivot);
+    assert_eq!(c.declaring_fqcn, "App\\Models\\Pivots\\Membership");
+}
+
+#[test]
+fn pivot_without_declared_class_does_not_classify() {
+    // The default `Relations\Pivot` is vendor territory — no card, no goto.
+    let (_d, view) = model(
+        r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    protected $fillable = ['email'];
+}
+"#,
+    );
+    assert!(classify_member(&view, "pivot", AccessForm::Property).is_none());
+}

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -3582,6 +3582,33 @@ fn factory_call_without_factory_file_does_not_classify() {
 }
 
 #[test]
+fn phantom_new_factory_override_does_not_classify() {
+    // `newFactory()` names a class with no file on disk. The declared
+    // override is authoritative (no convention fallback), and a phantom
+    // FQCN must not surface as a Factory tag — hover would render a card
+    // for a class that isn't there.
+    let override_model = r#"<?php
+namespace App\Models;
+use Database\Factories\Custom\GhostFactory;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    protected static function newFactory() { return GhostFactory::new(); }
+}
+"#;
+    let p = project_files(&[
+        ("app/Models/User.php", override_model),
+        // A conventional factory EXISTS on disk — proving the phantom
+        // override refuses rather than silently falling back to it.
+        ("database/factories/UserFactory.php", USER_FACTORY_SRC),
+    ]);
+    let r = resolve_static_call(&p.index, &p.root, FACTORY_CALLER, "factory");
+    assert!(
+        r.is_none(),
+        "a phantom newFactory target must not classify; got {r:?}"
+    );
+}
+
+#[test]
 fn factory_chain_declared_state_classifies_as_factory_method() {
     // `User::factory()->suspended()` — the chain's subject re-targets to the
     // factory, and a state the factory DECLARES tags FactoryMethod (not a

--- a/laravel-lsp/src/method_name_completion/tests.rs
+++ b/laravel-lsp/src/method_name_completion/tests.rs
@@ -400,6 +400,8 @@ fn empty_view() -> ClassView {
         relationships: Vec::new(),
         casts: std::collections::HashMap::new(),
         table_name: None,
+        collection_class: None,
+        pivot_class: None,
         column_surface: Vec::new(),
         callstatic_surface: Vec::new(),
     }

--- a/laravel-lsp/src/pattern_disk_cache.rs
+++ b/laravel-lsp/src/pattern_disk_cache.rs
@@ -101,7 +101,7 @@ use crate::salsa_impl::ParsedPatternsData;
 ///        mis-decode. The bump also guarantees every restored non-vendor entry
 ///        carries context, so no "refs present but context missing" state can
 ///        exist on the resolve path.
-const SCHEMA_VERSION: u32 = 11;
+const SCHEMA_VERSION: u32 = 12;
 
 const CACHE_FILENAME: &str = "pattern_cache.bin";
 

--- a/laravel-lsp/src/query_chain/eloquent_completion.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion.rs
@@ -21,7 +21,9 @@ use super::chain::*;
 use crate::class_locator::find_php_class_file;
 use crate::completion_format::CompletionDoc;
 use crate::database::DatabaseSchemaProvider;
-use crate::laravel_introspector::{map_cast_to_php_type, relationship_to_php_type, ModelMetadata};
+use crate::laravel_introspector::{
+    map_cast_to_php_type, relationship_to_php_type_with_collection, ModelMetadata,
+};
 use std::path::Path;
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, CompletionItemLabelDetails};
 use tracing::info;
@@ -627,8 +629,15 @@ pub async fn relations(
         .relationships
         .into_iter()
         .map(|rel| {
-            let php_type =
-                relationship_to_php_type(&rel.relationship_type, rel.related_model.as_deref());
+            // Related model's custom collection, when declared (#30 item 4).
+            let collection_class = rel.related_model.as_deref().and_then(|related| {
+                crate::laravel_introspector::chain::collection_class_for(related, project_root)
+            });
+            let php_type = relationship_to_php_type_with_collection(
+                &rel.relationship_type,
+                rel.related_model.as_deref(),
+                collection_class.as_deref(),
+            );
             let name = rel.method_name;
             let insert_text = match wrap_with_quote {
                 Some(q) => format!("{q}{name}{q}"),

--- a/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
+++ b/laravel-lsp/src/query_chain/eloquent_completion/tests.rs
@@ -319,6 +319,40 @@ class User extends Model {
 }
 
 #[tokio::test]
+async fn relations_detail_uses_related_models_custom_collection() {
+    // The RELATED model declares `$collectionClass` — the to-many detail
+    // label swaps the default `Collection<Post>` for the custom class
+    // (#30 item 4), driving `collection_class_for` → the `Some` branch of
+    // `relationship_to_php_type_with_collection` end-to-end.
+    let user = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function posts() {
+        return $this->hasMany(Post::class);
+    }
+}
+"#;
+    let post = r#"<?php
+namespace App\Models;
+use App\Support\PostCollection;
+use Illuminate\Database\Eloquent\Model;
+class Post extends Model {
+    protected $collectionClass = PostCollection::class;
+}
+"#;
+    let (dir, root) = project_with_model("User", user);
+    std::fs::write(dir.path().join("app/Models/Post.php"), post).expect("write Post");
+    let ctx = make_ctx("App\\Models\\User");
+    let items = relations(&ctx, None, &root).await;
+    let posts = items.iter().find(|i| i.label == "posts").expect("posts");
+    assert_eq!(
+        posts.detail.as_deref(),
+        Some("PostCollection<Post> (hasMany)")
+    );
+}
+
+#[tokio::test]
 async fn relations_returns_empty_when_model_file_missing() {
     let dir = TempDir::new().unwrap();
     let root = dir.path().to_path_buf();

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -3290,6 +3290,23 @@ pub enum MagicMemberKind {
     /// which the consumers drop as Intelephense's territory — because a facade
     /// call is precisely what Intelephense CAN'T see through, so we own it.
     FacadeMethod,
+    /// A model's `factory()` call (`User::factory()`). The method itself is
+    /// `HasFactory::factory()` — vendor trait magic no PHP LSP resolves to the
+    /// project's factory class without ide-helper. `declaring_fqcn` is the
+    /// resolved factory FQCN (`newFactory()` override or Laravel convention);
+    /// the goto/hover target is that factory class's declaration line.
+    Factory,
+    /// A method called on a factory-rooted chain (`User::factory()->state(…)`,
+    /// a custom state like `->suspended()`). `declaring_fqcn` is the class that
+    /// actually declares the method (the project factory, or the vendor
+    /// `Factories\Factory` base). Distinct from `PlainMember` — which consumers
+    /// drop as Intelephense's — because the chain's factory subject is exactly
+    /// what Intelephense can't type without ide-helper.
+    FactoryMethod,
+    /// A many-to-many `->pivot` attribute on a model that declares a custom
+    /// pivot class (`protected $pivotClass = MembershipPivot::class;`).
+    /// `declaring_fqcn` is that pivot FQCN; the target is its class line.
+    Pivot,
     /// Generic (non-magic) property on a resolved class.
     PlainMember,
 }

--- a/laravel-lsp/src/tests/factory_goto_def_handler.rs
+++ b/laravel-lsp/src/tests/factory_goto_def_handler.rs
@@ -1,0 +1,207 @@
+//! End-to-end coverage for factory goto-definition through the real Backend
+//! handler `LaravelLanguageServer::create_magic_member_location` (issue #30
+//! item 3).
+//!
+//! The actor-side classification (`resolve_and_classify` → `kind == Factory`
+//! with the resolved factory FQCN) is covered in `member_resolver/tests.rs`.
+//! What this covers is the goto-target *producer*: the
+//! `MagicMemberKind::Factory | Pivot` arm of `create_magic_member_location`
+//! in `main.rs`, which must land on the FACTORY CLASS's declaration line —
+//! there is no member-named method to narrow to (`factory()` is vendor-trait
+//! magic). Mirrors `macro_goto_def_handler.rs`: prime the live Salsa actor
+//! exactly as the server does during indexing, then drive the real handler.
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::salsa_impl::{AccessForm, Confidence, MemberAccessReferenceData};
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use tower_lsp::lsp_types::GotoDefinitionResponse;
+use tower_lsp::LspService;
+
+/// Build a server instance for testing (same shape as the macro handler test).
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+const MODEL_SRC: &str = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    protected $fillable = ['email'];
+}
+"#;
+
+/// The factory class declaration sits on line 3 (0-based): `<?php`=0,
+/// `namespace`=1, `use Factory`=2, `class UserFactory`=3.
+const FACTORY_SRC: &str = r#"<?php
+namespace Database\Factories;
+use Illuminate\Database\Eloquent\Factories\Factory;
+class UserFactory extends Factory {
+    public function suspended(): static { return $this->state(['active' => false]); }
+}
+"#;
+
+const CALLER_SRC: &str = r#"<?php
+namespace Database\Seeders;
+use App\Models\User;
+class UserSeeder {
+    public function run(): void { User::factory()->create(); }
+}
+"#;
+
+/// Find the (line, column) of `needle` in `src`, 0-based — repo convention.
+fn position_of(src: &str, needle: &str) -> (u32, u32) {
+    for (row, line) in src.lines().enumerate() {
+        if let Some(col) = line.find(needle) {
+            return (row as u32, col as u32);
+        }
+    }
+    panic!("{needle} not found in fixture");
+}
+
+/// A `MemberAccessReferenceData` for the `User::factory()` call site. The
+/// handler re-resolves from the file's parsed patterns using `line`/`column`,
+/// so only the member position drives resolution.
+fn factory_ref() -> MemberAccessReferenceData {
+    let (line, column) = position_of(CALLER_SRC, "factory");
+    let receiver_byte_start = CALLER_SRC.find("User::factory").expect("call in fixture");
+    MemberAccessReferenceData {
+        member: "factory".to_string(),
+        receiver: "User".to_string(),
+        receiver_byte_start,
+        receiver_byte_end: receiver_byte_start + "User".len(),
+        is_nullsafe: false,
+        form: AccessForm::StaticCall,
+        line,
+        column,
+        end_column: column + "factory".len() as u32,
+        declaring_fqcn: None,
+        kind: None,
+        confidence: Confidence::Unresolved,
+    }
+}
+
+/// Prime `server`'s live Salsa actor with a project containing the model, its
+/// conventional factory, and the caller — registering each file and forcing
+/// its parse so the class-hierarchy index knows the factory's declaration
+/// line, exactly as indexing would. Returns the caller path.
+async fn prime_factory_project(server: &LaravelLanguageServer, root: &Path) -> PathBuf {
+    let files = [
+        (root.join("app/Models/User.php"), MODEL_SRC),
+        (root.join("database/factories/UserFactory.php"), FACTORY_SRC),
+        (root.join("database/seeders/UserSeeder.php"), CALLER_SRC),
+    ];
+    std::fs::write(
+        root.join("composer.json"),
+        r#"{
+  "autoload": { "psr-4": { "App\\": "app/" } },
+  "autoload-dev": { "psr-4": { "Database\\Factories\\": "database/factories/" } }
+}"#,
+    )
+    .unwrap();
+
+    server
+        .salsa
+        .register_config_files(root.to_path_buf(), None, None, None)
+        .await
+        .unwrap();
+    for (path, src) in &files {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, src).unwrap();
+        server
+            .salsa
+            .update_file(path.clone(), 1, src.to_string())
+            .await
+            .unwrap();
+        server.salsa.get_patterns(path.clone()).await.unwrap();
+    }
+    files[2].0.clone()
+}
+
+/// Pull the single `LocationLink` out of a goto-def response.
+fn single_link(resp: GotoDefinitionResponse) -> tower_lsp::lsp_types::LocationLink {
+    let links = match resp {
+        GotoDefinitionResponse::Link(links) => links,
+        other => panic!("expected GotoDefinitionResponse::Link, got {other:?}"),
+    };
+    assert_eq!(
+        links.len(),
+        1,
+        "exactly one LocationLink for a resolved factory"
+    );
+    links.into_iter().next().unwrap()
+}
+
+#[tokio::test]
+async fn factory_call_goto_lands_on_factory_class_line() {
+    // `User::factory()` → the conventional `UserFactory` class declaration.
+    // The handler must return a `Link` targeting the factory file at the
+    // class's line (3, 0-based) with a zero-width caret — no `factory`
+    // method exists on the factory class to narrow to.
+    let dir = TempDir::new().unwrap();
+    let server = test_server();
+    let caller = prime_factory_project(&server, dir.path()).await;
+    let factory = dir.path().join("database/factories/UserFactory.php");
+
+    let resp = server
+        .create_magic_member_location(&caller, &factory_ref())
+        .await
+        .expect("a model with a conventional factory resolves to a goto Link");
+
+    let link = single_link(resp);
+    assert_eq!(
+        link.target_uri.to_file_path().expect("file:// target"),
+        factory,
+        "goto lands on the factory class file"
+    );
+    assert_eq!(
+        link.target_range.start.line, 3,
+        "goto lands on the factory class's 0-based declaration line"
+    );
+    assert_eq!(
+        link.target_range.start.character, 0,
+        "zero-width caret — no member-named method on the factory to narrow to"
+    );
+}
+
+#[tokio::test]
+async fn factory_call_without_factory_file_does_not_resolve() {
+    // Same project WITHOUT the factory file: the conventional candidate
+    // doesn't resolve, nothing else claims `factory`, so the handler degrades
+    // to `None` — no panic, no bogus location.
+    let dir = TempDir::new().unwrap();
+    let server = test_server();
+    let root = dir.path();
+    let model = root.join("app/Models/User.php");
+    let caller = root.join("database/seeders/UserSeeder.php");
+    std::fs::write(
+        root.join("composer.json"),
+        r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#,
+    )
+    .unwrap();
+
+    server
+        .salsa
+        .register_config_files(root.to_path_buf(), None, None, None)
+        .await
+        .unwrap();
+    for (path, src) in [(&model, MODEL_SRC), (&caller, CALLER_SRC)] {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, src).unwrap();
+        server
+            .salsa
+            .update_file(path.clone(), 1, src.to_string())
+            .await
+            .unwrap();
+        server.salsa.get_patterns(path.clone()).await.unwrap();
+    }
+
+    let resp = server
+        .create_magic_member_location(&caller, &factory_ref())
+        .await;
+    assert!(
+        resp.is_none(),
+        "a model with no factory must not produce a goto target; got {resp:?}"
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -17,6 +17,7 @@ mod diagnostic_severity;
 mod directive_navigation_containment;
 mod dynamic_where_sparseness;
 mod expected_path_diagnostic_containment;
+mod factory_goto_def_handler;
 mod flux_component_context;
 mod flux_component_hover;
 mod flux_goto_def_handler;


### PR DESCRIPTION
## Summary
Implements the remaining scope of #30: **factory chain navigation** (item 3) and **custom Eloquent collection / pivot resolution** (item 4). Items 1 (relationship navigation) and 2 (facade resolution) were already shipped in PRs #76/#77 and #254 — see the triage comment on the issue.

## Changes
- **`factory_resolver.rs` (new)** — model → factory FQCN resolution: honors an explicit `newFactory()` override (parsed from the declaring file through use-aliases + namespace), falls back to Laravel's `Database\Factories\…Factory` convention, gated on the factory class actually resolving via the PSR-4-aware `ClassFileResolver`.
- **`member_resolver.rs`** — `classify_against` gains a factory arm: call-form `factory` on a Model view → `MagicMemberKind::Factory` (live + recipe/index paths). `Model::factory()->…` chains re-target the chain subject to the factory FQCN; methods genuinely declared on the factory classify as `MagicMemberKind::FactoryMethod` and navigate to their declaration. The existing relation-hop bail (factory states vs. scopes) is preserved — regression-locked by `population_skips_factory_state_calls`.
- **`chain.rs`** — `ClassView`/`ModelMetadata` parse `$collectionClass` (property default, `newCollection()` return type, or its `new X(…)` body) and `$pivotClass`; restating the framework default is not surfaced as an override.
- **Type inference / hover / completion** — `relationship_to_php_type_with_collection` swaps the custom collection FQCN into both completion sites; `->pivot` classifies as `MagicMemberKind::Pivot` with the resolved pivot FQCN; hover cards label "Model factory" / "Factory method" / "Pivot model". `create_magic_member_location` routes Factory|Pivot goto to the class line.
- **Cache schema bumps** — `pattern_disk_cache` 11→12, `magic_disk_cache` 4→5 (bincode, non-self-describing).
- **Docs** — factory-chain goto and custom collection/pivot examples in `docs/go-to-definition.md` and `docs/autocomplete.md`.

## Acceptance Criteria
- [x] `User::factory()` resolves the project's factory FQCN (convention or namespaced factories path), honoring an explicit `newFactory()` override; goto-definition jumps to the factory file
- [x] Goto-definition on `factory()` works for both imported/aliased (`User::factory()`) and fully-qualified (`\App\Models\User::factory()`) receivers
- [x] Hover on a `factory()` call shows a class card for the resolved factory FQCN, matching the existing hover-card style
- [x] Chained state calls (`User::factory()->state(…)->create()`) — clicking a method genuinely declared on the resolved factory navigates to its declaration in the factory file
- [x] The relation-hop bail in `member_resolver.rs` (factory receivers excluded from relationship/scope classification) is preserved and regression-locked
- [x] `protected $collectionClass` / `newCollection()` override types query-builder & relationship results as the custom collection FQCN in hover cards and completion
- [x] `protected $pivotClass` surfaces as the resolved pivot FQCN on the relationship's `->pivot` accessor
- [x] Models without overrides show unchanged default-collection/default-pivot behavior — no regression
- [x] Unit tests cover factory discovery, `$collectionClass`, and `$pivotClass` parsing (incl. absence-of-override defaults); e2e handler test covers goto-definition on `User::factory()`
- [x] `docs/go-to-definition.md` and `docs/autocomplete.md` gain matching examples

## Test Plan
- [x] Full `cargo test` green — 2735 tests (2186 lib + 469 + 80 across targets), 0 failed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets` clean (exit 0, no lints)
- [x] New coverage: `chain/tests.rs` (collection/pivot parsing + defaults), `member_resolver/tests.rs` (classification: convention, `newFactory`, FQ receiver, chained FactoryMethod, no-factory refusal, pivot), `tests/factory_goto_def_handler.rs` (e2e goto on `User::factory()`)

Fixes #30