### PR TITLE
test: assert the full detail card (URI + action + source link) in found_route_renders_detail_card

### DIFF
--- a/laravel-lsp/src/tests/route_hover.rs
+++ b/laravel-lsp/src/tests/route_hover.rs
@@ -112,4 +112,21 @@ async fn found_route_renders_detail_card() {
         rendered.contains("GET"),
         "the detail card must carry the HTTP verb, got: {rendered:?}"
     );
+    // `hover_for_route` formats the detail line as `` `GET /` → `action` `` —
+    // assert the backticked verb+URI pair rather than a bare "/" (which any
+    // source link would satisfy vacuously).
+    assert!(
+        rendered.contains("`GET /`"),
+        "the detail card must carry the URI, got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("HomeController@index"),
+        "the detail card must carry the action, got: {rendered:?}"
+    );
+    // The source link built via `source_link(&def.file, Some(def.line + 1))`
+    // always displays the originating file path, whatever the link shape.
+    assert!(
+        rendered.contains("routes/web.php"),
+        "the detail card must carry a source link to the route's file, got: {rendered:?}"
+    );
 }


### PR DESCRIPTION
## Summary
Implements #265 — hardens `found_route_renders_detail_card` so it actually verifies the full detail card its name (and failure message) promises. Previously a regression that dropped the URI/action from the detail line, or dropped the source link, would still pass.

## Changes
- `laravel-lsp/src/tests/route_hover.rs`: added three assertions to `found_route_renders_detail_card`:
  - `rendered.contains("\`GET /\`")` — the backticked verb+URI detail-line pair (stricter than a bare `"/"`, which the source link alone would satisfy vacuously)
  - `rendered.contains("HomeController@index")` — the fixture's action
  - `rendered.contains("routes/web.php")` — the source link's display path, present in both the `file://` link and the unlinked-fallback shapes of `source_link(&def.file, Some(def.line + 1))`
- No rendering-logic changes; test-only diff (+17 lines, one file)

## Acceptance Criteria
- [x] `found_route_renders_detail_card` asserts the rendered hover includes the fixture's URI — via the stricter detail-line check `\`GET /\``
- [x] The same test asserts the rendered hover includes the fixture's action (`HomeController@index`)
- [x] The same test asserts a source-link substring identifying the route's originating file (`routes/web.php`)
- [x] The three pre-existing assertions (non-empty, no `"not found"` trailer, contains `"GET"`) are preserved unchanged
- [x] `laravel-lsp/src/hover/tests.rs` (`render_full_section_set_in_order`, `render_source_link_only`) left untouched
- [x] `cargo test -p laravel-lsp found_route_renders_detail_card` passes

## Test Plan
- [x] Targeted test passes: `cargo test found_route_renders_detail_card` (1 passed)
- [x] Full suite green: 2165 + 467 + 80 tests, 0 failed
- [x] `cargo fmt --check` clean, `cargo clippy --all-targets` clean

Fixes #265