### PR TITLE
Query-chain relation-collection detection: nullsafe (?->) and $this-rooted chains

### DIFF
--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -1855,7 +1855,7 @@ fn foreach_parts<'t>(foreach: Node<'t>, bytes: &[u8]) -> Option<(Node<'t>, Strin
 /// FQCN of the class lexically enclosing `node`, or `None` when `node` isn't
 /// inside a class (e.g. a free function, or a `$this` inside a trait — whose
 /// runtime class is unknowable statically).
-fn enclosing_class_fqcn(node: Node, bytes: &[u8]) -> Option<String> {
+pub(crate) fn enclosing_class_fqcn(node: Node, bytes: &[u8]) -> Option<String> {
     let class = enclosing_class_node(node)?;
     let class_name = class
         .child_by_field_name("name")

--- a/laravel-lsp/src/query_chain/diagnostics/tests.rs
+++ b/laravel-lsp/src/query_chain/diagnostics/tests.rs
@@ -620,6 +620,219 @@ async fn scoped_relation_collection_flags_typo_on_related_table() {
     );
 }
 
+// ---- nullsafe / $this-rooted / scope-before-relation shapes (issue #272) --
+
+#[tokio::test]
+async fn nullsafe_relation_collection_validates_against_related_table() {
+    // `$user?->competitions()?->get()` — nullsafe links are chain structure
+    // like plain `->` (a null root short-circuits at runtime), so the
+    // collection still validates against the related table.
+    let (_dir, root, db) = competitions_project().await;
+    let source = "<?php\nuse App\\Models\\User;\n/** @var User $user */\n$regs = $user?->competitions()?->get();\n$regs->whereIn('type', ['league'])->pluck('id');\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "nullsafe executed relation must validate against competitions: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn nullsafe_relation_collection_flags_typo_on_related_table() {
+    // Companion negative: the nullsafe detection narrows the table, it does
+    // not silence diagnostics — `typo` still flags against competitions.
+    let (_dir, root, db) = competitions_project().await;
+    let source = "<?php\nuse App\\Models\\User;\n/** @var User $user */\n$regs = $user?->competitions()?->get();\n$regs->whereIn('typo', ['league'])->pluck('id');\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "typo in the nullsafe collection chain still flags: {diags:?}"
+    );
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_COLUMN);
+    assert!(
+        diags[0].message.contains("competitions"),
+        "diagnostic should name the competitions table; got: {}",
+        diags[0].message
+    );
+}
+
+#[tokio::test]
+async fn this_rooted_relation_collection_validates_against_related_table() {
+    // `$this->competitions()->get()` inside a model method — the relation
+    // resolves against the enclosing class's model (User), so the collection
+    // validates against competitions.
+    let (_dir, root, db) = competitions_project().await;
+    let source = "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass User extends Model {\n    public function run() {\n        $regs = $this->competitions()->get();\n        $regs->whereIn('type', ['league'])->pluck('id');\n    }\n}\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "$this-rooted executed relation must validate against competitions: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn this_rooted_relation_collection_flags_typo_on_related_table() {
+    // Companion negative for the $this root: `typo` isn't a competitions
+    // column — flagged, and against the competitions table.
+    let (_dir, root, db) = competitions_project().await;
+    let source = "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass User extends Model {\n    public function run() {\n        $regs = $this->competitions()->get();\n        $regs->whereIn('typo', ['league'])->pluck('id');\n    }\n}\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "typo in the $this-rooted collection chain still flags: {diags:?}"
+    );
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_COLUMN);
+    assert!(
+        diags[0].message.contains("competitions"),
+        "diagnostic should name the competitions table; got: {}",
+        diags[0].message
+    );
+}
+
+/// A `Registration` model with a `user` belongsTo relation — the
+/// `$this->user->…` property-rooted fixture (issue #272).
+const REGISTRATION_MODEL: &str = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Registration extends Model {
+    public function user() { return $this->belongsTo(User::class); }
+}
+"#;
+
+/// Seed the property-rooted fixture set: Registration → user → User →
+/// competitions → Competition, with users/competitions tables.
+async fn registrations_project() -> (TempDir, PathBuf, DatabaseSchemaProvider) {
+    let (dir, root) = project_with_models(&[
+        ("Registration", REGISTRATION_MODEL),
+        ("User", USER_WITH_COMPETITIONS),
+        ("Competition", COMPETITION_MODEL),
+    ]);
+    let db = provider_with(
+        root.clone(),
+        &[
+            ("users", &[("id", "int"), ("email", "string")]),
+            ("competitions", &[("id", "int"), ("type", "string")]),
+        ],
+    )
+    .await;
+    (dir, root, db)
+}
+
+#[tokio::test]
+async fn this_property_rooted_relation_collection_validates_against_related_table() {
+    // `$this->user->competitions()->get()` — the `user` property claim hops
+    // to User, then `competitions` rides the heuristic queue to Competition,
+    // so the collection validates against competitions.
+    let (_dir, root, db) = registrations_project().await;
+    let source = "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Registration extends Model {\n    public function run() {\n        $regs = $this->user->competitions()->get();\n        $regs->whereIn('type', ['league'])->pluck('id');\n    }\n}\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "$this->prop-rooted executed relation must validate against competitions: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn this_property_rooted_relation_collection_flags_typo_on_related_table() {
+    // Companion negative for the $this->prop root: still flagged, against
+    // the competitions table (two hops from Registration).
+    let (_dir, root, db) = registrations_project().await;
+    let source = "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Registration extends Model {\n    public function run() {\n        $regs = $this->user->competitions()->get();\n        $regs->whereIn('typo', ['league'])->pluck('id');\n    }\n}\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "typo in the $this->prop-rooted collection chain still flags: {diags:?}"
+    );
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_COLUMN);
+    assert!(
+        diags[0].message.contains("competitions"),
+        "diagnostic should name the competitions table; got: {}",
+        diags[0].message
+    );
+}
+
+/// `User` with a local scope AND a `competitions` relation — the
+/// root-scope-before-relation fixture (issue #272 AC #4).
+const USER_WITH_TENANT_SCOPE_AND_COMPETITIONS: &str = r#"<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {
+    public function scopeForCurrentTenant($query) { return $query->where('id', 1); }
+    public function competitions() { return $this->hasMany(Competition::class); }
+}
+"#;
+
+/// Seed the scope-before-relation fixture set.
+async fn tenant_competitions_project() -> (TempDir, PathBuf, DatabaseSchemaProvider) {
+    let (dir, root) = project_with_models(&[
+        ("User", USER_WITH_TENANT_SCOPE_AND_COMPETITIONS),
+        ("Competition", COMPETITION_MODEL),
+    ]);
+    let db = provider_with(
+        root.clone(),
+        &[
+            ("users", &[("id", "int"), ("email", "string")]),
+            ("competitions", &[("id", "int"), ("type", "string")]),
+        ],
+    )
+    .await;
+    (dir, root, db)
+}
+
+#[tokio::test]
+async fn root_scope_before_relation_collection_validates_against_related_table() {
+    // Issue #272 AC #4: `$user->forCurrentTenant()->competitions()->get()` —
+    // the seed call `forCurrentTenant` is a scope CallClaim whose miss keeps
+    // the running model (User), then `competitions` rides a heuristic hop to
+    // Competition. Each primitive is unit-tested; this pins the composed
+    // end-to-end shape.
+    let (_dir, root, db) = tenant_competitions_project().await;
+    let source = "<?php\nuse App\\Models\\User;\n/** @var User $user */\n$regs = $user->forCurrentTenant()->competitions()->get();\n$regs->whereIn('type', ['league'])->pluck('id');\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert!(
+        diags.is_empty(),
+        "scope-before-relation executed chain must validate against competitions: {diags:?}"
+    );
+}
+
+#[tokio::test]
+async fn root_scope_before_relation_collection_flags_typo_on_related_table() {
+    // Companion negative: the composed shape narrows the table, it does not
+    // silence diagnostics — `typo` flags against competitions, not users.
+    let (_dir, root, db) = tenant_competitions_project().await;
+    let source = "<?php\nuse App\\Models\\User;\n/** @var User $user */\n$regs = $user->forCurrentTenant()->competitions()->get();\n$regs->whereIn('typo', ['league'])->pluck('id');\n";
+    let chains = chains_of(source);
+
+    let diags = chain_diagnostics(&chains, &db, &root, source, DiagnosticSeverity::WARNING).await;
+    assert_eq!(
+        diags.len(),
+        1,
+        "typo after a scope-before-relation chain still flags: {diags:?}"
+    );
+    assert_eq!(code_of(&diags[0]), super::CODE_UNKNOWN_COLUMN);
+    assert!(
+        diags[0].message.contains("competitions"),
+        "diagnostic should name the competitions table; got: {}",
+        diags[0].message
+    );
+}
+
 #[tokio::test]
 async fn local_scope_before_terminator_still_flags_typo_on_root_table() {
     // Regression (PR #266 review): `forCurrentTenant` is a local scope, not a

--- a/laravel-lsp/src/query_chain/extractor.rs
+++ b/laravel-lsp/src/query_chain/extractor.rs
@@ -632,20 +632,21 @@ fn member_chain_receiver(node: Node, bytes: &[u8], aliases: &UseAliases) -> Chai
             // assignment shape first and emit the same receiver as the
             // property-access form (`$base->relation->…`): collection mode at
             // the base model, with the relation queued as a pending hop for
-            // the async finalize step. `from_call: true` — the claimed name
-            // is a method call, so a finalize miss may still be a local
-            // scope (see [`RelationHopKind::CallClaim`]). `call_hops` carries
-            // the chain's unrecognised middle calls (scopes, unmodeled
-            // builder methods, further relation hops) as heuristic hops.
-            if let Some((base_type, relation, call_hops)) = assignment.and_then(|(rhs, start)| {
+            // the async finalize step. `from_call` distinguishes a claimed
+            // method call (a finalize miss may still be a local scope, see
+            // [`RelationHopKind::CallClaim`]) from the `$this->prop->…`
+            // property claim (issue #272). `call_hops` carries the chain's
+            // unrecognised middle calls (scopes, unmodeled builder methods,
+            // further relation hops) as heuristic hops.
+            if let Some(cr) = assignment.and_then(|(rhs, start)| {
                 super::flow::resolve_collection_relation(rhs, start, bytes, aliases)
             }) {
                 return ChainReceiver::Eloquent(EloquentReceiver::RelationProperty {
                     var,
-                    base_type: Some(base_type),
-                    relation,
-                    from_call: true,
-                    call_hops,
+                    base_type: Some(cr.base),
+                    relation: cr.relation,
+                    from_call: cr.from_call,
+                    call_hops: cr.heuristic_hops,
                 });
             }
             // Phase 9: try to resolve `$var`'s declared class via either a

--- a/laravel-lsp/src/query_chain/flow.rs
+++ b/laravel-lsp/src/query_chain/flow.rs
@@ -65,6 +65,7 @@ use super::methods::{
     chain_effect, is_eloquent_static_starter, is_known_builder_method, COLLECTION_TERMINATORS,
 };
 use super::use_aliases::{resolve_class_name, UseAliases};
+use crate::member_resolver::enclosing_class_fqcn;
 use crate::salsa_impl::Confidence;
 
 /// Cap how many `$a = $b->...; $b = $a->...; ...` hops we'll follow.
@@ -156,8 +157,10 @@ pub fn latest_assignment_before<'tree>(
 /// apply — only [`ChainEffect::None`] builder methods pass through), and the
 /// outermost call is a [`COLLECTION_TERMINATORS`] entry (`get`, `pluck`, …).
 /// The chain root is a variable resolvable to a model (via the normal flow
-/// walk), an Eloquent static starter (`User::query()`), or a construction
-/// (`(new User)`).
+/// walk), an Eloquent static starter (`User::query()`), a construction
+/// (`(new User)`), `$this` (the enclosing class's model), or a `$this->prop`
+/// relation-property access (`$this->user->competitions()->get()`). Chain
+/// links may be joined by `->` or nullsafe `?->` interchangeably.
 ///
 /// *Unrecognised* middle calls don't reject the shape — mirroring the inline
 /// cursor collector ([`crate::query_chain::cursor`]), each is a heuristic
@@ -167,31 +170,34 @@ pub fn latest_assignment_before<'tree>(
 /// so the finalize step resolves them after the receiver's claim, with a
 /// miss keeping the running model unchanged.
 ///
-/// Returns `(base_model_fqcn, relation_name, heuristic_hops)` so the
-/// extractor can emit a collection-mode receiver with the relation (and any
-/// heuristic candidates) queued as pending hops — the relation→related-model
-/// resolution needs a model-file read, so it stays deferred to the async
-/// finalize step. `None` means the assignment doesn't match the shape
-/// (callers fall back to plain flow typing).
+/// Returns a [`CollectionRelation`] so the extractor can emit a
+/// collection-mode receiver with the relation (and any heuristic candidates)
+/// queued as pending hops — the relation→related-model resolution needs a
+/// model-file read, so it stays deferred to the async finalize step. `None`
+/// means the assignment doesn't match the shape (callers fall back to plain
+/// flow typing).
 pub fn resolve_collection_relation(
     rhs: Node,
     assignment_start: usize,
     bytes: &[u8],
     aliases: &UseAliases,
-) -> Option<(String, String, Vec<String>)> {
+) -> Option<CollectionRelation> {
     let outer = unwrap_parens(rhs);
-    if outer.kind() != "member_call_expression" {
+    if !is_member_call(outer) {
         return None;
     }
 
     // Collect the chain's method names outermost → innermost, stopping at
     // the first non-call node (the chain root). Parens along the way are
     // syntactic wrapping, not chain structure — unwrap them so a
-    // `(new User)->competitions()->get()` root is still reached.
+    // `(new User)->competitions()->get()` root is still reached. Nullsafe
+    // links (`?->`) are chain structure like plain `->` — a null root
+    // short-circuits the whole chain at runtime, so the non-null result
+    // still types to the related collection.
     let mut methods: Vec<&str> = Vec::new();
     let mut node = outer;
     let root = loop {
-        if node.kind() == "member_call_expression" {
+        if is_member_call(node) {
             methods.push(node_text(node.child_by_field_name("name")?, bytes)?);
             node = unwrap_parens(node.child_by_field_name("object")?);
         } else {
@@ -199,18 +205,72 @@ pub fn resolve_collection_relation(
         }
     };
 
-    // Shape gate: a collection terminator on top, the relation candidate at
-    // the bottom, and no *recognised* middle method whose [`ChainEffect`]
-    // isn't `None`. A mid-chain `get()` (FlipToCollection), `toBase()`
-    // (FlipToBase), or `first()` (Terminate) means everything after it
-    // operates on a collection / base builder / single model, not the
-    // relation query, so typing the variable to the related model would be
-    // wrong. Table-qualified column strings in the middle links are just
-    // arguments — they never affect this method-name walk.
+    // Split terminator (outermost) off, then pick the relation claim by root
+    // shape. For call-rooted chains (`$user->…`, `User::query()->…`,
+    // `(new User)->…`, `$this->…`) the claim is the deepest *call*. For a
+    // `$this->prop` root the claim is the *property* itself — the deepest
+    // call then rides the heuristic-hop queue like any other middle call.
     let (&terminator, rest) = methods.split_first()?;
-    let (&relation, middle) = rest.split_last()?;
+    let (base, relation, from_call, middle) = match root.kind() {
+        // `$this->user->competitions()->get()` — a relation accessed as a
+        // property on `$this`, resolved against the enclosing class's model.
+        // Only a bare-`$this` object is handled; the runtime class of
+        // `$other->prop` would itself need resolving first.
+        "member_access_expression" | "nullsafe_member_access_expression" => {
+            let object = root.child_by_field_name("object")?;
+            if object.kind() != "variable_name" || node_text(object, bytes)? != "$this" {
+                return None;
+            }
+            let relation = node_text(root.child_by_field_name("name")?, bytes)?;
+            let base = enclosing_class_fqcn(root, bytes)?;
+            (base, relation, false, rest)
+        }
+        _ => {
+            let (&relation, middle) = rest.split_last()?;
+            if is_known_builder_method(relation) {
+                return None;
+            }
+            // Type the chain root: `$this` is the enclosing class; `$base`
+            // goes via the normal flow walk (bounded at this assignment, so
+            // we don't re-find the assignment we're inside); a static
+            // Eloquent starter (`User::query()->relation()->get()`) or a
+            // construction (`(new User)->relation()->get()` — parens already
+            // unwrapped by the walk above) classify directly.
+            let base = match root.kind() {
+                "variable_name" if node_text(root, bytes)? == "$this" => {
+                    enclosing_class_fqcn(root, bytes)?
+                }
+                "variable_name" => {
+                    let raw = node_text(root, bytes)?;
+                    let base_var = raw.trim_start_matches('$').to_string();
+                    resolve_with_boundary(
+                        root,
+                        assignment_start,
+                        bytes,
+                        &base_var,
+                        aliases,
+                        0,
+                        None,
+                    )?
+                    .0
+                }
+                "scoped_call_expression" => classify_scoped_call(root, bytes, aliases)?,
+                "object_creation_expression" => extract_new_class(root, bytes, aliases)?,
+                _ => return None,
+            };
+            (base, relation, true, middle)
+        }
+    };
+
+    // Shape gate: a collection terminator on top, and no *recognised* middle
+    // method whose [`ChainEffect`] isn't `None`. A mid-chain `get()`
+    // (FlipToCollection), `toBase()` (FlipToBase), or `first()` (Terminate)
+    // means everything after it operates on a collection / base builder /
+    // single model, not the relation query, so typing the variable to the
+    // related model would be wrong. Table-qualified column strings in the
+    // middle links are just arguments — they never affect this method-name
+    // walk.
     if !COLLECTION_TERMINATORS.contains(&terminator)
-        || is_known_builder_method(relation)
         || middle
             .iter()
             .any(|m| is_known_builder_method(m) && chain_effect(m) != ChainEffect::None)
@@ -228,22 +288,35 @@ pub fn resolve_collection_relation(
         .map(|m| m.to_string())
         .collect();
 
-    // Type the chain root: `$base` via the normal flow walk (bounded at this
-    // assignment, so we don't re-find the assignment we're inside), a static
-    // Eloquent starter (`User::query()->relation()->get()`), or a
-    // construction (`(new User)->relation()->get()` — parens already
-    // unwrapped by the walk above).
-    let base = match root.kind() {
-        "variable_name" => {
-            let raw = node_text(root, bytes)?;
-            let base_var = raw.trim_start_matches('$').to_string();
-            resolve_with_boundary(root, assignment_start, bytes, &base_var, aliases, 0, None)?.0
-        }
-        "scoped_call_expression" => classify_scoped_call(root, bytes, aliases)?,
-        "object_creation_expression" => extract_new_class(root, bytes, aliases)?,
-        _ => return None,
-    };
-    Some((base, relation.to_string(), heuristic_hops))
+    Some(CollectionRelation {
+        base,
+        relation: relation.to_string(),
+        from_call,
+        heuristic_hops,
+    })
+}
+
+/// A detected executed-relation-collection assignment
+/// ([`resolve_collection_relation`]): the resolved base model, the relation
+/// claim to defer, whether the claim was a method *call* (`false` for the
+/// `$this->prop->…` property form — the split decides miss semantics, see
+/// [`super::chain::RelationHopKind`]), and the chain's unrecognised middle
+/// calls in source order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CollectionRelation {
+    pub base: String,
+    pub relation: String,
+    pub from_call: bool,
+    pub heuristic_hops: Vec<String>,
+}
+
+/// Whether `node` is a member call joined by `->` or `?->` — both are chain
+/// structure for the walks in this module.
+fn is_member_call(node: Node) -> bool {
+    matches!(
+        node.kind(),
+        "member_call_expression" | "nullsafe_member_call_expression"
+    )
 }
 
 /// Like [`resolve`], but also reports the [`Confidence`] tier of the

--- a/laravel-lsp/src/query_chain/flow/tests.rs
+++ b/laravel-lsp/src/query_chain/flow/tests.rs
@@ -557,7 +557,7 @@ function search() {
 
 /// Run [`super::resolve_collection_relation`] against the Nth occurrence of
 /// `$var` in the snippet.
-fn resolve_collection_at(src: &str, var: &str, n: usize) -> Option<(String, String, Vec<String>)> {
+fn resolve_collection_full(src: &str, var: &str, n: usize) -> Option<super::CollectionRelation> {
     let wrapped = format!("<?php\n{src}");
     let tree = parse_php(&wrapped).expect("parse");
     let bytes = wrapped.as_bytes();
@@ -565,6 +565,17 @@ fn resolve_collection_at(src: &str, var: &str, n: usize) -> Option<(String, Stri
     let node = find_nth_var(&tree, bytes, var, n)?;
     let (rhs, start) = super::latest_assignment_before(node, bytes, var)?;
     super::resolve_collection_relation(rhs, start, bytes, &aliases)
+}
+
+/// [`resolve_collection_full`] projected to the `(base, relation, hops)`
+/// triple the pre-#272 assertions were written against, with the call-claim
+/// flag asserted (every shape here claims a method *call*; the property-claim
+/// form has its own dedicated tests).
+fn resolve_collection_at(src: &str, var: &str, n: usize) -> Option<(String, String, Vec<String>)> {
+    resolve_collection_full(src, var, n).map(|cr| {
+        assert!(cr.from_call, "expected a call claim, got a property claim");
+        (cr.base, cr.relation, cr.heuristic_hops)
+    })
 }
 
 /// `resolve_collection_at` with no heuristic middle hops expected — the
@@ -801,4 +812,145 @@ function run() {
 }
 "#;
     assert_eq!(resolve_collection_at(src, "x", 1), None);
+}
+
+// ---- nullsafe (`?->`) and `$this`-rooted chains (issue #272) --------------
+
+#[test]
+fn collection_relation_detects_nullsafe_chain() {
+    // `?->` links are chain structure like `->`: a null root short-circuits
+    // at runtime, so the non-null result still types to the related
+    // collection.
+    let src = r#"
+use App\Models\User;
+function run(User $user) {
+    $regs = $user?->competitions()?->get();
+    $regs->whereIn('type', ['league']);
+}
+"#;
+    assert_eq!(
+        resolve_collection_simple(src, "regs", 1),
+        Some(("App\\Models\\User".to_string(), "competitions".to_string()))
+    );
+}
+
+#[test]
+fn collection_relation_detects_mixed_nullsafe_and_plain_links() {
+    // Operators can mix mid-chain (`$user?->competitions()->get()`).
+    let src = r#"
+use App\Models\User;
+function run(User $user) {
+    $regs = $user?->competitions()->get();
+    $regs->whereIn('type', ['league']);
+}
+"#;
+    assert_eq!(
+        resolve_collection_simple(src, "regs", 1),
+        Some(("App\\Models\\User".to_string(), "competitions".to_string()))
+    );
+}
+
+#[test]
+fn collection_relation_nullsafe_still_rejects_mid_chain_mode_flip() {
+    // The mode-flip gate applies to nullsafe chains the same as plain ones.
+    let src = r#"
+use App\Models\User;
+function run(User $user) {
+    $rows = $user?->competitions()?->toBase()?->get();
+    $rows->filter();
+}
+"#;
+    assert_eq!(resolve_collection_at(src, "rows", 1), None);
+}
+
+#[test]
+fn collection_relation_detects_this_rooted_chain() {
+    // `$this->competitions()->get()` inside a class method — the relation
+    // resolves against the enclosing class's model (a call claim, same as
+    // the bare-`$var` form).
+    let src = r#"
+namespace App\Models;
+class User {
+    public function run() {
+        $regs = $this->competitions()->get();
+        $regs->whereIn('type', ['league']);
+    }
+}
+"#;
+    let cr = resolve_collection_full(src, "regs", 1).expect("detected");
+    assert_eq!(cr.base, "App\\Models\\User");
+    assert_eq!(cr.relation, "competitions");
+    assert!(cr.from_call, "a called relation is a call claim");
+    assert!(
+        cr.heuristic_hops.is_empty(),
+        "no hops: {:?}",
+        cr.heuristic_hops
+    );
+}
+
+#[test]
+fn collection_relation_detects_this_property_rooted_chain() {
+    // `$this->user->competitions()->get()` — the `user` *property* is the
+    // relation claim (from_call: false — a property can't be a scope, so a
+    // finalize miss must clear rather than consult scopes); the deepest call
+    // (`competitions`) rides the heuristic-hop queue.
+    let src = r#"
+namespace App\Models;
+class Registration {
+    public function run() {
+        $regs = $this->user->competitions()->get();
+        $regs->whereIn('type', ['league']);
+    }
+}
+"#;
+    let cr = resolve_collection_full(src, "regs", 1).expect("detected");
+    assert_eq!(cr.base, "App\\Models\\Registration");
+    assert_eq!(cr.relation, "user");
+    assert!(!cr.from_call, "a property claim is not a call claim");
+    assert_eq!(cr.heuristic_hops, vec!["competitions".to_string()]);
+}
+
+#[test]
+fn collection_relation_rejects_this_root_outside_class() {
+    // `$this` in a free function has no enclosing class — nothing to resolve
+    // against, so detection must not fire.
+    let src = r#"
+function run() {
+    $regs = $this->competitions()->get();
+    $regs->whereIn('type', ['league']);
+}
+"#;
+    assert_eq!(resolve_collection_at(src, "regs", 1), None);
+}
+
+#[test]
+fn collection_relation_rejects_this_root_known_builder_call() {
+    // `$this->where(...)->get()` — the deepest call is a recognised builder
+    // method, so the collection holds the enclosing model itself, not a
+    // relation's model. Same gate as the bare-`$var` form.
+    let src = r#"
+namespace App\Models;
+class User {
+    public function run() {
+        $rows = $this->where('active', 1)->get();
+        $rows->pluck('id');
+    }
+}
+"#;
+    assert_eq!(resolve_collection_at(src, "rows", 1), None);
+}
+
+#[test]
+fn collection_relation_rejects_non_this_property_root() {
+    // `$user->profile->competitions()->get()` — a property root on anything
+    // but `$this` would need the object's runtime class resolved first;
+    // detection stays out rather than guessing.
+    let src = r#"
+use App\Models\User;
+function run(User $user) {
+    $regs = $user->profile->competitions()->get();
+    $regs->whereIn('type', ['league']);
+}
+"#;
+    assert_eq!(resolve_collection_at(src, "regs", 1), None);
 }


### PR DESCRIPTION
## Summary
Implements #272 — extends the query-chain executed-relation-collection detection (issue #246's shape) to nullsafe (`?->`) and `$this`-rooted chains, and pins the root-scope-before-relation composition with a dedicated end-to-end test.

## Changes
- `flow.rs` — `resolve_collection_relation` now accepts `nullsafe_member_call_expression` links as chain structure (mixed `->`/`?->` chains included), resolves a bare-`$this` root via the enclosing class's FQCN, and handles a `$this->prop` root by making the *property* the relation claim (the deepest call rides the heuristic-hop queue). Returns a new `CollectionRelation` struct carrying a `from_call` flag, since the property claim must seed `RelationHopKind::Claim` (miss → clear) rather than `CallClaim` (miss → consult scopes).
- `extractor.rs` — the bare-`$var` receiver path passes the struct's `from_call` through instead of hardcoding `true`.
- `member_resolver.rs` — `enclosing_class_fqcn` promoted to `pub(crate)` for reuse by the flow walk.
- `flow/tests.rs` — 8 new unit tests (nullsafe, mixed-operator, nullsafe mode-flip gate, $this call root, $this->prop root, $this outside a class, $this builder-call gate, non-$this property root); existing helper projects the new struct so all pre-existing assertions run unchanged.
- `diagnostics/tests.rs` — 8 new end-to-end tests: paired positive/typo for the nullsafe, $this-rooted, and $this->prop-rooted shapes, plus the paired scope-before-relation pin.

## Acceptance Criteria
- [x] `$var = $user?->competitions()?->get()` (nullsafe) detected as an executed-relation collection; downstream chain validates against the related table — paired positive/typo tests (`nullsafe_relation_collection_*`).
- [x] `$var = $this->competitions()->get()` and `$var = $this->user->competitions()->get()` detected likewise, relation resolved against the enclosing class's model — paired positive/typo tests (`this_rooted_*`, `this_property_rooted_*`).
- [x] Existing bare-`$var`, static-root, `(new X)`-root detection and the `RelationProperty` property-access path do not regress — full suite passes unchanged (2790 tests).
- [x] Dedicated end-to-end regression test for the root-scope-before-relation shape, mirroring `scoped_relation_collection_flags_typo_on_related_table` with a paired positive/typo pair (`root_scope_before_relation_collection_*`).

## Test Plan
- [x] All existing tests pass (`cargo test`: 2241 + 469 + 80, 0 failures)
- [x] New tests cover the changes (16 added: 8 unit, 8 end-to-end)
- [x] `cargo clippy --all-targets` clean, `cargo fmt` applied

Fixes #272