### PR TITLE
Fix worktree-related root discovery and add real hover for forwarded builder methods

### DIFF
--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -142,6 +142,22 @@ fn git_main_worktree_root(path: &Path) -> Option<PathBuf> {
     }
 }
 
+/// True if `path` is the MAIN worktree of its repository (not a linked one).
+///
+/// Only meaningful once the caller already knows `path` is *some* worktree
+/// of a repo whose identity matters — e.g. after [`is_same_git_repo`]
+/// confirmed two candidates share a repo, this tells them apart. Used to
+/// prefer the main checkout over a linked worktree when both resolve the
+/// same project: a linked worktree only gets what its branch happened to
+/// have at creation time (issue: a model class added on `main` after a
+/// Claude Code agent worktree branched off was invisible from inside that
+/// worktree — `git worktree add` is a point-in-time snapshot, not a live
+/// mirror), so once the active root drifts onto a linked worktree it should
+/// self-correct back to main, never the other way around.
+pub fn is_main_worktree(path: &Path) -> bool {
+    git_main_worktree_root(path).is_none()
+}
+
 /// Resolve `relative` under `root`, falling back to the same relative path
 /// under the main worktree root when `root` is a linked worktree and the
 /// file isn't present locally.

--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -127,6 +127,56 @@ pub fn is_same_git_repo(a: &Path, b: &Path) -> bool {
     }
 }
 
+/// The main worktree root for `path`'s repository — the checkout `git
+/// worktree add` was run from, found by taking [`git_common_dir`]'s parent
+/// (the shared `.git` directory always lives directly under the main
+/// worktree). Returns `None` when `path` isn't a git repo at all, or is
+/// already the main worktree itself (nothing to fall back to).
+fn git_main_worktree_root(path: &Path) -> Option<PathBuf> {
+    let main_root = git_common_dir(path)?.parent()?.to_path_buf();
+    let path_canonical = path.canonicalize().ok()?;
+    if path_canonical == main_root {
+        None
+    } else {
+        Some(main_root)
+    }
+}
+
+/// Resolve `relative` under `root`, falling back to the same relative path
+/// under the main worktree root when `root` is a linked worktree and the
+/// file isn't present locally.
+///
+/// A linked worktree only gets git-tracked files — `git worktree add` never
+/// copies anything gitignored, so local dev config the project deliberately
+/// keeps untracked (`.env`, `docker-compose.override.yml`) is simply absent
+/// from a fresh worktree, even though the project it belongs to has one.
+/// Falling back to the main worktree's copy is safe specifically *because*
+/// the file is untracked: there's no tracked-file divergence between
+/// branches to accidentally paper over, only a copy that was never there to
+/// begin with.
+///
+/// Returns `root.join(relative)` unchanged when that exists, or when no
+/// fallback applies (not a worktree, or absent everywhere) — every existing
+/// caller's "file missing" handling keeps working as before.
+pub fn resolve_worktree_fallback(root: &Path, relative: &str) -> PathBuf {
+    let local = root.join(relative);
+    if local.exists() {
+        return local;
+    }
+
+    match git_main_worktree_root(root) {
+        Some(main_root) => {
+            let shared = main_root.join(relative);
+            if shared.exists() {
+                shared
+            } else {
+                local
+            }
+        }
+        None => local,
+    }
+}
+
 /// Load Blade component aliases from all known sources.
 ///
 /// Three independent sources are merged into a single `HashMap<alias, view-dot-path>`,

--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -67,6 +67,66 @@ pub fn find_project_root(file_path: &Path) -> Option<PathBuf> {
     }
 }
 
+/// Resolve a directory's real git "common dir" — the directory holding the
+/// repository's shared object database and refs.
+///
+/// For an ordinary checkout this is just `<root>/.git`. For a **linked
+/// worktree** (`git worktree add`), `.git` is a *file* (not a directory)
+/// containing a `gitdir: <path>` pointer into the main checkout's
+/// `.git/worktrees/<name>/` admin directory, which itself contains a
+/// `commondir` file naming the actual shared `.git` directory (typically
+/// `../..`, relative to that admin directory). Following both hops and
+/// canonicalizing lands on the same path for every worktree of one repo,
+/// linked or main.
+fn git_common_dir(root: &Path) -> Option<PathBuf> {
+    let dot_git = root.join(".git");
+    let meta = fs::symlink_metadata(&dot_git).ok()?;
+
+    let git_dir = if meta.is_dir() {
+        dot_git
+    } else {
+        let contents = fs::read_to_string(&dot_git).ok()?;
+        let pointer = contents.trim().strip_prefix("gitdir:")?.trim();
+        let pointer_path = PathBuf::from(pointer);
+        if pointer_path.is_absolute() {
+            pointer_path
+        } else {
+            root.join(pointer_path)
+        }
+    };
+
+    let commondir_file = git_dir.join("commondir");
+    let common_dir = if commondir_file.is_file() {
+        let contents = fs::read_to_string(&commondir_file).ok()?;
+        let relative = PathBuf::from(contents.trim());
+        if relative.is_absolute() {
+            relative
+        } else {
+            git_dir.join(relative)
+        }
+    } else {
+        git_dir
+    };
+
+    common_dir.canonicalize().ok()
+}
+
+/// True if `a` and `b` are two worktrees (linked or main) of the same git
+/// repository.
+///
+/// Every worktree is a full checkout, so it carries its own `composer.json`
+/// and `artisan` — indistinguishable, by [`find_project_root`]'s markers
+/// alone, from a genuinely separate nested Laravel project. This check lets
+/// callers tell the two apart: a discovered root that's just another
+/// worktree of the project already open should never be treated as a
+/// distinct project root.
+pub fn is_same_git_repo(a: &Path, b: &Path) -> bool {
+    match (git_common_dir(a), git_common_dir(b)) {
+        (Some(dir_a), Some(dir_b)) => dir_a == dir_b,
+        _ => false,
+    }
+}
+
 /// Load Blade component aliases from all known sources.
 ///
 /// Three independent sources are merged into a single `HashMap<alias, view-dot-path>`,

--- a/laravel-lsp/src/config/tests.rs
+++ b/laravel-lsp/src/config/tests.rs
@@ -1,4 +1,80 @@
 use super::*;
+use tempfile::TempDir;
+
+/// Turns `worktree_root` into a linked worktree of `main_root`, reproducing
+/// the on-disk layout `git worktree add` produces: a `.git` *file* in the
+/// worktree pointing at an admin dir under the main repo's
+/// `.git/worktrees/<name>/`, which names the shared `.git` dir via a
+/// `commondir` file (test helper for `is_same_git_repo`).
+fn link_worktree(main_root: &Path, worktree_root: &Path, name: &str) {
+    let admin_dir = main_root.join(".git").join("worktrees").join(name);
+    fs::create_dir_all(&admin_dir).unwrap();
+    fs::write(admin_dir.join("commondir"), "../..\n").unwrap();
+
+    fs::create_dir_all(worktree_root).unwrap();
+    fs::write(
+        worktree_root.join(".git"),
+        format!("gitdir: {}\n", admin_dir.display()),
+    )
+    .unwrap();
+}
+
+#[test]
+fn same_git_repo_true_for_main_and_linked_worktree() {
+    let tmp = TempDir::new().unwrap();
+    let main_root = tmp.path().join("project");
+    fs::create_dir_all(main_root.join(".git")).unwrap();
+
+    let worktree_root = tmp.path().join("worktree");
+    link_worktree(&main_root, &worktree_root, "feature-branch");
+
+    assert!(is_same_git_repo(&main_root, &worktree_root));
+    assert!(
+        is_same_git_repo(&worktree_root, &main_root),
+        "the check must be symmetric"
+    );
+}
+
+#[test]
+fn same_git_repo_false_for_two_unrelated_repos() {
+    let tmp = TempDir::new().unwrap();
+    let repo_a = tmp.path().join("repo-a");
+    let repo_b = tmp.path().join("repo-b");
+    fs::create_dir_all(repo_a.join(".git")).unwrap();
+    fs::create_dir_all(repo_b.join(".git")).unwrap();
+
+    assert!(!is_same_git_repo(&repo_a, &repo_b));
+}
+
+#[test]
+fn same_git_repo_false_when_neither_is_a_git_repo() {
+    // No git plumbing at all on either side (e.g. a plain nested Laravel
+    // project that isn't version-controlled) — must not be treated as a
+    // worktree pair, and existing "nested project" discovery is unaffected.
+    let tmp = TempDir::new().unwrap();
+    let a = tmp.path().join("a");
+    let b = tmp.path().join("b");
+    fs::create_dir_all(&a).unwrap();
+    fs::create_dir_all(&b).unwrap();
+
+    assert!(!is_same_git_repo(&a, &b));
+}
+
+#[test]
+fn same_git_repo_false_for_distinct_repo_nested_underneath() {
+    // A nested Laravel project that happens to be its own git repository
+    // (e.g. a submodule) must NOT be mistaken for a worktree of the outer
+    // project just because it's physically nested underneath it — only a
+    // shared git common dir means "same project".
+    let tmp = TempDir::new().unwrap();
+    let outer = tmp.path().join("outer");
+    fs::create_dir_all(outer.join(".git")).unwrap();
+
+    let inner = outer.join("packages").join("billing");
+    fs::create_dir_all(inner.join(".git")).unwrap();
+
+    assert!(!is_same_git_repo(&outer, &inner));
+}
 
 /// Extract base_path(...) calls from a line (test helper)
 fn extract_base_path(line: &str) -> Option<&str> {

--- a/laravel-lsp/src/config/tests.rs
+++ b/laravel-lsp/src/config/tests.rs
@@ -77,6 +77,27 @@ fn same_git_repo_false_for_distinct_repo_nested_underneath() {
 }
 
 #[test]
+fn is_main_worktree_true_for_the_main_checkout() {
+    let tmp = TempDir::new().unwrap();
+    let main_root = tmp.path().join("project");
+    fs::create_dir_all(main_root.join(".git")).unwrap();
+
+    assert!(is_main_worktree(&main_root));
+}
+
+#[test]
+fn is_main_worktree_false_for_a_linked_worktree() {
+    let tmp = TempDir::new().unwrap();
+    let main_root = tmp.path().join("project");
+    fs::create_dir_all(main_root.join(".git")).unwrap();
+
+    let worktree_root = tmp.path().join("worktree");
+    link_worktree(&main_root, &worktree_root, "feature-branch");
+
+    assert!(!is_main_worktree(&worktree_root));
+}
+
+#[test]
 fn worktree_fallback_prefers_local_file_when_present() {
     let tmp = TempDir::new().unwrap();
     let main_root = tmp.path().join("project");

--- a/laravel-lsp/src/config/tests.rs
+++ b/laravel-lsp/src/config/tests.rs
@@ -76,6 +76,100 @@ fn same_git_repo_false_for_distinct_repo_nested_underneath() {
     assert!(!is_same_git_repo(&outer, &inner));
 }
 
+#[test]
+fn worktree_fallback_prefers_local_file_when_present() {
+    let tmp = TempDir::new().unwrap();
+    let main_root = tmp.path().join("project");
+    fs::create_dir_all(main_root.join(".git")).unwrap();
+    fs::write(main_root.join(".env"), "MAIN=1\n").unwrap();
+
+    let worktree_root = tmp.path().join("worktree");
+    link_worktree(&main_root, &worktree_root, "feature-branch");
+    fs::write(worktree_root.join(".env"), "LOCAL=1\n").unwrap();
+
+    assert_eq!(
+        resolve_worktree_fallback(&worktree_root, ".env"),
+        worktree_root.join(".env"),
+        "a file that exists locally must never be shadowed by the main worktree's copy"
+    );
+}
+
+#[test]
+fn worktree_fallback_reaches_main_worktree_when_local_file_is_gitignored_absent() {
+    // The motivating case: `.env` is gitignored, so `git worktree add` never
+    // copies it — a fresh worktree has none, even though the project does.
+    let tmp = TempDir::new().unwrap();
+    let main_root = tmp.path().join("project");
+    fs::create_dir_all(main_root.join(".git")).unwrap();
+    fs::write(main_root.join(".env"), "DB_HOST=mysql\n").unwrap();
+
+    let worktree_root = main_root
+        .join(".claude")
+        .join("worktrees")
+        .join("gifted-heisenberg-3c0899");
+    link_worktree(&main_root, &worktree_root, "gifted-heisenberg-3c0899");
+    // No .env written under worktree_root — exactly the gitignored-absence case.
+
+    // The resolved main root comes back canonicalized (derived from
+    // `git_common_dir`, which canonicalizes to prove repo identity) — on
+    // macOS that's `/private/var/...`, not the `/var/...` symlink `TempDir`
+    // hands back, so compare against the canonical form.
+    assert_eq!(
+        resolve_worktree_fallback(&worktree_root, ".env"),
+        main_root.canonicalize().unwrap().join(".env"),
+        "a file missing locally must fall back to the main worktree's copy"
+    );
+}
+
+#[test]
+fn worktree_fallback_returns_local_path_when_absent_everywhere() {
+    let tmp = TempDir::new().unwrap();
+    let main_root = tmp.path().join("project");
+    fs::create_dir_all(main_root.join(".git")).unwrap();
+    // No .env anywhere, main root included.
+
+    let worktree_root = tmp.path().join("worktree");
+    link_worktree(&main_root, &worktree_root, "feature-branch");
+
+    assert_eq!(
+        resolve_worktree_fallback(&worktree_root, ".env"),
+        worktree_root.join(".env"),
+        "with no copy anywhere, callers must see the same 'missing' local path as before"
+    );
+}
+
+#[test]
+fn worktree_fallback_is_a_noop_outside_any_worktree() {
+    // A plain checkout (no linked worktree involved) with a missing file
+    // must behave exactly as a bare `root.join(relative)` always did — no
+    // git plumbing means no fallback candidate to try.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    fs::create_dir_all(root.join(".git")).unwrap();
+
+    assert_eq!(resolve_worktree_fallback(&root, ".env"), root.join(".env"));
+}
+
+#[test]
+fn worktree_fallback_is_a_noop_for_the_main_worktree_itself() {
+    // Calling the resolver FROM the main worktree (not a linked one) must
+    // not try to fall back to itself — `git_main_worktree_root` returns
+    // `None` when `path` already IS the main root.
+    let tmp = TempDir::new().unwrap();
+    let main_root = tmp.path().join("project");
+    fs::create_dir_all(main_root.join(".git")).unwrap();
+
+    let worktree_root = tmp.path().join("worktree");
+    link_worktree(&main_root, &worktree_root, "feature-branch");
+
+    // No .env anywhere; querying the MAIN root (not the worktree) for a
+    // missing file must just return the local (main-root) path.
+    assert_eq!(
+        resolve_worktree_fallback(&main_root, ".env"),
+        main_root.join(".env")
+    );
+}
+
 /// Extract base_path(...) calls from a line (test helper)
 fn extract_base_path(line: &str) -> Option<&str> {
     // Match: base_path('some/path') or base_path("some/path")

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -1417,7 +1417,7 @@ impl DatabaseSchemaProvider {
     /// whatever line followed), which was sent as the literal password
     /// to MySQL and rejected as bad credentials.
     fn resolve_env(&self, key: &str) -> Option<String> {
-        let env_path = self.project_root.join(".env");
+        let env_path = crate::config::resolve_worktree_fallback(&self.project_root, ".env");
         let content = match std::fs::read_to_string(&env_path) {
             Ok(c) => c,
             Err(e) => {
@@ -1858,7 +1858,7 @@ impl DatabaseSchemaProvider {
         filenames: &[&str],
     ) -> Option<DetectedEndpoint> {
         for filename in filenames {
-            let path = self.project_root.join(filename);
+            let path = crate::config::resolve_worktree_fallback(&self.project_root, filename);
             let Ok(content) = std::fs::read_to_string(&path) else {
                 continue;
             };

--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -259,6 +259,11 @@ pub fn magic_member_card(
         MagicMemberKind::FactoryMethod => "Factory method",
         // `->pivot` on a model with a custom `$pivotClass`.
         MagicMemberKind::Pivot => "Pivot model",
+        // A `__call`-forwarded Eloquent/Query builder method (`orderByDesc`,
+        // `where`, …) — real vendor signature, sourced without ide-helper.
+        // Worth a card for the same reason `FacadeMethod` is: Intelephense
+        // can't see the forwarding either, ide-helper or not.
+        MagicMemberKind::BuilderMethod => "Query builder method",
         // Generic property — Intelephense already covers it. Don't duplicate.
         MagicMemberKind::PlainMember => return String::new(),
     };

--- a/laravel-lsp/src/hover/tests.rs
+++ b/laravel-lsp/src/hover/tests.rs
@@ -267,6 +267,31 @@ fn magic_member_card_labels_each_kind() {
     assert_eq!(label(MagicMemberKind::Factory), "**Model factory**");
     assert_eq!(label(MagicMemberKind::FactoryMethod), "**Factory method**");
     assert_eq!(label(MagicMemberKind::Pivot), "**Pivot model**");
+    assert_eq!(
+        label(MagicMemberKind::BuilderMethod),
+        "**Query builder method**"
+    );
+}
+
+#[test]
+fn magic_member_card_builder_method_renders_vendor_signature_and_summary() {
+    // The builder-method fallback has no decl_file to slice — its
+    // signature/summary come pre-extracted from `BuilderMethodIndex` and are
+    // passed straight through the existing `definition`/`description` slots.
+    let card = magic_member_card(
+        MagicMemberKind::BuilderMethod,
+        "orderByDesc",
+        "Illuminate\\Database\\Query\\Builder",
+        Confidence::High,
+        Some("public function orderByDesc($column)"),
+        None,
+        Some("Add an \"order by\" clause in descending order to the query."),
+        None,
+    );
+    assert!(card.contains("**Query builder method**"));
+    assert!(card.contains("`orderByDesc` on `Illuminate\\Database\\Query\\Builder`"));
+    assert!(card.contains("public function orderByDesc($column)"));
+    assert!(card.contains("Add an \"order by\" clause in descending order to the query."));
 }
 
 #[test]

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -7532,11 +7532,34 @@ impl LaravelLanguageServer {
                 // any in-flight DB connection for no reason: it's the same
                 // project.
                 if is_same_git_repo(&discovered_root, current) {
-                    debug!(
-                        "Discovered root {:?} is a worktree of the current repo {:?} — keeping current root",
-                        discovered_root, current
-                    );
-                    false
+                    // Same repo, different worktree — don't thrash between
+                    // them (that's the case above). But an asymmetric
+                    // exception: self-correct BACK to the main worktree if
+                    // the active root has drifted onto a linked one. A
+                    // linked worktree is a point-in-time snapshot — a class
+                    // added on `main` after the worktree branched off is
+                    // invisible from inside it (confirmed live: a model
+                    // class only main had went unresolved for every hover/
+                    // goto while root sat on a Claude Code agent worktree),
+                    // so once stuck there nothing else would ever pull it
+                    // back. Never the other direction: switching FROM main
+                    // TO a linked worktree is exactly the original
+                    // disruptive hijack this guard exists to prevent.
+                    if !laravel_lsp::config::is_main_worktree(current)
+                        && laravel_lsp::config::is_main_worktree(&discovered_root)
+                    {
+                        info!(
+                            "Discovered root {:?} is the main worktree — correcting back from linked worktree {:?}",
+                            discovered_root, current
+                        );
+                        true
+                    } else {
+                        debug!(
+                            "Discovered root {:?} is a worktree of the current repo {:?} — keeping current root",
+                            discovered_root, current
+                        );
+                        false
+                    }
                 } else {
                     // Check if file is outside current root
                     let file_outside_root = !file_path.starts_with(current);

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -5610,13 +5610,27 @@ impl LaravelLanguageServer {
     /// and incremental updates automatically.
     ///
     /// Priority: .env.example=0, .env.local=1, .env=2 (higher wins)
+    ///
+    /// Each path runs through `resolve_worktree_fallback`: `.env`/`.env.local`
+    /// are gitignored, so a linked worktree never has its own copy — fall
+    /// back to the main worktree's file rather than resolving env() calls
+    /// against nothing.
     async fn register_env_files_with_salsa(&self, root: &Path) {
         // Define env files with their priorities
         // Priority: 0=.env.example, 1=.env.local, 2=.env
         let env_files = [
-            (root.join(".env.example"), 0u8),
-            (root.join(".env.local"), 1u8),
-            (root.join(".env"), 2u8),
+            (
+                laravel_lsp::config::resolve_worktree_fallback(root, ".env.example"),
+                0u8,
+            ),
+            (
+                laravel_lsp::config::resolve_worktree_fallback(root, ".env.local"),
+                1u8,
+            ),
+            (
+                laravel_lsp::config::resolve_worktree_fallback(root, ".env"),
+                2u8,
+            ),
         ];
 
         let documents = self.documents.read().await;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4130,6 +4130,41 @@ impl LaravelLanguageServer {
         Some(items)
     }
 
+    /// Fetch (or populate) the per-project-root cache of parsed Eloquent +
+    /// Query builder methods, sourced straight from the project's own
+    /// `vendor/laravel/framework` — no `ide-helper` stubs required. Shared by
+    /// `Model::|` completion and builder-method hover (M6.x): first checks
+    /// the read lock; on miss, parses synchronously off the executor thread,
+    /// then takes the write lock to insert. Two concurrent first-misses can
+    /// race — the second parse is wasted work but the insert overwrites
+    /// cleanly, so correctness is fine. `None` when `vendor/` doesn't have
+    /// either Builder file (the user probably hasn't run `composer install`).
+    async fn get_builder_method_index(
+        &self,
+        root: &Path,
+    ) -> Option<Arc<laravel_lsp::laravel_introspector::BuilderMethodIndex>> {
+        let cached = {
+            let cache = self.builder_method_index_cache.read().await;
+            cache.get(root).cloned()
+        };
+        if let Some(arc) = cached {
+            return Some(arc);
+        }
+        let root_for_parse = root.to_path_buf();
+        let parsed = tokio::task::spawn_blocking(move || {
+            laravel_lsp::laravel_introspector::parse_builder_methods(&root_for_parse)
+        })
+        .await
+        .ok()
+        .flatten()?;
+        let arc = Arc::new(parsed);
+        self.builder_method_index_cache
+            .write()
+            .await
+            .insert(root.to_path_buf(), arc.clone());
+        Some(arc)
+    }
+
     /// Method-name completion at `Model::|` (and partial-typed variants
     /// like `Model::wher|`).
     ///
@@ -4220,32 +4255,7 @@ impl LaravelLanguageServer {
         }
 
         // 5. Fetch (or populate) the per-project-root builder method index.
-        // First check the read lock; on miss, parse synchronously off the
-        // executor thread, then take the write lock to insert. Two
-        // concurrent first-misses can race — the second parse is wasted
-        // work but the insert overwrites cleanly, so correctness is fine.
-        let index = {
-            let cache = self.builder_method_index_cache.read().await;
-            cache.get(&root).cloned()
-        };
-        let index = match index {
-            Some(arc) => arc,
-            None => {
-                let root_for_parse = root.clone();
-                let parsed = tokio::task::spawn_blocking(move || {
-                    laravel_lsp::laravel_introspector::parse_builder_methods(&root_for_parse)
-                })
-                .await
-                .ok()
-                .flatten()?;
-                let arc = Arc::new(parsed);
-                self.builder_method_index_cache
-                    .write()
-                    .await
-                    .insert(root.clone(), arc.clone());
-                arc
-            }
-        };
+        let index = self.get_builder_method_index(&root).await?;
 
         // 6. Render items. Builder methods + local scopes from the
         // resolved model (and its parents/traits). Scope extraction
@@ -18841,13 +18851,32 @@ return [
         let Ok(path) = uri.to_file_path() else {
             return String::new();
         };
+        // Builder-method hover (`orderByDesc`, `where`, …) needs the project's
+        // parsed vendor Builder surface — fetch/populate the cached index for
+        // the current root so `resolve_and_classify` can fall back to it when
+        // nothing in the model's own hierarchy declares the member. `None`
+        // when there's no root yet or vendor/ is missing; the Salsa side
+        // degrades to today's behavior (no card) in that case.
+        let root = self.root_path.read().await.clone();
+        let builder_index = match &root {
+            Some(root) => self.get_builder_method_index(root).await,
+            None => None,
+        };
+        info!(
+            "🪄 hover_for_magic_member: root={:?} builder_index={}",
+            root,
+            builder_index.is_some()
+        );
         let data = match self
             .salsa
-            .resolve_magic_member_at(path, member_ref.line, member_ref.column)
+            .resolve_magic_member_at(path, member_ref.line, member_ref.column, builder_index)
             .await
         {
             Ok(Some(d)) => d,
-            _ => return String::new(),
+            other => {
+                info!("🪄 hover_for_magic_member: resolve_magic_member_at -> {other:?}");
+                return String::new();
+            }
         };
         // Method-backed member (relationship / scope / accessor / facade method):
         // read the declaring file (usually a different file — the model, or a
@@ -18882,6 +18911,14 @@ return [
                 .filter(|s| !s.is_empty()),
             _ => None,
         };
+        // Builder-forwarded method: no decl_file to slice (there's no
+        // project-local declaration), so the general snippet extraction above
+        // always yields `None` for this kind — fill in from the pre-extracted
+        // vendor signature/summary instead. `builder_signature`/`_summary` are
+        // `Some` only for `MagicMemberKind::BuilderMethod`, so this can't
+        // clobber any other kind's real snippet/description.
+        let definition = definition.or_else(|| data.builder_signature.clone());
+        let facade_description = facade_description.or_else(|| data.builder_summary.clone());
 
         // Columns (M6.2): confirm + type via migrations-first, DB fallback. A
         // *tentative* column (the resolver couldn't classify it — a plain,
@@ -19014,12 +19051,18 @@ return [
         use laravel_lsp::salsa_impl::MagicMemberKind;
         let data = self
             .salsa
-            .resolve_magic_member_at(file_path.to_path_buf(), member.line, member.column)
+            // Goto-definition never wants the builder-method fallback — a
+            // vendor-forwarded method has no project-local declaration to
+            // jump to.
+            .resolve_magic_member_at(file_path.to_path_buf(), member.line, member.column, None)
             .await
             .ok()
             .flatten()?;
 
-        if matches!(data.kind, MagicMemberKind::PlainMember) {
+        if matches!(
+            data.kind,
+            MagicMemberKind::PlainMember | MagicMemberKind::BuilderMethod
+        ) {
             return None;
         }
 
@@ -19188,7 +19231,14 @@ return [
         // 1. Identify the column under the cursor: model FQCN + column name.
         let data = self
             .salsa
-            .resolve_magic_member_at(file_path.to_path_buf(), position.line, position.character)
+            // Column rename only ever matches `MagicMemberKind::Column` below —
+            // no builder-method fallback needed here.
+            .resolve_magic_member_at(
+                file_path.to_path_buf(),
+                position.line,
+                position.character,
+                None,
+            )
             .await
             .ok()
             .flatten()?;
@@ -23252,7 +23302,9 @@ impl LanguageServer for LaravelLanguageServer {
         // `email`.
         if let Ok(Some(data)) = self
             .salsa
-            .resolve_magic_member_at(file_path.clone(), position.line, position.character)
+            // Prepare-rename only matches `Column` below — no builder-method
+            // fallback needed here.
+            .resolve_magic_member_at(file_path.clone(), position.line, position.character, None)
             .await
         {
             if matches!(data.kind, laravel_lsp::salsa_impl::MagicMemberKind::Column) {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -24,7 +24,7 @@ use laravel_lsp::cache_manager::{
 };
 use laravel_lsp::command_index::{build_command_index, CommandIndex};
 use laravel_lsp::completion_format::CompletionDoc;
-use laravel_lsp::config::find_project_root;
+use laravel_lsp::config::{find_project_root, is_same_git_repo};
 use laravel_lsp::middleware_parser::{middleware_base_alias, resolve_class_to_file};
 use laravel_lsp::migration_index::{build_migration_index, MigrationIndex};
 use laravel_lsp::path_containment::{
@@ -7507,32 +7507,50 @@ impl LaravelLanguageServer {
                 true
             }
             Some(current) => {
-                // Check if file is outside current root
-                let file_outside_root = !file_path.starts_with(current);
-
-                // Check if discovered root is more specific (nested within current root)
-                let more_specific =
-                    discovered_root.starts_with(current) && discovered_root != *current;
-
-                if file_outside_root {
-                    info!(
-                        "File {:?} is outside current root {:?}, switching to discovered root: {:?}",
-                        file_path, current, discovered_root
-                    );
-                    true
-                } else if more_specific {
-                    info!(
-                        "Discovered more specific Laravel root {:?} (current: {:?})",
+                // A linked git worktree is a full checkout, so it carries its
+                // own composer.json + artisan — indistinguishable, by marker
+                // alone, from a genuinely separate/nested Laravel project.
+                // Without this check, opening a file inside a worktree (e.g.
+                // one of Claude Code's `.claude/worktrees/<name>/`, or any
+                // manually-created sibling worktree) would look like either
+                // "more specific" or "outside root" below and hijack the
+                // active project root, forcing a full re-index and aborting
+                // any in-flight DB connection for no reason: it's the same
+                // project.
+                if is_same_git_repo(&discovered_root, current) {
+                    debug!(
+                        "Discovered root {:?} is a worktree of the current repo {:?} — keeping current root",
                         discovered_root, current
                     );
-                    true
-                } else {
-                    // File is within current root and discovered isn't more specific
-                    debug!(
-                        "Keeping current root {:?} for file {:?}",
-                        current, file_path
-                    );
                     false
+                } else {
+                    // Check if file is outside current root
+                    let file_outside_root = !file_path.starts_with(current);
+
+                    // Check if discovered root is more specific (nested within current root)
+                    let more_specific =
+                        discovered_root.starts_with(current) && discovered_root != *current;
+
+                    if file_outside_root {
+                        info!(
+                            "File {:?} is outside current root {:?}, switching to discovered root: {:?}",
+                            file_path, current, discovered_root
+                        );
+                        true
+                    } else if more_specific {
+                        info!(
+                            "Discovered more specific Laravel root {:?} (current: {:?})",
+                            discovered_root, current
+                        );
+                        true
+                    } else {
+                        // File is within current root and discovered isn't more specific
+                        debug!(
+                            "Keeping current root {:?} for file {:?}",
+                            current, file_path
+                        );
+                        false
+                    }
                 }
             }
         };

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -19,6 +19,7 @@
 use crate::class_hierarchy_index::ClassHierarchyIndex;
 use crate::laravel_introspector::chain::{analyze, ClassView, LaravelClassKind};
 use crate::laravel_introspector::model_metadata::pascal_to_snake;
+use crate::laravel_introspector::BuilderMethodIndex;
 use crate::parser::parse_php;
 use crate::query_chain::flow;
 use crate::query_chain::use_aliases::{extract_use_aliases, resolve_class_name, UseAliases};
@@ -441,6 +442,9 @@ pub fn resolve_member_access_entries(
             resolver,
             classviews,
             project_root,
+            None, // index population never wants a builder-method fallback —
+            // vendor-forwarded methods stay out of rename/references, same as
+            // PlainMember.
             deps.as_deref_mut(),
         ) else {
             continue;
@@ -505,6 +509,7 @@ pub fn resolve_and_classify(
     resolver: &impl ClassFileResolver,
     classviews: &ClassViewCache,
     project_root: &Path,
+    builder_index: Option<&BuilderMethodIndex>,
     mut deps: Option<&mut HashSet<String>>,
 ) -> Option<ResolvedMemberAccess> {
     // A container-resolution receiver records its *abstract* binding key as an
@@ -604,6 +609,7 @@ pub fn resolve_and_classify(
         resolver,
         classviews,
         project_root,
+        builder_index,
     ) {
         record_macro_decl_dep(&resolved, &fqcn, member, resolver, deps.as_deref_mut());
         return Some(resolved);
@@ -635,6 +641,7 @@ pub fn resolve_and_classify(
             resolver,
             classviews,
             project_root,
+            builder_index,
         )?;
         record_macro_decl_dep(&resolved, &model, member, resolver, deps);
         return Some(resolved);
@@ -695,6 +702,7 @@ fn classify_against(
     resolver: &impl ClassFileResolver,
     classviews: &ClassViewCache,
     project_root: &Path,
+    builder_index: Option<&BuilderMethodIndex>,
 ) -> Option<ResolvedMemberAccess> {
     // A class the index knows: classify against its real surfaces first.
     if let Some(file_path) = resolver.class_file(fqcn) {
@@ -746,6 +754,29 @@ fn classify_against(
                     kind: classified.kind,
                     confidence,
                 });
+            }
+            // Builder-forwarded fallback: nothing in the model's own hierarchy
+            // declares `member` — for an Eloquent model that's the common case
+            // for `__call`/`forwardCallTo`-forwarded Builder methods
+            // (`orderByDesc`, `where`, `first`, …). Intelephense can't see that
+            // forwarding without a generated `_ide_helper.php`, so unlike a
+            // genuine `PlainMember` this is NOT Intelephense's covered
+            // territory — `builder_index` sources the real signature from
+            // vendor source directly, ide-helper or not.
+            if form.is_call() && view.kind == LaravelClassKind::Model {
+                if let Some(index) = builder_index {
+                    if let Some(m) = index
+                        .merged_surface()
+                        .into_iter()
+                        .find(|m| m.name == member)
+                    {
+                        return Some(ResolvedMemberAccess {
+                            declaring_fqcn: m.source_class.clone(),
+                            kind: MagicMemberKind::BuilderMethod,
+                            confidence,
+                        });
+                    }
+                }
             }
         }
         // A facade call whose member is NOT declared on the concrete — the
@@ -2525,6 +2556,9 @@ pub fn resolve_member_access_entries_with_context(
             resolver,
             classviews,
             project_root,
+            None, // index population never wants a builder-method fallback —
+            // vendor-forwarded methods stay out of rename/references, same as
+            // PlainMember.
             deps.as_deref_mut(),
         ) else {
             continue;
@@ -2565,6 +2599,7 @@ fn resolve_recipe_and_classify(
     resolver: &impl ClassFileResolver,
     classviews: &ClassViewCache,
     project_root: &Path,
+    builder_index: Option<&BuilderMethodIndex>,
     mut deps: Option<&mut HashSet<String>>,
 ) -> Option<ResolvedMemberAccess> {
     // Container-binding attempt dependency (see [`resolve_and_classify`]'s
@@ -2647,6 +2682,7 @@ fn resolve_recipe_and_classify(
         resolver,
         classviews,
         project_root,
+        builder_index,
     ) {
         record_macro_decl_dep(&resolved, &fqcn, member, resolver, deps.as_deref_mut());
         return Some(resolved);
@@ -2669,6 +2705,7 @@ fn resolve_recipe_and_classify(
             resolver,
             classviews,
             project_root,
+            builder_index,
         )?;
         record_macro_decl_dep(&resolved, &model, member, resolver, deps);
         return Some(resolved);

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -348,6 +348,7 @@ fn resolve_in(p: &Project, caller: &str, member: &str) -> Option<ResolvedMemberA
         &cache,
         &p.root,
         None,
+        None,
     )
 }
 
@@ -406,6 +407,7 @@ fn resolve_with(
         resolver,
         &cache,
         root,
+        None,
         None,
     )
 }
@@ -629,6 +631,7 @@ fn resolve_static_call(
         &cache,
         root,
         None,
+        None,
     )
 }
 
@@ -846,6 +849,7 @@ fn resolve_call_member(
         resolver,
         &cache,
         root,
+        None,
         None,
     )
 }
@@ -2390,6 +2394,222 @@ class C {
 }
 
 #[test]
+fn population_indexes_chain_rooted_on_order_by_desc() {
+    // Regression: `orderByDesc` was missing from `ELOQUENT_STATIC_STARTERS`
+    // (query_chain/methods.rs) even though its `orderBy` sibling was present,
+    // so `resolve_call_chain_receiver`'s static-scope branch bailed before
+    // classifying anything chained after it — `active` never resolved for
+    // hover/goto/rename on a chain rooted this way.
+    let p = project("app/Models/User.php", SCOPED_MODEL);
+    let caller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+class C {
+    public function a() { return User::orderByDesc('name')->active()->get(); }
+}
+"#;
+    let refs = member_refs_of(caller);
+    let entries = resolve_member_access_entries(
+        caller,
+        &refs,
+        &p.index,
+        &ClassViewCache::new(),
+        &p.root,
+        None,
+    );
+    assert!(
+        has_entry(&entries, "App\\Models\\User", "active"),
+        "a chain rooted on `orderByDesc` must still resolve later scope calls; got {entries:?}"
+    );
+}
+
+// ─── Builder-method hover fallback (`classify_against`'s new branch) ──────
+//
+// `orderByDesc` (and friends) aren't declared anywhere in a model's own
+// class hierarchy — they're `__call`-forwarded to the underlying query
+// builder. Without `ide-helper`-generated stubs, Intelephense can't see that
+// forwarding either, so this LSP fills the gap itself using the real vendor
+// signature from `BuilderMethodIndex`, sourced independent of ide-helper.
+
+const FAKE_ELOQUENT_BUILDER: &str = r#"<?php
+namespace Illuminate\Database\Eloquent;
+class Builder
+{
+}
+"#;
+
+const FAKE_QUERY_BUILDER: &str = r#"<?php
+namespace Illuminate\Database\Query;
+class Builder
+{
+    /**
+     * Add an "order by" clause in descending order to the query.
+     */
+    public function orderByDesc($column)
+    {
+        return $this;
+    }
+}
+"#;
+
+/// Write minimal fake vendor Eloquent + Query Builder classes into `root`
+/// (real files on disk — `parse_builder_methods` reads them, exactly like
+/// production) and build the real `BuilderMethodIndex` from them.
+fn fake_builder_index(root: &std::path::Path) -> crate::laravel_introspector::BuilderMethodIndex {
+    use crate::laravel_introspector::{ELOQUENT_BUILDER_REL_PATH, QUERY_BUILDER_REL_PATH};
+    let eloquent_path = root.join(ELOQUENT_BUILDER_REL_PATH);
+    fs::create_dir_all(eloquent_path.parent().unwrap()).unwrap();
+    fs::write(&eloquent_path, FAKE_ELOQUENT_BUILDER).unwrap();
+    let query_path = root.join(QUERY_BUILDER_REL_PATH);
+    fs::create_dir_all(query_path.parent().unwrap()).unwrap();
+    fs::write(&query_path, FAKE_QUERY_BUILDER).unwrap();
+    crate::laravel_introspector::parse_builder_methods(root)
+        .expect("fake vendor Builder files should parse")
+}
+
+/// Find the `scope` of the `scoped_call_expression` named `member` (the
+/// `<scope>::{member}()` receiver) — mirrors `resolve_static_call`'s internal
+/// lookup, inlined here so this test alone can pass a `builder_index` without
+/// widening that shared helper's signature across its ~14 other call sites.
+fn static_call_scope<'t>(
+    tree: &'t tree_sitter::Tree,
+    bytes: &[u8],
+    member: &str,
+) -> Option<tree_sitter::Node<'t>> {
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "scoped_call_expression"
+            && n.child_by_field_name("name")
+                .and_then(|nm| nm.utf8_text(bytes).ok())
+                == Some(member)
+        {
+            return n.child_by_field_name("scope");
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    None
+}
+
+#[test]
+fn builder_method_fallback_resolves_forwarded_call() {
+    let p = project("app/Models/User.php", SCOPED_MODEL);
+    let index = fake_builder_index(&p.root);
+    let caller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+class C {
+    public function a() { return User::orderByDesc('name'); }
+}
+"#;
+    let tree = parse_php(caller).expect("parse caller");
+    let bytes = caller.as_bytes();
+    let aliases = extract_use_aliases(&tree, caller);
+    let receiver = static_call_scope(&tree, bytes, "orderByDesc").expect("find receiver");
+    let cache = ClassViewCache::new();
+
+    let resolved = resolve_and_classify(
+        receiver,
+        "orderByDesc",
+        AccessForm::StaticCall,
+        bytes,
+        &aliases,
+        &p.index,
+        &cache,
+        &p.root,
+        Some(&index),
+        None,
+    )
+    .expect("orderByDesc should resolve via the builder-index fallback");
+
+    assert_eq!(resolved.kind, MagicMemberKind::BuilderMethod);
+    assert_eq!(
+        resolved.declaring_fqcn,
+        "Illuminate\\Database\\Query\\Builder"
+    );
+}
+
+#[test]
+fn builder_method_fallback_absent_without_index() {
+    // Same call site as above, but `builder_index: None` (the "vendor/
+    // missing, or caller doesn't want the fallback" case — goto/rename/
+    // references all pass `None`) — must fall back to today's behavior: no
+    // classification at all, not a guess.
+    let p = project("app/Models/User.php", SCOPED_MODEL);
+    let caller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+class C {
+    public function a() { return User::orderByDesc('name'); }
+}
+"#;
+    let tree = parse_php(caller).expect("parse caller");
+    let bytes = caller.as_bytes();
+    let aliases = extract_use_aliases(&tree, caller);
+    let receiver = static_call_scope(&tree, bytes, "orderByDesc").expect("find receiver");
+    let cache = ClassViewCache::new();
+
+    let resolved = resolve_and_classify(
+        receiver,
+        "orderByDesc",
+        AccessForm::StaticCall,
+        bytes,
+        &aliases,
+        &p.index,
+        &cache,
+        &p.root,
+        None,
+        None,
+    );
+
+    assert_eq!(
+        resolved, None,
+        "without a builder_index the fallback must not fire — no card, same as before this feature"
+    );
+}
+
+#[test]
+fn builder_method_fallback_ignores_property_form() {
+    // Builder methods are always calls in Laravel — a property-form read of
+    // the same name (however contrived) must not be misclassified as one,
+    // even with a matching builder_index. Proves the `form.is_call()` gate.
+    let p = project("app/Models/User.php", SCOPED_MODEL);
+    let index = fake_builder_index(&p.root);
+    let caller = r#"<?php
+namespace App\Http\Controllers;
+use App\Models\User;
+class C {
+    public function a(User $user) { return $user->orderByDesc; }
+}
+"#;
+    let tree = parse_php(caller).expect("parse caller");
+    let bytes = caller.as_bytes();
+    let aliases = extract_use_aliases(&tree, caller);
+    let receiver = receiver_of(&tree, bytes, "orderByDesc").expect("find receiver");
+    let cache = ClassViewCache::new();
+
+    let resolved = resolve_and_classify(
+        receiver,
+        "orderByDesc",
+        AccessForm::Property,
+        bytes,
+        &aliases,
+        &p.index,
+        &cache,
+        &p.root,
+        Some(&index),
+        None,
+    );
+
+    assert_eq!(
+        resolved, None,
+        "a property-form access must not trigger the call-only builder-method fallback"
+    );
+}
+
+#[test]
 fn population_indexes_builder_param_scope_body_calls() {
     // `$query->active()` inside another scope's body — the receiver types as
     // the Eloquent Builder (no scopes declared there); resolution retries
@@ -3509,6 +3729,7 @@ fn resolve_instance_call(
         resolver,
         &cache,
         root,
+        None,
         None,
     )
 }

--- a/laravel-lsp/src/query_chain/methods.rs
+++ b/laravel-lsp/src/query_chain/methods.rs
@@ -373,6 +373,8 @@ pub const ELOQUENT_STATIC_STARTERS: &[&str] = &[
     "latest",
     "oldest",
     "orderBy",
+    "orderByDesc",
+    "orderByRaw",
     "groupBy",
     "having",
     "select",

--- a/laravel-lsp/src/query_chain/methods/tests.rs
+++ b/laravel-lsp/src/query_chain/methods/tests.rs
@@ -137,6 +137,11 @@ fn is_eloquent_static_starter_recognises_idiomatic_forms() {
     assert!(is_eloquent_static_starter("with"));
     assert!(is_eloquent_static_starter("create"));
     assert!(is_eloquent_static_starter("count"));
+    // Regression: `orderBy` was recognised but its `Desc`/`Raw` siblings
+    // weren't, silently breaking chain-root propagation for anything chained
+    // after `Model::orderByDesc(...)` / `Model::orderByRaw(...)`.
+    assert!(is_eloquent_static_starter("orderByDesc"));
+    assert!(is_eloquent_static_starter("orderByRaw"));
 }
 
 #[test]

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{mpsc, oneshot};
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::config::kebab_to_pascal_case;
 use crate::middleware_parser::middleware_base_alias;
@@ -3307,6 +3307,18 @@ pub enum MagicMemberKind {
     /// pivot class (`protected $pivotClass = MembershipPivot::class;`).
     /// `declaring_fqcn` is that pivot FQCN; the target is its class line.
     Pivot,
+    /// A query/Eloquent builder method reached via `__call`/`forwardCallTo`
+    /// (`Model::orderByDesc(...)`, `->where(...)`) that isn't declared on the
+    /// model or its class hierarchy at all. Unlike `PlainMember`, this is
+    /// deliberately NOT dropped as Intelephense's territory: without a
+    /// generated `_ide_helper.php`, Intelephense has no way to see the
+    /// `Model`/`Eloquent\Builder` → `Query\Builder` forwarding either, so
+    /// hovering these is a real gap this LSP can close on its own —
+    /// `declaring_fqcn` names the REAL vendor class the method lives on
+    /// (`Illuminate\Database\Query\Builder`, usually), sourced straight from
+    /// vendor code via [`crate::laravel_introspector::BuilderMethodIndex`],
+    /// no ide-helper stubs required.
+    BuilderMethod,
     /// Generic (non-magic) property on a resolved class.
     PlainMember,
 }
@@ -3689,6 +3701,15 @@ pub struct MagicMemberHoverData {
     /// so invisible to the source-only `ClassView`). The main side must confirm
     /// it against migrations/DB before rendering, and skip the card otherwise.
     pub tentative: bool,
+    /// For `MagicMemberKind::BuilderMethod` only: the real vendor signature
+    /// (e.g. `public function orderByDesc($column, $order = 'desc')`), pulled
+    /// straight from `BuilderMethodIndex` — no `decl_file`/`decl_line` snippet
+    /// extraction applies here, the text is already extracted. `None` for
+    /// every other kind.
+    pub builder_signature: Option<String>,
+    /// For `MagicMemberKind::BuilderMethod` only: the method's PHPDoc summary
+    /// line, if vendor source has one. `None` for every other kind.
+    pub builder_summary: Option<String>,
 }
 
 /// Resolution result for renaming a magic member (M7). Crosses the async
@@ -5182,6 +5203,12 @@ pub enum SalsaRequest {
         path: PathBuf,
         line: u32,
         column: u32,
+        /// The caller's already-cached per-root builder-method surface (real
+        /// vendor signatures for `__call`-forwarded Eloquent/Query builder
+        /// methods), so a builder-forwarded member like `orderByDesc` can get
+        /// a real hover card instead of nothing. `None` when the caller
+        /// couldn't build one (e.g. vendor/ absent).
+        builder_index: Option<Arc<crate::laravel_introspector::BuilderMethodIndex>>,
         reply: oneshot::Sender<Option<MagicMemberHoverData>>,
     },
 
@@ -6056,11 +6083,18 @@ impl SalsaHandle {
 
     /// Resolve + classify the magic member at `(line, column)` for a hover card
     /// (M6). `Ok(None)` when the position isn't a resolvable magic member.
+    ///
+    /// `builder_index`: the caller's cached per-root builder-method surface
+    /// (see `Backend::get_builder_method_index`), passed through so a
+    /// `__call`-forwarded Eloquent/Query builder method (`orderByDesc`, …)
+    /// can render a real card. `None` when the caller has none available or
+    /// doesn't want the fallback (goto/rename/references never do).
     pub async fn resolve_magic_member_at(
         &self,
         path: PathBuf,
         line: u32,
         column: u32,
+        builder_index: Option<Arc<crate::laravel_introspector::BuilderMethodIndex>>,
     ) -> Result<Option<MagicMemberHoverData>, &'static str> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
@@ -6068,6 +6102,7 @@ impl SalsaHandle {
                 path,
                 line,
                 column,
+                builder_index,
                 reply: reply_tx,
             })
             .await
@@ -7299,9 +7334,15 @@ impl SalsaActor {
                     path,
                     line,
                     column,
+                    builder_index,
                     reply,
                 } => {
-                    let result = self.handle_resolve_magic_member_at(&path, line, column);
+                    let result = self.handle_resolve_magic_member_at(
+                        &path,
+                        line,
+                        column,
+                        builder_index.as_deref(),
+                    );
                     let _ = reply.send(result);
                 }
                 SalsaRequest::ResolveFacadeReceiverAt {
@@ -8925,6 +8966,8 @@ impl SalsaActor {
                 &resolver,
                 &classviews,
                 &project_root,
+                None, // find-references never wants a builder-method fallback —
+                // vendor-forwarded methods aren't renameable/referenceable.
                 None, // query-time path — no dependency recording
             ) {
                 // find-references threshold: HIGH + MEDIUM.
@@ -8964,12 +9007,25 @@ impl SalsaActor {
         path: &PathBuf,
         line: u32,
         column: u32,
+        builder_index: Option<&crate::laravel_introspector::BuilderMethodIndex>,
     ) -> Option<MagicMemberHoverData> {
         let patterns = self.handle_get_patterns(path)?;
         let member_ref = match patterns.find_at_position(line, column) {
             Some(PatternAtPosition::MemberAccess(m)) => m,
-            _ => return None,
+            _ => {
+                info!(
+                    "🪄 hover_for_magic_member: no MemberAccess pattern at {:?}:{line}:{column}",
+                    path
+                );
+                return None;
+            }
         };
+        info!(
+            "🪄 hover_for_magic_member: member='{}' form={:?} builder_index={}",
+            member_ref.member,
+            member_ref.form,
+            builder_index.is_some()
+        );
         let project_root = self.config_root.clone()?;
 
         self.ensure_file_registered(path);
@@ -9001,15 +9057,28 @@ impl SalsaActor {
                 &resolver,
                 &classviews,
                 &project_root,
+                builder_index,
                 None, // query-time path — no dependency recording
             ) {
                 Some(r) if matches!(r.confidence, Confidence::High | Confidence::Medium) => {
                     (r.declaring_fqcn, r.kind, r.confidence, false)
                 }
-                Some(_) => return None,
+                Some(r) => {
+                    info!(
+                        "🪄 hover_for_magic_member: classified as {:?} but confidence {:?} too low, dropping",
+                        r.kind, r.confidence
+                    );
+                    return None;
+                }
                 // An unclassified CALL can't be a column — the tentative-column
                 // fallback below is a property-read concept.
-                None if member_ref.form.is_call() => return None,
+                None if member_ref.form.is_call() => {
+                    info!(
+                        "🪄 hover_for_magic_member: '{}' did not classify at all (call-form, no column fallback)",
+                        member_ref.member
+                    );
+                    return None;
+                }
                 None => {
                     let (fqcn, confidence) = crate::member_resolver::resolve_expression_type(
                         receiver,
@@ -9046,6 +9115,46 @@ impl SalsaActor {
                 decl_line,
                 decl_end_line: None,
                 tentative: false,
+                builder_signature: None,
+                builder_summary: None,
+            });
+        }
+
+        // A builder-forwarded method (`Model::orderByDesc(...)`, `->where(...)`):
+        // no real declaration site in the project — `declaring_fqcn` already
+        // names the real vendor class (`classify_against`'s fallback set it to
+        // the matched `ParsedMethod::source_class`), and the signature/summary
+        // come straight from `builder_index`, not a file+line snippet. Look the
+        // method back up by name (a second, cheap linear scan over the ~30-200
+        // entry merged surface) to pull those strings — `ResolvedMemberAccess`
+        // has no room to carry them through the classify step itself.
+        if kind == MagicMemberKind::BuilderMethod {
+            let (builder_signature, builder_summary) = builder_index
+                .and_then(|index| {
+                    index
+                        .merged_surface()
+                        .into_iter()
+                        .find(|m| m.name == member_ref.member)
+                })
+                .map(|m| (Some(m.signature.clone()), m.summary.clone()))
+                .unwrap_or((None, None));
+            info!(
+                "🪄 hover_for_magic_member: '{}' classified as BuilderMethod (declaring={}), signature_found={}",
+                member_ref.member,
+                declaring_fqcn,
+                builder_signature.is_some()
+            );
+            return Some(MagicMemberHoverData {
+                declaring_fqcn,
+                member: member_ref.member.clone(),
+                kind,
+                confidence,
+                decl_file: None,
+                decl_line: None,
+                decl_end_line: None,
+                tentative: false,
+                builder_signature,
+                builder_summary,
             });
         }
 
@@ -9113,6 +9222,8 @@ impl SalsaActor {
             decl_line,
             decl_end_line,
             tentative,
+            builder_signature: None,
+            builder_summary: None,
         })
     }
 
@@ -9229,6 +9340,8 @@ impl SalsaActor {
             &resolver,
             &classviews,
             &project_root,
+            None, // rename never wants a builder-method fallback — a
+            // vendor-forwarded method has no declaration here to rewrite.
             None, // query-time path — no dependency recording
         )?;
         if !matches!(resolved.confidence, Confidence::High | Confidence::Medium) {

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -2804,7 +2804,7 @@ async fn resolve_magic_member_at_classifies_static_scope_call() {
     let (line, col) = position_of(SCOPE_CALLER_SRC, "active");
 
     let data = handle
-        .resolve_magic_member_at(caller_path, line, col)
+        .resolve_magic_member_at(caller_path, line, col, None)
         .await
         .unwrap()
         .expect("scope call should resolve");
@@ -2873,7 +2873,7 @@ class C {
 
     let (line, col) = position_of(caller_src, "somethingUnknown");
     let data = handle
-        .resolve_magic_member_at(caller_path, line, col)
+        .resolve_magic_member_at(caller_path, line, col, None)
         .await
         .unwrap();
     assert!(
@@ -2928,7 +2928,7 @@ class C {
     let (line, col) = position_of(caller_src, "whereEmail");
     // Precondition: the finder itself resolves (hover/goto see it)...
     let hover = handle
-        .resolve_magic_member_at(caller_path.clone(), line, col)
+        .resolve_magic_member_at(caller_path.clone(), line, col, None)
         .await
         .unwrap()
         .expect("finder should classify for hover/goto");
@@ -2985,7 +2985,7 @@ class C {
 
     let (line, col) = position_of(caller_src, "active");
     let data = handle
-        .resolve_magic_member_at(caller_path.clone(), line, col)
+        .resolve_magic_member_at(caller_path.clone(), line, col, None)
         .await
         .unwrap()
         .expect("mid-chain scope call should resolve");
@@ -4084,7 +4084,7 @@ class Ids {
     // Cursor on the `uuid7` member token.
     let (line, col) = position_of(caller_src, "uuid7");
     let data = handle
-        .resolve_magic_member_at(caller_path, line, col)
+        .resolve_magic_member_at(caller_path, line, col, None)
         .await
         .unwrap()
         .expect("a registered macro call should resolve");
@@ -4235,7 +4235,7 @@ async fn assert_facade_method_resolves(caller_body: &str, member: &str) -> Magic
     let (_dir, handle, caller_path, caller_src) = auth_facade_e2e_project(caller_body).await;
     let (line, col) = position_of(&caller_src, member);
     let data = handle
-        .resolve_magic_member_at(caller_path, line, col)
+        .resolve_magic_member_at(caller_path, line, col, None)
         .await
         .unwrap()
         .unwrap_or_else(|| {
@@ -4371,7 +4371,7 @@ class AboutController {
     // none — `check` appears only in the call).
     let (line, col) = position_of(caller_src, "check");
     let data = handle
-        .resolve_magic_member_at(caller_path, line, col)
+        .resolve_magic_member_at(caller_path, line, col, None)
         .await
         .unwrap()
         .expect("imported `Auth::check()` must resolve, not None");
@@ -4390,7 +4390,7 @@ async fn facade_e2e_undeclared_method_degrades_to_class_never_none() {
         auth_facade_e2e_project(r#"\Auth::guard();"#).await;
     let (line, col) = position_of(&caller_src, "guard");
     let data = handle
-        .resolve_magic_member_at(caller_path, line, col)
+        .resolve_magic_member_at(caller_path, line, col, None)
         .await
         .unwrap()
         .expect("undeclared facade method must degrade, not return None");
@@ -4492,7 +4492,7 @@ class AboutController {{
 
     let (line, col) = position_of(&caller_src, member);
     let data = handle
-        .resolve_magic_member_at(caller_path, line, col)
+        .resolve_magic_member_at(caller_path, line, col, None)
         .await
         .unwrap()
         .unwrap_or_else(|| panic!("`{caller_body}` must resolve to a facade method, got None"));
@@ -4675,7 +4675,7 @@ async fn helper_chain_e2e_view_make_resolves_to_concrete_factory() {
         view_helper_e2e_project(r#"view()->make('welcome');"#).await;
     let (line, col) = position_of(&caller_src, "make");
     let data = handle
-        .resolve_magic_member_at(caller_path, line, col)
+        .resolve_magic_member_at(caller_path, line, col, None)
         .await
         .unwrap()
         .expect("`view()->make()` must resolve, not None");
@@ -4698,7 +4698,7 @@ async fn helper_chain_e2e_two_hop_render_resolves_to_concrete_implementor() {
         view_helper_e2e_project(r#"view()->make('welcome')->render();"#).await;
     let (line, col) = position_of(&caller_src, "render");
     let data = handle
-        .resolve_magic_member_at(caller_path, line, col)
+        .resolve_magic_member_at(caller_path, line, col, None)
         .await
         .unwrap()
         .expect("two-hop `view()->make()->render()` must resolve, not None");

--- a/laravel-lsp/src/tests/laravel_root_worktree_discovery.rs
+++ b/laravel-lsp/src/tests/laravel_root_worktree_discovery.rs
@@ -77,6 +77,58 @@ async fn keeps_root_when_opened_file_is_in_a_worktree_of_the_active_repo() {
 }
 
 #[tokio::test]
+async fn self_corrects_from_linked_worktree_back_to_main() {
+    // Confirmed live in a real session: once `root_path` drifted onto a
+    // linked worktree (however that happened — e.g. an agent touching a
+    // worktree file before the user opened anything in main), the original
+    // "keep current root" guard made it sticky FOREVER, because every file
+    // in either tree looks like "same repo, don't switch". A linked
+    // worktree is a point-in-time snapshot of its branch — a model class
+    // added on `main` after the worktree branched off is invisible from
+    // inside it, so hover/goto for that class silently failed for the rest
+    // of the session with no way to recover short of restarting the LSP.
+    // Opening a file that lives in `main` must pull the root back.
+    let tmp = TempDir::new().unwrap();
+
+    let main_root = tmp.path().join("project");
+    std::fs::create_dir_all(main_root.join(".git")).unwrap();
+    std::fs::write(main_root.join("composer.json"), "{}").unwrap();
+    std::fs::write(main_root.join("artisan"), "").unwrap();
+
+    let worktree_root = main_root
+        .join(".claude")
+        .join("worktrees")
+        .join("gifted-heisenberg-3c0899");
+    link_worktree(&main_root, &worktree_root, "gifted-heisenberg-3c0899");
+    std::fs::write(worktree_root.join("composer.json"), "{}").unwrap();
+    std::fs::write(worktree_root.join("artisan"), "").unwrap();
+
+    // A file that exists only in `main` (the worktree's branch never got
+    // it) — the exact shape of the real failure.
+    let file = main_root
+        .join("app")
+        .join("Models")
+        .join("ReleaseNoteGroup.php");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(&file, "<?php\n").unwrap();
+
+    let backend = backend();
+    // Root starts stuck on the linked worktree, as it would after the
+    // original hijack (or, as observed live, after startup for reasons
+    // upstream of this guard).
+    *backend.root_path.write().await = Some(worktree_root);
+
+    backend.try_discover_from_file(&file).await;
+
+    assert_eq!(
+        *backend.root_path.read().await,
+        Some(main_root),
+        "opening a file that resolves to the main worktree must self-correct \
+         back to it — a linked worktree must never be permanently sticky"
+    );
+}
+
+#[tokio::test]
 async fn switches_root_for_a_file_outside_any_known_repo() {
     // Negative control: two unrelated directories (neither is a worktree of
     // the other, and neither carries git plumbing at all) must still trigger

--- a/laravel-lsp/src/tests/laravel_root_worktree_discovery.rs
+++ b/laravel-lsp/src/tests/laravel_root_worktree_discovery.rs
@@ -1,0 +1,111 @@
+//! `try_discover_from_file` must not hijack the active Laravel project root
+//! when the discovered root is just another git worktree of the same repo
+//! (issue: opening a file inside a Claude Code agent worktree under
+//! `.claude/worktrees/<name>/` — or any manually-created sibling worktree —
+//! forced a full re-index and aborted an in-flight DB connection, because
+//! every worktree is a full checkout and therefore carries its own
+//! `composer.json` + `artisan`, tripping the "more specific root" heuristic
+//! as a false positive).
+//!
+//! `config::is_same_git_repo` (unit-tested directly in `config/tests.rs`) is
+//! the guard; this test proves it's actually wired into the call site.
+
+use crate::LaravelLanguageServer;
+use tempfile::TempDir;
+use tower_lsp::LspService;
+
+/// Mirrors the `backend()` harness in `db_provider_init_idempotency.rs`.
+fn backend() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// Turns `worktree_root` into a linked worktree of `main_root`, reproducing
+/// the on-disk layout `git worktree add` produces: a `.git` *file* in the
+/// worktree pointing at an admin dir under the main repo's
+/// `.git/worktrees/<name>/`, which names the shared `.git` dir via a
+/// `commondir` file.
+fn link_worktree(main_root: &std::path::Path, worktree_root: &std::path::Path, name: &str) {
+    let admin_dir = main_root.join(".git").join("worktrees").join(name);
+    std::fs::create_dir_all(&admin_dir).unwrap();
+    std::fs::write(admin_dir.join("commondir"), "../..\n").unwrap();
+
+    std::fs::create_dir_all(worktree_root).unwrap();
+    std::fs::write(
+        worktree_root.join(".git"),
+        format!("gitdir: {}\n", admin_dir.display()),
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn keeps_root_when_opened_file_is_in_a_worktree_of_the_active_repo() {
+    let tmp = TempDir::new().unwrap();
+
+    let main_root = tmp.path().join("project");
+    std::fs::create_dir_all(main_root.join(".git")).unwrap();
+    std::fs::write(main_root.join("composer.json"), "{}").unwrap();
+    std::fs::write(main_root.join("artisan"), "").unwrap();
+
+    // A nested worktree, the shape Claude Code creates for agent branches.
+    let worktree_root = main_root
+        .join(".claude")
+        .join("worktrees")
+        .join("gifted-heisenberg-3c0899");
+    link_worktree(&main_root, &worktree_root, "gifted-heisenberg-3c0899");
+    std::fs::write(worktree_root.join("composer.json"), "{}").unwrap();
+    std::fs::write(worktree_root.join("artisan"), "").unwrap();
+
+    let file = worktree_root
+        .join("app")
+        .join("Notifications")
+        .join("ReleaseNotification.php");
+    std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+    std::fs::write(&file, "<?php\n").unwrap();
+
+    let backend = backend();
+    *backend.root_path.write().await = Some(main_root.clone());
+
+    backend.try_discover_from_file(&file).await;
+
+    assert_eq!(
+        *backend.root_path.read().await,
+        Some(main_root),
+        "a file opened inside a worktree of the already-active repo must not \
+         switch the project root — same project, not a nested one"
+    );
+}
+
+#[tokio::test]
+async fn switches_root_for_a_file_outside_any_known_repo() {
+    // Negative control: two unrelated directories (neither is a worktree of
+    // the other, and neither carries git plumbing at all) must still trigger
+    // the pre-existing "file outside root" switch — the new guard only
+    // suppresses the same-repo-worktree case, nothing else.
+    let tmp = TempDir::new().unwrap();
+
+    let root_a = tmp.path().join("project-a");
+    std::fs::create_dir_all(&root_a).unwrap();
+    std::fs::write(root_a.join("composer.json"), "{}").unwrap();
+    std::fs::write(root_a.join("artisan"), "").unwrap();
+
+    let root_b = tmp.path().join("project-b");
+    std::fs::create_dir_all(&root_b).unwrap();
+    std::fs::write(root_b.join("composer.json"), "{}").unwrap();
+    std::fs::write(root_b.join("artisan"), "").unwrap();
+    let file_b = root_b.join("routes").join("web.php");
+    std::fs::create_dir_all(file_b.parent().unwrap()).unwrap();
+    std::fs::write(&file_b, "<?php\n").unwrap();
+
+    let backend = backend();
+    *backend.root_path.write().await = Some(root_a);
+
+    backend.try_discover_from_file(&file_b).await;
+
+    assert_eq!(
+        *backend.root_path.read().await,
+        Some(root_b),
+        "an unrelated project outside the current root must still switch, \
+         same as before this fix"
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -31,6 +31,7 @@ mod helper_identifier_hover;
 mod inertia_code_action;
 mod inertia_completion_context;
 mod inertia_handler;
+mod laravel_root_worktree_discovery;
 mod livewire_component_resolution;
 mod livewire_tag_navigation_containment;
 mod loop_variable_resolution;


### PR DESCRIPTION
## Summary

Four related fixes, all stemming from one investigation: the LSP was silently misbehaving whenever a git worktree (e.g. a Claude Code agent worktree under `.claude/worktrees/<name>/`) sat alongside the main checkout.

- **Root-hijack fix**: opening a file inside a linked worktree no longer forces a full re-index and aborts an in-flight DB connection — every worktree carries its own `composer.json`/`artisan` (it's a full checkout), which previously tripped the "more specific root" heuristic as a false positive.
- **Gitignored-config fallback**: `.env`, `.env.local`, and `docker-compose.override.yml` are gitignored, so a linked worktree never has its own copy. DB config resolution and Sail port detection now fall back to the main worktree's copy when the local one is missing.
- **Root self-correction**: the same-repo-worktree guard was symmetric — once `root_path` landed on a linked worktree (by any path), it stayed there forever, since every file in either tree looked like "same repo, don't switch." Confirmed live: a model class added on `main` after a worktree branched off was invisible from inside it, breaking hover/goto for the rest of the session. The guard now only refuses `main → linked worktree` switches (the original hijack); `linked worktree → main` is welcomed as a self-correction.
- **Real hover for forwarded builder methods**: without `laravel-ide-helper`, Intelephense can't see `Model`/`Eloquent Builder`'s `__call` forwarding to `Query\Builder` either, so plain builder methods (`orderByDesc`, `where`, `first`, ...) got no hover from either tool. `MagicMemberKind::BuilderMethod` now falls back to the project's real, parsed vendor Builder surface (already built for `Model::|` completion) when nothing in the model's own hierarchy declares the called member — real vendor signature + PHPDoc summary, no ide-helper required. Scoped to hover only; goto/rename/find-references keep their exact prior behavior. Also fixed `orderByDesc`/`orderByRaw` being missing from `ELOQUENT_STATIC_STARTERS` (their `orderBy` sibling was present), which silently broke chain-root propagation for anything chained after them.

## Test plan

- [x] Full suite green (2278 lib + 480 bin + 80 doc tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Every new guard mutation-tested (temporarily disabling each fix's core condition turns its regression test red, confirmed, then restored)
- [x] Root self-correction fix verified against the real `decisioncloud` repo's actual worktree layout (same machine access) — confirmed `is_same_git_repo`/`is_main_worktree` behave correctly against real `git worktree add` output, and reproduced the actual failure (`ReleaseNoteGroup.php` missing from the worktree) that explained why hover was still failing after the first three fixes
- [x] Manually verified end-to-end in Zed against the real `decisioncloud` project — hover now works for `orderByDesc`