### PR TITLE
fix: 🐛 resolve loadViewsFrom __DIR__-relative paths against the provider directory

### DIFF
--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -1707,6 +1707,16 @@ pub struct ParsedServiceProvider<'db> {
     pub anonymous_component_namespaces: Vec<ParsedAnonymousComponentNamespaceReg<'db>>,
 }
 
+/// Resolve the relative fragment captured from a
+/// `loadViewsFrom(__DIR__ . '<rel>', 'ns')` registration against the
+/// provider's directory. The capture keeps its leading slash
+/// ("/../resources/views"), and `Path::join` REPLACES the receiver when
+/// handed an absolute path — strip it, or every `__DIR__.'/…'` registration
+/// resolves to a nonsense root-relative path.
+fn resolve_load_views_relative(provider_dir: &Path, relative: &str) -> PathBuf {
+    provider_dir.join(relative.trim_start_matches('/').trim_start_matches("./"))
+}
+
 /// Parse a service provider file and extract middleware, bindings, views, and components
 #[salsa::tracked]
 pub fn parse_service_provider_source<'db>(
@@ -1964,7 +1974,7 @@ pub fn parse_service_provider_source<'db>(
             // Resolve __DIR__ + relative path
             // __DIR__ is the directory containing the service provider file
             let provider_dir = path.parent().unwrap_or(path.as_path());
-            let view_path = provider_dir.join(relative_path_str);
+            let view_path = resolve_load_views_relative(provider_dir, relative_path_str);
             let resolved_path = if view_path.exists() {
                 Some(view_path.canonicalize().unwrap_or(view_path))
             } else {

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -4982,3 +4982,28 @@ async fn both_constructors_agree_on_php_use_class_refs() {
         "warm and on-demand constructors disagree"
     );
 }
+
+// ─── loadViewsFrom() __DIR__-relative path resolution ──────────────────────
+//
+// The `LOAD_VIEWS_RE` capture keeps the leading slash of the concatenated
+// fragment (`__DIR__ . '/../resources/views'` captures "/../resources/views"),
+// and `Path::join` REPLACES its receiver when handed an absolute path — so
+// every `loadViewsFrom(__DIR__.'…')` registration silently resolved to a
+// root-relative nonsense path and the namespace never worked.
+
+#[test]
+fn load_views_relative_fragment_resolves_against_provider_dir() {
+    let provider_dir = PathBuf::from("/pkg/src/Providers");
+    assert_eq!(
+        resolve_load_views_relative(&provider_dir, "/../../resources/views"),
+        PathBuf::from("/pkg/src/Providers/../../resources/views")
+    );
+    assert_eq!(
+        resolve_load_views_relative(&provider_dir, "/views"),
+        PathBuf::from("/pkg/src/Providers/views")
+    );
+    assert_eq!(
+        resolve_load_views_relative(&provider_dir, "./views"),
+        PathBuf::from("/pkg/src/Providers/views")
+    );
+}


### PR DESCRIPTION
`LOAD_VIEWS_RE`'s path capture keeps the leading slash of the concatenated fragment — `loadViewsFrom(__DIR__ . '/../resources/views', 'courier')` captures `"/../resources/views"` — and Rust's `Path::join` **replaces** its receiver when handed an absolute path. Every `__DIR__`-relative registration therefore resolved to a nonsense root-relative path, so the registered namespace never matched a real directory: `view('ns::…')` goto/diagnostics, `<x-ns::…>` anonymous components, and namespaced view completion were dead for app and vendor providers alike.

Easy to confirm on any project with such a provider: the cache blob shows entries like `"courier": "/../resources/views"`.

The sibling extractors (`resolve_php_path_expr`, `vendor_translations::join_relative`) already strip the slash — this brings the `loadViewsFrom` extractor in line. The join is extracted into a small pure helper so the behavior finally has a regression test (there was none).

Full test suite green.
