### PR TITLE
fix: 🐛 stop nested module directories from hijacking the project root

### DIFF
--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -24,6 +24,14 @@ pub fn find_project_root(file_path: &Path) -> Option<PathBuf> {
         current = current.parent()?;
     }
 
+    // A composer.json + app/ + resources/ match without its own dependency
+    // tree is only *tentative*: module directories in modular monoliths
+    // (e.g. app/{Parent}/{Module}/ with a composer.json merged into the
+    // workspace manifest via composer-merge-plugin) match the same markers.
+    // Keep walking and prefer any ancestor that is unambiguously a project
+    // root; fall back to the tentative match only when no ancestor is one.
+    let mut tentative: Option<PathBuf> = None;
+
     // Walk up the directory tree
     loop {
         // Check for Laravel markers
@@ -43,15 +51,6 @@ pub fn find_project_root(file_path: &Path) -> Option<PathBuf> {
             return Some(current.to_path_buf());
         }
 
-        // Or if we find composer.json + app/ + resources/ (Laravel app)
-        if has_composer && has_app && has_resources {
-            info!(
-                "Found Laravel project root at {:?} (composer.json + app + resources)",
-                current
-            );
-            return Some(current.to_path_buf());
-        }
-
         // Or if we find composer.json + src/ + vendor/ (Laravel package)
         // This pattern recognizes Laravel package development
         if has_composer && has_src && has_vendor {
@@ -62,9 +61,36 @@ pub fn find_project_root(file_path: &Path) -> Option<PathBuf> {
             return Some(current.to_path_buf());
         }
 
+        // composer.json + app/ + resources/ (Laravel app). With a vendor/
+        // of its own it is a real installed root; without one it could be
+        // a merged nested module, so only record it and keep walking.
+        if has_composer && has_app && has_resources {
+            if has_vendor {
+                info!(
+                    "Found Laravel project root at {:?} (composer.json + app + resources + vendor)",
+                    current
+                );
+                return Some(current.to_path_buf());
+            }
+            if tentative.is_none() {
+                tentative = Some(current.to_path_buf());
+            }
+        }
+
         // Move up one directory
-        current = current.parent()?;
+        match current.parent() {
+            Some(parent) => current = parent,
+            None => break,
+        }
     }
+
+    if let Some(root) = &tentative {
+        info!(
+            "Found Laravel project root at {:?} (composer.json + app + resources; no stronger ancestor root)",
+            root
+        );
+    }
+    tentative
 }
 
 /// Resolve a directory's real git "common dir" — the directory holding the

--- a/laravel-lsp/src/config/tests.rs
+++ b/laravel-lsp/src/config/tests.rs
@@ -897,3 +897,88 @@ fn parse_facade_aliases_absent_key_yields_empty() {
     let source = "<?php return ['name' => 'Laravel'];";
     assert!(parse_facade_aliases(source).is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// find_project_root — nested-module (composer-merge-plugin) layouts
+// ---------------------------------------------------------------------------
+
+/// Lay down a minimal workspace: root with composer.json + artisan + app/ +
+/// resources/, and one module at app/Legal/GuaranteeLabel with its own
+/// composer.json + app/ + resources/ + config/ (the merge-plugin shape).
+fn modular_workspace() -> (TempDir, PathBuf, PathBuf) {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    fs::write(root.join("composer.json"), "{}").unwrap();
+    fs::write(root.join("artisan"), "").unwrap();
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::create_dir_all(root.join("resources")).unwrap();
+    fs::create_dir_all(root.join("config")).unwrap();
+
+    let module = root.join("app/Legal/GuaranteeLabel");
+    fs::create_dir_all(module.join("app/Providers")).unwrap();
+    fs::create_dir_all(module.join("resources/views")).unwrap();
+    fs::create_dir_all(module.join("config")).unwrap();
+    fs::write(module.join("composer.json"), "{}").unwrap();
+    (tmp, root, module)
+}
+
+#[test]
+fn project_root_walks_past_nested_module_to_workspace_root() {
+    let (_tmp, root, module) = modular_workspace();
+    let file = module.join("config/legal-guaranteelabel.php");
+    fs::write(&file, "<?php return [];").unwrap();
+
+    let found = find_project_root(&file).unwrap();
+    assert_eq!(found, root, "module dir must not hijack the project root");
+}
+
+#[test]
+fn project_root_keeps_nested_app_with_its_own_artisan() {
+    let (_tmp, _root, module) = modular_workspace();
+    fs::write(module.join("artisan"), "").unwrap();
+    let file = module.join("config/legal-guaranteelabel.php");
+    fs::write(&file, "<?php return [];").unwrap();
+
+    let found = find_project_root(&file).unwrap();
+    assert_eq!(found, module, "a genuine nested app stays its own root");
+}
+
+#[test]
+fn project_root_standalone_package_with_src_and_vendor_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let pkg = tmp.path().join("package");
+    fs::create_dir_all(pkg.join("src")).unwrap();
+    fs::create_dir_all(pkg.join("vendor")).unwrap();
+    fs::write(pkg.join("composer.json"), "{}").unwrap();
+    let file = pkg.join("src/Provider.php");
+    fs::write(&file, "<?php").unwrap();
+
+    assert_eq!(find_project_root(&file).unwrap(), pkg);
+}
+
+#[test]
+fn project_root_app_without_artisan_but_with_vendor_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let app = tmp.path().join("app-root");
+    fs::create_dir_all(app.join("app")).unwrap();
+    fs::create_dir_all(app.join("resources")).unwrap();
+    fs::create_dir_all(app.join("vendor")).unwrap();
+    fs::write(app.join("composer.json"), "{}").unwrap();
+    let file = app.join("app/Thing.php");
+    fs::write(&file, "<?php").unwrap();
+
+    assert_eq!(find_project_root(&file).unwrap(), app);
+}
+
+#[test]
+fn project_root_tentative_match_returned_without_stronger_ancestor() {
+    let tmp = TempDir::new().unwrap();
+    let app = tmp.path().join("bare-app");
+    fs::create_dir_all(app.join("app")).unwrap();
+    fs::create_dir_all(app.join("resources")).unwrap();
+    fs::write(app.join("composer.json"), "{}").unwrap();
+    let file = app.join("app/Thing.php");
+    fs::write(&file, "<?php").unwrap();
+
+    assert_eq!(find_project_root(&file).unwrap(), app);
+}

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -5952,6 +5952,23 @@ impl LaravelLanguageServer {
         if cache.has_cached_data() {
             // 1. Store cached Laravel config directly in memory (bypasses Salsa)
             if let Some(cached_config) = cache.get_laravel_config() {
+                // A cache written while the root was hijacked by a nested
+                // module directory (composer-merge-plugin layouts) would
+                // re-pin that module as the root forever. A cached root
+                // strictly inside the workspace root that is not a
+                // standalone app of its own is poisoned — discard it and
+                // fall through to a fresh rescan.
+                let cached_root_nested =
+                    cached_config.root != root && cached_config.root.starts_with(root);
+                let cached_root_standalone = cached_config.root.join("artisan").exists()
+                    || cached_config.root.join("vendor").is_dir();
+                if cached_root_nested && !cached_root_standalone {
+                    warn!(
+                        "📂 Cached Laravel root {:?} is a nested non-standalone directory inside {:?} — discarding poisoned cache and rescanning",
+                        cached_config.root, root
+                    );
+                    return vec![RescanType::Vendor, RescanType::App, RescanType::NodeModules];
+                }
                 info!(
                     "📋 Loading cached Laravel config: {} view paths, root: {:?}",
                     cached_config.view_paths.len(),
@@ -7585,11 +7602,26 @@ impl LaravelLanguageServer {
                         );
                         true
                     } else if more_specific {
-                        info!(
-                            "Discovered more specific Laravel root {:?} (current: {:?})",
-                            discovered_root, current
-                        );
-                        true
+                        // A nested directory only replaces an established
+                        // root when it is a standalone app of its own
+                        // (artisan or an installed vendor/ tree). Merged
+                        // module manifests (composer-merge-plugin layouts
+                        // like app/{Parent}/{Module}/composer.json) must
+                        // never re-root the whole server.
+                        let standalone = discovered_root.join("artisan").exists()
+                            || discovered_root.join("vendor").is_dir();
+                        if standalone {
+                            info!(
+                                "Discovered more specific Laravel root {:?} (current: {:?})",
+                                discovered_root, current
+                            );
+                        } else {
+                            debug!(
+                                "Ignoring nested non-standalone root candidate {:?} — keeping current root {:?}",
+                                discovered_root, current
+                            );
+                        }
+                        standalone
                     } else {
                         // File is within current root and discovered isn't more specific
                         debug!(


### PR DESCRIPTION
`find_project_root` accepts the **first** ancestor matching `composer.json + app/ + resources/`. In modular monoliths (composer-merge-plugin layouts — `app/{Parent}/{Module}/` with per-module `composer.json` merged into the workspace manifest), every module matches those markers. Opening any module file re-roots the entire server onto the module directory: `.env` resolution, route/migration/command indexes, DB config, the vendor scan, and the file watchers all point at a subdirectory — and the poisoned root is persisted into the disk cache, pinning it across sessions. (In the repo that surfaced this, 38 of 46 modules matched the markers.)

Three coordinated changes, all covered by new tests:

- `find_project_root`: a `composer.json + app + resources` match **without its own `vendor/`** is only tentative; the walk continues and prefers any ancestor that is unambiguously a root (`artisan`, or an installed dependency tree). The tentative match is returned only when no stronger ancestor exists — standalone apps and package checkouts resolve exactly as before.
- `try_discover_from_file`: a nested candidate only replaces an established root when it is a standalone app of its own.
- `load_cache_data`: a cached root strictly inside the workspace root that is not standalone is recognised as poisoned, discarded, and a full rescan triggered — existing caches self-heal on the next start.

Full test suite green.
