### PR TITLE
feat: ✨ show every locale's value in the translation hover

### DIFF
--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -205,6 +205,34 @@ pub fn translation_card(
     })
 }
 
+/// Multi-locale variant of [`translation_card`]: one value line per locale
+/// that defines the key, each with its own source link, so a `de` + `en`
+/// catalogue shows both translations at once. Locales that don't define the
+/// key are skipped; when none does, the not-found trailer renders instead.
+pub fn translation_card_locales(
+    key: &str,
+    entries: &[(String, Option<String>, Option<String>)],
+) -> String {
+    let mut body = format!("`{}`", leaf_segment(key));
+    let mut any = false;
+    for (locale, value, source_link) in entries {
+        let Some(value) = value else {
+            continue;
+        };
+        any = true;
+        body.push_str(&format!("\n\n**{locale}** — “{value}”"));
+        if let Some(link) = source_link {
+            body.push_str("\n\n");
+            body.push_str(link);
+        }
+    }
+    if !any {
+        body.push_str("\n\n");
+        body.push_str(TRANSLATION_NOT_FOUND_TRAILER);
+    }
+    body
+}
+
 /// The leaf of a translation key: the last `.`-segment, after dropping any
 /// `namespace::` prefix. `app::notification.task.title` → `title`,
 /// `messages.welcome` → `welcome`, a spaced JSON text key → unchanged.

--- a/laravel-lsp/src/hover/tests.rs
+++ b/laravel-lsp/src/hover/tests.rs
@@ -726,3 +726,39 @@ fn translation_card_without_value_shows_not_found_trailer() {
         format!("`key` · en\n\n{TRANSLATION_NOT_FOUND_TRAILER}")
     );
 }
+
+#[test]
+fn translation_card_locales_renders_every_defined_locale() {
+    let card = translation_card_locales(
+        "legal::contract.prefill.failed_title",
+        &[
+            (
+                "de".to_string(),
+                Some("Analyse fehlgeschlagen".to_string()),
+                Some("[lang/de/contract.php](file:///x)".to_string()),
+            ),
+            (
+                "en".to_string(),
+                Some("Analysis failed".to_string()),
+                Some("[lang/en/contract.php](file:///y)".to_string()),
+            ),
+        ],
+    );
+    assert!(card.starts_with("`failed_title`"));
+    assert!(card.contains("**de** — “Analyse fehlgeschlagen”"));
+    assert!(card.contains("**en** — “Analysis failed”"));
+    assert!(card.contains("[lang/de/contract.php](file:///x)"));
+}
+
+#[test]
+fn translation_card_locales_skips_missing_and_falls_back_to_trailer() {
+    let card = translation_card_locales(
+        "messages.welcome",
+        &[
+            ("de".to_string(), None, None),
+            ("en".to_string(), None, None),
+        ],
+    );
+    assert!(card.contains(TRANSLATION_NOT_FOUND_TRAILER));
+    assert!(!card.contains("**de**"));
+}

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -20000,33 +20000,79 @@ return [
     /// (outer quotes stripped) in a plain code block, link to the lang file.
     async fn hover_for_translation(&self, key: &str, root: Option<&Path>) -> String {
         use laravel_lsp::hover;
-        let locale = "en";
-        let resolution = match root {
-            Some(r) => {
-                let vendor_map = self.vendor_translation_namespaces_for(r).await;
-                let map_ref = vendor_map.as_ref().map(|m| m.as_ref());
-                laravel_lsp::translation_lookup::resolve_translation_detailed(
-                    r, key, locale, map_ref,
-                )
+        let Some(r) = root else {
+            return hover::translation_card(key, "en", None, None);
+        };
+        let vendor_map = self.vendor_translation_namespaces_for(r).await;
+        let map_ref = vendor_map.as_ref().map(|m| m.as_ref());
+
+        // Every locale that could define the key: the locale directories
+        // (and `{locale}.json` catalogues) of the key's lang dir(s) — the
+        // published vendor override plus the registered namespace dir for
+        // namespaced keys, the project lang dirs otherwise.
+        let mut lang_dirs: Vec<PathBuf> = Vec::new();
+        if let Some((namespace, _)) = key.split_once("::") {
+            lang_dirs.push(r.join("lang/vendor").join(namespace));
+            if let Some(dir) = map_ref.and_then(|m| m.get(namespace)) {
+                lang_dirs.push(dir.clone());
             }
-            None => None,
-        };
-        let link = match &resolution {
-            Some(res) => Some(self.source_link(&res.source_file, None).await),
-            None => None,
-        };
-        // Translation values are PHP literals (`'foo'`) — strip the outer
-        // quotes and cap the length for in-block display.
-        let value = resolution.as_ref().map(|r| {
-            let v = r.value.trim();
-            let unquoted = v
-                .strip_prefix('\'')
-                .and_then(|s| s.strip_suffix('\''))
-                .or_else(|| v.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
-                .unwrap_or(v);
-            hover::truncate_for_display(unquoted, 200)
-        });
-        hover::translation_card(key, locale, value.as_deref(), link.as_deref())
+        } else {
+            lang_dirs.push(r.join("lang"));
+            lang_dirs.push(r.join("resources/lang"));
+        }
+        let mut locales: Vec<String> = Vec::new();
+        for dir in &lang_dirs {
+            let Ok(dir_entries) = std::fs::read_dir(dir) else {
+                continue;
+            };
+            for entry in dir_entries.flatten() {
+                let path = entry.path();
+                let locale = if path.is_dir() {
+                    path.file_name()
+                        .and_then(|n| n.to_str())
+                        .map(str::to_string)
+                } else if path.extension().is_some_and(|e| e == "json") {
+                    path.file_stem()
+                        .and_then(|n| n.to_str())
+                        .map(str::to_string)
+                } else {
+                    None
+                };
+                if let Some(locale) = locale {
+                    if locale != "vendor" && !locales.contains(&locale) {
+                        locales.push(locale);
+                    }
+                }
+            }
+        }
+        locales.sort();
+        if locales.is_empty() {
+            locales.push("en".to_string());
+        }
+
+        let mut entries: Vec<(String, Option<String>, Option<String>)> = Vec::new();
+        for locale in &locales {
+            let resolution = laravel_lsp::translation_lookup::resolve_translation_detailed(
+                r, key, locale, map_ref,
+            );
+            let link = match &resolution {
+                Some(res) => Some(self.source_link(&res.source_file, None).await),
+                None => None,
+            };
+            // Translation values are PHP literals (`'foo'`) — strip the outer
+            // quotes and cap the length for in-block display.
+            let value = resolution.as_ref().map(|res| {
+                let v = res.value.trim();
+                let unquoted = v
+                    .strip_prefix('\'')
+                    .and_then(|s| s.strip_suffix('\''))
+                    .or_else(|| v.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
+                    .unwrap_or(v);
+                hover::truncate_for_display(unquoted, 200)
+            });
+            entries.push((locale.clone(), value, link));
+        }
+        hover::translation_card_locales(key, &entries)
     }
 
     /// Middleware — header is the alias's class FQN (the new info beyond


### PR DESCRIPTION
The translation hover hardcodes locale `"en"`. A project maintaining `de` + `en` catalogues only ever sees the English value, and a key defined solely in a non-English locale renders as *not found*.

The hover now discovers which locales could define the key — the locale directories (and `{locale}.json` catalogues) of the key's lang dir(s): the published vendor override plus the registered namespace dir for namespaced keys, the project lang dirs otherwise — resolves the key per locale, and renders one line per defining locale with its own source link:

> `failed_title`
> **de** — "Analyse fehlgeschlagen" · [lang/de/contract.php]
> **en** — "Analysis failed" · [lang/en/contract.php]

Locales that don't define the key are skipped; when none does, the existing not-found trailer renders unchanged, as does the no-root fallback.

Full test suite green.
