### PR TITLE
fix: 🐛 Recognize realpath, path-helper, and spaced loadViewsFrom forms

### DIFF
--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -89,6 +89,7 @@ pub mod magic_disk_cache;
 pub mod naming;
 pub mod parser;
 pub mod path_containment;
+pub mod path_join;
 pub mod pattern_disk_cache;
 pub mod pattern_indexer;
 pub mod php_class;

--- a/laravel-lsp/src/path_join.rs
+++ b/laravel-lsp/src/path_join.rs
@@ -1,0 +1,159 @@
+//! Join a relative path fragment captured from PHP source onto a base
+//! directory — the single source of truth for the "strip, then join" rule.
+//!
+//! PHP registrations concatenate a directory base with a string literal
+//! (`__DIR__ . '/../resources/views'`, `resource_path('views/vendor/ns')`), and
+//! the captured fragment keeps its leading separator. Rust's [`Path::join`]
+//! treats a leading separator as rooted and **discards the receiver**, so
+//! joining a captured fragment verbatim silently yields a root-relative path
+//! that resolves to nothing — the namespace looks registered and never
+//! resolves (issue #285).
+//!
+//! The rule previously lived in four copies across `vendor_translations` and
+//! `salsa_impl`, two of which also stripped a leading `./` (issue #290).
+//!
+//! **On the `./` strip.** On Unix it is a no-op: `Path`'s component iterator
+//! normalizes `.` away, so `/pkg/./views` and `/pkg/views` compare, normalize,
+//! and resolve identically. It is *not* a no-op on Windows — `std::path`
+//! preserves `.` as a real `CurDir` component inside a **verbatim** path
+//! (`\\?\C:\...`), and Windows hands verbatim paths to the OS without
+//! normalizing them, so a stray `.` simply fails to resolve. `canonicalize`
+//! returns verbatim paths on Windows, so such a base is reachable here. The
+//! strip therefore stays.
+//!
+//! Separator matching goes through [`std::path::is_separator`], which is `/`
+//! on Unix and `/` or `\` on Windows — so a `\`-prefixed fragment, which is
+//! rooted on Windows and an ordinary filename character on Unix, is handled
+//! correctly on each without a `cfg`.
+
+use std::path::{Path, PathBuf};
+
+/// Join a relative fragment captured from PHP source onto `base`.
+///
+/// Strips leading separators and `./` segments so the fragment stays relative;
+/// without that, `Path::join` discards `base` entirely. The strip **loops**
+/// because one pass can expose a fresh leading separator — `".//views"`
+/// becomes `"/views"` after a single `./` removal, which would discard `base`
+/// again. On return the fragment begins with neither, so the join always
+/// extends `base`.
+///
+/// A leading `..` is preserved: `__DIR__ . '/../x'` genuinely means the parent
+/// directory, and callers collapse it with
+/// [`crate::route_discovery::normalize_path`] or `canonicalize`.
+pub fn join_relative(base: &Path, rel: &str) -> PathBuf {
+    let mut rel = rel;
+    loop {
+        let stripped = rel.trim_start_matches(std::path::is_separator);
+        // A `.` only counts as a current-directory segment when a separator
+        // follows it — otherwise `..` would lose a dot.
+        let stripped = match stripped.strip_prefix('.') {
+            Some(rest) if rest.starts_with(std::path::is_separator) => rest,
+            _ => stripped,
+        };
+        if stripped.len() == rel.len() {
+            break;
+        }
+        rel = stripped;
+    }
+    base.join(rel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_leading_slash_so_base_is_kept() {
+        assert_eq!(
+            join_relative(Path::new("/pkg/src/Providers"), "/../resources/views"),
+            PathBuf::from("/pkg/src/Providers/../resources/views")
+        );
+    }
+
+    #[test]
+    fn preserves_parent_dir_segments() {
+        assert_eq!(
+            join_relative(Path::new("/pkg/src"), "../resources/views"),
+            PathBuf::from("/pkg/src/../resources/views")
+        );
+    }
+
+    #[test]
+    fn plain_relative_fragment_is_unchanged() {
+        assert_eq!(
+            join_relative(Path::new("/pkg"), "resources/views"),
+            PathBuf::from("/pkg/resources/views")
+        );
+    }
+
+    /// The assertions that shipped with #285 as
+    /// `load_views_relative_fragment_resolves_against_provider_dir`, retained
+    /// verbatim against the promoted shared helper.
+    #[test]
+    fn load_views_relative_fragment_resolves_against_provider_dir() {
+        let provider_dir = PathBuf::from("/pkg/src/Providers");
+        assert_eq!(
+            join_relative(&provider_dir, "/../../resources/views"),
+            PathBuf::from("/pkg/src/Providers/../../resources/views")
+        );
+        assert_eq!(
+            join_relative(&provider_dir, "/views"),
+            PathBuf::from("/pkg/src/Providers/views")
+        );
+        assert_eq!(
+            join_relative(&provider_dir, "./views"),
+            PathBuf::from("/pkg/src/Providers/views")
+        );
+    }
+
+    /// Pins the Windows-verbatim contract described in the module docs — and
+    /// discriminates on every platform besides, since the `.` strip runs after
+    /// the separator strip and so exposes a separator that only the loop
+    /// re-trims.
+    #[test]
+    fn strips_leading_dot_slash() {
+        assert_eq!(
+            join_relative(Path::new("/pkg/src"), "./views"),
+            PathBuf::from("/pkg/src/views")
+        );
+    }
+
+    /// A single strip pass turns `.//views` into `/views`, which `Path::join`
+    /// then treats as rooted and uses to discard `base` — a fail-open the
+    /// `./` strip itself would otherwise manufacture, on every platform.
+    #[test]
+    fn repeated_strip_never_leaves_a_rooted_fragment() {
+        for rel in [".//views", "//views", "././views", "/./views"] {
+            let joined = join_relative(Path::new("/pkg/src"), rel);
+            assert!(
+                joined.starts_with("/pkg/src"),
+                "fragment {rel:?} discarded the base, yielding {joined:?}"
+            );
+        }
+    }
+
+    /// `is_separator` is platform-defined: a `\\`-prefixed fragment is rooted on
+    /// Windows and an ordinary filename on Unix. One assertion per platform.
+    #[cfg(unix)]
+    #[test]
+    fn backslash_fragment_is_an_ordinary_filename_on_unix() {
+        assert_eq!(
+            join_relative(Path::new("/pkg"), "\\views"),
+            PathBuf::from("/pkg/\\views")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn backslash_fragment_is_stripped_on_windows() {
+        assert_eq!(
+            join_relative(Path::new(r"C:\pkg"), r"\views"),
+            PathBuf::from(r"C:\pkg\views")
+        );
+    }
+
+    #[test]
+    fn empty_fragment_yields_the_base() {
+        assert_eq!(join_relative(Path::new("/pkg"), ""), PathBuf::from("/pkg"));
+    }
+}

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -24,6 +24,10 @@ use crate::config::kebab_to_pascal_case;
 use crate::middleware_parser::middleware_base_alias;
 use crate::parser::{language_php, parse_php};
 use crate::queries::extract_all_php_patterns;
+// Single source of truth for the strip-then-join rule applied to relative
+// fragments captured from PHP source — a leading `/` would otherwise make
+// `Path::join` discard the base directory (issues #285, #290).
+use crate::path_join::join_relative;
 // Single source of truth for lexical path normalization. The local copy this
 // replaced popped unconditionally on `..`, so a `..` walking past root would
 // pop the `RootDir` component and silently relativize an absolute path (#117).
@@ -1707,16 +1711,6 @@ pub struct ParsedServiceProvider<'db> {
     pub anonymous_component_namespaces: Vec<ParsedAnonymousComponentNamespaceReg<'db>>,
 }
 
-/// Resolve the relative fragment captured from a
-/// `loadViewsFrom(__DIR__ . '<rel>', 'ns')` registration against the
-/// provider's directory. The capture keeps its leading slash
-/// ("/../resources/views"), and `Path::join` REPLACES the receiver when
-/// handed an absolute path — strip it, or every `__DIR__.'/…'` registration
-/// resolves to a nonsense root-relative path.
-fn resolve_load_views_relative(provider_dir: &Path, relative: &str) -> PathBuf {
-    provider_dir.join(relative.trim_start_matches('/').trim_start_matches("./"))
-}
-
 /// Parse a service provider file and extract middleware, bindings, views, and components
 #[salsa::tracked]
 pub fn parse_service_provider_source<'db>(
@@ -1733,9 +1727,22 @@ pub fn parse_service_provider_source<'db>(
             r#"\$this->app->alias\s*\(\s*\\?([A-Za-z0-9_\\]+)(?:::class)?\s*,\s*['"]([^'"]+)['"]\s*\)"#
         ).unwrap();
 
-        /// Matches $this->loadViewsFrom(__DIR__.'/../path', 'namespace')
+        /// Matches `$this->loadViewsFrom(<path expression>, 'namespace')` with
+        /// arbitrary whitespace around the `->` (Pint puts a fluent `->` on its
+        /// own line). The first argument is captured whole and handed to
+        /// [`resolve_php_path_expr`], so `__DIR__ . '/rel'`,
+        /// `realpath(__DIR__ . '/rel')` and `resource_path('views/vendor/ns')`
+        /// all resolve through one path rather than a pattern each.
+        ///
+        /// Receivers other than `$this` (`static::`, `$this->app->`) are
+        /// deliberately NOT matched: the framework resolves those against a
+        /// different object, and guessing a directory for them would register
+        /// a wrong path rather than none. Runtime-computed arguments
+        /// (`loadViewsFrom($dir, $name)`) stay out of reach lexically — the
+        /// builder-convention reconstruction further down covers the common
+        /// package case.
         static ref LOAD_VIEWS_RE: Regex = Regex::new(
-            r#"\$this->loadViewsFrom\s*\(\s*__DIR__\s*\.\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]+)['"]\s*\)"#
+            r#"\$this\s*->\s*loadViewsFrom\s*\(\s*(.+?)\s*,\s*['"]([^'"]+)['"]\s*\)"#
         ).unwrap();
 
         /// Matches a class-backed component registration with the tag first:
@@ -1962,38 +1969,43 @@ pub fn parse_service_provider_source<'db>(
         }
     }
 
-    // Parse loadViewsFrom() registrations
-    // Example: $this->loadViewsFrom(__DIR__.'/../resources/views', 'courier')
-    for cap in LOAD_VIEWS_RE.captures_iter(text) {
-        if let (Some(relative_path), Some(namespace)) = (cap.get(1), cap.get(2)) {
-            let relative_path_str = relative_path.as_str();
-            let namespace_str = namespace.as_str();
+    // Parse loadViewsFrom() registrations. The first argument is captured as
+    // a whole expression and resolved by `resolve_php_path_expr`, so every
+    // supported shape goes through one path:
+    //   $this->loadViewsFrom(__DIR__ . '/../resources/views', 'courier')
+    //   $this->loadViewsFrom(realpath(__DIR__ . '/../views'), 'courier')
+    //   $this->loadViewsFrom(resource_path('views/vendor/shop'), 'shop')
+    // See the notes on LOAD_VIEWS_RE for the shapes deliberately left
+    // unmatched, and why registering nothing beats registering a guess.
+    let provider_dir = path.parent().unwrap_or(path.as_path());
+    let registrations = LOAD_VIEWS_RE.captures_iter(text).filter_map(|cap| {
+        let (expr, namespace) = (cap.get(1)?, cap.get(2)?);
+        Some((
+            resolve_php_path_expr(expr.as_str(), &root, provider_dir)?,
+            namespace,
+        ))
+    });
 
-            let line = text[..namespace.start()].lines().count() as u32;
+    for (view_path, namespace) in registrations {
+        let line = text[..namespace.start()].lines().count() as u32;
+        let resolved_path = if view_path.exists() {
+            Some(view_path.canonicalize().unwrap_or(view_path))
+        } else {
+            // For non-existent paths, store the normalized form so the
+            // diagnostic can show the expected location even if it
+            // doesn't resolve on disk yet.
+            Some(normalize_path(&view_path))
+        };
 
-            // Resolve __DIR__ + relative path
-            // __DIR__ is the directory containing the service provider file
-            let provider_dir = path.parent().unwrap_or(path.as_path());
-            let view_path = resolve_load_views_relative(provider_dir, relative_path_str);
-            let resolved_path = if view_path.exists() {
-                Some(view_path.canonicalize().unwrap_or(view_path))
-            } else {
-                // For non-existent paths, store the normalized form so the
-                // diagnostic can show the expected location even if it
-                // doesn't resolve on disk yet.
-                Some(normalize_path(&view_path))
-            };
-
-            let pkg_namespace = PackageNamespace::new(db, namespace_str.to_string());
-            view_namespaces.push(ParsedViewNamespaceReg::new(
-                db,
-                pkg_namespace,
-                resolved_path,
-                line,
-                priority,
-                path.clone(),
-            ));
-        }
+        let pkg_namespace = PackageNamespace::new(db, namespace.as_str().to_string());
+        view_namespaces.push(ParsedViewNamespaceReg::new(
+            db,
+            pkg_namespace,
+            resolved_path,
+            line,
+            priority,
+            path.clone(),
+        ));
     }
 
     // Parse imperative View-factory namespace registrations:
@@ -2841,9 +2853,19 @@ fn resolve_php_path_expr(expr: &str, root: &Path, provider_dir: &Path) -> Option
         ).unwrap();
         /// A bare string literal.
         static ref LITERAL_RE: Regex = Regex::new(r#"^['"]([^'"]+)['"]$"#).unwrap();
+        /// `realpath(<expr>)` — unwrapped and resolved as its inner expression.
+        static ref REALPATH_RE: Regex = Regex::new(r#"^realpath\s*\(\s*(.+?)\s*\)$"#).unwrap();
     }
 
     let expr = expr.trim();
+
+    // `realpath(X)` is a pure syntactic pass-through here: it resolves exactly
+    // as `X` does. PHP's runtime behaviour — following symlinks, returning
+    // `false` for a missing path — is out of scope for a static pass, which
+    // never touches the filesystem to decide what a registration names.
+    if let Some(cap) = REALPATH_RE.captures(expr) {
+        return resolve_php_path_expr(cap.get(1).unwrap().as_str(), root, provider_dir);
+    }
 
     if let Some(cap) = HELPER_RE.captures(expr) {
         let helper = cap.get(1).unwrap().as_str();
@@ -2862,14 +2884,14 @@ fn resolve_php_path_expr(expr: &str, root: &Path, provider_dir: &Path) -> Option
         let joined = if sub.is_empty() {
             base
         } else {
-            base.join(sub.trim_start_matches('/'))
+            join_relative(&base, sub)
         };
         return Some(normalize_path(&joined));
     }
 
     if let Some(cap) = DIR_CONST_RE.captures(expr) {
-        let sub = cap.get(1).unwrap().as_str().trim_start_matches('/');
-        return Some(normalize_path(&provider_dir.join(sub)));
+        let sub = cap.get(1).unwrap().as_str();
+        return Some(normalize_path(&join_relative(provider_dir, sub)));
     }
 
     if let Some(cap) = LITERAL_RE.captures(expr) {

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -4983,27 +4983,191 @@ async fn both_constructors_agree_on_php_use_class_refs() {
     );
 }
 
-// ─── loadViewsFrom() __DIR__-relative path resolution ──────────────────────
+// ─── loadViewsFrom() path resolution (issues #285, #290) ───────────────────
 //
-// The `LOAD_VIEWS_RE` capture keeps the leading slash of the concatenated
-// fragment (`__DIR__ . '/../resources/views'` captures "/../resources/views"),
-// and `Path::join` REPLACES its receiver when handed an absolute path — so
-// every `loadViewsFrom(__DIR__.'…')` registration silently resolved to a
-// root-relative nonsense path and the namespace never worked.
+// `LOAD_VIEWS_RE` captures the concatenated fragment with its leading slash
+// (`__DIR__ . '/../resources/views'` captures "/../resources/views"), and
+// `Path::join` REPLACES its receiver when handed an absolute path — so every
+// `loadViewsFrom(__DIR__.'…')` registration silently resolved to a
+// root-relative nonsense path and the namespace never worked (#285).
+//
+// The strip-and-join rule itself is unit-tested next to the function it lives
+// on, in `path_join`. These tests pin the *behaviour* the bug broke: that a
+// registration ends up pointing at a real directory. They fail against the
+// pre-#285 parser, which yielded `Some("/../resources/views")`.
 
 #[test]
-fn load_views_relative_fragment_resolves_against_provider_dir() {
-    let provider_dir = PathBuf::from("/pkg/src/Providers");
-    assert_eq!(
-        resolve_load_views_relative(&provider_dir, "/../../resources/views"),
-        PathBuf::from("/pkg/src/Providers/../../resources/views")
+fn load_views_from_dir_relative_registers_real_directory() {
+    let ns = discovered_view_namespaces(
+        r#"<?php
+class CourierServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'courier');
+    }
+}
+"#,
+        "/pkg/src/Providers/CourierServiceProvider.php",
     );
     assert_eq!(
-        resolve_load_views_relative(&provider_dir, "/views"),
-        PathBuf::from("/pkg/src/Providers/views")
+        ns,
+        vec![(
+            "courier".to_string(),
+            Some(PathBuf::from("/pkg/src/resources/views"))
+        )]
+    );
+}
+
+#[test]
+fn load_views_from_accepts_whitespace_around_the_arrow() {
+    // Space before the arrow, space after it, and the Pint-style line break
+    // that puts a fluent `->` on its own line.
+    for (label, receiver) in [
+        ("space before", "$this ->loadViewsFrom"),
+        ("space after", "$this-> loadViewsFrom"),
+        ("line break", "$this\n            ->loadViewsFrom"),
+    ] {
+        let source = format!(
+            "<?php\nclass P extends ServiceProvider\n{{\n    public function boot()\n    {{\n        {receiver}(__DIR__ . '/views', 'spaced');\n    }}\n}}\n"
+        );
+        let ns = discovered_view_namespaces(&source, "/pkg/src/P.php");
+        assert_eq!(
+            ns,
+            vec![("spaced".to_string(), Some(PathBuf::from("/pkg/src/views")))],
+            "{label} form did not register"
+        );
+    }
+}
+
+#[test]
+fn load_views_from_unwraps_realpath() {
+    let ns = discovered_view_namespaces(
+        r#"<?php
+class P extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->loadViewsFrom(realpath(__DIR__ . '/../resources/views'), 'wrapped');
+    }
+}
+"#,
+        "/pkg/src/Providers/P.php",
     );
     assert_eq!(
-        resolve_load_views_relative(&provider_dir, "./views"),
-        PathBuf::from("/pkg/src/Providers/views")
+        ns,
+        vec![(
+            "wrapped".to_string(),
+            Some(PathBuf::from("/pkg/src/resources/views"))
+        )]
+    );
+}
+
+#[test]
+fn load_views_from_resolves_path_helper_arguments() {
+    let ns = discovered_view_namespaces(
+        r#"<?php
+class P extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->loadViewsFrom(resource_path('views/vendor/shop'), 'shop');
+    }
+}
+"#,
+        "/pkg/src/P.php",
+    );
+    assert_eq!(
+        ns,
+        vec![(
+            "shop".to_string(),
+            Some(PathBuf::from("/proj/resources/views/vendor/shop"))
+        )]
+    );
+}
+
+#[test]
+fn load_views_from_ignores_unsupported_receivers() {
+    // Only `$this->loadViewsFrom(...)` is recognised. Static and
+    // property-chain receivers register nothing rather than registering a
+    // wrong directory — see the note above `LOAD_VIEWS_RE`.
+    let ns = discovered_view_namespaces(
+        r#"<?php
+class P extends ServiceProvider
+{
+    public function boot()
+    {
+        static::loadViewsFrom(__DIR__ . '/views', 'nope');
+        $this->app->loadViewsFrom(__DIR__ . '/views', 'alsonope');
+    }
+}
+"#,
+        "/pkg/src/P.php",
+    );
+    assert!(ns.is_empty(), "unexpected registrations: {ns:?}");
+}
+
+/// Guards the widened first-argument capture against swallowing across calls:
+/// three differently-shaped registrations in one provider must each resolve
+/// independently.
+#[test]
+fn multiple_differently_shaped_registrations_resolve_independently() {
+    let ns = discovered_view_namespaces(
+        r#"<?php
+class P extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'plain');
+        $this->loadViewsFrom(realpath(__DIR__ . '/../resources/admin'), 'wrapped');
+        $this->loadViewsFrom(resource_path('views/vendor/shop'), 'helper');
+    }
+}
+"#,
+        "/pkg/src/Providers/P.php",
+    );
+    assert_eq!(
+        ns,
+        vec![
+            (
+                "plain".to_string(),
+                Some(PathBuf::from("/pkg/src/resources/views"))
+            ),
+            (
+                "wrapped".to_string(),
+                Some(PathBuf::from("/pkg/src/resources/admin"))
+            ),
+            (
+                "helper".to_string(),
+                Some(PathBuf::from("/proj/resources/views/vendor/shop"))
+            ),
+        ]
+    );
+}
+
+/// The first-argument capture is non-greedy. A greedy `(.+)` backtracks to the
+/// LAST `, 'ns')` on the line, swallowing an intervening registration whole —
+/// so two calls sharing a line collapse into one. Line-separated calls cannot
+/// catch this, because `.` does not match a newline.
+#[test]
+fn two_registrations_on_one_line_are_captured_separately() {
+    let ns = discovered_view_namespaces(
+        r#"<?php
+class P extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->loadViewsFrom(__DIR__ . '/a', 'one'); $this->loadViewsFrom(__DIR__ . '/b', 'two');
+    }
+}
+"#,
+        "/pkg/src/P.php",
+    );
+    assert_eq!(
+        ns,
+        vec![
+            ("one".to_string(), Some(PathBuf::from("/pkg/src/a"))),
+            ("two".to_string(), Some(PathBuf::from("/pkg/src/b"))),
+        ]
     );
 }

--- a/laravel-lsp/src/vendor_translations.rs
+++ b/laravel-lsp/src/vendor_translations.rs
@@ -38,6 +38,7 @@
 //! follow-up once the scan time becomes a noticeable cost on first hover.
 
 use crate::parser::parse_php;
+use crate::path_join::join_relative;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::collections::HashMap;
@@ -314,15 +315,6 @@ fn resolve_dir_base(node: tree_sitter::Node, bytes: &[u8], provider_dir: &Path) 
         }
         _ => None,
     }
-}
-
-/// Join a captured relative fragment onto a base directory. PHP source like
-/// `__DIR__.'/../resources/lang'` yields a fragment starting with `/`; Rust's
-/// `Path::join` treats a leading `/` as absolute and discards the receiver, so
-/// strip leading `/` and `./` before joining.
-fn join_relative(base: &Path, rel: &str) -> PathBuf {
-    let rel = rel.trim_start_matches('/').trim_start_matches("./");
-    base.join(rel)
 }
 
 /// The first string-literal argument of a function call, or `None`.


### PR DESCRIPTION
Fixes #290.

Follow-up to #285. Three strands: the regression test #285 claimed but didn't have, consolidation of the strip-then-join rule it duplicated, and the `loadViewsFrom` registration shapes that still silently registered nothing.

## What changed

**One shared join helper (`laravel-lsp/src/path_join.rs`).** The strip-then-join rule lived in four copies across `vendor_translations` and `salsa_impl`; `resolve_load_views_relative` and the private `join_relative` are gone, and both `resolve_php_path_expr` branches now route through the shared one.

**One resolution path for `loadViewsFrom`.** `LOAD_VIEWS_RE` now captures the first argument whole and hands it to `resolve_php_path_expr`, which grew a `realpath()` branch defined as a pure syntactic pass-through. `__DIR__` concatenations, `realpath()` wrappers and Laravel path helpers all resolve through one path rather than a pattern each. Whitespace around the `->` is accepted, including the Pint-style line break.

**Receivers that can't be resolved lexically** (`static::`, `$this->app->`, runtime-computed arguments) are documented next to the pattern and pinned by a test asserting they register **nothing** rather than a wrong directory.

## A note on the `/` vs `./` box in #290

That box asks for tests proving the four copies diverged on `./`. They didn't — not observably. `Path` compares by components and its iterator normalizes `.` away, so `/pkg/./views` and `/pkg/views` are equal, normalize equal, and resolve equal. Tests written against that box pass with the `./` strip removed; they cannot discriminate.

The strip is kept anyway, for a different and real reason: `std::path` preserves `.` as a live `CurDir` component inside a Windows **verbatim** path (`parse_single_component`, gated on `HAS_PREFIXES && prefix_verbatim()`), and Windows hands verbatim paths to the OS unnormalized — so a stray `.` there simply fails to resolve. `canonicalize` returns verbatim paths on Windows, so such a base is reachable from this code.

Two consequences:

- The strip loops. One pass can *expose* a fresh leading separator — `".//views"` becomes `"/views"` — which would discard the base. That fail-open is platform-independent and is manufactured by the `./` strip itself, so the loop is what makes keeping the strip safe.
- Separator matching goes through `std::path::is_separator` (`/` on Unix, `/` or `\` on Windows), so a `\`-prefixed fragment — rooted on Windows, an ordinary filename character on Unix — is handled correctly on each without a `cfg`.

CI is `ubuntu-latest` only, so none of the Windows behaviour is exercised there. `backslash_fragment_is_stripped_on_windows` is `#[cfg(windows)]` and waiting.

**Suggest rewording that box in #290** — as written its premise doesn't hold on the platform CI runs.

## Acceptance criteria

- [x] Regression test added via `discovered_view_namespaces()`, asserting the resolved `view_path`. Named `load_views_from_dir_relative_registers_real_directory`. Proven to fail with the join logic reverted — output below
- [x] Failing/passing output included below
- [x] `resolve_load_views_relative` and its call site deleted; no strip-then-join reimplementation remains under another name. `grep -n trim_start_matches laravel-lsp/src/salsa_impl.rs laravel-lsp/src/vendor_translations.rs` → **no hits**; `grep -rn "fn join_relative" laravel-lsp/src/` → **one hit**, `path_join.rs:30`
- [x] `join_relative` lifted to a shared module and used by the former call site and both `resolve_php_path_expr` trim sites
- [x] `/` vs `./` resolved explicitly to stripping both — see the note above on why the prescribed tests can't discriminate, and what replaces them
- [x] Whitespace around `->` — all three shapes (`$this ->`, `$this-> `, Pint line break) in one test
- [x] `resource_path(...)` and `realpath(...)` via whole-expression capture routed through `resolve_php_path_expr`, with `realpath()` as a syntactic pass-through
- [x] Multi-registration test — plus a same-line variant, since line-separated calls can't catch a greedy capture (`.` doesn't match newline)
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-features` clean — output below

## Test plan

Regression proof, with the join logic reverted to a plain `provider_dir.join(relative)`:

```
$ cargo test -p laravel-lsp load_views_from_dir_relative_registers_real_directory
test salsa_impl::tests::load_views_from_dir_relative_registers_real_directory ... FAILED
  left: [("courier", Some("/../resources/views"))]
 right: [("courier", Some("/pkg/src/resources/views"))]
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2386 filtered out
```

Strip restored, this branch as pushed:

```
$ cargo test -p laravel-lsp load_views_from_dir_relative_registers_real_directory
test salsa_impl::tests::load_views_from_dir_relative_registers_real_directory ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2386 filtered out
```

Every new test is mutation-verified — each goes red when its target breaks:

| Mutation | Result |
|---|---|
| Remove the separator strip (the #285 bug) | **11 fail** |
| Single pass instead of the loop | **3 fail** — `.//views` yields `//views`, base discarded |
| Strip `.` unconditionally (drop the `..` guard) | **3 fail** — `../resources/views` loses a dot |
| Delete the `realpath()` pass-through branch | `load_views_from_unwraps_realpath` **fails** |
| Make the first-argument capture greedy | `two_registrations_on_one_line_are_captured_separately` **fails** |
| Loosen the receiver to `(?:\$this|static)` | `load_views_from_ignores_unsupported_receivers` **fails** |

The CI job's own commands:

```
$ cargo fmt --check                                  # clean
$ cargo clippy --all-targets -- -D warnings          # exit 0
$ cargo test --all-features
test result: ok. 2387 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 480 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 80 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
