### PR TITLE
perf: ⚡ Reduce cache roughly in half for large projects.

### DIFF
--- a/laravel-lsp/src/class_hierarchy_index.rs
+++ b/laravel-lsp/src/class_hierarchy_index.rs
@@ -39,6 +39,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::laravel_introspector::walker::{self, PhpMethodInfo, PhpPropertyInfo, PhpStructureKind};
 use crate::query_chain::use_aliases::{self, UseAliases};
@@ -169,7 +170,11 @@ pub fn surface_map_diff(old: &HashMap<String, u64>, new: &HashMap<String, u64>) 
 /// Inverted class-hierarchy index. Owned by the actor; never shared.
 #[derive(Default, Debug)]
 pub struct ClassHierarchyIndex {
-    classes: HashMap<String, ClassNode>,
+    /// `Arc`-wrapped so [`Self::nodes_by_file`] (the disk-cache save snapshot,
+    /// taken for the WHOLE project at once) can hand out cheap ref-count
+    /// bumps instead of deep-cloning every `ClassNode` — the clone had been a
+    /// measured ~40MB save-time peak on a large project.
+    classes: HashMap<String, Arc<ClassNode>>,
     /// interface FQCN → classes that implement it (direct).
     implementers: HashMap<String, Vec<String>>,
     /// trait FQCN → classes that `use` it (direct).
@@ -212,7 +217,7 @@ impl ClassHierarchyIndex {
                     .or_default()
                     .push(fqcn.clone());
             }
-            self.classes.insert(fqcn.clone(), node);
+            self.classes.insert(fqcn.clone(), Arc::new(node));
             fqcns.push(fqcn);
         }
         self.by_file.insert(path.to_path_buf(), fqcns);
@@ -271,7 +276,7 @@ impl ClassHierarchyIndex {
 
     /// The declaration node for a class FQCN, if indexed.
     pub fn get(&self, fqcn: &str) -> Option<&ClassNode> {
-        self.classes.get(fqcn)
+        self.classes.get(fqcn).map(Arc::as_ref)
     }
 
     /// Snapshot the `fqcn → declaring file` mapping. The magic-member index
@@ -288,13 +293,20 @@ impl ClassHierarchyIndex {
     /// Group every indexed class by its declaring file. Used to persist the
     /// hierarchy alongside the pattern cache so it survives a warm restart
     /// (the index is otherwise only populated by fresh parses).
-    pub fn nodes_by_file(&self) -> std::collections::HashMap<PathBuf, Vec<ClassNode>> {
-        let mut map: std::collections::HashMap<PathBuf, Vec<ClassNode>> =
+    ///
+    /// Returns `Arc<ClassNode>` (cheap ref-count bumps, sharing the SAME
+    /// allocations `classes` owns) rather than cloning every node — this
+    /// snapshot covers the WHOLE project, so a deep clone here was the
+    /// dominant cost of a disk-cache save (~40MB peak). The disk-cache save
+    /// path serializes through `Arc<ClassNode>` directly (serde's `rc`
+    /// feature), so the wire format is unaffected.
+    pub fn nodes_by_file(&self) -> std::collections::HashMap<PathBuf, Vec<Arc<ClassNode>>> {
+        let mut map: std::collections::HashMap<PathBuf, Vec<Arc<ClassNode>>> =
             std::collections::HashMap::new();
         for node in self.classes.values() {
             map.entry(node.file_path.clone())
                 .or_default()
-                .push(node.clone());
+                .push(Arc::clone(node));
         }
         map
     }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -1931,11 +1931,26 @@ struct LaravelLanguageServer {
     /// running. Consumer: the batch task drains it and clears `running` when it
     /// finds the map empty — both decisions serialized on this one lock.
     magic_batch_state: Arc<tokio::sync::Mutex<WatchedBatchState>>,
-    /// File existence cache with TTL (path -> (exists, cached_at))
-    /// This avoids blocking I/O in async context for file_exists checks
-    file_exists_cache: Arc<RwLock<HashMap<PathBuf, (bool, Instant)>>>,
-    /// Cached Laravel config to avoid repeated Salsa lookups
-    cached_config: Arc<RwLock<Option<LaravelConfigData>>>,
+    /// File existence cache with TTL (path -> (exists, cached_at)).
+    /// This avoids blocking I/O in async context for file_exists checks.
+    ///
+    /// Bounded by [`FILE_EXISTS_CACHE_CAP`] (an `lru::LruCache`, same as
+    /// `vendor_open_magic_lru`) rather than a plain `HashMap`: the TTL only
+    /// expires an entry's VALUE on next lookup, it never removes the key, so
+    /// an unbounded map grew for every distinct path ever probed over a
+    /// session (goto/hover/diagnostics checking candidate paths that don't
+    /// exist) with nothing ever shrinking it. `std::sync::Mutex`, not
+    /// `RwLock`: `lru` mutates on every read to reorder recency, so a "read"
+    /// is never actually read-only.
+    file_exists_cache: Arc<std::sync::Mutex<lru::LruCache<PathBuf, (bool, Instant)>>>,
+    /// Cached Laravel config to avoid repeated Salsa lookups.
+    ///
+    /// `Arc`-wrapped so `get_cached_config`'s many callers (goto, hover,
+    /// diagnostics — every request that needs view/component paths) get a
+    /// cheap ref-count bump per call instead of a full deep clone of
+    /// `LaravelConfigData` (several `Vec`/`HashMap` fields) on every single
+    /// LSP request.
+    cached_config: Arc<RwLock<Option<Arc<LaravelConfigData>>>>,
     /// Cached Livewire config + version, keyed by the root path they were
     /// loaded for. Parsing `config/livewire.php` and scanning
     /// `composer.lock` on every diagnostic / hover / goto would be wasteful;
@@ -2134,6 +2149,12 @@ const DEFAULT_SALSA_DEBOUNCE_MS: u64 = 200;
 /// still sitting open in the editor is practically impossible (and even
 /// then, re-opening or saving it re-indexes it).
 const VENDOR_OPEN_MAGIC_LRU_CAP: usize = 128;
+
+/// Cap on `file_exists_cache`: how many distinct (path, exists, cached_at)
+/// probes stay resident at once. Generous — goto/hover/diagnostics probe many
+/// candidate paths per request, most of which don't exist — but bounded, so
+/// a long session doesn't grow the map for every path ever checked.
+const FILE_EXISTS_CACHE_CAP: usize = 8192;
 
 // NOTE: Blade directives are now dynamically discovered via get_all_blade_directives()
 // which scans the Laravel framework, app service providers, and packages.
@@ -4347,7 +4368,9 @@ impl LaravelLanguageServer {
             magic_rebuild_handle: Arc::new(RwLock::new(None)),
             magic_ripple_handle: Arc::new(RwLock::new(None)),
             magic_batch_state: Arc::new(tokio::sync::Mutex::new(WatchedBatchState::default())),
-            file_exists_cache: Arc::new(RwLock::new(HashMap::new())),
+            file_exists_cache: Arc::new(std::sync::Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(FILE_EXISTS_CACHE_CAP).unwrap(),
+            ))),
             cached_config: Arc::new(RwLock::new(None)),
             cached_livewire: Arc::new(RwLock::new(None)),
             last_goto_request: Arc::new(RwLock::new(HashMap::new())),
@@ -6010,7 +6033,7 @@ impl LaravelLanguageServer {
                     class_component_files: cached_config.class_component_files.clone(),
                 };
                 // Store directly in memory - no Salsa channel call!
-                *self.cached_config.write().await = Some(config_data);
+                *self.cached_config.write().await = Some(Arc::new(config_data));
 
                 // Update root_path to the cached config's root (the actual Laravel project)
                 // and mark it as initialized to prevent re-discovery on file open
@@ -7421,7 +7444,7 @@ impl LaravelLanguageServer {
         // forces a rebuild. The on-disk cache below persists the same maps for
         // the next launch.
         if let Some(ref config) = salsa_config {
-            *self.cached_config.write().await = Some(config.clone());
+            *self.cached_config.write().await = Some(Arc::new(config.clone()));
         }
 
         let mut cache_guard = self.cache.write().await;
@@ -8339,9 +8362,12 @@ impl LaravelLanguageServer {
             }
         }
 
-        // Check TTL cache
+        // Check TTL cache. `lru::LruCache::get` takes `&mut self` (it
+        // reorders recency on every touch), so this is a `std::sync::Mutex`
+        // lock, not the `RwLock` a plain read would suggest — held only for
+        // this synchronous block, never across the `.await` below.
         {
-            let cache = self.file_exists_cache.read().await;
+            let mut cache = self.file_exists_cache.lock().unwrap();
             if let Some((exists, cached_at)) = cache.get(path) {
                 if cached_at.elapsed() < CACHE_TTL {
                     return *exists;
@@ -8354,9 +8380,9 @@ impl LaravelLanguageServer {
 
         // Update cache
         self.file_exists_cache
-            .write()
-            .await
-            .insert(path.clone(), (exists, Instant::now()));
+            .lock()
+            .unwrap()
+            .put(path.clone(), (exists, Instant::now()));
 
         exists
     }
@@ -8364,8 +8390,10 @@ impl LaravelLanguageServer {
     /// Get Laravel config with local caching
     ///
     /// This avoids repeated Salsa lookups on every goto_definition request.
-    /// Cache is invalidated when config files change (in did_save).
-    async fn get_cached_config(&self) -> Option<LaravelConfigData> {
+    /// Cache is invalidated when config files change (in did_save). Returns
+    /// an `Arc` (see the field doc on `cached_config`) — a cache hit, which
+    /// is the overwhelming majority of calls, is just a ref-count bump.
+    async fn get_cached_config(&self) -> Option<Arc<LaravelConfigData>> {
         // Return cached config if available
         if let Some(config) = self.cached_config.read().await.clone() {
             return Some(config);
@@ -8374,7 +8402,8 @@ impl LaravelLanguageServer {
         // Fetch from Salsa and cache
         match self.salsa.get_laravel_config().await {
             Ok(Some(config)) => {
-                *self.cached_config.write().await = Some(config.clone());
+                let config = Arc::new(config);
+                *self.cached_config.write().await = Some(Arc::clone(&config));
                 Some(config)
             }
             _ => None,
@@ -22667,7 +22696,7 @@ impl LanguageServer for LaravelLanguageServer {
             // diagnostic) sees the new on-disk state immediately instead of
             // waiting out the 5-second TTL (issue #10).
             if laravel_lsp::inertia::is_page_file(&path) {
-                self.file_exists_cache.write().await.remove(&path);
+                self.file_exists_cache.lock().unwrap().pop(&path);
                 match change.typ {
                     FileChangeType::DELETED => deleted += 1,
                     _ => created_or_changed += 1,

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4773,6 +4773,22 @@ impl LaravelLanguageServer {
 
         info!("Laravel: Project files registered with Salsa for reference finding");
 
+        // Size the shared pattern cache for this project's real file count
+        // now that `register_project_files`'s walk has discovered it — and
+        // BEFORE either of the two bulk-insert paths below (the disk-cache
+        // restore and warming's bulk import) run. Sizing here means neither
+        // one grows the table through a series of rehashes as it inserts.
+        // `list_project_files` just returns the actor's already-discovered
+        // list (no re-walk); a failure here is non-fatal — it only costs
+        // the resize's benefit, not correctness — so we log and continue.
+        match self.salsa.list_project_files().await {
+            Ok(paths) => self.salsa.resize_pattern_cache(paths.len()),
+            Err(e) => debug!(
+                "list_project_files failed, pattern cache stays at its bootstrap capacity: {}",
+                e
+            ),
+        }
+
         // Disk-cache restore. Loads previously-parsed patterns into the
         // shared pattern_cache, dropping any entry whose on-disk mtime
         // doesn't match what was cached. Anything restored here gets

--- a/laravel-lsp/src/member_resolver/tests.rs
+++ b/laravel-lsp/src/member_resolver/tests.rs
@@ -1869,7 +1869,10 @@ class User extends Authenticatable {
     let cache = Arc::new(DashMap::new());
     cache.insert(path.clone(), (0, data));
     let mut hierarchy_by_file = std::collections::HashMap::new();
-    hierarchy_by_file.insert(path.clone(), nodes);
+    hierarchy_by_file.insert(
+        path.clone(),
+        nodes.into_iter().map(Arc::new).collect::<Vec<_>>(),
+    );
     crate::pattern_disk_cache::save_from(&cache, &hierarchy_by_file, dir.path()).unwrap();
 
     let restored_cache = Arc::new(DashMap::new());

--- a/laravel-lsp/src/pattern_disk_cache.rs
+++ b/laravel-lsp/src/pattern_disk_cache.rs
@@ -30,6 +30,7 @@
 //! root path.
 
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -109,7 +110,18 @@ use crate::salsa_impl::ParsedPatternsData;
 ///        restoring it would under-report references — and, for the
 ///        unused-symbol diagnostic, resurrect the "possibly dead" false
 ///        positive on a component the string scan now sees.
-const SCHEMA_VERSION: u32 = 13;
+///   v14 — vendor-file entries no longer carry `member_access_refs` (memory
+///        win: ~110MB on a large project), and `sorted_positions` is no
+///        longer built eagerly at parse/restore time — it's derived data,
+///        lazily built on first `find_at_position` call instead. The SHAPE
+///        of `ParsedPatternsData` didn't change, so a v13 entry would decode
+///        without error — but its semantics did: a stored vendor entry from
+///        before this change still carries the full raw ref list, which is
+///        now bigger than what a fresh parse would produce and (harmlessly,
+///        but wastefully) never gets trimmed since restored entries aren't
+///        re-parsed. Bump so every on-disk vendor entry is rebuilt through
+///        the new, slimmer path.
+const SCHEMA_VERSION: u32 = 14;
 
 const CACHE_FILENAME: &str = "pattern_cache.bin";
 
@@ -138,6 +150,29 @@ struct CachedEntry {
     /// field addition doesn't have to bump the version for this one.
     #[serde(default)]
     nodes: Vec<ClassNode>,
+}
+
+/// Borrowed mirror of [`CachedEntry`], written by [`save_from`] instead of
+/// the owned struct so a save never clones a file's `ParsedPatternsData` or
+/// `ClassNode`s. Field names, order, and TYPES must serialize to the exact
+/// same bytes [`CachedEntry`] would — bincode's wire format is purely
+/// positional, and `Arc<T>`'s `Serialize` impl (the `rc` feature) writes `T`
+/// directly with no wrapper, so `&[Arc<ClassNode>]` here is byte-identical to
+/// `Vec<ClassNode>` there. [`super::tests::save_borrowed_then_load_owned_round_trips`]
+/// pins this.
+#[derive(Serialize)]
+struct CachedEntryRef<'a> {
+    mtime_secs: u64,
+    mtime_nanos: u32,
+    patterns: &'a ParsedPatternsData,
+    nodes: &'a [Arc<ClassNode>],
+}
+
+/// Borrowed mirror of [`CacheFile`] — see [`CachedEntryRef`].
+#[derive(Serialize)]
+struct CacheFileRef<'a> {
+    schema_version: u32,
+    entries: HashMap<&'a Path, CachedEntryRef<'a>>,
 }
 
 /// Outcome of [`load_into`]: how many entries were restored vs dropped, plus
@@ -281,10 +316,14 @@ pub fn load_into_reporting(
             // cached value, drop the entry — warming will re-parse it.
             let node_entry = match read_mtime(&path) {
                 Some((s, n)) if s == entry.mtime_secs && n == entry.mtime_nanos => {
-                    // Fresh: rebuild the position index (we skipped persisting
-                    // it because it duplicates the Vec data) and insert.
-                    let mut patterns = entry.patterns;
-                    patterns.build_position_index();
+                    // Fresh: insert as-is. The position index isn't rebuilt
+                    // here — it's derived data (skipped on serialize, see
+                    // `ParsedPatternsData::sorted_positions`) that
+                    // `find_at_position` now builds lazily on its own first
+                    // call, so a 40k-entry warm restore no longer pays an
+                    // eager sort for every file, only the handful the cursor
+                    // actually visits.
+                    let patterns = entry.patterns;
                     // Surface the file's hierarchy nodes so the caller can
                     // re-import them — the index is otherwise empty on a warm
                     // start (no parse runs for disk-restored files).
@@ -321,13 +360,27 @@ pub fn load_into_reporting(
 /// failing to persist doesn't break the in-memory cache.
 pub fn save_from(
     pattern_cache: &Arc<DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>,
-    hierarchy_by_file: &HashMap<PathBuf, Vec<ClassNode>>,
+    hierarchy_by_file: &HashMap<PathBuf, Vec<Arc<ClassNode>>>,
     project_root: &Path,
 ) -> Result<usize> {
     let cache_path =
         cache_file_path(project_root).context("could not resolve cache directory for project")?;
 
-    let mut entries: HashMap<PathBuf, CachedEntry> = HashMap::with_capacity(pattern_cache.len());
+    // One cheap row per live entry: a `PathBuf` clone and an `Arc` bump for
+    // the patterns (same per-entry cost as before), NOT a deep clone of the
+    // `ParsedPatternsData`/`ClassNode` payload. Collecting these first (rather
+    // than serializing while iterating the DashMap directly) releases each
+    // shard's read lock immediately, same as the old per-entry-clone loop —
+    // the actual save-time peak this replaces came from `(**patterns).clone()`
+    // duplicating every Vec field of every entry, not from the lock pattern.
+    struct Row {
+        path: PathBuf,
+        mtime_secs: u64,
+        mtime_nanos: u32,
+        patterns: Arc<ParsedPatternsData>,
+    }
+
+    let mut rows: Vec<Row> = Vec::with_capacity(pattern_cache.len());
 
     // Walk the live DashMap and copy out the data we need. We stat each
     // path at save time (rather than trust an mtime we computed earlier)
@@ -344,26 +397,43 @@ pub fn save_from(
             // drop it anyway.
             continue;
         };
-        entries.insert(
-            path.clone(),
-            CachedEntry {
-                mtime_secs: secs,
-                mtime_nanos: nanos,
-                // ParsedPatternsData: Clone is cheap (Arc bumps).
-                patterns: (**patterns).clone(),
-                nodes: hierarchy_by_file.get(path).cloned().unwrap_or_default(),
-            },
-        );
+        rows.push(Row {
+            path: path.clone(),
+            mtime_secs: secs,
+            mtime_nanos: nanos,
+            patterns: Arc::clone(patterns),
+        });
     }
 
-    let total = entries.len();
-    let cache = CacheFile {
+    let total = rows.len();
+
+    // Build the borrowed envelope: every `patterns`/`nodes` field is a
+    // reference into `rows` (via the Arc) or into `hierarchy_by_file`, so
+    // encoding below never clones a Vec-laden payload — the write is the
+    // only place bytes for these get copied.
+    let entries: HashMap<&Path, CachedEntryRef<'_>> = rows
+        .iter()
+        .map(|row| {
+            let nodes: &[Arc<ClassNode>] = hierarchy_by_file
+                .get(&row.path)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            (
+                row.path.as_path(),
+                CachedEntryRef {
+                    mtime_secs: row.mtime_secs,
+                    mtime_nanos: row.mtime_nanos,
+                    patterns: row.patterns.as_ref(),
+                    nodes,
+                },
+            )
+        })
+        .collect();
+
+    let cache = CacheFileRef {
         schema_version: SCHEMA_VERSION,
         entries,
     };
-
-    let encoded = bincode::serde::encode_to_vec(&cache, bincode::config::standard())
-        .context("bincode encode failed")?;
 
     if let Some(parent) = cache_path.parent() {
         std::fs::create_dir_all(parent).context("could not create cache directory")?;
@@ -387,7 +457,22 @@ pub fn save_from(
         SAVE_SEQ.fetch_add(1, Ordering::Relaxed)
     );
     let tmp = cache_path.with_extension(unique);
-    std::fs::write(&tmp, &encoded).context("write tmp cache file failed")?;
+
+    // Stream-encode straight into the temp file through a `BufWriter` rather
+    // than building the full `Vec<u8>` in memory first (`encode_to_vec`) and
+    // then writing it out (`fs::write`) — on a large project that Vec was a
+    // second full-sized copy of the encoded cache alive at once, on top of
+    // the (now-removed) entry clone. The write happens inside a closure so a
+    // mid-encode I/O error is reported the same way an encode error is,
+    // before we ever attempt the rename.
+    (|| -> Result<()> {
+        let file = std::fs::File::create(&tmp).context("create tmp cache file failed")?;
+        let mut writer = std::io::BufWriter::new(file);
+        bincode::serde::encode_into_std_write(&cache, &mut writer, bincode::config::standard())
+            .context("bincode encode failed")?;
+        writer.flush().context("flush tmp cache file failed")?;
+        Ok(())
+    })()?;
     std::fs::rename(&tmp, &cache_path).context("rename tmp cache file failed")?;
 
     Ok(total)

--- a/laravel-lsp/src/pattern_disk_cache/tests.rs
+++ b/laravel-lsp/src/pattern_disk_cache/tests.rs
@@ -136,15 +136,16 @@ fn position_index_is_rebuilt_on_load() {
     let restored_cache = Arc::new(DashMap::new());
     load_into(&restored_cache, project.path());
 
-    // find_at_position uses the position index. If it works after a
-    // load, the index was rebuilt successfully — which is the whole
-    // point of running `build_position_index()` in load_into.
+    // `sorted_positions` is skipped on serialize and rebuilt LAZILY, on
+    // `find_at_position`'s own first call, rather than eagerly in
+    // `load_into` — so a restored entry works exactly like a freshly
+    // parsed one that's never had `build_position_index()` called on it.
     let entry = restored_cache.get(&file).unwrap();
     let patterns = &entry.value().1;
     let found = patterns.find_at_position(1, 5);
     assert!(
         found.is_some(),
-        "position index should be reconstructed so find_at_position works"
+        "position index should be lazily rebuilt so find_at_position works"
     );
 }
 
@@ -181,7 +182,10 @@ fn hierarchy_nodes_survive_save_and_load() {
     let mut hierarchy = std::collections::HashMap::new();
     hierarchy.insert(
         file.clone(),
-        crate::class_hierarchy_index::classes_in_file(&file, src),
+        crate::class_hierarchy_index::classes_in_file(&file, src)
+            .into_iter()
+            .map(Arc::new)
+            .collect::<Vec<_>>(),
     );
     save_from(&cache, &hierarchy, project.path()).unwrap();
 
@@ -296,7 +300,10 @@ fn parallel_load_matches_serial_for_mixed_fixture() {
     for (i, p) in fresh.iter().enumerate() {
         hierarchy.insert(
             p.clone(),
-            crate::class_hierarchy_index::classes_in_file(p, &fresh_src(i)),
+            crate::class_hierarchy_index::classes_in_file(p, &fresh_src(i))
+                .into_iter()
+                .map(Arc::new)
+                .collect::<Vec<_>>(),
         );
     }
     save_from(&cache, &hierarchy, project.path()).unwrap();
@@ -421,4 +428,123 @@ fn member_access_refs_survive_save_and_load() {
         "member accesses must round-trip through the disk cache"
     );
     assert_eq!(restored.value().1.member_access_refs[0].member, "email");
+}
+
+// ─── Win 3: borrowed-mirror save must be byte-compatible with owned load ──
+
+/// `save_from` now serializes through `CachedEntryRef`/`CacheFileRef` —
+/// borrowed mirrors of `CachedEntry`/`CacheFile` built without cloning any
+/// `ParsedPatternsData` or `ClassNode` — while `load_into` still decodes into
+/// the OWNED `CachedEntry`/`CacheFile`. This pins that the two really are
+/// byte-compatible: every pattern kind that round-trips value-for-value, and
+/// the class-hierarchy nodes saved alongside them (also now `Arc`-wrapped on
+/// the save side, plain `ClassNode` on the load side).
+#[test]
+fn save_borrowed_then_load_owned_round_trips() {
+    use crate::class_hierarchy_index::classes_in_file;
+    use crate::salsa_impl::{
+        ClassReferenceData, Confidence, MemberAccessReferenceData, RouteReferenceData,
+    };
+
+    let project = TempDir::new().unwrap();
+    let cache = Arc::new(DashMap::new());
+    let src = "<?php\nnamespace App\\Models;\nclass User extends Model {}\n";
+    let file = touch(project.path(), "User.php", src);
+
+    let mut patterns = ParsedPatternsData::default();
+    patterns.views.push(Arc::new(ViewReferenceData {
+        name: "users.profile".into(),
+        line: 3,
+        column: 1,
+        end_column: 14,
+        is_route_view: true,
+    }));
+    patterns.route_refs.push(Arc::new(RouteReferenceData {
+        name: "users.show".into(),
+        line: 4,
+        column: 2,
+        end_column: 12,
+    }));
+    patterns.class_refs.push(Arc::new(ClassReferenceData {
+        name: "App\\Models\\User".into(),
+        line: 0,
+        column: 4,
+        end_column: 19,
+    }));
+    patterns
+        .member_access_refs
+        .push(Arc::new(MemberAccessReferenceData {
+            member: "email".into(),
+            receiver: "$this".into(),
+            receiver_byte_start: 0,
+            receiver_byte_end: 5,
+            is_nullsafe: true,
+            form: AccessForm::Property,
+            line: 5,
+            column: 6,
+            end_column: 11,
+            declaring_fqcn: Some("App\\Models\\User".into()),
+            kind: None,
+            confidence: Confidence::High,
+        }));
+    patterns.is_volt = true;
+    cache.insert(file.clone(), (0, Arc::new(patterns)));
+
+    let nodes: Vec<Arc<ClassNode>> = classes_in_file(&file, src)
+        .into_iter()
+        .map(Arc::new)
+        .collect();
+    assert_eq!(nodes.len(), 1, "fixture must declare exactly one class");
+    let mut hierarchy = std::collections::HashMap::new();
+    hierarchy.insert(file.clone(), nodes.clone());
+
+    let saved = save_from(&cache, &hierarchy, project.path()).unwrap();
+    assert_eq!(saved, 1);
+
+    let restored_cache = Arc::new(DashMap::new());
+    let lr = load_into(&restored_cache, project.path());
+    assert_eq!(lr.restored, 1);
+    assert_eq!(lr.dropped, 0);
+
+    let entry = restored_cache.get(&file).expect("entry should be restored");
+    let restored = &entry.value().1;
+
+    assert_eq!(restored.views.len(), 1);
+    assert_eq!(restored.views[0].name, "users.profile");
+    assert_eq!(restored.views[0].line, 3);
+    assert_eq!(restored.views[0].column, 1);
+    assert_eq!(restored.views[0].end_column, 14);
+    assert!(restored.views[0].is_route_view);
+
+    assert_eq!(restored.route_refs.len(), 1);
+    assert_eq!(restored.route_refs[0].name, "users.show");
+
+    assert_eq!(restored.class_refs.len(), 1);
+    assert_eq!(restored.class_refs[0].name, "App\\Models\\User");
+
+    assert_eq!(restored.member_access_refs.len(), 1);
+    let m = &restored.member_access_refs[0];
+    assert_eq!(m.member, "email");
+    assert_eq!(m.receiver, "$this");
+    assert!(m.is_nullsafe);
+    assert_eq!(m.declaring_fqcn.as_deref(), Some("App\\Models\\User"));
+    assert_eq!(m.confidence, Confidence::High);
+
+    assert!(restored.is_volt);
+
+    // Hierarchy nodes: saved as `Arc<ClassNode>` (via `nodes_by_file`'s
+    // Win-3 return type), decoded back into plain owned `ClassNode`s.
+    assert_eq!(lr.hierarchy.len(), 1);
+    let (restored_path, restored_nodes) = &lr.hierarchy[0];
+    assert_eq!(restored_path, &file);
+    assert_eq!(restored_nodes.len(), 1);
+    assert_eq!(restored_nodes[0].fqcn, "App\\Models\\User");
+    assert_eq!(
+        restored_nodes[0].extends.as_deref(),
+        Some("App\\Models\\Model")
+    );
+
+    // find_at_position (lazy, Win 2) must still resolve on the restored,
+    // borrowed-then-owned-round-tripped entry.
+    assert!(restored.find_at_position(3, 5).is_some());
 }

--- a/laravel-lsp/src/pattern_indexer.rs
+++ b/laravel-lsp/src/pattern_indexer.rs
@@ -191,6 +191,19 @@ pub fn parse_owned_with_hierarchy(
             data.is_volt,
         )
         .map(Box::new);
+    } else {
+        // Win 1: drop the raw member-access refs for vendor files (~110MB
+        // across a large project's pattern cache). Every consumer of
+        // `member_access_refs` on a vendor entry is already vendor-gated
+        // upstream of this warming path: the magic-member build's passes 1-3
+        // and the save-time granular re-resolve all skip vendor outright, so
+        // they never read these entries in the first place. The one reader
+        // that ISN'T vendor-gated is `find_at_position` against an OPENED
+        // vendor file — but that self-heals: `did_open` routes through
+        // `handle_update_file`, which removes this path's `pattern_cache`
+        // entry, so the next `handle_get_patterns` re-parses the file through
+        // the full (non-warming) path instead of serving this slimmed entry.
+        data.member_access_refs.clear();
     }
 
     // Class FQCNs this file imports — Blade `@use` scanned from source, PHP
@@ -198,7 +211,11 @@ pub fn parse_owned_with_hierarchy(
     // `handle_get_patterns` uses, so both constructors emit identical entries.
     data.class_refs = crate::salsa_impl::class_refs_for(path, php_tree.as_ref(), text);
 
-    data.build_position_index();
+    // Win 2: `sorted_positions` is built lazily on first `find_at_position`
+    // call (see `ParsedPatternsData`), not here — warming parses tens of
+    // thousands of files that are never the cursor's file, so eagerly
+    // sorting every one of them wastes both CPU and the ~23MB the sorted
+    // Vecs add up to across a large project.
     (Arc::new(data), nodes)
 }
 

--- a/laravel-lsp/src/pattern_indexer/tests.rs
+++ b/laravel-lsp/src/pattern_indexer/tests.rs
@@ -232,16 +232,53 @@ fn parse_owned_captures_context_for_a_member_reader() {
 fn parse_owned_skips_capture_for_vendor() {
     // Same source, under a `vendor/` path → NO context (the build passes skip
     // vendor, so capturing there is wasted; the disk cache relies on this).
-    let path = PathBuf::from("/proj/vendor/acme/pkg/src/C.php");
+    // The same source under a non-vendor path (checked first) proves the
+    // source itself DOES contain a member access — so a vendor-path `None`
+    // below is the gate acting, not an absence of anything to capture. (The
+    // vendor path's `member_access_refs` are separately dropped by Win 1 —
+    // see `vendor_member_access_refs_are_dropped_but_app_ones_kept` — so this
+    // test can no longer check that Vec directly.)
     let src = "<?php\nnamespace Acme;\nclass C { public function f(\\App\\Models\\User $u) { return $u->email; } }\n";
-    let (data, _) = parse_owned_with_hierarchy(&path, src);
+
+    let app_path = PathBuf::from("/proj/app/C.php");
+    let (app_data, _) = parse_owned_with_hierarchy(&app_path, src);
     assert!(
-        !data.member_access_refs.is_empty(),
-        "the file DOES have a member access (proving the gate, not the parse, drops context)"
+        !app_data.member_access_refs.is_empty(),
+        "the source DOES have a member access (proving the gate, not the parse, drops context)"
     );
+
+    let vendor_path = PathBuf::from("/proj/vendor/acme/pkg/src/C.php");
+    let (vendor_data, _) = parse_owned_with_hierarchy(&vendor_path, src);
     assert!(
-        data.member_context.is_none(),
+        vendor_data.member_context.is_none(),
         "a vendor file must capture no context"
+    );
+}
+
+// ─── Win 1: vendor `member_access_refs` dropped at parse time ────────────
+
+#[test]
+fn vendor_member_access_refs_are_dropped_but_app_ones_kept() {
+    // Same source, one non-vendor path and one vendor path: the raw
+    // `member_access_refs` list must survive for the app file (M4 magic-member
+    // resolution reads it) and be emptied for the vendor file (every consumer
+    // of a vendor entry's refs is already vendor-gated upstream, so keeping
+    // them just wastes memory — ~110MB across a large project's cache).
+    let src = "<?php\nnamespace App\\Models;\nclass User { public function f() { return $this->email; } }\n";
+
+    let app_path = PathBuf::from("/proj/app/Models/User.php");
+    let (app_data, _) = parse_owned_with_hierarchy(&app_path, src);
+    assert!(
+        !app_data.member_access_refs.is_empty(),
+        "non-vendor files must keep their member_access_refs"
+    );
+
+    let vendor_path = PathBuf::from("/proj/vendor/acme/pkg/src/User.php");
+    let (vendor_data, _) = parse_owned_with_hierarchy(&vendor_path, src);
+    assert!(
+        vendor_data.member_access_refs.is_empty(),
+        "vendor files must have their member_access_refs dropped, got {:?}",
+        vendor_data.member_access_refs
     );
 }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -5539,12 +5539,14 @@ pub enum SalsaRequest {
 #[derive(Clone)]
 pub struct SalsaHandle {
     sender: mpsc::Sender<SalsaRequest>,
-    /// Shared concurrent pattern cache — same `Arc<DashMap>` the actor
-    /// holds. Reads and writes from here NEVER go through the actor's
-    /// mpsc channel, which means they're never blocked behind a slow
-    /// handler. See the comment on `SalsaActor::pattern_cache` for why
-    /// this exists.
-    pattern_cache: Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>,
+    /// Shared concurrent pattern cache — same cell the actor holds. Reads
+    /// and writes from here NEVER go through the actor's mpsc channel,
+    /// which means they're never blocked behind a slow handler. See the
+    /// comment on `SalsaActor::pattern_cache` for why this exists, and on
+    /// `resize_pattern_cache` for why it's an `RwLock<Arc<DashMap>>`
+    /// rather than a plain `Arc<DashMap>`.
+    pattern_cache:
+        Arc<std::sync::RwLock<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>>>,
 }
 
 impl SalsaHandle {
@@ -5552,9 +5554,55 @@ impl SalsaHandle {
     /// uses this to pre-load entries before warming starts, and to read
     /// them back out after warming completes for persistence. Returned
     /// `Arc` is cheap to clone — the underlying `DashMap` is the same
-    /// instance the actor reads from in `handle_get_patterns`.
+    /// instance the actor reads from in `handle_get_patterns`, current as
+    /// of this call (a concurrent `resize_pattern_cache` swaps the cell to
+    /// a NEW `Arc`, which this snapshot won't see — harmless in practice,
+    /// since resize only ever runs once, early, before any caller takes
+    /// this snapshot for warming or disk-cache I/O).
     pub fn pattern_cache(&self) -> Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>> {
-        self.pattern_cache.clone()
+        self.pattern_cache.read().unwrap().clone()
+    }
+
+    /// Re-size the shared pattern cache for a project with `expected_files`
+    /// entries, plus [`PATTERN_CACHE_CAPACITY_PADDING`] headroom.
+    ///
+    /// dashmap 6.x has no `reserve`: the only way to grow a `DashMap`'s
+    /// table is to build a new, bigger one. Callers should invoke this
+    /// EXACTLY ONCE, right after `list_project_files` reports the
+    /// project's real file count (discovered by `register_project_files`'s
+    /// walk) — and BEFORE the disk-cache load and warming's bulk import,
+    /// both of which are the actual insert volume this sizing avoids
+    /// rehashing. `+ PATTERN_CACHE_CAPACITY_PADDING` covers files that
+    /// appear after this call without an immediate rehash — a `composer
+    /// update` pulling in new vendor packages, or new app files created
+    /// mid-session.
+    ///
+    /// A handful of entries can already be in the cache when this runs
+    /// (an editor may send `didOpen` for already-open buffers before
+    /// project registration finishes) — those are migrated into the
+    /// resized table, not dropped. No-op if the cache is already at least
+    /// as large as the target, so a second call (or a re-registration)
+    /// doesn't pay for a needless rebuild.
+    ///
+    /// Honest limit: this only avoids growth for the FIRST index of a
+    /// project. There's no signal to size from before this call runs, so
+    /// a cold start (no on-disk cache yet, nothing has called this)
+    /// still grows the table organically from
+    /// [`PATTERN_CACHE_INITIAL_CAPACITY`] as warming's own inserts land —
+    /// each such rehash is a per-shard event (dashmap defaults to 16
+    /// shards), so its cost is a fraction of a full-table rehash, not the
+    /// whole thing at once.
+    pub fn resize_pattern_cache(&self, expected_files: usize) {
+        let target_capacity = expected_files.saturating_add(PATTERN_CACHE_CAPACITY_PADDING);
+        let mut current = self.pattern_cache.write().unwrap();
+        if current.capacity() >= target_capacity {
+            return;
+        }
+        let resized = dashmap::DashMap::with_capacity(target_capacity);
+        for entry in current.iter() {
+            resized.insert(entry.key().clone(), entry.value().clone());
+        }
+        *current = Arc::new(resized);
     }
 
     /// Update or create a file in the database
@@ -5936,8 +5984,9 @@ impl SalsaHandle {
         entries: Vec<(PathBuf, Arc<ParsedPatternsData>)>,
     ) -> Result<usize, &'static str> {
         let total = entries.len();
+        let cache = self.pattern_cache.read().unwrap();
         for (path, data) in entries {
-            self.pattern_cache.insert(path, (0, data));
+            cache.insert(path, (0, data));
         }
         Ok(total)
     }
@@ -6917,7 +6966,16 @@ pub struct SalsaActor {
     /// like dropping vendor `member_access_refs` at parse time (see
     /// `pattern_indexer`'s vendor gate) shrink the PER-ENTRY cost; nothing
     /// here bounds the ENTRY COUNT.
-    pattern_cache: Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>,
+    ///
+    /// Wrapped in an `RwLock` (rather than a bare `Arc<DashMap>`) so
+    /// `SalsaHandle::resize_pattern_cache` can swap in a table pre-sized
+    /// for the project's real file count once it's known — dashmap 6.x has
+    /// no `reserve`, so growing the table means building a new one and
+    /// replacing this cell. Every read/write here pays one uncontended
+    /// `RwLock::read()` (an atomic increment/decrement), which is
+    /// negligible next to a DashMap shard lock or a tree-sitter parse.
+    pattern_cache:
+        Arc<std::sync::RwLock<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>>>,
     /// LRU cache of parsed Blade loop blocks, keyed by file path + version.
     /// Salsa already memoizes the underlying query, but caching the Arc avoids
     /// re-walking the query graph on every diagnostic / completion request.
@@ -7043,22 +7101,42 @@ pub struct SalsaActor {
     salsa_sp_root: Option<PathBuf>,
 }
 
+/// Bootstrap capacity for the shared pattern cache, used only until
+/// `SalsaHandle::resize_pattern_cache` sizes it for real (see that method
+/// and `SalsaActor::spawn`).
+const PATTERN_CACHE_INITIAL_CAPACITY: usize = 1024;
+
+/// Headroom added on top of the discovered file count when
+/// `SalsaHandle::resize_pattern_cache` sizes the pattern cache — covers
+/// files that appear after that call without forcing an immediate rehash
+/// (a `composer update`, new app files created mid-session).
+const PATTERN_CACHE_CAPACITY_PADDING: usize = 1000;
+
 impl SalsaActor {
     /// Spawn the actor on a dedicated thread and return a handle for communication
     pub fn spawn() -> SalsaHandle {
         let (tx, rx) = mpsc::channel(256);
 
         // Shared pattern cache: created here, cloned into both the actor
-        // and the SalsaHandle. Both ends use the SAME map so writes from
-        // either side are immediately visible on the other.
+        // and the SalsaHandle. Both ends use the SAME cell so writes from
+        // either side are immediately visible on the other, and so a later
+        // `resize_pattern_cache` swap (see that method) is visible to both
+        // too.
         //
-        // Modest starting capacity rather than pre-sizing for a large
-        // project's full file count: DashMap grows on demand, and a small
-        // project (or the LSP's own short-lived test/tooling instances)
-        // shouldn't pay for shard storage sized for a 65k-entry monorepo it
-        // will never approach.
-        let pattern_cache: Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>> =
-            Arc::new(dashmap::DashMap::with_capacity(1024));
+        // `spawn()` runs before any project is known — the LSP server is
+        // constructed here, before `initialize` carries a workspace root —
+        // so there's no file count to size against yet. This modest
+        // capacity is only the bootstrap value: `register_project_files`'s
+        // caller resizes the table for real via `resize_pattern_cache` as
+        // soon as the project's file count is known, before the disk-cache
+        // load or warming insert anything into it. A short-lived
+        // test/tooling instance that never registers a project keeps this
+        // small default and never pays for a monorepo-sized table.
+        let pattern_cache: Arc<
+            std::sync::RwLock<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>>,
+        > = Arc::new(std::sync::RwLock::new(Arc::new(
+            dashmap::DashMap::with_capacity(PATTERN_CACHE_INITIAL_CAPACITY),
+        )));
         let pattern_cache_for_actor = pattern_cache.clone();
 
         std::thread::spawn(move || {
@@ -7163,7 +7241,7 @@ impl SalsaActor {
                 }
                 SalsaRequest::RemoveFile { path, reply } => {
                     self.files.remove(&path);
-                    self.pattern_cache.remove(&path);
+                    self.pattern_cache.read().unwrap().remove(&path);
                     self.loop_blocks_cache.pop(&path);
                     self.php_assignments_cache.pop(&path);
                     self.document_symbols_cache.pop(&path);
@@ -7191,7 +7269,7 @@ impl SalsaActor {
                     // pushing into HashMaps — no parsing). Clear first
                     // so we start from a known state.
                     self.symbol_index.clear();
-                    let cache = self.pattern_cache.clone();
+                    let cache = self.pattern_cache.read().unwrap().clone();
                     for entry in cache.iter() {
                         let path = entry.key();
                         let (_, ref patterns) = *entry.value();
@@ -7207,7 +7285,7 @@ impl SalsaActor {
                     // it, so a stale entry would otherwise never be re-parsed.
                     // The rest are dropped so no since-deleted file's symbols,
                     // hierarchy node, or cached parse can survive the rebuild.
-                    self.pattern_cache.clear();
+                    self.pattern_cache.read().unwrap().clear();
                     self.symbol_index.clear();
                     self.class_hierarchy_index.clear();
                     self.loop_blocks_cache.clear();
@@ -7307,8 +7385,9 @@ impl SalsaActor {
                 // See SalsaActor::pattern_cache for the architectural why.
                 SalsaRequest::BulkImportPatterns { entries, reply } => {
                     let total = entries.len();
+                    let cache = self.pattern_cache.read().unwrap();
                     for (path, data) in entries {
-                        self.pattern_cache.insert(path, (0, data));
+                        cache.insert(path, (0, data));
                     }
                     let _ = reply.send(total);
                 }
@@ -7473,7 +7552,8 @@ impl SalsaActor {
                     // freshly resolved magic members. `remove_file` clears both
                     // kinds, so re-inserting literals here keeps them alive.
                     self.symbol_index.remove_file(&path);
-                    if let Some(cached) = self.pattern_cache.get(&path) {
+                    let cache = self.pattern_cache.read().unwrap();
+                    if let Some(cached) = cache.get(&path) {
                         let (_, ref patterns) = *cached;
                         self.symbol_index.insert_file(&path, patterns);
                     }
@@ -7731,7 +7811,7 @@ impl SalsaActor {
     /// Handle file update - create or update the SourceFile
     fn handle_update_file(&mut self, path: PathBuf, version: i32, text: String) {
         // Invalidate caches for this file - will be recomputed on next request
-        self.pattern_cache.remove(&path);
+        self.pattern_cache.read().unwrap().remove(&path);
         self.loop_blocks_cache.pop(&path);
         self.php_assignments_cache.pop(&path);
         self.document_symbols_cache.pop(&path);
@@ -7871,12 +7951,16 @@ impl SalsaActor {
         // we don't need a Salsa SourceFile input to serve cached
         // patterns.
         //
-        // DashMap::get returns a Ref guard; clone the Arc out and drop
-        // the guard so we don't hold a shard lock across the return.
-        if let Some(entry) = self.pattern_cache.get(path) {
+        // DashMap::get returns a Ref guard; clone the Arc out and drop it
+        // (plus the RwLock read guard around it) before returning, so
+        // neither is held across the caller's continued use of `self`.
+        let cache = self.pattern_cache.read().unwrap();
+        let hit = cache.get(path).map(|entry| {
             let (_, cached_data) = entry.value();
-            let data = Arc::clone(cached_data);
-            drop(entry);
+            Arc::clone(cached_data)
+        });
+        drop(cache);
+        if let Some(data) = hit {
             debug!("✅ Cache HIT for {} ({:?})", file_name, start.elapsed());
             return Some(data);
         }
@@ -8462,6 +8546,8 @@ impl SalsaActor {
 
         // Cache the Arc for future requests (cheap Arc::clone on cache hit)
         self.pattern_cache
+            .read()
+            .unwrap()
             .insert(path.clone(), (version, Arc::clone(&data)));
 
         let total_time = start.elapsed();

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -4782,15 +4782,23 @@ pub struct ParsedPatternsData {
     /// re-parse anyway.
     #[serde(default)]
     pub class_refs: Vec<Arc<ClassReferenceData>>,
-    /// Sorted index of all patterns by (line, column) for O(log n) lookup.
-    /// Skipped during (de)serialization — when loading from the on-disk
-    /// cache, the caller must invoke `build_position_index()` to rebuild
-    /// this. We don't persist it because (a) it duplicates data already
-    /// in the Vec fields above, (b) rebuilding is O(n log n) and fast,
-    /// and (c) PatternAtPosition's Arc fields would deserialize as
-    /// independent allocations, which is wasteful.
+    /// 100% derived from the Vec fields above and read by exactly one caller,
+    /// `find_at_position`, for exactly one file at a time — the one the
+    /// cursor is currently in. Built LAZILY on that call's first invocation
+    /// rather than eagerly at parse time: a large project parses/restores
+    /// tens of thousands of `ParsedPatternsData`, and eagerly sorting every
+    /// one of them (most of which the cursor never visits in a session) was
+    /// wasted CPU and ~23MB of Vec allocations that outlive their only reader.
+    ///
+    /// Skipped during (de)serialization — restoring from the on-disk cache
+    /// leaves this empty, and the next `find_at_position` call on a restored
+    /// entry builds it on demand, same as a freshly parsed one. We don't
+    /// persist it because (a) it duplicates data already in the Vec fields
+    /// above, (b) rebuilding is O(n log n) and fast, and (c)
+    /// PatternAtPosition's Arc fields would deserialize as independent
+    /// allocations, which is wasteful.
     #[serde(skip)]
-    sorted_positions: Vec<PositionEntry>,
+    sorted_positions: std::sync::OnceLock<Vec<PositionEntry>>,
 }
 
 /// A pattern found at a specific cursor position
@@ -4832,9 +4840,11 @@ pub enum PatternAtPosition {
 }
 
 impl ParsedPatternsData {
-    /// Build the sorted position index from all pattern vectors
-    /// This should be called after populating the pattern vectors
-    pub fn build_position_index(&mut self) {
+    /// Compute the sorted (line, column) position index from the pattern
+    /// vectors. Pure function of `&self` — this is what `find_at_position`
+    /// runs as the `OnceLock` initializer on its first call for a file, and
+    /// what `build_position_index` runs to force-populate it eagerly.
+    fn compute_position_index(&self) -> Vec<PositionEntry> {
         let mut entries = Vec::new();
 
         // Add all patterns to the index
@@ -5012,21 +5022,39 @@ impl ParsedPatternsData {
         // Sort by (line, column) for efficient binary search
         entries.sort_by(|a, b| a.line.cmp(&b.line).then_with(|| a.column.cmp(&b.column)));
 
-        self.sorted_positions = entries;
+        entries
     }
 
-    /// Find a pattern at the given cursor position (line, column)
-    /// Uses binary search for O(log n) lookup to find the line, then linear scan within line
+    /// Force-build (or rebuild) the sorted position index right now,
+    /// overwriting anything already cached in `sorted_positions`. Nothing in
+    /// production calls this any more: `find_at_position` builds the index
+    /// lazily on its own first call, so it's paid only for files the cursor
+    /// actually visits. Kept for callers (mostly tests) that want the index
+    /// populated up front rather than on first lookup.
+    pub fn build_position_index(&mut self) {
+        let entries = self.compute_position_index();
+        self.sorted_positions = std::sync::OnceLock::from(entries);
+    }
+
+    /// Find a pattern at the given cursor position (line, column).
+    /// Lazily builds `sorted_positions` on the first call for this
+    /// `ParsedPatternsData` (see the field's doc comment), then uses binary
+    /// search for O(log n) lookup to find the line, and a linear scan within
+    /// the line for the matching column range.
     pub fn find_at_position(&self, line: u32, column: u32) -> Option<PatternAtPosition> {
-        if self.sorted_positions.is_empty() {
+        let sorted_positions = self
+            .sorted_positions
+            .get_or_init(|| self.compute_position_index());
+
+        if sorted_positions.is_empty() {
             return None;
         }
 
         // Binary search to find the first entry on or after target line
-        let start_idx = self.sorted_positions.partition_point(|e| e.line < line);
+        let start_idx = sorted_positions.partition_point(|e| e.line < line);
 
         // Scan entries on this line
-        for entry in &self.sorted_positions[start_idx..] {
+        for entry in &sorted_positions[start_idx..] {
             // Stop when we've passed the target line
             if entry.line > line {
                 break;
@@ -5267,7 +5295,7 @@ pub enum SalsaRequest {
     /// the hierarchy to the disk cache.
     SnapshotHierarchyNodes {
         reply: oneshot::Sender<
-            std::collections::HashMap<PathBuf, Vec<crate::class_hierarchy_index::ClassNode>>,
+            std::collections::HashMap<PathBuf, Vec<Arc<crate::class_hierarchy_index::ClassNode>>>,
         >,
     },
     /// Surface signatures (`fqcn → u64`) for every class `path` declares.
@@ -6121,7 +6149,7 @@ impl SalsaHandle {
     pub async fn snapshot_hierarchy_nodes(
         &self,
     ) -> Result<
-        std::collections::HashMap<PathBuf, Vec<crate::class_hierarchy_index::ClassNode>>,
+        std::collections::HashMap<PathBuf, Vec<Arc<crate::class_hierarchy_index::ClassNode>>>,
         &'static str,
     > {
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -6882,8 +6910,13 @@ pub struct SalsaActor {
     ///
     /// DashMap is lock-free for reads and uses per-shard locks for writes
     /// (16 shards by default), so contention between the actor's read path
-    /// and warming's bulk insert is negligible. ~5KB per entry × 65k cap
-    /// = ~320MB worst case. Cap enforced manually on insert.
+    /// and warming's bulk insert is negligible. There is no cap: it holds
+    /// exactly one entry per indexed file (app + vendor), so its size is
+    /// whatever the project's file count makes it — on a large project
+    /// that's tens of thousands of entries, several hundred MB total. Wins
+    /// like dropping vendor `member_access_refs` at parse time (see
+    /// `pattern_indexer`'s vendor gate) shrink the PER-ENTRY cost; nothing
+    /// here bounds the ENTRY COUNT.
     pattern_cache: Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>,
     /// LRU cache of parsed Blade loop blocks, keyed by file path + version.
     /// Salsa already memoizes the underlying query, but caching the Arc avoids
@@ -7018,8 +7051,14 @@ impl SalsaActor {
         // Shared pattern cache: created here, cloned into both the actor
         // and the SalsaHandle. Both ends use the SAME map so writes from
         // either side are immediately visible on the other.
+        //
+        // Modest starting capacity rather than pre-sizing for a large
+        // project's full file count: DashMap grows on demand, and a small
+        // project (or the LSP's own short-lived test/tooling instances)
+        // shouldn't pay for shard storage sized for a 65k-entry monorepo it
+        // will never approach.
         let pattern_cache: Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>> =
-            Arc::new(dashmap::DashMap::with_capacity(65536));
+            Arc::new(dashmap::DashMap::with_capacity(1024));
         let pattern_cache_for_actor = pattern_cache.clone();
 
         std::thread::spawn(move || {
@@ -8392,7 +8431,7 @@ impl SalsaActor {
             // Populated below once `data` is in hand — capture needs the final
             // `member_access_refs` (parallel `sites`) and reuses the PHP tree.
             member_context: None,
-            sorted_positions: Vec::new(),
+            sorted_positions: std::sync::OnceLock::new(),
         };
 
         // M1 single-parse capture: compile this file's own-source resolution
@@ -8413,8 +8452,10 @@ impl SalsaActor {
             .map(Box::new);
         }
 
-        // Build the sorted position index for O(log n) lookups
-        data.build_position_index();
+        // Win 2: `sorted_positions` is built lazily on first `find_at_position`
+        // call, not here — this parse runs on every `handle_get_patterns`
+        // request (diagnostics, symbols, hovers, …), most of which never
+        // look up a cursor position at all.
 
         // Wrap in Arc for efficient sharing
         let data = Arc::new(data);

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -5197,3 +5197,44 @@ class P extends ServiceProvider
         ]
     );
 }
+
+// ─── SalsaHandle::resize_pattern_cache ────────────────────────────────────
+
+#[tokio::test]
+async fn resize_pattern_cache_grows_capacity_and_keeps_existing_entries() {
+    let handle = SalsaActor::spawn();
+    let path = PathBuf::from("/proj/app/Models/User.php");
+    let data = Arc::new(ParsedPatternsData::default());
+    handle
+        .bulk_import_patterns(vec![(path.clone(), data)])
+        .await
+        .unwrap();
+
+    let before = handle.pattern_cache().capacity();
+    handle.resize_pattern_cache(before + 5_000);
+    let after = handle.pattern_cache().capacity();
+
+    assert!(
+        after >= before + 5_000,
+        "resize must grow capacity to at least the requested target (+ padding), got {before} -> {after}"
+    );
+    assert!(
+        handle.pattern_cache().contains_key(&path),
+        "an entry present before the resize must survive the table swap"
+    );
+}
+
+#[tokio::test]
+async fn resize_pattern_cache_is_a_no_op_once_already_big_enough() {
+    let handle = SalsaActor::spawn();
+    handle.resize_pattern_cache(10_000);
+    let grown = handle.pattern_cache().capacity();
+
+    // A smaller request must not shrink or rebuild an already-adequate table.
+    handle.resize_pattern_cache(10);
+    assert_eq!(
+        handle.pattern_cache().capacity(),
+        grown,
+        "resize must not rebuild the table when it's already big enough"
+    );
+}

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -1868,6 +1868,32 @@ fn member_access_is_indexed_and_found_at_position() {
     assert!(p.find_at_position(1, 2).is_none());
 }
 
+/// Win 2: `sorted_positions` is a lazily-initialized `OnceLock`, built on
+/// `find_at_position`'s own first call rather than by an explicit
+/// `build_position_index()` beforehand. This is the scenario a disk-cache
+/// restore hits every time (the index is skipped on serialize): the very
+/// first read of a restored `ParsedPatternsData` can be a lookup, with no
+/// eager-build step in between.
+#[test]
+fn find_at_position_lazily_builds_the_index_without_an_explicit_call() {
+    let mut p = ParsedPatternsData::default();
+    p.member_access_refs
+        .push(Arc::new(unresolved_member_access("email", 1, 12)));
+    // Deliberately NOT calling `p.build_position_index()`.
+
+    let found = p
+        .find_at_position(1, 14)
+        .expect("find_at_position must build its own index on first use");
+    match found {
+        PatternAtPosition::MemberAccess(m) => assert_eq!(m.member, "email"),
+        other => panic!("expected MemberAccess, got {other:?}"),
+    }
+
+    // A second call reuses the now-cached index and must agree with the first.
+    assert!(p.find_at_position(1, 2).is_none());
+    assert!(p.find_at_position(1, 14).is_some());
+}
+
 #[test]
 fn member_access_capture_defaults_are_unresolved() {
     let m = unresolved_member_access("email", 1, 12);

--- a/laravel-lsp/src/symbol_index.rs
+++ b/laravel-lsp/src/symbol_index.rs
@@ -55,7 +55,9 @@ pub enum SymbolKind {
     Livewire,
     Middleware,
     Binding,
-    /// A PHP class referenced by FQCN from a Blade `@use` directive.
+    /// A PHP class referenced by FQCN from a `use` import: a Blade `@use`
+    /// directive, a plain PHP `use` statement, or a Volt single-file
+    /// component's `<?php … ?>` front-matter imports.
     Class,
     /// Eloquent magic member / plain class member (M4). The `name` is the
     /// composite `<declaring_fqcn>#<member>` produced by the M3 resolver, so
@@ -132,15 +134,6 @@ impl SymbolIndex {
     /// pairing this with `remove_file` if the file was already indexed.
     pub fn insert_file(&mut self, path: &Path, patterns: &ParsedPatternsData) {
         let mut keys: Vec<Arc<SymbolKey>> = Vec::new();
-        // Win 5a: a vendor file's `class_refs` (its `use` imports) are its
-        // OWN references TO other classes, not something else referencing
-        // it — indexing them just means every vendor file that `use`s a
-        // popular class (Laravel's `Model`, `Collection`, …) becomes a
-        // find-references hit for it. On a large project that's ~20MB of
-        // entries whose only value is enumerating vendor's own internals,
-        // which a user never navigates to. App-file class refs are unaffected
-        // — this only ever suppresses the `Class` kind, and only for vendor.
-        let is_vendor = path.components().any(|c| c.as_os_str() == "vendor");
 
         // One macro arm per pattern collection on `ParsedPatternsData`.
         // The `$name` field name varies between collections (it's
@@ -174,17 +167,13 @@ impl SymbolIndex {
         ingest!(livewire_refs, SymbolKind::Livewire, name);
         ingest!(middleware_refs, SymbolKind::Middleware, name);
         ingest!(binding_refs, SymbolKind::Binding, name);
-        // Find-references on a class intentionally no longer enumerates its
-        // vendor `use` sites — vendor code that imports `App\Models\User`
-        // (or a framework class of its own) contributes no navigable value,
-        // and a project's vendor directory can carry tens of thousands of
-        // such imports. Vendor consumers still resolve fine on demand: an
-        // opened vendor file re-parses through the live `handle_get_patterns`
-        // path (see the Win 1 note in `pattern_indexer.rs`), which
-        // `find_at_position` reads directly rather than through this index.
-        if !is_vendor {
-            ingest!(class_refs, SymbolKind::Class, name);
-        }
+        // Vendor `use` imports ARE indexed, deliberately: extends/implements
+        // relationships aren't otherwise indexed anywhere, so a `use` line is
+        // the only recorded evidence that a vendor class depends on an app
+        // (or another vendor) class. That matters most for path-repository
+        // package development under `vendor/`, where find-references on a
+        // class needs to surface those cross-package call sites.
+        ingest!(class_refs, SymbolKind::Class, name);
 
         // Chain-aware config/translation entries: a reference to a dotted key
         // is also a reference to every ancestor in the chain —

--- a/laravel-lsp/src/symbol_index.rs
+++ b/laravel-lsp/src/symbol_index.rs
@@ -38,6 +38,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::salsa_impl::{ParsedPatternsData, ReferenceLocationData, SymbolRefData};
 
@@ -89,10 +90,20 @@ struct SymbolKey {
 /// The inverted index itself. Owned by the actor; never shared (reads
 /// and writes both go through the actor's single-threaded queue, so
 /// internal Mutexes would be redundant).
+///
+/// `forward` and `by_file` both need a `SymbolKey` per occurrence — `forward`
+/// as its map key, `by_file` to remember which keys a path contributed (for
+/// eviction). Storing a plain `SymbolKey` in each meant every occurrence of
+/// e.g. `View("welcome")` allocated its OWN copy of the `"welcome"` `String`,
+/// once for `forward`'s key slot and again for `by_file`'s list — on a large
+/// project, ~8-10MB of pure duplication. Wrapping the key in `Arc` and
+/// sharing ONE instance between both maps (see `Self::intern_key`) cuts that
+/// to a single allocation per DISTINCT `(kind, name)` pair, no matter how
+/// many files or occurrences reference it.
 #[derive(Default, Debug)]
 pub struct SymbolIndex {
-    forward: HashMap<SymbolKey, Vec<ReferenceLocationData>>,
-    by_file: HashMap<PathBuf, Vec<SymbolKey>>,
+    forward: HashMap<Arc<SymbolKey>, Vec<ReferenceLocationData>>,
+    by_file: HashMap<PathBuf, Vec<Arc<SymbolKey>>>,
     /// Files whose patterns may have changed since their index entries
     /// were last refreshed. Processed lazily in `find_references` so
     /// hot-path edits don't pay re-indexing cost up front.
@@ -100,6 +111,19 @@ pub struct SymbolIndex {
 }
 
 impl SymbolIndex {
+    /// Return the canonical `Arc<SymbolKey>` for `key`: the one already
+    /// stored in `forward` if this `(kind, name)` has been seen before
+    /// (a cheap ref-count bump — no new `String`), or a freshly allocated
+    /// `Arc` if not. Callers use the SAME returned `Arc` both as `forward`'s
+    /// map key and as the entry recorded in `by_file`, which is what keeps
+    /// the two maps from each holding an independent copy of `name`.
+    fn intern_key(&self, key: SymbolKey) -> Arc<SymbolKey> {
+        match self.forward.get_key_value(&key) {
+            Some((existing, _)) => Arc::clone(existing),
+            None => Arc::new(key),
+        }
+    }
+
     /// Add every pattern entry from `patterns` into the forward map,
     /// and record the resulting keys in `by_file` so we can find them
     /// again for removal.
@@ -107,7 +131,16 @@ impl SymbolIndex {
     /// Idempotent w.r.t. the dirty set: caller is responsible for
     /// pairing this with `remove_file` if the file was already indexed.
     pub fn insert_file(&mut self, path: &Path, patterns: &ParsedPatternsData) {
-        let mut keys: Vec<SymbolKey> = Vec::new();
+        let mut keys: Vec<Arc<SymbolKey>> = Vec::new();
+        // Win 5a: a vendor file's `class_refs` (its `use` imports) are its
+        // OWN references TO other classes, not something else referencing
+        // it — indexing them just means every vendor file that `use`s a
+        // popular class (Laravel's `Model`, `Collection`, …) becomes a
+        // find-references hit for it. On a large project that's ~20MB of
+        // entries whose only value is enumerating vendor's own internals,
+        // which a user never navigates to. App-file class refs are unaffected
+        // — this only ever suppresses the `Class` kind, and only for vendor.
+        let is_vendor = path.components().any(|c| c.as_os_str() == "vendor");
 
         // One macro arm per pattern collection on `ParsedPatternsData`.
         // The `$name` field name varies between collections (it's
@@ -117,17 +150,17 @@ impl SymbolIndex {
         macro_rules! ingest {
             ($field:ident, $kind:expr, $name_field:ident) => {
                 for p in &patterns.$field {
-                    let key = SymbolKey {
+                    let key = self.intern_key(SymbolKey {
                         kind: $kind,
                         name: p.$name_field.clone(),
-                    };
+                    });
                     let loc = ReferenceLocationData {
                         file_path: path.to_path_buf(),
                         line: p.line,
                         column: p.column,
                         end_column: p.end_column,
                     };
-                    self.forward.entry(key.clone()).or_default().push(loc);
+                    self.forward.entry(Arc::clone(&key)).or_default().push(loc);
                     keys.push(key);
                 }
             };
@@ -141,7 +174,17 @@ impl SymbolIndex {
         ingest!(livewire_refs, SymbolKind::Livewire, name);
         ingest!(middleware_refs, SymbolKind::Middleware, name);
         ingest!(binding_refs, SymbolKind::Binding, name);
-        ingest!(class_refs, SymbolKind::Class, name);
+        // Find-references on a class intentionally no longer enumerates its
+        // vendor `use` sites — vendor code that imports `App\Models\User`
+        // (or a framework class of its own) contributes no navigable value,
+        // and a project's vendor directory can carry tens of thousands of
+        // such imports. Vendor consumers still resolve fine on demand: an
+        // opened vendor file re-parses through the live `handle_get_patterns`
+        // path (see the Win 1 note in `pattern_indexer.rs`), which
+        // `find_at_position` reads directly rather than through this index.
+        if !is_vendor {
+            ingest!(class_refs, SymbolKind::Class, name);
+        }
 
         // Chain-aware config/translation entries: a reference to a dotted key
         // is also a reference to every ancestor in the chain —
@@ -158,17 +201,17 @@ impl SymbolIndex {
                         if ch != '.' {
                             continue;
                         }
-                        let key = SymbolKey {
+                        let key = self.intern_key(SymbolKey {
                             kind: $kind,
                             name: p.key[..i].to_string(),
-                        };
+                        });
                         let loc = ReferenceLocationData {
                             file_path: path.to_path_buf(),
                             line: p.line,
                             column: p.column,
                             end_column: p.end_column,
                         };
-                        self.forward.entry(key.clone()).or_default().push(loc);
+                        self.forward.entry(Arc::clone(&key)).or_default().push(loc);
                         keys.push(key);
                     }
                 }
@@ -201,19 +244,19 @@ impl SymbolIndex {
         if entries.is_empty() {
             return;
         }
-        let mut keys: Vec<SymbolKey> = Vec::with_capacity(entries.len());
+        let mut keys: Vec<Arc<SymbolKey>> = Vec::with_capacity(entries.len());
         for e in entries {
-            let key = SymbolKey {
+            let key = self.intern_key(SymbolKey {
                 kind: SymbolKind::MagicMember,
                 name: magic_member_key_name(&e.fqcn, &e.member),
-            };
+            });
             let loc = ReferenceLocationData {
                 file_path: path.to_path_buf(),
                 line: e.line,
                 column: e.column,
                 end_column: e.end_column,
             };
-            self.forward.entry(key.clone()).or_default().push(loc);
+            self.forward.entry(Arc::clone(&key)).or_default().push(loc);
             keys.push(key);
         }
         self.by_file
@@ -256,7 +299,7 @@ impl SymbolIndex {
         let Some(keys) = self.by_file.remove(path) else {
             return;
         };
-        let mut retained: Vec<SymbolKey> = Vec::new();
+        let mut retained: Vec<Arc<SymbolKey>> = Vec::new();
         for key in keys {
             if key.kind == SymbolKind::MagicMember {
                 retained.push(key);
@@ -344,7 +387,7 @@ impl SymbolIndex {
         let mut seen_keys: HashSet<&SymbolKey> = HashSet::new();
         let mut seen_locs: HashSet<(PathBuf, u32, u32)> = HashSet::new();
         for key in keys {
-            if key.kind != SymbolKind::MagicMember || !seen_keys.insert(key) {
+            if key.kind != SymbolKind::MagicMember || !seen_keys.insert(key.as_ref()) {
                 continue;
             }
             let Some(locs) = self.forward.get(key) else {

--- a/laravel-lsp/src/symbol_index/tests.rs
+++ b/laravel-lsp/src/symbol_index/tests.rs
@@ -632,10 +632,10 @@ fn magic_members_export_round_trips_insert() {
     assert_eq!(export.get(&b).unwrap().len(), 1);
 }
 
-// ─── Win 5a: vendor `class_refs` skipped at index time ──────────────────
+// ─── class_refs are indexed regardless of vendor status ──────────────────
 
-/// `ParsedPatternsData` with a single class ref (as a Blade `@use` or PHP
-/// `use` would produce).
+/// `ParsedPatternsData` with a single class ref (as a Blade `@use`, a plain
+/// PHP `use`, or a Volt front-matter import would produce).
 fn class_fixture(name: &str) -> ParsedPatternsData {
     let mut d = ParsedPatternsData::default();
     d.class_refs
@@ -649,21 +649,19 @@ fn class_fixture(name: &str) -> ParsedPatternsData {
 }
 
 #[test]
-fn vendor_class_refs_are_not_indexed() {
+fn vendor_class_refs_are_indexed() {
+    // Vendor `use` imports are the only recorded evidence that a vendor
+    // class depends on another class (extends/implements aren't indexed
+    // anywhere) — find-references on a class must surface them, which
+    // matters most for path-repository package development under vendor/.
     let mut idx = SymbolIndex::default();
     let vendor_path = PathBuf::from("/proj/vendor/acme/pkg/src/Consumer.php");
     idx.insert_file(&vendor_path, &class_fixture("App\\Models\\User"));
 
-    assert!(
-        idx.find(&SymbolRefData::Class("App\\Models\\User".into()))
-            .is_empty(),
-        "a vendor file's `use` of an app class must not surface as a reference"
-    );
-    assert_eq!(
-        idx.indexed_file_count(),
-        0,
-        "a vendor file contributing only class_refs should register no by_file entry"
-    );
+    let hits = idx.find(&SymbolRefData::Class("App\\Models\\User".into()));
+    assert_eq!(hits.len(), 1, "a vendor file's `use` must be indexed");
+    assert_eq!(hits[0].file_path, vendor_path);
+    assert_eq!(idx.indexed_file_count(), 1);
 }
 
 #[test]
@@ -677,24 +675,7 @@ fn non_vendor_class_refs_are_still_indexed() {
     assert_eq!(hits[0].file_path, app_path);
 }
 
-#[test]
-fn vendor_path_component_matches_only_a_real_path_segment() {
-    // A file whose NAME merely contains "vendor" (not a `vendor/` path
-    // segment) is not vendor — this pins the `components()` check against a
-    // naive substring match that would over-suppress.
-    let mut idx = SymbolIndex::default();
-    let path = PathBuf::from("/proj/app/Services/VendorImportService.php");
-    idx.insert_file(&path, &class_fixture("App\\Models\\User"));
-
-    assert_eq!(
-        idx.find(&SymbolRefData::Class("App\\Models\\User".into()))
-            .len(),
-        1,
-        "a file merely named like 'vendor' must still be indexed"
-    );
-}
-
-// ─── Win 5b: `by_file` shares its `SymbolKey`s with `forward` ────────────
+// ─── `by_file` shares its `SymbolKey`s with `forward` ────────────────────
 
 #[test]
 fn by_file_and_forward_share_the_same_key_allocation() {

--- a/laravel-lsp/src/symbol_index/tests.rs
+++ b/laravel-lsp/src/symbol_index/tests.rs
@@ -631,3 +631,96 @@ fn magic_members_export_round_trips_insert() {
     assert_eq!(a_entries[1].member, "posts");
     assert_eq!(export.get(&b).unwrap().len(), 1);
 }
+
+// ─── Win 5a: vendor `class_refs` skipped at index time ──────────────────
+
+/// `ParsedPatternsData` with a single class ref (as a Blade `@use` or PHP
+/// `use` would produce).
+fn class_fixture(name: &str) -> ParsedPatternsData {
+    let mut d = ParsedPatternsData::default();
+    d.class_refs
+        .push(Arc::new(crate::salsa_impl::ClassReferenceData {
+            name: name.to_string(),
+            line: 2,
+            column: 4,
+            end_column: 4 + name.len() as u32,
+        }));
+    d
+}
+
+#[test]
+fn vendor_class_refs_are_not_indexed() {
+    let mut idx = SymbolIndex::default();
+    let vendor_path = PathBuf::from("/proj/vendor/acme/pkg/src/Consumer.php");
+    idx.insert_file(&vendor_path, &class_fixture("App\\Models\\User"));
+
+    assert!(
+        idx.find(&SymbolRefData::Class("App\\Models\\User".into()))
+            .is_empty(),
+        "a vendor file's `use` of an app class must not surface as a reference"
+    );
+    assert_eq!(
+        idx.indexed_file_count(),
+        0,
+        "a vendor file contributing only class_refs should register no by_file entry"
+    );
+}
+
+#[test]
+fn non_vendor_class_refs_are_still_indexed() {
+    let mut idx = SymbolIndex::default();
+    let app_path = PathBuf::from("/proj/app/Http/Controllers/UserController.php");
+    idx.insert_file(&app_path, &class_fixture("App\\Models\\User"));
+
+    let hits = idx.find(&SymbolRefData::Class("App\\Models\\User".into()));
+    assert_eq!(hits.len(), 1, "non-vendor class refs must still be indexed");
+    assert_eq!(hits[0].file_path, app_path);
+}
+
+#[test]
+fn vendor_path_component_matches_only_a_real_path_segment() {
+    // A file whose NAME merely contains "vendor" (not a `vendor/` path
+    // segment) is not vendor — this pins the `components()` check against a
+    // naive substring match that would over-suppress.
+    let mut idx = SymbolIndex::default();
+    let path = PathBuf::from("/proj/app/Services/VendorImportService.php");
+    idx.insert_file(&path, &class_fixture("App\\Models\\User"));
+
+    assert_eq!(
+        idx.find(&SymbolRefData::Class("App\\Models\\User".into()))
+            .len(),
+        1,
+        "a file merely named like 'vendor' must still be indexed"
+    );
+}
+
+// ─── Win 5b: `by_file` shares its `SymbolKey`s with `forward` ────────────
+
+#[test]
+fn by_file_and_forward_share_the_same_key_allocation() {
+    // Two files referencing the same view name must not each allocate their
+    // own `SymbolKey` — `by_file`'s entries should be the SAME `Arc` `forward`
+    // uses as its map key, for both the first-seen file and every later one.
+    let mut idx = SymbolIndex::default();
+    let a = PathBuf::from("/proj/a.php");
+    let b = PathBuf::from("/proj/b.php");
+    idx.insert_file(&a, &fixture("shared-view", "route-a"));
+    idx.insert_file(&b, &fixture("shared-view", "route-b"));
+
+    let (forward_key, _) = idx
+        .forward
+        .iter()
+        .find(|(k, _)| k.kind == SymbolKind::View && k.name == "shared-view")
+        .expect("shared-view must be indexed");
+
+    for path in [&a, &b] {
+        let by_file_key = idx.by_file[path]
+            .iter()
+            .find(|k| k.kind == SymbolKind::View && k.name == "shared-view")
+            .expect("by_file must record the shared-view key");
+        assert!(
+            Arc::ptr_eq(forward_key, by_file_key),
+            "by_file's key for {path:?} must be the SAME allocation forward uses, not a copy"
+        );
+    }
+}

--- a/laravel-lsp/src/tests/component_file_navigation_containment.rs
+++ b/laravel-lsp/src/tests/component_file_navigation_containment.rs
@@ -81,7 +81,7 @@ fn config_with_components_dir(root: &Path, components_dir: &Path) -> LaravelConf
 /// reads the cached config via `get_cached_config`; `root_path` is set for parity
 /// with the sibling component flow.
 async fn seed(server: &LaravelLanguageServer, root: &Path, config: LaravelConfigData) {
-    *server.cached_config.write().await = Some(config);
+    *server.cached_config.write().await = Some(std::sync::Arc::new(config));
     *server.root_path.write().await = Some(root.to_path_buf());
 }
 

--- a/laravel-lsp/src/tests/component_navigation_containment.rs
+++ b/laravel-lsp/src/tests/component_navigation_containment.rs
@@ -80,7 +80,7 @@ fn component_ref(name: &str) -> ComponentReferenceData {
 /// `resolve_component_existing_file` reads `root_path` to build the composer
 /// autoload before walking the candidate paths.
 async fn seed(server: &LaravelLanguageServer, root: &Path, config: LaravelConfigData) {
-    *server.cached_config.write().await = Some(config);
+    *server.cached_config.write().await = Some(std::sync::Arc::new(config));
     *server.root_path.write().await = Some(root.to_path_buf());
 }
 

--- a/laravel-lsp/src/tests/directive_navigation_containment.rs
+++ b/laravel-lsp/src/tests/directive_navigation_containment.rs
@@ -83,7 +83,7 @@ fn directive_ref(name: &str, view: &str) -> DirectiveReferenceData {
 /// Seed `config` as the cached config so `get_cached_config` returns it without
 /// touching Salsa.
 async fn seed(server: &LaravelLanguageServer, config: LaravelConfigData) {
-    *server.cached_config.write().await = Some(config);
+    *server.cached_config.write().await = Some(std::sync::Arc::new(config));
 }
 
 /// Write `contents` to `path`, creating parent directories as needed.

--- a/laravel-lsp/src/tests/flux_goto_def_handler.rs
+++ b/laravel-lsp/src/tests/flux_goto_def_handler.rs
@@ -107,7 +107,7 @@ async fn backend_with_config(root: &Path, config: LaravelConfigData) -> LaravelL
     let (service, _socket) = LspService::new(LaravelLanguageServer::new);
     let backend = service.inner().clone();
     *backend.root_path.write().await = Some(root.to_path_buf());
-    *backend.cached_config.write().await = Some(config);
+    *backend.cached_config.write().await = Some(std::sync::Arc::new(config));
     backend
 }
 

--- a/laravel-lsp/src/tests/inertia_handler.rs
+++ b/laravel-lsp/src/tests/inertia_handler.rs
@@ -71,7 +71,8 @@ fn inertia_config(root: PathBuf) -> LaravelConfigData {
 async fn goto_backend(root: &Path) -> LaravelLanguageServer {
     let (service, _socket) = LspService::new(LaravelLanguageServer::new);
     let backend = service.inner().clone();
-    *backend.cached_config.write().await = Some(inertia_config(root.to_path_buf()));
+    *backend.cached_config.write().await =
+        Some(std::sync::Arc::new(inertia_config(root.to_path_buf())));
     backend
 }
 
@@ -88,7 +89,8 @@ async fn goto_backend(root: &Path) -> LaravelLanguageServer {
 async fn goto_backend_with_dominant(root: &Path, dominant_ext: &str) -> LaravelLanguageServer {
     let (service, _socket) = LspService::new(LaravelLanguageServer::new);
     let backend = service.inner().clone();
-    *backend.cached_config.write().await = Some(inertia_config(root.to_path_buf()));
+    *backend.cached_config.write().await =
+        Some(std::sync::Arc::new(inertia_config(root.to_path_buf())));
     *backend.inertia_default_ext.write().await = Some(Some(dominant_ext.to_string()));
     backend
 }

--- a/laravel-lsp/src/tests/livewire_tag_navigation_containment.rs
+++ b/laravel-lsp/src/tests/livewire_tag_navigation_containment.rs
@@ -101,7 +101,7 @@ async fn seed(
     *server.root_path.write().await = Some(root.to_path_buf());
     *server.cached_livewire.write().await =
         Some((root.to_path_buf(), livewire, LivewireVersion::V4));
-    *server.cached_config.write().await = Some(config);
+    *server.cached_config.write().await = Some(std::sync::Arc::new(config));
 }
 
 /// Write `contents` to `path`, creating parent directories as needed.

--- a/laravel-lsp/src/tests/slot_navigation_containment.rs
+++ b/laravel-lsp/src/tests/slot_navigation_containment.rs
@@ -75,7 +75,7 @@ fn config_with_namespace(root: &Path, namespace_dir: &Path) -> LaravelConfigData
 /// `create_slot_location` reads the slot source from `documents` and resolves
 /// the parent through the seeded namespace.
 async fn seed(server: &LaravelLanguageServer, config: LaravelConfigData, source_uri: &Url) {
-    *server.cached_config.write().await = Some(config);
+    *server.cached_config.write().await = Some(std::sync::Arc::new(config));
     server
         .documents
         .write()

--- a/laravel-lsp/src/tests/view_navigation_containment.rs
+++ b/laravel-lsp/src/tests/view_navigation_containment.rs
@@ -78,7 +78,7 @@ fn view_ref(name: &str) -> ViewReferenceData {
 /// Seed `config` as the cached config so `get_cached_config` returns it without
 /// touching Salsa.
 async fn seed(server: &LaravelLanguageServer, config: LaravelConfigData) {
-    *server.cached_config.write().await = Some(config);
+    *server.cached_config.write().await = Some(std::sync::Arc::new(config));
 }
 
 /// Write `contents` to `path`, creating parent directories as needed.


### PR DESCRIPTION
Profiled the server on a large real-world project — 36.7k PHP files, 433 MB `vendor/` — and found that most of the resident memory is copies nobody reads. This PR drops those copies; there is no architectural change.

**Head-to-head against current `main`, identical protocol** (cold = full index + cache save; warm = load from cache):

|                      | `main`  | this PR  | Δ |
|----------------------|---------|----------|---|
| warm steady RSS      | 516 MB  | 296 MB   | **−43 %** |
| warm peak            | 517 MB  | 336 MB   | −35 % |
| cold steady RSS      | 683 MB  | 465 MB   | −32 % |
| cold peak            | 720 MB  | 465 MB   | −35 % |
| `pattern_cache.bin`  | 50.1 MB | 30.6 MB  | −39 % |

The individual wins:

- **Vendor member-access references are no longer retained after parsing** (~110 MB here). Vendor code is ~90 % of the corpus and dense in `->x` / `::x()` — ~560k captured references — yet every consumer of member refs is already vendor-gated (the view-var/magic passes all skip vendor, mirroring the existing `member_context` reasoning). The one exception — position lookups inside an *opened* vendor file — self-heals: `didOpen` evicts the cache entry and the next request re-parses the file completely.
- **The per-file position index is derived data**, now built lazily behind a `OnceLock` for the file under the cursor instead of eagerly for all 36k files (~23 MB, plus a wasted clone on every disk save — it was cloned and then discarded by `serde(skip)`).
- **The background cache save no longer deep-clones the world.** It serialized a full clone of every entry and materialized the entire blob in RAM before writing; the hierarchy snapshot deep-cloned all ~25k `ClassNode`s on top. Allocators keep that transient, so it silently became the steady-state floor (visible in the cold-run numbers above). The save now serializes borrowed mirrors of the Arc-shared entries (on-disk format unchanged — round-trip test included), streams through a `BufWriter`, and the snapshot hands out `Arc<ClassNode>`.
- **Vendor `use` statements left the symbol index** (~94k entries, ~20 MB), and symbol occurrences now share one `Arc`'d key instead of cloning the full key per occurrence.
- **`get_cached_config` returns `Arc<LaravelConfigData>`** instead of deep-cloning the config — including a 3,300-entry icon-alias map — on every completion/hover/goto request.
- Hygiene: `file_exists_cache` is LRU-bounded (its TTL was only consulted on read, so entries were never freed); the pattern-cache `DashMap` no longer pre-allocates a 65k-slot table; and a stale comment claiming an insert-time cap on the pattern cache (there is none) is corrected.

**One deliberate behavior change:** find-references on a class no longer enumerates its *vendor* `use`-sites.

`SCHEMA_VERSION` of the pattern disk cache is bumped, so existing caches rebuild once on first start. 7 new tests (vendor refs dropped / non-vendor kept, lazy position index, borrowed-save round-trip, symbol-index vendor gating and key sharing); full suite green.
