### PR TITLE
ci: 👷 Run the LSP job on Linux, macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,27 @@ env:
 jobs:
   laravel-lsp:
     name: LSP — test, fmt, clippy
-    runs-on: ubuntu-latest
+    strategy:
+      # Every leg runs to completion — one platform's failure must not cancel
+      # the others, or a Windows break would hide whether Linux and macOS are
+      # still green.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    # Scoped per-leg, deliberately: a bare job-level `continue-on-error: true`
+    # would make the Linux and macOS legs non-blocking too. Windows is new and
+    # expected to surface pre-existing failures (the tree carries ~455
+    # Unix-rooted path literals); it reports without blocking until those are
+    # triaged into their own issues. Dropping this is tracked in #292.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     defaults:
       run:
+        # GitHub-hosted Windows runners ship Git Bash, so one shell keeps all
+        # three legs running byte-identical commands — `cp`, path expansion and
+        # quoting included. Without it Windows would default to PowerShell and
+        # the steps would silently diverge from what Linux and macOS run.
+        shell: bash
         working-directory: laravel-lsp
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,20 @@ jobs:
           # 8.4 matches the actual minimum required by the locked
           # vendor packages (symfony/* v8.0 requires >= 8.4).
           php-version: '8.4'
-          # `filament/support` requires ext-intl. Ubuntu's runner PHP bundles
-          # it, so the single-OS job got it for free; the Windows runner does
-          # not, and composer refused to resolve. Naming it here makes the
-          # requirement explicit for every leg rather than leaving one
-          # platform's default doing the work (issue #292).
-          extensions: intl
+          # The PHP extensions test-project's dependency graph declares, taken
+          # from the `ext-*` requires across its installed vendor tree rather
+          # than guessed. Ubuntu's runner PHP bundles these, so the single-OS
+          # job got them for free; the Windows runner bundles fewer, and
+          # composer refused to resolve — first on ext-intl (filament/support),
+          # then ext-fileinfo (league/flysystem-local). Listing the whole set
+          # makes the requirement explicit for every leg instead of leaving one
+          # platform's defaults to carry it, and avoids discovering them one
+          # failed run at a time (issue #292).
+          #
+          # `pcntl` and `posix` appear in that scan too but are deliberately
+          # absent: they do not exist on Windows, and nothing in the resolved
+          # graph hard-requires them.
+          extensions: intl, fileinfo, mbstring, dom, tokenizer, iconv, filter, bcmath, openssl, libxml, ctype, xmlwriter, curl, zip, xml, gmp
 
       - name: Install test-project Composer dependencies
         # `test-project/vendor/` AND `composer.lock` are gitignored — the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
           # 8.4 matches the actual minimum required by the locked
           # vendor packages (symfony/* v8.0 requires >= 8.4).
           php-version: '8.4'
+          # `filament/support` requires ext-intl. Ubuntu's runner PHP bundles
+          # it, so the single-OS job got it for free; the Windows runner does
+          # not, and composer refused to resolve. Naming it here makes the
+          # requirement explicit for every leg rather than leaving one
+          # platform's default doing the work (issue #292).
+          extensions: intl
 
       - name: Install test-project Composer dependencies
         # `test-project/vendor/` AND `composer.lock` are gitignored — the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    # Scoped per-leg, deliberately: a bare job-level `continue-on-error: true`
-    # would make the Linux and macOS legs non-blocking too. Windows is new and
-    # expected to surface pre-existing failures (the tree carries ~455
-    # Unix-rooted path literals); it reports without blocking until those are
-    # triaged into their own issues. Dropping this is tracked in #292.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     defaults:
       run:
         # GitHub-hosted Windows runners ship Git Bash, so one shell keeps all

--- a/laravel-lsp/src/cache_manager.rs
+++ b/laravel-lsp/src/cache_manager.rs
@@ -379,11 +379,19 @@ impl CacheManager {
         match glob::glob(&pattern_str) {
             Ok(paths) => {
                 for entry in paths.flatten() {
+                    // Cache keys use forward slashes on every platform: every
+                    // other writer passes a literal like "bootstrap/app.php",
+                    // and the invalidation in `invalidate` matches with
+                    // `starts_with("app/Providers/")`. Deriving a key from an
+                    // OS path without normalizing produced `app\Providers\…`
+                    // on Windows, which that check never matched — so the App
+                    // rescan never cleared these entries and the provider
+                    // rescan was skipped (issue #292).
                     let relative = entry
                         .strip_prefix(&self.project_root)
                         .unwrap_or(&entry)
                         .to_string_lossy()
-                        .to_string();
+                        .replace('\\', "/");
 
                     if self.needs_rescan(&relative) {
                         return true;

--- a/laravel-lsp/src/class_locator.rs
+++ b/laravel-lsp/src/class_locator.rs
@@ -457,6 +457,17 @@ fn search_roots(root: &Path) -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+
+    /// Does the path contain `name` as a whole path segment?
+    ///
+    /// `Path::components` is separator-agnostic, so this is correct on every
+    /// platform — unlike `to_string_lossy().contains("vendor/")`, which only
+    /// matches a forward-slash spelling and so never fired on Windows
+    /// (issue #292).
+    fn has_component(path: &std::path::Path, name: &str) -> bool {
+        path.components()
+            .any(|c| c.as_os_str().to_string_lossy() == name)
+    }
     use super::*;
     use std::time::Duration;
     use tempfile::TempDir;
@@ -712,7 +723,7 @@ mod tests {
         let first =
             find_php_class_file_in_app_or_vendor("App\\Widgets\\Panel", &root).expect("resolves");
         assert!(
-            first.to_string_lossy().contains("vendor/"),
+            has_component(&first, "vendor"),
             "with no app file, resolution lands in vendor; got {first:?}"
         );
 
@@ -757,7 +768,7 @@ mod tests {
         let first = find_php_class_file_in_app_or_vendor("Modules\\Blog\\Thing", &root)
             .expect("vendor walk resolves");
         assert!(
-            first.to_string_lossy().contains("vendor/"),
+            has_component(&first, "vendor"),
             "with no app file, the walk lands in vendor; got {first:?}"
         );
 

--- a/laravel-lsp/src/composer_autoload/tests.rs
+++ b/laravel-lsp/src/composer_autoload/tests.rs
@@ -347,9 +347,14 @@ fn source_roots_drop_root_escaping_project_via_containment_guard() {
     // regression removing the containment guard would let it through and fail
     // this test.
     let outside = TempDir::new().unwrap();
+    // `\` is an escape character in JSON, so a Windows path interpolated raw
+    // makes the whole composer.json unparseable — every autoload root then
+    // comes back empty, including the legitimate one this test asserts on
+    // (issue #292).
+    let outside_json = outside.path().display().to_string().replace('\\', "\\\\");
     let composer = format!(
         r#"{{ "autoload": {{ "psr-4": {{ "Evil\\": "{}", "App\\": "app/" }} }} }}"#,
-        outside.path().display()
+        outside_json
     );
     let (_dir, root) = project_with_files(&[
         ("composer.json", &composer),

--- a/laravel-lsp/src/file_watcher.rs
+++ b/laravel-lsp/src/file_watcher.rs
@@ -84,6 +84,22 @@ pub const METHOD: &str = "workspace/didChangeWatchedFiles";
 /// fixed `app/Http/Controllers/**/*.php`) is left in place — duplicate
 /// events collapse in the idempotent watched-files handler, so the
 /// overlap is harmless.
+/// A path rendered with forward slashes, for embedding in an LSP glob pattern.
+///
+/// LSP glob patterns are forward-slash by specification, while `Path::display`
+/// emits the platform separator. Interpolating a joined path on Windows
+/// therefore produced `C:\proj\resources\views/**/*.blade.php` — both
+/// separators in one pattern. Beyond being wrong per spec, the mixed spelling
+/// defeated the string-equality dedup that collapses duplicate PSR-4 roots, so
+/// the same directory was registered twice (issue #292).
+///
+/// A literal backslash in a Unix filename would be rewritten here, but a glob
+/// base is a directory path the LSP client will match with `/` regardless, so
+/// the spec-correct spelling wins.
+fn glob_base(path: &std::path::Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}
+
 pub fn build_watchers(
     root: &Path,
     view_paths: &[PathBuf],
@@ -116,7 +132,7 @@ pub fn build_watchers(
 
     // Routes.
     watchers.push(FileSystemWatcher {
-        glob_pattern: GlobPattern::String(format!("{}/routes/**/*.php", root.display())),
+        glob_pattern: GlobPattern::String(format!("{}/routes/**/*.php", glob_base(root))),
         kind,
     });
 
@@ -136,11 +152,11 @@ pub fn build_watchers(
     // we register one pair per configured path.
     for view_path in view_paths {
         watchers.push(FileSystemWatcher {
-            glob_pattern: GlobPattern::String(format!("{}/**/*.blade.php", view_path.display())),
+            glob_pattern: GlobPattern::String(format!("{}/**/*.blade.php", glob_base(view_path))),
             kind,
         });
         watchers.push(FileSystemWatcher {
-            glob_pattern: GlobPattern::String(format!("{}/**/*.php", view_path.display())),
+            glob_pattern: GlobPattern::String(format!("{}/**/*.php", glob_base(view_path))),
             kind,
         });
     }
@@ -149,7 +165,7 @@ pub fn build_watchers(
     // location; the config layer already resolved which one applies.
     if let Some(lw) = livewire_path {
         watchers.push(FileSystemWatcher {
-            glob_pattern: GlobPattern::String(format!("{}/**/*.php", lw.display())),
+            glob_pattern: GlobPattern::String(format!("{}/**/*.php", glob_base(lw))),
             kind,
         });
     }
@@ -161,11 +177,11 @@ pub fn build_watchers(
     // cover PHP source and Blade views; the `.json.php` data-file
     // skip lives in the warming filter, not at the watcher layer.
     watchers.push(FileSystemWatcher {
-        glob_pattern: GlobPattern::String(format!("{}/vendor/**/*.php", root.display())),
+        glob_pattern: GlobPattern::String(format!("{}/vendor/**/*.php", glob_base(root))),
         kind,
     });
     watchers.push(FileSystemWatcher {
-        glob_pattern: GlobPattern::String(format!("{}/vendor/**/*.blade.php", root.display())),
+        glob_pattern: GlobPattern::String(format!("{}/vendor/**/*.blade.php", glob_base(root))),
         kind,
     });
 
@@ -179,7 +195,7 @@ pub fn build_watchers(
     let pages_dir = crate::inertia::pages_dir(root);
     for ext in crate::inertia::PAGE_EXTENSIONS {
         watchers.push(FileSystemWatcher {
-            glob_pattern: GlobPattern::String(format!("{}/**/*.{}", pages_dir.display(), ext)),
+            glob_pattern: GlobPattern::String(format!("{}/**/*.{}", glob_base(&pages_dir), ext)),
             kind,
         });
     }
@@ -198,7 +214,7 @@ pub fn build_watchers(
         })
         .collect();
     for src_root in psr4_roots {
-        let glob = format!("{}/**/*.php", src_root.display());
+        let glob = format!("{}/**/*.php", glob_base(src_root));
         // Skip a glob already emitted — whether by a fixed watcher or an
         // earlier PSR-4 root this call (defensive: `project_source_roots`
         // already dedups, but two identical roots must never double-register).

--- a/laravel-lsp/src/file_watcher/tests.rs
+++ b/laravel-lsp/src/file_watcher/tests.rs
@@ -81,10 +81,13 @@ fn watchers_register_each_configured_view_path() {
     let watchers = build_watchers(&root, &view_paths, None, &[]);
 
     for view_path in &view_paths {
+        // Compare against the same forward-slash rendering the watcher emits.
+        // LSP glob patterns are forward-slash by specification, so building the
+        // expectation from a platform-separator `Path` would only match on
+        // Unix (issue #292).
+        let expected_base = super::glob_base(view_path);
         let has_blade = watchers.iter().any(|w| match &w.glob_pattern {
-            GlobPattern::String(s) => {
-                s.contains(view_path.to_string_lossy().as_ref()) && s.ends_with("*.blade.php")
-            }
+            GlobPattern::String(s) => s.contains(&expected_base) && s.ends_with("*.blade.php"),
             _ => false,
         });
         assert!(has_blade, "missing blade watcher for {:?}", view_path);
@@ -215,7 +218,7 @@ fn watchers_include_a_recursive_glob_per_psr4_root() {
 
     let globs = globs_of(&watchers);
     for src in &psr4 {
-        let expected = format!("{}/**/*.php", src.display());
+        let expected = format!("{}/**/*.php", super::glob_base(src));
         assert!(
             globs.iter().any(|g| g == &expected),
             "missing PSR-4 glob {expected}: {globs:?}"

--- a/laravel-lsp/src/file_watcher/tests.rs
+++ b/laravel-lsp/src/file_watcher/tests.rs
@@ -237,7 +237,7 @@ fn psr4_glob_that_exactly_duplicates_an_existing_one_is_skipped() {
     let psr4 = vec![root.join("app"), root.join("app")];
     let watchers = build_watchers(&root, &[root.join("resources/views")], None, &psr4);
 
-    let expected = format!("{}/app/**/*.php", root.display());
+    let expected = format!("{}/app/**/*.php", super::glob_base(&root));
     let count = globs_of(&watchers)
         .into_iter()
         .filter(|g| g == &expected)
@@ -260,7 +260,7 @@ fn overlapping_psr4_glob_coexists_with_fixed_controllers_glob() {
     assert!(
         globs
             .iter()
-            .any(|g| g == &format!("{}/app/**/*.php", root.display())),
+            .any(|g| g == &format!("{}/app/**/*.php", super::glob_base(&root))),
         "missing widened app glob: {globs:?}"
     );
     assert!(

--- a/laravel-lsp/src/inertia.rs
+++ b/laravel-lsp/src/inertia.rs
@@ -42,7 +42,10 @@ pub fn is_page_file(path: &Path) -> bool {
     let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
         return false;
     };
-    PAGE_EXTENSIONS.contains(&ext) && path.to_string_lossy().contains(&format!("{PAGES_DIR}/"))
+    // Segment matching, not substring: the old `contains("{PAGES_DIR}/")`
+    // only matched a forward-slash spelling, so no file was ever recognised
+    // as an Inertia page on Windows (issue #292).
+    PAGE_EXTENSIONS.contains(&ext) && crate::path_segments::contains_segments(path, PAGES_DIR)
 }
 
 /// Whether a captured page name is safe to turn into a filesystem path.

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -90,6 +90,7 @@ pub mod naming;
 pub mod parser;
 pub mod path_containment;
 pub mod path_join;
+pub mod path_segments;
 pub mod pattern_disk_cache;
 pub mod pattern_indexer;
 pub mod php_class;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -94,6 +94,9 @@ pub mod pattern_disk_cache;
 pub mod pattern_indexer;
 pub mod php_class;
 pub mod php_string_components;
+/// Shared fixture helpers. Test-only: never compiled into the shipped library.
+#[cfg(test)]
+pub mod test_paths;
 // php_outline was consolidated into `laravel_introspector::walker`.
 pub mod php_variable_rename;
 pub mod queries;

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -95,8 +95,12 @@ pub mod pattern_disk_cache;
 pub mod pattern_indexer;
 pub mod php_class;
 pub mod php_string_components;
-/// Shared fixture helpers. Test-only: never compiled into the shipped library.
-#[cfg(test)]
+/// Shared fixture helpers.
+///
+/// Not `#[cfg(test)]`: the binary crate's own test tree (`src/tests/`) links
+/// against this library as a dependency, and a `cfg(test)` module is absent
+/// from that artifact. Ten lines of always-compiled helper is the cost of one
+/// spelling of an absolute-path fixture across both crates.
 pub mod test_paths;
 // php_outline was consolidated into `laravel_introspector::walker`.
 pub mod php_variable_rename;

--- a/laravel-lsp/src/livewire_config.rs
+++ b/laravel-lsp/src/livewire_config.rs
@@ -74,7 +74,7 @@ impl LivewireConfig {
             make_command_type: ComponentFormat::Sfc,
             make_command_emoji: true,
             class_namespace: "App\\Livewire".to_string(),
-            class_path: root.join("app/Livewire"),
+            class_path: root.join("app").join("Livewire"),
             view_path: root.join("resources/views/livewire"),
         }
     }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -17933,7 +17933,8 @@ return [
             // Per Laravel docs: "you should ensure you are only calling the env function
             // from within your application's configuration (config) files"
             // https://laravel.com/docs/12.x/configuration#configuration-caching
-            let is_config_file = file_path.to_string_lossy().contains("/config/");
+            let is_config_file =
+                laravel_lsp::path_segments::contains_segments(&file_path, "config");
             if !is_config_file && !patterns.env_refs.is_empty() {
                 for env_ref in &patterns.env_refs {
                     let diagnostic = Diagnostic {
@@ -22670,12 +22671,18 @@ impl LanguageServer for LaravelLanguageServer {
             // `Commands/` directory (app or package). That heuristic keeps the
             // index fresh without rebuilding on every unrelated `.php` save.
             if !commands_changed {
-                let p = path.to_string_lossy();
-                if p.ends_with(".php") && p.contains("/Commands/") {
+                // `.php` stays a string suffix test — a filename extension has
+                // no separators. The directory test does not: `/Commands/`
+                // never matched a Windows path (issue #292).
+                if path.to_string_lossy().ends_with(".php")
+                    && laravel_lsp::path_segments::contains_segments(&path, "Commands")
+                {
                     commands_changed = true;
                 }
             }
-            if !migrations_changed && path.to_string_lossy().contains("database/migrations") {
+            if !migrations_changed
+                && laravel_lsp::path_segments::contains_segments(&path, "database/migrations")
+            {
                 migrations_changed = true;
             }
             // Snapshot the file's pre-change surface for the incremental magic

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -12288,8 +12288,10 @@ impl LaravelLanguageServer {
         // 1. Anonymous: resources/views/components/button.blade.php (no class)
         // 2. Class-based: app/View/Components/Button.php with resources/views/components/button.blade.php
 
-        // Check if this is in the components directory
-        if !blade_path.contains("/components/") {
+        // Check if this is in the components directory. Normalized first:
+        // `blade_path` is a path rendered as a string, so on Windows it carries
+        // backslashes and the forward-slash marker never matched (issue #292).
+        if !Self::with_forward_slashes(blade_path).contains("/components/") {
             return None;
         }
 
@@ -22467,11 +22469,10 @@ impl LanguageServer for LaravelLanguageServer {
         // Check for lock file changes that trigger rescans
         if let Ok(path) = uri.to_file_path() {
             let file_name = path.file_name().and_then(|n| n.to_str());
-            let path_str = path.to_string_lossy();
 
             // Invalidate config cache if config-related files change
             let is_config_file = matches!(file_name, Some("composer.json"))
-                || path_str.contains("/config/")
+                || laravel_lsp::path_segments::contains_segments(&path, "config")
                 || matches!(file_name, Some("view.php" | "livewire.php"));
 
             if is_config_file {
@@ -22488,7 +22489,13 @@ impl LanguageServer for LaravelLanguageServer {
                     info!("📦 Package lock changed, queuing node_modules rescan");
                     self.queue_background_rescan(RescanType::NodeModules).await;
                 }
-                Some(name) if name.ends_with(".php") && path_str.contains("app/Providers/") => {
+                Some(name)
+                    if name.ends_with(".php")
+                        && laravel_lsp::path_segments::contains_segments(
+                            &path,
+                            "app/Providers",
+                        ) =>
+                {
                     info!("📦 App provider changed, queuing app rescan");
                     self.queue_background_rescan(RescanType::App).await;
                 }
@@ -22519,7 +22526,7 @@ impl LanguageServer for LaravelLanguageServer {
                         .as_ref()
                         .is_some_and(|idx| idx.source_files.contains(&normalized))
                 };
-                if in_index || path_str.contains("/routes/") {
+                if in_index || laravel_lsp::path_segments::contains_segments(&path, "routes") {
                     if let Some(root) = self.root_path.read().await.clone() {
                         info!("🛣️  Route file saved — rebuilding route index");
                         self.rebuild_route_index(&root).await;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -14005,7 +14005,7 @@ impl LaravelLanguageServer {
             },
             None => {
                 // Default to app/Livewire if no config
-                let v3_path = root.join("app/Livewire");
+                let v3_path = root.join("app").join("Livewire");
                 let v2_path = root.join("app/Http/Livewire");
                 if v3_path.exists() {
                     v3_path

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -5027,6 +5027,11 @@ impl LaravelLanguageServer {
                     // no size cap and chokes on these exact files.
                     // The empty patterns are ~30 bytes each in the
                     // serialized disk cache; negligible.
+                    // NOTE: this is a real OS path, so on Windows it carries `\`. The
+                    // branches below match forward-slash markers and must normalize first
+                    // — without it, editing a service provider or a config file never
+                    // re-registered with Salsa on Windows, so middleware aliases, bindings
+                    // and config values silently stopped updating (issue #292).
                     let path_str = path.to_string_lossy();
                     if path_str.ends_with(".json.php") {
                         return Some((
@@ -8756,7 +8761,9 @@ impl LaravelLanguageServer {
                     debug!("Failed to update service provider in Salsa: {}", e);
                 }
             }
-        } else if path_str.contains("app/Providers") && filename.ends_with(".php") {
+        } else if Self::with_forward_slashes(&path_str).contains("app/Providers")
+            && filename.ends_with(".php")
+        {
             // App service provider - Service provider file
             if let Some(root) = root_path {
                 debug!("📦 Updating Salsa: ServiceProviderFile ({})", filename);
@@ -8791,7 +8798,9 @@ impl LaravelLanguageServer {
             {
                 debug!("Failed to update env file in Salsa: {}", e);
             }
-        } else if path_str.contains("/config/") && filename.ends_with(".php") {
+        } else if Self::with_forward_slashes(&path_str).contains("/config/")
+            && filename.ends_with(".php")
+        {
             // Config file (config/*.php) - needs BOTH ConfigFile AND SourceFile treatment
             // ConfigFile: for config discovery (view paths, namespaces, etc.)
             // SourceFile: for pattern extraction (env() calls, etc.)

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -11236,9 +11236,21 @@ impl LaravelLanguageServer {
         vars
     }
 
+    /// A path with every separator normalized to `/`, so the marker matching
+    /// below reads the same on every platform.
+    ///
+    /// These paths arrive as strings rather than `Path`s, and on Windows they
+    /// carry `\\`. Matching a literal `"/components/"` against
+    /// `...\\views\\components\\button.blade.php` simply never fires, so the
+    /// component-variable inference silently produced nothing there (issue
+    /// #292).
+    fn with_forward_slashes(path: &str) -> String {
+        path.replace('\\', "/")
+    }
+
     /// Check if a blade file is a component file (in resources/views/components/)
     fn is_component_file(path: &str) -> bool {
-        path.contains("/components/") && path.ends_with(".blade.php")
+        Self::with_forward_slashes(path).contains("/components/") && path.ends_with(".blade.php")
     }
 
     /// Extract variables passed to a view from any PHP file that renders it
@@ -11828,19 +11840,22 @@ impl LaravelLanguageServer {
     ) -> Vec<(String, String)> {
         let vars = Vec::new();
 
-        // Check if this is a component view (in resources/views/components/)
-        let components_marker = format!("{}resources/views/components/", std::path::MAIN_SEPARATOR);
-        let components_marker_alt = "resources/views/components/";
+        // Check if this is a component view (in resources/views/components/).
+        // Normalize first: the previous marker was built as
+        // `format!("{}resources/views/components/", MAIN_SEPARATOR)`, which on
+        // Windows yields `\resources/views/components/` — a mix of both
+        // separators that matches no real path on any platform (issue #292).
+        let normalized = Self::with_forward_slashes(blade_path);
 
-        if !blade_path.contains(&components_marker) && !blade_path.contains(components_marker_alt) {
+        if !normalized.contains("resources/views/components/") {
             return vars;
         }
 
         // Extract component name from path
         // e.g., resources/views/components/button.blade.php -> Button
         // e.g., resources/views/components/forms/input.blade.php -> Forms/Input
-        let relative = if let Some(idx) = blade_path.find("components/") {
-            &blade_path[idx + 11..] // Skip "components/"
+        let relative = if let Some(idx) = normalized.find("components/") {
+            &normalized[idx + "components/".len()..]
         } else {
             return vars;
         };

--- a/laravel-lsp/src/middleware_parser/tests.rs
+++ b/laravel-lsp/src/middleware_parser/tests.rs
@@ -9,7 +9,10 @@ fn test_resolve_class_to_file() {
     assert!(result.is_some());
     let path = result.unwrap();
     assert!(path.ends_with("Authenticate.php"));
-    assert!(path.to_string_lossy().contains("app/Http/Middleware"));
+    assert!(crate::path_segments::contains_segments(
+        &path,
+        "app/Http/Middleware"
+    ));
 }
 
 #[test]

--- a/laravel-lsp/src/path_segments.rs
+++ b/laravel-lsp/src/path_segments.rs
@@ -1,0 +1,122 @@
+//! Match whole path segments, separator-agnostically.
+//!
+//! The gap `Path` leaves open. `starts_with`, `ends_with` and `strip_prefix`
+//! all compare components and are correct on every platform, but there is no
+//! built-in for "does this path contain this run of segments *anywhere*". That
+//! question kept being answered with `to_string_lossy().contains("/config/")`,
+//! which matches only a forward-slash spelling and so never fired on Windows —
+//! config-file detection, Inertia page detection, migration and Artisan
+//! command change detection all silently did nothing there (issue #292).
+//!
+//! Not to be confused with an extension check. `path.to_string_lossy()
+//! .ends_with(".blade.php")` is correct and must stay a string comparison: a
+//! filename suffix contains no separators, `Path::extension` returns only the
+//! last extension (`php`, never `blade.php`), and `Path::ends_with` compares
+//! whole components — so it is `false` for `".blade.php"` and would silently
+//! break every such check if "modernized".
+
+use std::path::Path;
+
+/// Does `path` contain `needle` as a consecutive run of whole segments?
+///
+/// `needle` is spelled with forward slashes on every platform —
+/// `contains_segments(p, "database/migrations")` — because it describes
+/// segments, not a literal substring. Matching goes through
+/// [`Path::components`], so it holds wherever the path itself came from.
+///
+/// Matching whole segments also fixes a bug the substring form had on *every*
+/// platform: `contains("/config/")` matched a directory called
+/// `configuration`; this does not.
+pub fn contains_segments(path: &Path, needle: &str) -> bool {
+    let needle: Vec<&str> = needle.split('/').filter(|s| !s.is_empty()).collect();
+    if needle.is_empty() {
+        return false;
+    }
+    let components: Vec<String> = path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    components
+        .windows(needle.len())
+        .any(|window| window.iter().zip(&needle).all(|(have, want)| have == want))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn matches_a_single_segment() {
+        assert!(contains_segments(
+            &PathBuf::from("/proj/config/app.php"),
+            "config"
+        ));
+    }
+
+    #[test]
+    fn matches_a_consecutive_run_of_segments() {
+        assert!(contains_segments(
+            &PathBuf::from("/proj/database/migrations/2026_01_01_create.php"),
+            "database/migrations"
+        ));
+    }
+
+    /// The run must be consecutive — segments that appear apart do not match.
+    #[test]
+    fn rejects_a_non_consecutive_run() {
+        assert!(!contains_segments(
+            &PathBuf::from("/proj/database/seeders/migrations/x.php"),
+            "database/migrations"
+        ));
+    }
+
+    /// Whole segments only. The substring form this replaces matched
+    /// `configuration` for `"/config/"` on every platform, not just Windows.
+    #[test]
+    fn rejects_a_partial_segment() {
+        assert!(!contains_segments(
+            &PathBuf::from("/proj/configuration/app.php"),
+            "config"
+        ));
+        assert!(!contains_segments(
+            &PathBuf::from("/proj/myconfig/app.php"),
+            "config"
+        ));
+    }
+
+    #[test]
+    fn rejects_an_absent_segment() {
+        assert!(!contains_segments(
+            &PathBuf::from("/proj/app/Models/User.php"),
+            "config"
+        ));
+    }
+
+    #[test]
+    fn an_empty_needle_never_matches() {
+        assert!(!contains_segments(&PathBuf::from("/proj/config"), ""));
+        assert!(!contains_segments(&PathBuf::from("/proj/config"), "/"));
+    }
+
+    /// The point of the helper: a Windows path carries `\`, and `components`
+    /// splits on it there. Only runnable on Windows, because `Path` parsing is
+    /// platform-gated — on Unix a backslash is an ordinary filename character,
+    /// so this exact string is one component. The Windows CI leg runs it.
+    #[cfg(windows)]
+    #[test]
+    fn matches_segments_in_a_windows_path() {
+        assert!(contains_segments(
+            &PathBuf::from(r"C:\Users\dev\proj\config\app.php"),
+            "config"
+        ));
+        assert!(contains_segments(
+            &PathBuf::from(r"C:\Users\dev\proj\database\migrations\x.php"),
+            "database/migrations"
+        ));
+        assert!(!contains_segments(
+            &PathBuf::from(r"C:\Users\dev\proj\configuration\app.php"),
+            "config"
+        ));
+    }
+}

--- a/laravel-lsp/src/query_chain/code_actions/tests.rs
+++ b/laravel-lsp/src/query_chain/code_actions/tests.rs
@@ -374,16 +374,24 @@ fn migration_action_creates_timestamped_file_with_stub() {
 
 #[test]
 fn migration_action_none_for_relation() {
+    // A platform-absolute root, so the `None` is genuinely because the
+    // diagnostic is a relation rather than a column. With a prefixless
+    // "/srv/app" this passed on Windows for the wrong reason: the internal
+    // `Url::from_file_path` failed first, and the assertion would have held
+    // even with the kind check broken (issue #292).
+    let root = crate::test_paths::abs("/srv/app");
     let d = diag(json!({"kind": "relation", "name": "postss", "replacement": "posts"}));
-    assert!(migration_action(&d, Path::new("/srv/app"), "2026_05_29_120000").is_none());
+    assert!(migration_action(&d, &root, "2026_05_29_120000").is_none());
 }
 
 #[test]
 fn migration_action_none_without_table() {
+    // Absolute on every platform — see the note above.
+    let root = crate::test_paths::abs("/srv/app");
     let d = diag(
         json!({"kind": "column", "name": "phone"}), // no table
     );
-    assert!(migration_action(&d, Path::new("/srv/app"), "2026_05_29_120000").is_none());
+    assert!(migration_action(&d, &root, "2026_05_29_120000").is_none());
 }
 
 // ---- qualify_actions (ambiguous columns, issue #24) ------------------------

--- a/laravel-lsp/src/query_chain/code_actions/tests.rs
+++ b/laravel-lsp/src/query_chain/code_actions/tests.rs
@@ -346,7 +346,10 @@ fn create_file_content(action: &tower_lsp::lsp_types::CodeAction) -> String {
 #[test]
 fn migration_action_creates_timestamped_file_with_stub() {
     let d = diag(json!({"kind": "column", "name": "phone", "table": "users"}));
-    let root = Path::new("/srv/app");
+    // A platform-absolute root: `Url::from_file_path` rejects a prefixless
+    // "/srv/app" on Windows, so the action silently produced None there.
+    let root_buf = crate::test_paths::abs("/srv/app");
+    let root = root_buf.as_path();
     let action =
         into_action(migration_action(&d, root, "2026_05_29_120000").expect("a migration action"));
     assert_eq!(

--- a/laravel-lsp/src/rename/tests.rs
+++ b/laravel-lsp/src/rename/tests.rs
@@ -1,10 +1,11 @@
 use super::*;
+use crate::test_paths::abs;
 use std::path::PathBuf;
 use tower_lsp::lsp_types::{DocumentChangeOperation, DocumentChanges, OneOf, ResourceOp};
 
 fn target(path: &str, line: u32, start: u32, end: u32, new_text: &str) -> EditTarget {
     EditTarget {
-        file_path: PathBuf::from(path),
+        file_path: abs(path),
         line,
         start_column: start,
         end_column: end,
@@ -14,8 +15,8 @@ fn target(path: &str, line: u32, start: u32, end: u32, new_text: &str) -> EditTa
 
 fn file_rename(old: &str, new: &str) -> FileRename {
     FileRename {
-        old_path: PathBuf::from(old),
-        new_path: PathBuf::from(new),
+        old_path: abs(old),
+        new_path: abs(new),
     }
 }
 

--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -1172,7 +1172,10 @@ fn normalize_path_resolves_interior_parent_dir_and_stays_absolute() {
     // A `..` after a `Normal` segment pops that segment; the path stays absolute.
     let result = normalize_path(&PathBuf::from("/app/models/../views"));
     assert_eq!(result, PathBuf::from("/app/views"));
-    assert!(result.is_absolute(), "absolute input must stay absolute");
+    // `has_root`, not `is_absolute`: on Windows a leading separator with no
+    // drive prefix is rooted but *not* absolute, and rootedness is the
+    // invariant this test exists for (issue #292).
+    assert!(result.has_root(), "rooted input must stay rooted");
 }
 
 #[test]
@@ -1182,8 +1185,8 @@ fn normalize_path_never_pops_root_dir() {
     // and the result stays rooted (the buggy copy returned a relative `escape`).
     let result = normalize_path(&PathBuf::from("/app/../../escape"));
     assert!(
-        result.is_absolute(),
-        "absolute input must stay absolute, got {result:?}"
+        result.has_root(),
+        "rooted input must stay rooted, got {result:?}"
     );
     assert_eq!(result, PathBuf::from("/../escape"));
 }

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -1310,7 +1310,7 @@ pub fn parse_livewire_config(db: &dyn Db, file: ConfigFile, root: PathBuf) -> Op
 
     // Look for class_namespace patterns
     if text.contains("App\\Livewire") || text.contains("App\\\\Livewire") {
-        return Some(root.join("app/Livewire"));
+        return Some(root.join("app").join("Livewire"));
     }
 
     if text.contains("App\\Http\\Livewire") || text.contains("App\\\\Http\\\\Livewire") {
@@ -1351,7 +1351,7 @@ pub fn build_laravel_config<'db>(
             .and_then(|f| parse_livewire_config(db, f, root.clone()))
             .or_else(|| {
                 // Default Livewire paths
-                let v3_path = root.join("app/Livewire");
+                let v3_path = root.join("app").join("Livewire");
                 let v2_path = root.join("app/Http/Livewire");
                 if v3_path.exists() {
                     Some(v3_path)

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -191,7 +191,7 @@ fn unaliased_component_falls_back_to_directory_convention() {
     assert!(
         paths
             .iter()
-            .all(|p| !p.to_string_lossy().contains("buttons/light-button")),
+            .all(|p| !crate::path_segments::contains_segments(p, "buttons/light-button")),
         "alias must not bleed into unrelated lookups: {:?}",
         paths,
     );
@@ -208,7 +208,7 @@ fn namespaced_component_bypasses_alias_map() {
     assert!(
         paths
             .iter()
-            .all(|p| !p.to_string_lossy().contains("components/never/this")),
+            .all(|p| !crate::path_segments::contains_segments(p, "components/never/this")),
         "namespaced lookup must bypass alias map: {:?}",
         paths,
     );
@@ -619,7 +619,7 @@ fn unregistered_anonymous_prefix_does_not_borrow_registered_directory() {
     assert!(
         paths
             .iter()
-            .all(|p| !p.to_string_lossy().contains("backstage/components")),
+            .all(|p| !crate::path_segments::contains_segments(p, "backstage/components")),
         "unregistered prefix must not resolve into a registered anon directory: {:?}",
         paths,
     );

--- a/laravel-lsp/src/test_paths.rs
+++ b/laravel-lsp/src/test_paths.rs
@@ -1,0 +1,46 @@
+//! Absolute-path fixtures that hold on every platform.
+//!
+//! A literal like `"/tmp/routes/web.php"` is absolute on Unix but merely
+//! *rooted* on Windows — it carries no drive prefix, so `Path::is_absolute`
+//! is false and `Url::from_file_path` refuses it. Any code that turns a path
+//! into a URI then returns `None`, and the test sees an empty result rather
+//! than the failure's real cause (issue #292).
+//!
+//! Fixtures that need a genuinely absolute path build it here instead of
+//! spelling one inline.
+
+use std::path::PathBuf;
+
+/// An absolute path for the current platform, from a Unix-style spelling.
+///
+/// `abs("/tmp/routes/web.php")` yields `/tmp/routes/web.php` on Unix and
+/// `C:\tmp\routes\web.php` on Windows.
+pub fn abs(spelling: &str) -> PathBuf {
+    let relative = spelling.trim_start_matches('/');
+    if cfg!(windows) {
+        PathBuf::from(format!(r"C:\{}", relative.replace('/', r"\")))
+    } else {
+        PathBuf::from(format!("/{relative}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abs_is_absolute_on_this_platform() {
+        // The whole point: `is_absolute` must hold wherever the suite runs,
+        // which a bare "/tmp/..." literal does not satisfy on Windows.
+        assert!(abs("/tmp/routes/web.php").is_absolute());
+        assert!(abs("tmp/routes/web.php").is_absolute());
+    }
+
+    #[test]
+    fn abs_round_trips_through_a_file_url() {
+        // The exact conversion that silently returned None on Windows.
+        let url = tower_lsp::lsp_types::Url::from_file_path(abs("/tmp/routes/web.php"))
+            .expect("fixture path must convert to a file URL");
+        assert_eq!(url.scheme(), "file");
+    }
+}

--- a/laravel-lsp/src/tests/component_navigation_containment.rs
+++ b/laravel-lsp/src/tests/component_navigation_containment.rs
@@ -17,7 +17,12 @@ use crate::LaravelLanguageServer;
 use laravel_lsp::salsa_impl::{ComponentReferenceData, LaravelConfigData};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+// Used only by the `#[cfg(unix)]` symlink fixture below — without the
+// same gate the import is dead on Windows, and `-D warnings` makes that a
+// hard error (issue #292).
+#[cfg(unix)]
+use std::path::PathBuf;
 use tower_lsp::lsp_types::GotoDefinitionResponse;
 use tower_lsp::{lsp_types::Url, LspService};
 

--- a/laravel-lsp/src/tests/directive_navigation_containment.rs
+++ b/laravel-lsp/src/tests/directive_navigation_containment.rs
@@ -18,7 +18,12 @@ use crate::LaravelLanguageServer;
 use laravel_lsp::salsa_impl::{DirectiveReferenceData, LaravelConfigData};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+// Used only by the `#[cfg(unix)]` symlink fixture below — without the
+// same gate the import is dead on Windows, and `-D warnings` makes that a
+// hard error (issue #292).
+#[cfg(unix)]
+use std::path::PathBuf;
 use tower_lsp::lsp_types::GotoDefinitionResponse;
 use tower_lsp::{lsp_types::Url, LspService};
 

--- a/laravel-lsp/src/tests/folio_cursor_containment.rs
+++ b/laravel-lsp/src/tests/folio_cursor_containment.rs
@@ -8,7 +8,12 @@
 //! tests drive the private methods directly by building the server through
 //! `tower_lsp::LspService` and reaching its inner value with `inner()`.
 
-use crate::{path_within_root, LaravelLanguageServer};
+use crate::LaravelLanguageServer;
+// Used only by the `#[cfg(unix)]` symlink fixture below — without the
+// same gate the import is dead on Windows, and `-D warnings` makes that a
+// hard error (issue #292).
+#[cfg(unix)]
+use crate::path_within_root;
 use laravel_lsp::route_discovery::{RouteDefinition, RouteIndex, PRIORITY_APP};
 use std::fs;
 use std::path::Path;

--- a/laravel-lsp/src/tests/inertia_code_action.rs
+++ b/laravel-lsp/src/tests/inertia_code_action.rs
@@ -56,8 +56,12 @@ fn missing_page_emits_error_diagnostic() {
     // ones, now that both families share a single `source`.
     assert!(diag.data.is_none());
     assert!(diag.message.contains("Auth/Login"), "{}", diag.message);
+    // The message embeds a display path, which carries the platform separator.
+    // Compare in one rendering rather than assuming forward slashes (#292).
     assert!(
-        diag.message.contains("resources/js/Pages/Auth/Login.vue"),
+        diag.message
+            .replace('\\', "/")
+            .contains("resources/js/Pages/Auth/Login.vue"),
         "{}",
         diag.message
     );

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -55,3 +55,4 @@ mod view_navigation_containment;
 mod vite_completion_context;
 mod warm_parse_progress;
 mod watched_files_magic;
+mod windows_path_separators;

--- a/laravel-lsp/src/tests/query_chain_completion_handler.rs
+++ b/laravel-lsp/src/tests/query_chain_completion_handler.rs
@@ -155,8 +155,10 @@ const PROPERTY_RECEIVER_HOP: &str = "<?php\n\
 /// Run the real completion entry point and return the offered labels.
 async fn completion_labels(server: &LaravelLanguageServer, template: &str) -> Vec<String> {
     let (content, position) = cursor_at(template);
-    let uri = Url::from_file_path("/tmp/watson-219-fixture/Controller.php")
-        .expect("absolute path → file uri");
+    let uri = Url::from_file_path(laravel_lsp::test_paths::abs(
+        "/tmp/watson-219-fixture/Controller.php",
+    ))
+    .expect("absolute path → file uri");
     let items = server
         .try_query_chain_completion(&content, position, &uri)
         .await

--- a/laravel-lsp/src/tests/rename_integration.rs
+++ b/laravel-lsp/src/tests/rename_integration.rs
@@ -416,15 +416,15 @@ fn view_rename_assembles_workspace_edit_with_text_and_file_move() {
     // op for the .blade.php move. Verify the assembled WorkspaceEdit
     // matches that shape.
     let targets = vec![EditTarget {
-        file_path: PathBuf::from("/tmp/app/Http/Controllers/UserController.php"),
+        file_path: laravel_lsp::test_paths::abs("/tmp/app/Http/Controllers/UserController.php"),
         line: 12,
         start_column: 18,
         end_column: 31,
         new_text: "users.account".to_string(),
     }];
     let renames = vec![FileRename {
-        old_path: PathBuf::from("/tmp/resources/views/users/profile.blade.php"),
-        new_path: PathBuf::from("/tmp/resources/views/users/account.blade.php"),
+        old_path: laravel_lsp::test_paths::abs("/tmp/resources/views/users/profile.blade.php"),
+        new_path: laravel_lsp::test_paths::abs("/tmp/resources/views/users/account.blade.php"),
     }];
 
     let edit =
@@ -457,14 +457,14 @@ fn text_only_rename_emits_edits_variant() {
     // resource operations.
     let targets = vec![
         EditTarget {
-            file_path: PathBuf::from("/tmp/routes/web.php"),
+            file_path: laravel_lsp::test_paths::abs("/tmp/routes/web.php"),
             line: 3,
             start_column: 30,
             end_column: 34,
             new_text: "home".to_string(),
         },
         EditTarget {
-            file_path: PathBuf::from("/tmp/app/HomeController.php"),
+            file_path: laravel_lsp::test_paths::abs("/tmp/app/HomeController.php"),
             line: 12,
             start_column: 18,
             end_column: 22,
@@ -499,8 +499,8 @@ fn rename_file_op_carries_safe_collision_options() {
     // silently clobbering. Verify the option flags survive the
     // WorkspaceEdit construction.
     let renames = vec![FileRename {
-        old_path: PathBuf::from("/tmp/users/profile.blade.php"),
-        new_path: PathBuf::from("/tmp/users/account.blade.php"),
+        old_path: laravel_lsp::test_paths::abs("/tmp/users/profile.blade.php"),
+        new_path: laravel_lsp::test_paths::abs("/tmp/users/account.blade.php"),
     }];
     let edit = build_rename_workspace_edit(&[], &renames).expect("edit produced");
     let DocumentChanges::Operations(ops) = edit.document_changes.unwrap() else {
@@ -524,15 +524,15 @@ fn mixed_text_and_file_rename_annotates_text_edits_too() {
     // in `AnnotatedTextEdit` referencing the same change annotation —
     // so the client groups them as one reviewable change.
     let targets = vec![EditTarget {
-        file_path: PathBuf::from("/tmp/app/UserController.php"),
+        file_path: laravel_lsp::test_paths::abs("/tmp/app/UserController.php"),
         line: 0,
         start_column: 18,
         end_column: 31,
         new_text: "users.account".to_string(),
     }];
     let renames = vec![FileRename {
-        old_path: PathBuf::from("/tmp/users/profile.blade.php"),
-        new_path: PathBuf::from("/tmp/users/account.blade.php"),
+        old_path: laravel_lsp::test_paths::abs("/tmp/users/profile.blade.php"),
+        new_path: laravel_lsp::test_paths::abs("/tmp/users/account.blade.php"),
     }];
     let edit = build_rename_workspace_edit(&targets, &renames).expect("edit produced");
     let DocumentChanges::Operations(ops) = edit.document_changes.unwrap() else {

--- a/laravel-lsp/src/tests/rename_integration.rs
+++ b/laravel-lsp/src/tests/rename_integration.rs
@@ -31,7 +31,7 @@ use laravel_lsp::rename::{build_rename_edit, build_rename_workspace_edit, EditTa
 use laravel_lsp::salsa_impl::LaravelConfigData;
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tempfile::TempDir;
 use tower_lsp::lsp_types::{DocumentChangeOperation, DocumentChanges, OneOf, ResourceOp};
 

--- a/laravel-lsp/src/tests/scan_dir_containment.rs
+++ b/laravel-lsp/src/tests/scan_dir_containment.rs
@@ -24,7 +24,12 @@
 //! positive controls prove the gate does not over-refuse: an in-root symlink
 //! (target inside the root) and an ordinary subdirectory still yield candidates.
 
-use laravel_lsp::component_completion::{scan_anonymous_dir, scan_class_dir, ComponentCandidate};
+use laravel_lsp::component_completion::{scan_class_dir, ComponentCandidate};
+// Used only by the `#[cfg(unix)]` symlink fixture below — without the
+// same gate the import is dead on Windows, and `-D warnings` makes that a
+// hard error (issue #292).
+#[cfg(unix)]
+use laravel_lsp::component_completion::scan_anonymous_dir;
 use tempfile::TempDir;
 
 fn names(candidates: &[ComponentCandidate]) -> Vec<String> {

--- a/laravel-lsp/src/tests/slot_navigation_containment.rs
+++ b/laravel-lsp/src/tests/slot_navigation_containment.rs
@@ -16,7 +16,12 @@ use crate::LaravelLanguageServer;
 use laravel_lsp::salsa_impl::LaravelConfigData;
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+// Used only by the `#[cfg(unix)]` symlink fixture below — without the
+// same gate the import is dead on Windows, and `-D warnings` makes that a
+// hard error (issue #292).
+#[cfg(unix)]
+use std::path::PathBuf;
 use tower_lsp::lsp_types::{GotoDefinitionResponse, Position};
 use tower_lsp::{lsp_types::Url, LspService};
 

--- a/laravel-lsp/src/tests/view_navigation_containment.rs
+++ b/laravel-lsp/src/tests/view_navigation_containment.rs
@@ -17,7 +17,12 @@ use crate::LaravelLanguageServer;
 use laravel_lsp::salsa_impl::{LaravelConfigData, ViewReferenceData};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+// Used only by the `#[cfg(unix)]` symlink fixture below — without the
+// same gate the import is dead on Windows, and `-D warnings` makes that a
+// hard error (issue #292).
+#[cfg(unix)]
+use std::path::PathBuf;
 use tower_lsp::lsp_types::GotoDefinitionResponse;
 use tower_lsp::{lsp_types::Url, LspService};
 

--- a/laravel-lsp/src/tests/windows_path_separators.rs
+++ b/laravel-lsp/src/tests/windows_path_separators.rs
@@ -1,0 +1,79 @@
+//! Path matching that assumed a forward-slash separator.
+//!
+//! Three sites matched literal `"/components/"` or
+//! `"resources/views/components/"` against paths that arrive as **strings**,
+//! not `Path`s. On Windows those carry `\`, so the markers never fired and the
+//! component-variable inference silently produced nothing. One site was worse:
+//! it built its marker as
+//! `format!("{}resources/views/components/", MAIN_SEPARATOR)`, mixing a
+//! platform separator with hardcoded forward slashes — on Windows that is
+//! `\resources/views/components/`, which matches no real path anywhere
+//! (issue #292).
+//!
+//! These are pure string functions, so a Windows-shaped path exercises the fix
+//! on every platform — no `#[cfg(windows)]`, and the Linux and macOS CI legs
+//! catch a regression too.
+
+use crate::LaravelLanguageServer;
+
+const WINDOWS: &str = r"C:\Users\dev\proj\resources\views\components\button.blade.php";
+const UNIX: &str = "/home/dev/proj/resources/views/components/button.blade.php";
+
+#[test]
+fn component_files_are_recognised_with_either_separator() {
+    assert!(
+        LaravelLanguageServer::is_component_file(UNIX),
+        "forward-slash path must be recognised"
+    );
+    assert!(
+        LaravelLanguageServer::is_component_file(WINDOWS),
+        "backslash path must be recognised — this is what Windows actually passes"
+    );
+}
+
+#[test]
+fn non_component_blade_files_are_rejected_with_either_separator() {
+    assert!(!LaravelLanguageServer::is_component_file(
+        "/home/dev/proj/resources/views/welcome.blade.php"
+    ));
+    assert!(!LaravelLanguageServer::is_component_file(
+        r"C:\Users\dev\proj\resources\views\welcome.blade.php"
+    ));
+}
+
+#[test]
+fn a_component_path_is_not_matched_when_it_is_not_a_blade_file() {
+    assert!(!LaravelLanguageServer::is_component_file(
+        r"C:\Users\dev\proj\resources\views\components\button.php"
+    ));
+}
+
+#[test]
+fn separator_normalization_leaves_forward_slash_paths_alone() {
+    assert_eq!(LaravelLanguageServer::with_forward_slashes(UNIX), UNIX);
+    assert_eq!(
+        LaravelLanguageServer::with_forward_slashes(WINDOWS),
+        "C:/Users/dev/proj/resources/views/components/button.blade.php"
+    );
+}
+
+/// The marker site: a backslash path must reach the component-name extraction
+/// rather than bailing out at the guard. An empty result here would be
+/// indistinguishable from "component class not found", so the assertion is on
+/// the guard's own behaviour via the normalizer that feeds it.
+#[test]
+fn the_components_marker_matches_a_backslash_path() {
+    let normalized = LaravelLanguageServer::with_forward_slashes(WINDOWS);
+    assert!(
+        normalized.contains("resources/views/components/"),
+        "the normalized Windows path must clear the marker guard: {normalized}"
+    );
+    let idx = normalized
+        .find("components/")
+        .expect("component segment must be locatable");
+    assert_eq!(
+        &normalized[idx + "components/".len()..],
+        "button.blade.php",
+        "the offset must skip exactly the marker, leaving the component path"
+    );
+}

--- a/laravel-lsp/src/tests/windows_path_separators.rs
+++ b/laravel-lsp/src/tests/windows_path_separators.rs
@@ -77,3 +77,50 @@ fn the_components_marker_matches_a_backslash_path() {
         "the offset must skip exactly the marker, leaving the component path"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Shipped-code separator assumptions found by sweeping for the same bug class
+// ---------------------------------------------------------------------------
+
+/// `execute_salsa_update` classifies an edited file by matching forward-slash
+/// markers against `path.to_string_lossy()` — a real OS path. On Windows that
+/// carries backslashes, so a service provider and a config file both fell
+/// through to the default branch and were never re-registered with Salsa:
+/// middleware aliases, container bindings and config values stopped updating
+/// for the rest of the session, silently.
+#[test]
+fn salsa_dispatch_markers_match_a_windows_path() {
+    let provider = r"C:\Users\dev\proj\app\Providers\AppServiceProvider.php";
+    let config = r"C:\Users\dev\proj\config\app.php";
+
+    assert!(
+        LaravelLanguageServer::with_forward_slashes(provider).contains("app/Providers"),
+        "a Windows provider path must reach the ServiceProviderFile branch"
+    );
+    assert!(
+        LaravelLanguageServer::with_forward_slashes(config).contains("/config/"),
+        "a Windows config path must reach the ConfigFile branch"
+    );
+}
+
+/// The Unix spellings must keep matching — the normalization is additive.
+#[test]
+fn salsa_dispatch_markers_still_match_a_unix_path() {
+    assert!(LaravelLanguageServer::with_forward_slashes(
+        "/home/dev/proj/app/Providers/AppServiceProvider.php"
+    )
+    .contains("app/Providers"));
+    assert!(
+        LaravelLanguageServer::with_forward_slashes("/home/dev/proj/config/app.php")
+            .contains("/config/")
+    );
+}
+
+/// A path that is neither must still fall through to the default branch.
+#[test]
+fn salsa_dispatch_markers_reject_unrelated_paths() {
+    let normalized =
+        LaravelLanguageServer::with_forward_slashes(r"C:\Users\dev\proj\app\Models\User.php");
+    assert!(!normalized.contains("app/Providers"));
+    assert!(!normalized.contains("/config/"));
+}

--- a/laravel-lsp/src/translation_lookup/tests.rs
+++ b/laravel-lsp/src/translation_lookup/tests.rs
@@ -395,6 +395,12 @@ fn traversing_namespace_in_the_published_path_is_refused() {
     );
 }
 
+/// Symlink-based containment fixtures. Creating a symlink on Windows needs
+/// either Developer Mode or elevation, so `std::os::unix::fs::symlink` has no
+/// portable counterpart worth reaching for here — the guard these pin is
+/// platform-independent, only the fixture is not. Gated rather than dropped so
+/// the Unix and macOS legs keep covering it (issue #292).
+#[cfg(unix)]
 #[test]
 fn dotted_key_read_through_an_escaping_symlink_is_refused() {
     // Containment is canonical, not textual: `lang/en` is spelled inside the
@@ -419,6 +425,12 @@ fn dotted_key_read_through_an_escaping_symlink_is_refused() {
     );
 }
 
+/// Symlink-based containment fixtures. Creating a symlink on Windows needs
+/// either Developer Mode or elevation, so `std::os::unix::fs::symlink` has no
+/// portable counterpart worth reaching for here — the guard these pin is
+/// platform-independent, only the fixture is not. Gated rather than dropped so
+/// the Unix and macOS legs keep covering it (issue #292).
+#[cfg(unix)]
 #[test]
 fn text_key_read_through_an_escaping_symlink_is_refused() {
     // Same guard on the JSON catalogue read.

--- a/laravel-lsp/tests/integration_tests.rs
+++ b/laravel-lsp/tests/integration_tests.rs
@@ -1071,8 +1071,11 @@ mod resolution {
         // Test that kebab-case converts to PascalCase correctly
         let root = test_project_path();
         let path = resolve_livewire_path(&root, "actions.logout");
+        // Segment matching, not a forward-slash substring: the path carries the
+        // platform separator, so `contains("Actions/Logout.php")` only ever
+        // matched on Unix (issue #292).
         assert!(
-            path.to_string_lossy().contains("Actions/Logout.php"),
+            laravel_lsp::path_segments::contains_segments(&path, "Actions/Logout.php"),
             "Livewire path should use PascalCase: {:?}",
             path
         );


### PR DESCRIPTION
Fixes #292.

Both CI jobs ran only on `ubuntu-latest`, so no Windows-specific path regression could ever turn a check red. Zed ships Windows builds, and #291 landed a `#[cfg(windows)]` test with no runner to execute it.

Extends #292 slightly at Mike's request: **macOS as well as Windows**, so the matrix covers all three platforms the extension actually runs on rather than two.

## The matrix

```yaml
strategy:
  fail-fast: false
  matrix:
    os: [ubuntu-latest, macos-latest, windows-latest]
runs-on: ${{ matrix.os }}
continue-on-error: ${{ matrix.os == 'windows-latest' }}
defaults:
  run:
    shell: bash
    working-directory: laravel-lsp
```

- **`fail-fast: false`** — one platform breaking must not cancel the others, or a Windows break hides whether Linux and macOS are still green.
- **`continue-on-error` scoped per-leg**, not job-level. A bare `continue-on-error: true` would quietly make Linux and macOS non-blocking too — the opposite of the intent.
- **`shell: bash` on every leg.** GitHub-hosted Windows runners ship Git Bash, so all three legs run byte-identical commands — `cp`, quoting and path expansion included. Without it Windows defaults to PowerShell and the steps silently diverge from what Linux and macOS run, which defeats the point of the matrix. This is also what makes the `Bootstrap test fixture .env` step (`cp test-project/.env.example …`) work on Windows.
- **No matrix-conditional filtering.** All three legs run the same `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-features` — no `--skip`, no feature narrowing.
- **The `extension` job is untouched.** It builds for `wasm32-wasip2` and is host-agnostic.

## Three path-matching bugs fixed

All three would have failed on the Windows leg immediately. Blade paths reach these sites as **strings**, not `Path`s, so on Windows they carry `\` while each site matched a literal forward-slash marker:

| Site | Was | Problem |
|---|---|---|
| `is_component_file` | `path.contains("/components/")` | never fires on `…\views\components\x.blade.php` |
| `extract_component_variables` guard | `format!("{}resources/views/components/", MAIN_SEPARATOR)` | yields `\resources/views/components/` — mixes a platform separator with hardcoded forward slashes, matching **no real path on any platform** |
| `extract_component_variables` offset | `blade_path.find("components/")` | same forward-slash assumption |

All three now normalize separators first. The middle one is the interesting failure: it isn't merely Unix-specific, it is broken everywhere — on Linux the `_alt` fallback carried it, so the bug was invisible.

These are pure string functions, so the tests feed Windows-shaped paths and **run on every leg** rather than hiding behind `#[cfg(windows)]` — Linux and macOS catch a regression too. Mutation-verified: neutering the normalizer reddens 3 of the 5 new tests, the two survivors being the negative cases that are correctly unaffected.

## Line endings

**No test in `laravel-lsp` asserts on file content byte-for-byte.** Tests write their own fixtures into temp directories; `integration_tests.rs` reads checked-in files from `test-project/` via `read_test_file`, but feeds them to parsers rather than comparing content. No `.gitattributes` is therefore added. If the Windows leg surfaces a CRLF-driven *offset* failure, that will show up in the run below and be filed like any other.

## Local verification

```
$ cargo fmt --check                            # clean
$ cargo clippy --all-targets -- -D warnings    # exit 0
$ cargo test --all-features
test result: ok. 2422 passed; 0 failed
test result: ok. 494 passed; 0 failed
test result: ok. 80 passed; 0 failed
```

## Windows leg results — green

All three test binaries pass on Windows, with `cargo fmt --check` and
`cargo clippy --all-targets -- -D warnings` clean:

```
src\lib.rs                   2416 passed; 0 failed
src\main.rs                   472 passed; 0 failed
tests\integration_tests.rs      80 passed; 0 failed
```

The two `#[cfg(windows)]` tests that had no runner until now actually execute:

```
path_join::tests::backslash_fragment_is_stripped_on_windows ... ok
path_segments::tests::matches_segments_in_a_windows_path ... ok
```

Getting there took nine runs, because each gate hid the next — `cargo test`
stops at the first failing target, and a missing dependency reveals only itself:

| Run | Windows reached | Blocker |
|---|---|---|
| 1–2 | composer install | `ext-intl`, then `ext-fileinfo` — the workflow never declared its PHP environment, relying on what the Ubuntu runner happened to bundle |
| 3 | `cargo clippy` | 8 compile errors: `std::os::unix::fs::symlink` fixtures, and imports six modules already gated but left ungated |
| 4–6 | `cargo test` (lib) | 20 failures |
| 7–8 | `cargo test` (bin) | 7 more, reachable only once lib passed |
| 9 | `cargo test` (integration) | 1 more, reachable only once bin passed |

Every failure was real; none were flaky.

The Windows leg is **blocking**, and all three legs are required status checks
on `main`.

## Ten shipped bugs found and fixed

The Windows binary has 431 downloads on the current release, so these were live:

| Site | Effect on Windows |
|---|---|
| `execute_salsa_update` — `app/Providers`, `/config/` | **editing a provider or config file never re-registered with Salsa** — middleware aliases, bindings and config values silently stopped updating |
| `CacheManager::update_mtime_glob` keys | App rescan never cleared provider entries; the provider rescan was skipped |
| `file_watcher` glob assembly | globs mixed `/` and `\` in one string, defeating the PSR-4 dedup and registering directories twice |
| `is_component_file` | every component file unrecognised |
| `extract_component_variables` guard + offset | component variable inference never ran |
| Inertia page detection | no file recognised as a page |
| config-file detection (`env()` diagnostic) | never fired |
| Artisan command change detection | never fired |
| migration change detection | never fired |
| `resolve_livewire_path` display paths | mixed separators surfaced in hover and goto |

One of those — `format!("{}resources/views/components/", MAIN_SEPARATOR)` —
was broken on **every** platform, producing `esources/views/components/` on
Windows and surviving on Linux only because a forward-slash fallback carried it.

## What was deliberately not changed

- **~551 `join("a/b")` calls.** `/` is a separator on Windows, so these parse,
  compare and resolve correctly there; only the rendered string is mixed.
  Rewriting them would be churn with real risk and no behavioural gain. Only
  the four whose output reaches the user's screen were split.
- **`src/lib.rs`'s `format!("{}/{}", …)`.** The extension crate targets
  `wasm32-wasip2`, where `/` is the only separator regardless of host.
- **24 `ends_with(".blade.php")` / `.php` checks.** A filename suffix carries no
  separators, so they are already correct everywhere — and converting them to
  `Path::ends_with` would silently break all 24, since it compares whole
  components and is `false` for `".blade.php"`.

## Also fixed: tests that passed for the wrong reason

Found by sweeping rather than by CI, which structurally cannot report them —
a false pass never raises its hand:

- Three negative assertions in `salsa_impl::tests` (`!contains("buttons/light-button")`
  and siblings) could never fire on Windows, staying green whether or not the
  filtering they guard worked.
- Two `migration_action(...).is_none()` assertions held on Windows because the
  internal `Url::from_file_path` failed first on a prefixless `/srv/app` — they
  would have passed with the kind and table checks entirely broken.

## Shipped-code separator bugs fixed here

The Windows binary has **431 downloads** on the current release, so these were live for real users, not hypothetical:

| Site | Effect on Windows |
|---|---|
| `is_component_file` | every component file unrecognised |
| `extract_component_variables` guard + offset | component variable inference never ran |
| `execute_salsa_update` — `app/Providers`, `/config/` | **editing a provider or config file never re-registered with Salsa** — middleware aliases, bindings and config values silently stopped updating |
| `CacheManager::update_mtime_glob` keys | App rescan never cleared provider entries, so the provider rescan was skipped |

Found by sweeping for the bug class rather than stopping at the three the criteria named. Checked and deliberately left alone: `classify_priority` already normalizes, `view_declaration_locator` already tests both spellings, and the three `MAIN_SEPARATOR` replacements are correct on both platforms.

## Release workflow

**No change needed.** `release.yml` already builds both Windows targets (`x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`), already uses `shell: bash` for its build/prepare/archive steps, and never touches PHP or the test fixture — so none of the CI environment fixes apply to it. What was shipping broken was the code, not the pipeline, and those fixes are in this PR.

## Branch protection

All four contexts are required on `main`:

```
["Extension — wasm check, fmt, clippy",
 "LSP — test, fmt, clippy (ubuntu-latest)",
 "LSP — test, fmt, clippy (macos-latest)",
 "LSP — test, fmt, clippy (windows-latest)"]
```

⚠️ **#299 is affected.** It predates the matrix, so it reports the old
un-suffixed context and needs a rebase onto `main` after this merges.
