### PR TITLE
ci: run the laravel-lsp job on windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,11 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
       - name: cargo test
-        run: cargo test --all-features
+        # `--no-fail-fast` so one failing target doesn't hide the others: the
+        # Windows leg is here to inventory breakage, and stopping at the lib
+        # target would leave the bin + integration targets unreported. Applied
+        # to both legs — it widens what runs, it never narrows it.
+        run: cargo test --all-features --no-fail-fast
 
   extension:
     name: Extension — wasm check, fmt, clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,19 @@ env:
 jobs:
   laravel-lsp:
     name: LSP — test, fmt, clippy
-    runs-on: ubuntu-latest
+    # Zed ships Windows builds, so a Windows-only path regression reaches users
+    # with every check green. Run the same job on both hosts (issue #292).
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    # Scoped per-leg on purpose: a bare job-level `continue-on-error: true`
+    # would silently make the *existing* ubuntu-latest leg non-blocking too.
+    # The Windows leg reports without blocking merges until its pre-existing
+    # failures are triaged; then this comes off and its matrix-suffixed context
+    # joins branch protection's required checks.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     defaults:
       run:
         working-directory: laravel-lsp
@@ -32,6 +44,10 @@ jobs:
         # under `laravel-lsp/tests/integration_tests.rs` need one to
         # exercise env parsing + variable extraction.
         working-directory: .
+        # GitHub-hosted Windows runners default to PowerShell, where `cp` is an
+        # alias for Copy-Item rather than a real binary. Git Bash ships on every
+        # hosted Windows image, so pinning the shell keeps one command portable.
+        shell: bash
         run: cp test-project/.env.example test-project/.env
 
       - name: Setup PHP for test fixture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,14 @@ jobs:
           # 8.4 matches the actual minimum required by the locked
           # vendor packages (symfony/* v8.0 requires >= 8.4).
           php-version: '8.4'
-          # `filament/support` requires ext-intl. The Ubuntu PHP image happens
-          # to ship it, the Windows one does not, so `composer update` resolved
-          # on one host and failed on the other. Requesting it explicitly makes
-          # the fixture's real requirement the same on both legs instead of an
-          # accident of the runner image.
-          extensions: intl
+          # The fixture's Laravel 12 + Filament 5 tree has real platform
+          # requirements (`ext-intl` via filament/support, `ext-fileinfo` via
+          # league/flysystem-local, ...). The Ubuntu PHP image happens to ship
+          # them and the Windows one does not, so `composer update` resolved on
+          # one host and failed on the other. Request the set explicitly so both
+          # legs resolve against the same platform instead of an accident of the
+          # runner image. `extensions` is additive — the Ubuntu leg is unchanged.
+          extensions: intl, fileinfo, mbstring, openssl, tokenizer, xml, ctype, curl, dom, zip, bcmath, gd, exif, iconv, sqlite3, pdo_sqlite
 
       - name: Install test-project Composer dependencies
         # `test-project/vendor/` AND `composer.lock` are gitignored — the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
           # 8.4 matches the actual minimum required by the locked
           # vendor packages (symfony/* v8.0 requires >= 8.4).
           php-version: '8.4'
+          # `filament/support` requires ext-intl. The Ubuntu PHP image happens
+          # to ship it, the Windows one does not, so `composer update` resolved
+          # on one host and failed on the other. Requesting it explicitly makes
+          # the fixture's real requirement the same on both legs instead of an
+          # accident of the runner image.
+          extensions: intl
 
       - name: Install test-project Composer dependencies
         # `test-project/vendor/` AND `composer.lock` are gitignored — the

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -90,6 +90,7 @@ pub mod naming;
 pub mod parser;
 pub mod path_containment;
 pub mod path_join;
+pub mod path_slash;
 pub mod pattern_disk_cache;
 pub mod pattern_indexer;
 pub mod php_class;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -11237,8 +11237,13 @@ impl LaravelLanguageServer {
     }
 
     /// Check if a blade file is a component file (in resources/views/components/)
+    ///
+    /// `path` is native (it comes from `Url::to_file_path`), so the marker is
+    /// matched against a slash-normalized copy — on Windows the raw path is
+    /// `\`-separated and `"/components/"` never matches (issue #292).
     fn is_component_file(path: &str) -> bool {
-        path.contains("/components/") && path.ends_with(".blade.php")
+        laravel_lsp::path_slash::to_slash(path).contains("/components/")
+            && path.ends_with(".blade.php")
     }
 
     /// Extract variables passed to a view from any PHP file that renders it
@@ -11828,11 +11833,16 @@ impl LaravelLanguageServer {
     ) -> Vec<(String, String)> {
         let vars = Vec::new();
 
-        // Check if this is a component view (in resources/views/components/)
-        let components_marker = format!("{}resources/views/components/", std::path::MAIN_SEPARATOR);
-        let components_marker_alt = "resources/views/components/";
+        // Check if this is a component view (in resources/views/components/).
+        // `blade_path` is native (from `Url::to_file_path`), so normalize its
+        // separators once and keep the ordinary forward-slash marker. The old
+        // `format!("{}resources/views/components/", MAIN_SEPARATOR)` built
+        // `\resources/views/components/` on Windows and matched nothing at all
+        // — neither a native path nor a normalized one (issue #292).
+        let blade_path = laravel_lsp::path_slash::to_slash(blade_path);
+        let blade_path = blade_path.as_ref();
 
-        if !blade_path.contains(&components_marker) && !blade_path.contains(components_marker_alt) {
+        if !blade_path.contains("resources/views/components/") {
             return vars;
         }
 
@@ -12264,7 +12274,14 @@ impl LaravelLanguageServer {
         // 1. Anonymous: resources/views/components/button.blade.php (no class)
         // 2. Class-based: app/View/Components/Button.php with resources/views/components/button.blade.php
 
-        // Check if this is in the components directory
+        // Check if this is in the components directory. Both sides are native
+        // paths — `blade_path` comes from `Url::to_file_path` and `views_str`
+        // from `root.join(..)` — so both are slash-normalized before the
+        // forward-slash marker, prefix strip, and `split('/')` below, none of
+        // which match a `\`-separated Windows path (issue #292).
+        let blade_path = laravel_lsp::path_slash::to_slash(blade_path);
+        let blade_path = blade_path.as_ref();
+
         if !blade_path.contains("/components/") {
             return None;
         }
@@ -12273,6 +12290,7 @@ impl LaravelLanguageServer {
         // resources/views/components/forms/input.blade.php -> Forms/Input
         let views_components = root.join("resources").join("views").join("components");
         let views_str = views_components.to_string_lossy();
+        let views_str = laravel_lsp::path_slash::to_slash(views_str.as_ref());
 
         let relative = blade_path
             .strip_prefix(views_str.as_ref())?

--- a/laravel-lsp/src/path_slash.rs
+++ b/laravel-lsp/src/path_slash.rs
@@ -1,0 +1,106 @@
+//! Rewrite a native filesystem path's separators to `/` — the single source of
+//! truth for "match a forward-slash directory marker against a real path".
+//!
+//! Several call sites locate a directory inside a path by searching for a
+//! literal forward-slash marker (`"/components/"`,
+//! `"resources/views/components/"`) or split one on `'/'`. The paths they
+//! search are *native* — they come from [`url::Url::to_file_path`], which
+//! yields `C:\Users\…\resources\views\components\button.blade.php` on Windows
+//! — so every one of those markers silently fails to match there, and the
+//! feature behind it goes quietly dead rather than erroring (issue #292).
+//!
+//! Mixing [`std::path::MAIN_SEPARATOR`] into an otherwise forward-slash marker
+//! does not fix it: `format!("{}resources/views/components/", MAIN_SEPARATOR)`
+//! builds `\resources/views/components/` on Windows, which matches neither a
+//! native path nor a slash-normalized one.
+//!
+//! Normalizing the *path* once, then keeping the ordinary `/` marker, is the
+//! rule used instead. Matching goes through [`std::path::is_separator`] — `/`
+//! on Unix, `/` or `\` on Windows — so a Unix filename containing a literal
+//! backslash (a legal character there, and never a separator) is left alone,
+//! while every Windows separator is rewritten. No `cfg` needed, the same
+//! approach [`crate::path_join`] already takes.
+
+use std::borrow::Cow;
+
+/// Rewrite `path`'s native directory separators to `/`.
+///
+/// Borrows unchanged when there is nothing to rewrite, which on Unix is always
+/// — [`std::path::is_separator`] accepts only `/` there, so this is a no-op on
+/// the platform whose markers already work.
+///
+/// The result is for **matching and splitting only**. Do not hand it back to
+/// the filesystem: on Windows a verbatim path (`\\?\C:\…`, what `canonicalize`
+/// returns) is passed to the OS unnormalized, and a `/` inside one does not
+/// resolve.
+pub fn to_slash(path: &str) -> Cow<'_, str> {
+    if path.contains(|c| std::path::is_separator(c) && c != '/') {
+        Cow::Owned(
+            path.chars()
+                .map(|c| if std::path::is_separator(c) { '/' } else { c })
+                .collect(),
+        )
+    } else {
+        Cow::Borrowed(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forward_slash_path_is_borrowed_unchanged() {
+        let out = to_slash("/app/resources/views/components/button.blade.php");
+        assert!(matches!(out, Cow::Borrowed(_)), "no rewrite should borrow");
+        assert_eq!(out, "/app/resources/views/components/button.blade.php");
+    }
+
+    #[test]
+    fn marker_matches_after_normalizing() {
+        // The whole point: this assertion is false against the raw input on
+        // Windows and true after normalizing, on both platforms.
+        let native = if cfg!(windows) {
+            r"C:\app\resources\views\components\button.blade.php"
+        } else {
+            "/app/resources/views/components/button.blade.php"
+        };
+        assert!(to_slash(native).contains("/components/"));
+    }
+
+    #[test]
+    fn empty_path_is_unchanged() {
+        assert_eq!(to_slash(""), "");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn backslashes_become_slashes_on_windows() {
+        assert_eq!(
+            to_slash(r"C:\app\resources\views\components\button.blade.php"),
+            "C:/app/resources/views/components/button.blade.php"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_verbatim_prefix_is_normalized_too() {
+        // `canonicalize` returns verbatim paths on Windows, so this shape is
+        // reachable from ordinary code here.
+        assert_eq!(
+            to_slash(r"\\?\C:\app\resources\views\components\card.blade.php"),
+            "//?/C:/app/resources/views/components/card.blade.php"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn backslash_is_an_ordinary_filename_character_on_unix() {
+        // `\` is legal in a Unix filename and is never a separator there, so
+        // rewriting it would corrupt the path.
+        let weird = r"/app/we\ird/components/button.blade.php";
+        let out = to_slash(weird);
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert_eq!(out, weird);
+    }
+}

--- a/laravel-lsp/src/tests/component_navigation_containment.rs
+++ b/laravel-lsp/src/tests/component_navigation_containment.rs
@@ -17,7 +17,10 @@ use crate::LaravelLanguageServer;
 use laravel_lsp::salsa_impl::{ComponentReferenceData, LaravelConfigData};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+// Only the `#[cfg(unix)]` symlink tests below build a `PathBuf`.
+#[cfg(unix)]
+use std::path::PathBuf;
 use tower_lsp::lsp_types::GotoDefinitionResponse;
 use tower_lsp::{lsp_types::Url, LspService};
 

--- a/laravel-lsp/src/tests/directive_navigation_containment.rs
+++ b/laravel-lsp/src/tests/directive_navigation_containment.rs
@@ -18,7 +18,10 @@ use crate::LaravelLanguageServer;
 use laravel_lsp::salsa_impl::{DirectiveReferenceData, LaravelConfigData};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+// Only the `#[cfg(unix)]` symlink tests below build a `PathBuf`.
+#[cfg(unix)]
+use std::path::PathBuf;
 use tower_lsp::lsp_types::GotoDefinitionResponse;
 use tower_lsp::{lsp_types::Url, LspService};
 

--- a/laravel-lsp/src/tests/folio_cursor_containment.rs
+++ b/laravel-lsp/src/tests/folio_cursor_containment.rs
@@ -8,7 +8,10 @@
 //! tests drive the private methods directly by building the server through
 //! `tower_lsp::LspService` and reaching its inner value with `inner()`.
 
-use crate::{path_within_root, LaravelLanguageServer};
+use crate::LaravelLanguageServer;
+// Only the `#[cfg(unix)]` symlink tests below call the guard directly.
+#[cfg(unix)]
+use crate::path_within_root;
 use laravel_lsp::route_discovery::{RouteDefinition, RouteIndex, PRIORITY_APP};
 use std::fs;
 use std::path::Path;

--- a/laravel-lsp/src/tests/scan_dir_containment.rs
+++ b/laravel-lsp/src/tests/scan_dir_containment.rs
@@ -24,7 +24,10 @@
 //! positive controls prove the gate does not over-refuse: an in-root symlink
 //! (target inside the root) and an ordinary subdirectory still yield candidates.
 
-use laravel_lsp::component_completion::{scan_anonymous_dir, scan_class_dir, ComponentCandidate};
+use laravel_lsp::component_completion::{scan_class_dir, ComponentCandidate};
+// Only the `#[cfg(unix)]` symlink tests below scan an anonymous dir.
+#[cfg(unix)]
+use laravel_lsp::component_completion::scan_anonymous_dir;
 use tempfile::TempDir;
 
 fn names(candidates: &[ComponentCandidate]) -> Vec<String> {

--- a/laravel-lsp/src/tests/slot_navigation_containment.rs
+++ b/laravel-lsp/src/tests/slot_navigation_containment.rs
@@ -16,7 +16,10 @@ use crate::LaravelLanguageServer;
 use laravel_lsp::salsa_impl::LaravelConfigData;
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+// Only the `#[cfg(unix)]` symlink tests below build a `PathBuf`.
+#[cfg(unix)]
+use std::path::PathBuf;
 use tower_lsp::lsp_types::{GotoDefinitionResponse, Position};
 use tower_lsp::{lsp_types::Url, LspService};
 

--- a/laravel-lsp/src/tests/slot_variable_resolution.rs
+++ b/laravel-lsp/src/tests/slot_variable_resolution.rs
@@ -81,6 +81,29 @@ fn test_is_component_file() {
     ));
 }
 
+/// `is_component_file` receives a *native* path (`Url::to_file_path`), so on
+/// Windows it is `\`-separated and the `"/components/"` marker used to match
+/// nothing at all — `$slot`/`$attributes`/`$component` silently stopped being
+/// offered in every component file on that platform (issue #292).
+#[cfg(windows)]
+#[test]
+fn test_is_component_file_windows_native_separators() {
+    assert!(LaravelLanguageServer::is_component_file(
+        r"C:\app\resources\views\components\button.blade.php"
+    ));
+    assert!(LaravelLanguageServer::is_component_file(
+        r"C:\app\resources\views\components\forms\input.blade.php"
+    ));
+    // Still discriminating on Windows: a non-component Blade file, and a
+    // component-looking path that is not a Blade file, both stay out.
+    assert!(!LaravelLanguageServer::is_component_file(
+        r"C:\app\resources\views\welcome.blade.php"
+    ));
+    assert!(!LaravelLanguageServer::is_component_file(
+        r"C:\app\resources\views\components\button.php"
+    ));
+}
+
 #[test]
 fn test_extract_slot_variable_usages_complex() {
     let content = r#"

--- a/laravel-lsp/src/tests/view_navigation_containment.rs
+++ b/laravel-lsp/src/tests/view_navigation_containment.rs
@@ -17,7 +17,10 @@ use crate::LaravelLanguageServer;
 use laravel_lsp::salsa_impl::{LaravelConfigData, ViewReferenceData};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+// Only the `#[cfg(unix)]` symlink tests below build a `PathBuf`.
+#[cfg(unix)]
+use std::path::PathBuf;
 use tower_lsp::lsp_types::GotoDefinitionResponse;
 use tower_lsp::{lsp_types::Url, LspService};
 

--- a/laravel-lsp/src/translation_lookup/tests.rs
+++ b/laravel-lsp/src/translation_lookup/tests.rs
@@ -395,6 +395,9 @@ fn traversing_namespace_in_the_published_path_is_refused() {
     );
 }
 
+// Symlinks need `std::os::unix`; every other symlink-escape test in the
+// tree is already `#[cfg(unix)]`-gated the same way.
+#[cfg(unix)]
 #[test]
 fn dotted_key_read_through_an_escaping_symlink_is_refused() {
     // Containment is canonical, not textual: `lang/en` is spelled inside the
@@ -419,6 +422,9 @@ fn dotted_key_read_through_an_escaping_symlink_is_refused() {
     );
 }
 
+// Symlinks need `std::os::unix`; every other symlink-escape test in the
+// tree is already `#[cfg(unix)]`-gated the same way.
+#[cfg(unix)]
 #[test]
 fn text_key_read_through_an_escaping_symlink_is_refused() {
     // Same guard on the JSON catalogue read.


### PR DESCRIPTION
## Summary

Implements #292. The `laravel-lsp` job now runs on `windows-latest` as well as `ubuntu-latest`, so Windows path regressions are caught instead of shipping green.

The Windows leg is **not** green, and this PR does not pretend otherwise — that is the point of the issue. It reports without blocking merges, and its 28 failures are triaged into tracked issues below.

## Changes

**CI (`.github/workflows/ci.yml`)**

- `laravel-lsp` gains `strategy.matrix.os: [ubuntu-latest, windows-latest]`, `fail-fast: false`, `runs-on: ${{ matrix.os }}`. The `extension` job is untouched.
- `continue-on-error: ${{ matrix.os == 'windows-latest' }}` — scoped per-leg. A bare job-level `continue-on-error: true` would have made the existing Ubuntu leg non-blocking too.
- `shell: bash` on the fixture bootstrap step. `cp` is a PowerShell alias, not a binary, on hosted Windows images.
- `extensions: intl, fileinfo, mbstring, ...` on `setup-php`. The fixture's Laravel 12 + Filament 5 tree has real platform requirements; the Ubuntu image ships them and the Windows one does not, so `composer update` resolved on one host and failed on the other. The input is additive, so Ubuntu's resolution is unchanged.
- `cargo test --no-fail-fast` on **both** legs. `cargo test` stops at the first failing target, which hid the bin and integration targets entirely — an incomplete inventory for the triage this matrix exists to produce. This widens what runs; it never narrows it.

**Windows path fixes (`main.rs`, new `path_slash` module)**

`path_slash::to_slash` normalizes a native path's separators to `/` via `std::path::is_separator`, the same cfg-free approach `path_join` already takes. Three `main.rs` sites matched a forward-slash marker against a path from `Url::to_file_path`, which is `\`-separated on Windows.

**Test portability**

Two `translation_lookup` symlink tests called `std::os::unix::fs` ungated (E0433 on Windows); every other symlink test already carries `#[cfg(unix)]`. Six imports reachable only from gated tests take the same gate, since `RUSTFLAGS: -D warnings` makes an unused import a hard error. No test's coverage changes on Unix.

## Evidence

Reference run: [runs/32853835946](https://github.com/mike-bronner/zed-laravel/actions/runs/32853835946) — [Windows leg](https://github.com/mike-bronner/zed-laravel/actions/runs/32853835946/job/97820871562), [Ubuntu leg](https://github.com/mike-bronner/zed-laravel/actions/runs/32853835946/job/97820871533).

Both legs run identical invocations — `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-features --no-fail-fast`. No matrix-conditional filter, `--skip`, or feature narrowing.

**Raw Windows-leg summary:**

```
Running unittests src\lib.rs
test result: FAILED. 2392 passed; 20 failed; 0 ignored; 0 measured; 0 filtered out
Running unittests src\main.rs
test result: FAILED. 458 passed; 7 failed; 0 ignored; 0 measured; 0 filtered out
Running tests\integration_tests.rs
test result: FAILED. 79 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
Doc-tests laravel_lsp
test result: ok. 0 passed; 0 failed
```

**2929 passed, 28 failed.** `cargo fmt --check` and `cargo clippy` both pass on Windows.

`backslash_fragment_is_stripped_on_windows` (added in #291, `#[cfg(windows)]`) executes for the first time and passes:

```
test path_join::tests::backslash_fragment_is_stripped_on_windows ... ok
test path_slash::tests::backslashes_become_slashes_on_windows ... ok
test path_slash::tests::windows_verbatim_prefix_is_normalized_too ... ok
test tests::slot_variable_resolution::test_is_component_file_windows_native_separators ... ok
```

### The three `main.rs` marker sites — fixed, not confirmed correct

All three were **broken** on Windows. `path` reaches each of them from `uri.to_file_path()`, so it carries `\` separators there:

```rust
let file_path = uri.to_file_path().ok()?;
let path = file_path.to_str()?;
```

| Site | Was | Effect on Windows |
|---|---|---|
| `is_component_file` | `path.contains("/components/")` | Never matched. `$slot` / `$attributes` / `$component` silently stopped being offered in every component file. |
| `extract_component_variables` | `format!("{}resources/views/components/", MAIN_SEPARATOR)` | Built `\resources/views/components/` — a mixed separator matching neither a native nor a normalized path. The guard returned early, so component variables were never extracted. |
| `check_view_component_variable` | `blade_path.contains("/components/")`, then `strip_prefix` + `trim_start_matches('/')` + `split('/')` | Never matched. This is the site #292 did not name; it makes the identical assumption and is fixed here with the other two. |

Runtime value captured from the Windows CI log, showing the native separators these markers were matched against:

```
C:\Users\RUNNER~1\AppData\Local\Temp\.tmpfWLO8R\vendor\acme\widgets\src\Panel.php
```

### Line endings

**No test in `laravel-lsp` asserts on file content byte-for-byte.** All 34 `read_test_file` call sites assert with `.contains(...)`, which is CRLF-insensitive. No `.gitattributes` is added, and none is needed.

## Triaged failures

Every one of the 28 failures is filed. Grouped by shared root cause, with each group naming its cause and listing every test it covers.

| Issue | Root cause | Tests |
|---|---|---|
| #308 | `Url::from_file_path` rejects Unix-rooted, prefixless path literals | 19 |
| #309 | Production path construction mixes `Path::join` / `display()` with hardcoded `/` | 4 |
| #310 | `class_locator` tests assert a `/`-separated substring against a native path | 2 |
| #311 | `normalize_path`'s absolute-path invariant fails for Unix-rooted input | 2 |
| #312 | `composer_autoload` containment guard drops every source root | 1 |

This PR does not bulk-edit the ~455 Unix-rooted path literals.

Two more defects surfaced that are not Windows-leg failures:

- **#313** — branch protection requires `LSP — test, fmt, clippy (macos-latest)`, which **no PR workflow produces**. A required context that never reports blocks every merge. Reported rather than changed: editing the merge gate is a governance call. See the AC note below.
- **#314** — `parsed_class_file_reuses_cached_parse_for_same_stamp` flakes on the **Ubuntu** leg against a process-global cache shared by four parallel tests. Pre-existing; observed pass/fail/pass across three runs on this branch.

## Acceptance Criteria

- [x] `laravel-lsp` gains `strategy.matrix.os: [ubuntu-latest, windows-latest]`, `fail-fast: false`, `runs-on: ${{ matrix.os }}`; `continue-on-error` scoped per-leg via `${{ matrix.os == 'windows-latest' }}`. `extension` untouched.
- [x] Branch protection's required contexts are verified. **No change was needed — the target state was already live.** `gh api repos/mike-bronner/zed-laravel/branches/main/protection` returns `Extension — wasm check, fmt, clippy`, `LSP — test, fmt, clippy (ubuntu-latest)`, `LSP — test, fmt, clippy (macos-latest)`. The Ubuntu gate is already matrix-suffixed, so it is not dropped when this matrix lands, and `(windows-latest)` is correctly absent. The unrelated `(macos-latest)` entry is a pre-existing defect, filed as #313 rather than silently edited here.
- [x] The `Bootstrap test fixture .env` step works on `windows-latest` via `shell: bash`. Confirmed by a real run — step 5 `Bootstrap test fixture .env` reports `success` on the Windows leg.
- [x] The three forward-slash `components/` marker sites are **fixed**, not confirmed correct. Each was genuinely broken; the runtime separator is captured above, and `test_is_component_file_windows_native_separators` passes on the Windows leg.
- [x] A real CI run shows the Windows leg executing the same `fmt` / `clippy` / `test` invocations as Ubuntu, with no filters. `backslash_fragment_is_stripped_on_windows` appears in that run's output and passes.
- [x] This description quotes the run's raw failure count and summary. All 28 failures are filed as #308–#312, grouped by named root cause with every test name listed.
- [x] States plainly that no test asserts on file content byte-for-byte, so no `.gitattributes` is added.
- [x] `continue-on-error` stays scoped true for the Windows leg, and its matrix-suffixed context is not added to branch protection. Both deferred until #308–#312 land.

## Test Plan

- [x] Ubuntu leg green — 2426 + 489 + 80 tests, `fmt` and `clippy` clean.
- [x] Windows leg executes, `fmt` and `clippy` clean, 2929 tests pass and 28 fail — all triaged.
- [x] New `path_slash` unit tests pass on both platforms, including three `#[cfg(windows)]` cases verified on the real runner.
- [x] `#[cfg(unix)]` gating changes no test's behaviour on Unix — full suite still 2426 + 489 + 80 passing locally.

Fixes #292
