### PR TITLE
fix: 🐛 Path issues specific to Windows environment.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,4 +45,4 @@ Internal discovery and rationale documents. Not user guides — they record why 
 
 | Document | What it covers |
 |---|---|
-| [Unifying the route caches](route-cache-unification.md) | Benchmark-backed discovery for [#48](https://github.com/mike-bronner/zed-laravel/issues/48): whether the byte-scan route index and the tree-sitter route walkers should collapse onto one model |
+| [Unifying the route caches](route-cache-unification.md) | Benchmark-backed discovery for [#48](https://github.com/mike-bronner/zed-laravel/issues/48): whether the route index and the route walkers should collapse onto one model, plus the measured cost of the tree-sitter migration that followed |

--- a/docs/route-cache-unification.md
+++ b/docs/route-cache-unification.md
@@ -5,6 +5,41 @@
 > Numbers below come from `cargo bench --bench route_cache` (a **synthetic**
 > corpus; see the caveat at the end).
 
+## Outcome (superseded — A was implemented)
+
+> **This document's recommendation was overridden.** Option **A (full unify onto
+> tree-sitter)** was implemented for `build_route_index` while fixing a
+> user-facing correctness bug: the byte scanners had no notion of PHP comments
+> or heredocs, so a commented-out `function () {` or a bare apostrophe in prose
+> shifted every group boundary that followed it. Real route files carry both,
+> and routes downstream of the corruption were indexed under the wrong prefix
+> (or none), producing false "Route not found" diagnostics on routes that
+> `artisan route:list` resolves fine.
+>
+> B (hybrid) would have fixed the first-party case at ~1× cost, but was not the
+> option chosen. The measured price of A, re-run with the same bench after the
+> migration:
+>
+> | Corpus | `build_route_index` before | after | ratio |
+> |---|---|---|---|
+> | 500 vendor files | 38.0 ms | 151.4 ms | 4.0× |
+> | 2000 vendor files | 172.8 ms | 580.0 ms | 3.4× |
+> | 5000 vendor files | 368.5 ms | 1.43 s | 3.9× |
+>
+> On a real vendor-heavy project (139 route files, 93.5% vendor) the same
+> rebuild went 55.9 ms → 173.7 ms (3.1×), and the index gained 155 correctly
+> prefixed names it had previously been getting wrong.
+>
+> The realistic-path ratio is worse than the ~2.8× parse ratio predicted below
+> because `build_route_index` parses each file twice — once to discover
+> `->group(<path>)` load edges, once to extract routes. Collapsing those two
+> passes onto one cached parse is the obvious next optimization, and the hybrid
+> split described under **B** remains available if the cold-start cost proves
+> unacceptable on large projects.
+>
+> Everything below is the original discovery, kept as the record of what was
+> measured beforehand.
+
 ## TL;DR
 
 **Recommendation: B — hybrid, but deferred.** Unify the *first-party* route

--- a/laravel-lsp/Cargo.toml
+++ b/laravel-lsp/Cargo.toml
@@ -98,8 +98,9 @@ cc = "1.2"
 [dev-dependencies]
 tempfile = "3.27"
 
-# Discovery benchmark for issue #48 — compares the byte-scan vs tree-sitter
-# route-parsing strategies. Custom timing harness (no criterion dependency);
+# Route-parsing benchmark from issue #48 — now tracks the cost of the
+# tree-sitter route index against the shallower chain walker, plus the absolute
+# `build_route_index` wall clock. Custom timing harness (no criterion dependency);
 # run with `cargo bench --bench route_cache`.
 [[bench]]
 name = "route_cache"

--- a/laravel-lsp/benches/route_cache.rs
+++ b/laravel-lsp/benches/route_cache.rs
@@ -1,15 +1,18 @@
 //! Route-cache strategy benchmark — discovery for issue #48.
 //!
-//! Today route data is materialized into three caches built by two parsing
-//! strategies. This bench measures the two strategies head-to-head so the
-//! "unify onto one canonical source" decision rests on numbers, not intuition:
+//! Route data is materialized into three caches. Since the route index moved
+//! onto tree-sitter (see `docs/route-cache-unification.md`), BOTH strategies
+//! below parse PHP — the bench now measures how much extra work the index's
+//! richer model costs over the chain walker, and tracks the absolute cost of
+//! `build_route_index` so the tree-sitter migration's price stays visible:
 //!
-//! * **byte-scan** — [`extract_named_routes`], the strategy behind
+//! * **index** — [`extract_named_routes`], the strategy behind
 //!   `build_route_index` (the whole-project name→location index, incl.
 //!   `vendor/`).
-//! * **tree-sitter** — [`extract_route_chains`], the strategy behind the
+//! * **chain-walker** — [`extract_route_chains`], the strategy behind the
 //!   per-file declaration cache (rename / find-references) and the
-//!   document-symbols outline.
+//!   document-symbols outline. Same parse, shallower model: it stops at a
+//!   `RESOURCE` leaf where the index expands the CRUD sub-routes.
 //!
 //! It generates a synthetic corpus at three vendor scales (~500 / ~2000 /
 //! ~5000 files) whose route files mimic real-world shapes — named routes,
@@ -21,7 +24,7 @@
 //! 2. **route-save path** — re-parse a single representative project file with
 //!    each strategy;
 //! 3. **realistic init** — the real `build_route_index` (discovery + disk I/O +
-//!    load-graph expansion + byte-scan) against the on-disk corpus, i.e. the
+//!    load-graph expansion + extraction) against the on-disk corpus, i.e. the
 //!    cost paid today;
 //! 4. **memory** — estimated heap footprint of caching the tree-sitter rich
 //!    per-file model (`Vec<RouteChainNode>`) for every route file.
@@ -194,7 +197,7 @@ fn read_all(paths: &[PathBuf]) -> Vec<String> {
         .collect()
 }
 
-/// Recursively count every `Route::*` chain node (parity with the byte-scan
+/// Recursively count every `Route::*` chain node (parity with the index
 /// route-definition count, modulo resource granularity — see AC#4 demo).
 fn count_chain_nodes(chains: &[RouteChainNode]) -> usize {
     chains
@@ -265,7 +268,7 @@ fn bench_single_file(content: &str) -> (Duration, Duration) {
 }
 
 /// The real init cost paid today: discovery + disk read + load-graph expansion
-/// + byte-scan, via `build_route_index`.
+/// + extraction, via `build_route_index`.
 fn bench_realistic_init(root: &Path) -> (Duration, usize) {
     let start = Instant::now();
     let files = discover_route_files(root);
@@ -292,7 +295,7 @@ fn resource_granularity_demo() {
     let mut names: Vec<String> = bytescan.iter().filter_map(|(n, _)| n.clone()).collect();
     names.sort();
     println!(
-        "  byte-scan      -> {} named routes: {}",
+        "  index          -> {} named routes: {}",
         names.len(),
         names.join(", ")
     );
@@ -354,7 +357,7 @@ fn main() {
         let (ts_dur, ts_nodes, ts_bytes) = bench_treesitter(&all_contents);
         println!("[init / whole corpus, in-memory parse only]");
         println!(
-            "  byte-scan   : {:>9.2?}  ({:.2} us/file, {} route-defs)",
+            "  index       : {:>9.2?}  ({:.2} us/file, {} route-defs)",
             bs_dur,
             per_file_us(bs_dur, total_files),
             bs_defs
@@ -366,21 +369,21 @@ fn main() {
             ts_nodes
         );
         println!(
-            "  tree-sitter / byte-scan slowdown: {:.1}x",
+            "  chain-walker / index ratio: {:.1}x",
             ts_dur.as_secs_f64() / bs_dur.as_secs_f64().max(f64::EPSILON)
         );
 
         // 2. route-save path — single representative project file
         let (save_bs, save_ts) = bench_single_file(&project_contents[0]);
         println!("[route-save / single project file re-parse]");
-        println!("  byte-scan   : {save_bs:>9.2?}");
+        println!("  index       : {save_bs:>9.2?}");
         println!("  tree-sitter : {save_ts:>9.2?}");
         println!(
-            "  tree-sitter / byte-scan slowdown: {:.1}x",
+            "  chain-walker / index ratio: {:.1}x",
             save_ts.as_secs_f64() / save_bs.as_secs_f64().max(f64::EPSILON)
         );
 
-        // 3. realistic init — build_route_index (discovery + I/O + byte-scan)
+        // 3. realistic init — build_route_index (discovery + I/O + extraction)
         let (real_dur, indexed) = bench_realistic_init(&corpus.root);
         println!("[realistic init / build_route_index, disk + discovery]");
         println!(

--- a/laravel-lsp/src/route_discovery.rs
+++ b/laravel-lsp/src/route_discovery.rs
@@ -16,21 +16,8 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use tree_sitter::Node;
 use walkdir::WalkDir;
-
-/// A route group's contribution to its child routes' names. Built once per
-/// source file by [`find_route_groups`] and consulted by
-/// [`extract_named_routes`] when composing the final name of a `->name('X')`
-/// callsite that lives inside one or more enclosing groups.
-#[derive(Debug, Clone)]
-struct RouteGroupSpan {
-    /// Name prefix this group contributes — `"admin."`, `"api.v1."`, etc.
-    prefix: String,
-    /// Byte offset just past the opening `{` of the group's closure body.
-    body_start: usize,
-    /// Byte offset of the matching closing `}` of the group's closure body.
-    body_end: usize,
-}
 
 /// A `->group(...)`/`::group(...)` callsite that loads an *external file*
 /// instead of running a closure body (issue #43). Laravel `require`s the file
@@ -38,16 +25,13 @@ struct RouteGroupSpan {
 /// prefix — to every route declared in it.
 #[derive(Debug, Clone)]
 struct ExternalGroupLoad {
-    /// Byte offset of the `->`/`::` that introduces this `group(...)` call.
-    /// Used to locate enclosing closure groups in the same file.
-    offset: usize,
-    /// This load's OWN name prefix (from a chained `->as(...)`/`->name(...)`
-    /// link or an `['as' => ...]` array literal). May be empty.
-    own_prefix: String,
+    /// The full name prefix this load contributes to the target file: every
+    /// enclosing closure group's prefix followed by the load's own
+    /// `->as(...)`/`->name(...)`/`['as' => …]` prefix. May be empty.
+    edge_prefix: String,
     /// Resolved absolute path of the file this group loads.
     target: PathBuf,
 }
-
 /// A located route definition. Stored in [`RouteIndex`] keyed by route name.
 #[derive(Debug, Clone)]
 pub struct RouteDefinition {
@@ -237,7 +221,7 @@ pub fn discover_route_files(root: &Path) -> Vec<RouteFile> {
 /// file (discovered + referenced), keyed by normalized path.
 pub fn build_route_index(root: &Path, files: &[RouteFile]) -> RouteIndex {
     let expansion = expand_load_graph(root, files);
-    let effective = compute_effective_prefixes(root, &expansion.files, &expansion.contents);
+    let effective = compute_effective_prefixes(&expansion.files, &expansion.loads);
 
     let mut index = RouteIndex::new();
     for file in &expansion.files {
@@ -300,7 +284,7 @@ fn dedup_prefixes(prefixes: &[String]) -> Vec<String> {
 pub fn external_prefixes_for_file(root: &Path, file: &Path) -> Vec<String> {
     let files = discover_route_files(root);
     let expansion = expand_load_graph(root, &files);
-    let effective = compute_effective_prefixes(root, &expansion.files, &expansion.contents);
+    let effective = compute_effective_prefixes(&expansion.files, &expansion.loads);
 
     let key = normalize_path(file);
     let mut out = vec![String::new()];
@@ -324,7 +308,7 @@ pub fn external_prefixes_for_file(root: &Path, file: &Path) -> Vec<String> {
 pub fn external_prefixes_map(root: &Path) -> HashMap<PathBuf, Vec<String>> {
     let files = discover_route_files(root);
     let expansion = expand_load_graph(root, &files);
-    let effective = compute_effective_prefixes(root, &expansion.files, &expansion.contents);
+    let effective = compute_effective_prefixes(&expansion.files, &expansion.loads);
 
     let mut map: HashMap<PathBuf, Vec<String>> = HashMap::new();
     for (key, prefixes) in effective {
@@ -342,6 +326,10 @@ struct LoadGraphExpansion {
     files: Vec<RouteFile>,
     /// Each file's source text, keyed by normalized path.
     contents: HashMap<PathBuf, String>,
+    /// Each file's external group loads, keyed by normalized path. Captured
+    /// during the BFS so [`compute_effective_prefixes`] doesn't re-parse every
+    /// file just to rediscover the same edges.
+    loads: HashMap<PathBuf, Vec<ExternalGroupLoad>>,
 }
 
 /// BFS-expand `files` along external `->group(<path>)` load edges, reading each
@@ -355,6 +343,7 @@ fn expand_load_graph(root: &Path, files: &[RouteFile]) -> LoadGraphExpansion {
     // Original (non-normalized) path to use for the RouteDefinition's `file`.
     let mut paths: HashMap<PathBuf, PathBuf> = HashMap::new();
     let mut priorities: HashMap<PathBuf, u8> = HashMap::new();
+    let mut loads: HashMap<PathBuf, Vec<ExternalGroupLoad>> = HashMap::new();
 
     // Queue of (path, priority, depth) still to read/expand.
     let mut queue: std::collections::VecDeque<(PathBuf, u8, usize)> =
@@ -389,19 +378,21 @@ fn expand_load_graph(root: &Path, files: &[RouteFile]) -> LoadGraphExpansion {
             continue;
         };
 
-        // Discover this file's external `->group(<path>)` targets and enqueue
-        // any not yet read. Depth is capped in the spirit of MAX_LOAD_DEPTH so a
-        // pathological chain can't loop forever (the `already_seen` check breaks
-        // cycles directly).
+        // Discover this file's external `->group(<path>)` targets. Every file
+        // is scanned (the result is reused to build the prefix graph), but only
+        // an under-depth file enqueues its targets, so a pathological chain
+        // can't loop forever (the `already_seen` check breaks cycles directly).
+        let loader_dir = path.parent().unwrap_or(root).to_path_buf();
+        let file_loads = find_external_group_loads(&text, root, &loader_dir);
         if depth < MAX_LOAD_DEPTH {
-            let loader_dir = path.parent().unwrap_or(root).to_path_buf();
-            for load in find_external_group_loads(text.as_bytes(), root, &loader_dir) {
+            for load in &file_loads {
                 let target_key = normalize_path(&load.target);
                 if !contents.contains_key(&target_key) {
-                    queue.push_back((load.target, priority, depth + 1));
+                    queue.push_back((load.target.clone(), priority, depth + 1));
                 }
             }
         }
+        loads.insert(key.clone(), file_loads);
 
         paths.insert(key.clone(), path);
         contents.insert(key, text);
@@ -419,6 +410,7 @@ fn expand_load_graph(root: &Path, files: &[RouteFile]) -> LoadGraphExpansion {
     LoadGraphExpansion {
         files: expanded,
         contents,
+        loads,
     }
 }
 
@@ -433,9 +425,8 @@ const MAX_LOAD_DEPTH: usize = 10;
 /// (every file is also scanned directly). Cycles are broken by a per-target
 /// visited set, and chains are capped at [`MAX_LOAD_DEPTH`].
 fn compute_effective_prefixes(
-    root: &Path,
     files: &[RouteFile],
-    contents: &HashMap<PathBuf, String>,
+    loads: &HashMap<PathBuf, Vec<ExternalGroupLoad>>,
 ) -> HashMap<PathBuf, Vec<String>> {
     // Set of files we actually index — only these can receive inherited
     // prefixes, and only loads pointing at one matter.
@@ -446,34 +437,19 @@ fn compute_effective_prefixes(
     let mut edges: HashMap<PathBuf, Vec<(PathBuf, String)>> = HashMap::new();
     for file in files {
         let source = normalize_path(&file.path);
-        let Some(content) = contents.get(&source) else {
+        let Some(file_loads) = loads.get(&source) else {
             continue;
         };
-        let bytes = content.as_bytes();
-        let loader_dir = file.path.parent().unwrap_or(root).to_path_buf();
-        let loads = find_external_group_loads(bytes, root, &loader_dir);
-        if loads.is_empty() {
-            continue;
-        }
-        // Closure-group spans in the SAME file — needed to prepend any enclosing
-        // closure prefixes to each load's edge.
-        let groups = find_route_groups(bytes);
-        for load in loads {
+        // Each load already carries the enclosing closure groups' prefixes.
+        for load in file_loads {
             let target = normalize_path(&load.target);
             if !known.contains(&target) {
                 continue;
             }
-            let mut edge_prefix = String::new();
-            for grp in &groups {
-                if grp.body_start <= load.offset && load.offset < grp.body_end {
-                    edge_prefix.push_str(&grp.prefix);
-                }
-            }
-            edge_prefix.push_str(&load.own_prefix);
             edges
                 .entry(source.clone())
                 .or_default()
-                .push((target, edge_prefix));
+                .push((target, load.edge_prefix.clone()));
         }
     }
 
@@ -519,153 +495,561 @@ fn propagate(
     stack.pop();
 }
 
-/// Extract every `->name('X')` callsite from the given source.
+// ============================================================================
+// Syntax-tree route extraction
+// ============================================================================
+//
+// Route names, group prefixes and resource registrations are read from the PHP
+// syntax tree. The previous byte scanners had no concept of comments, so a
+// commented-out `function () {` or a bare apostrophe in prose ("it's") shifted
+// every brace/paren boundary that followed it: group closures appeared to end
+// hundreds of lines late and their name prefixes leaked onto unrelated routes,
+// while `->name('x')` inside a commented-out route was indexed as real.
+
+/// One `->method(...)` / `::method(...)` link of a fluent chain.
+struct ChainLink<'a> {
+    /// Method identifier exactly as written (`get`, `apiResource`, `name`).
+    method: String,
+    /// The call's `arguments` node.
+    args: Node<'a>,
+    /// The method-name identifier node — anchors resource definitions.
+    name_node: Node<'a>,
+    /// The `->` / `?->` / `::` operator node — anchors named-route definitions.
+    operator: Option<Node<'a>>,
+    /// True for `$obj->method(...)`, false for `Class::method(...)`.
+    instance: bool,
+}
+
+fn is_call_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "member_call_expression" | "nullsafe_member_call_expression" | "scoped_call_expression"
+    )
+}
+
+/// True when `node` is the outermost call of a fluent chain — i.e. no parent
+/// call uses it as the receiver. Chains are walked from this node inward.
+fn is_chain_root(node: Node) -> bool {
+    match node.parent() {
+        Some(parent) if is_call_kind(parent.kind()) => parent
+            .child_by_field_name("object")
+            .is_none_or(|receiver| receiver.id() != node.id()),
+        _ => true,
+    }
+}
+
+/// Collect a chain's links in SOURCE order (leftmost/innermost call first).
 ///
-/// Returns `(name, RouteDefinition)` pairs. The match is line-based and tolerant
-/// of whitespace inside the call: `->name('X')`, `->name ( "X" )`, etc.
+/// The AST nests a fluent chain receiver-first, so `Route::get(…)->name(…)` is
+/// a `name` call whose `object` is the `get` call. Walking `object` yields the
+/// chain outermost-inward; the result is reversed so callers can read it the
+/// way the source does.
+fn collect_links<'a>(chain: Node<'a>, source: &[u8]) -> Vec<ChainLink<'a>> {
+    let mut links = Vec::new();
+    let mut current = Some(chain);
+
+    while let Some(node) = current {
+        if !is_call_kind(node.kind()) {
+            break;
+        }
+        if let (Some(name_node), Some(args)) = (
+            node.child_by_field_name("name"),
+            node.child_by_field_name("arguments"),
+        ) {
+            if let Ok(method) = name_node.utf8_text(source) {
+                links.push(ChainLink {
+                    method: method.to_string(),
+                    args,
+                    name_node,
+                    operator: operator_node(node),
+                    instance: node.kind() != "scoped_call_expression",
+                });
+            }
+        }
+        // `scoped_call_expression` has a `scope`, not an `object`, so a facade
+        // call (`Route::…`) naturally terminates the walk.
+        current = node.child_by_field_name("object");
+    }
+
+    links.reverse();
+    links
+}
+
+/// The `->` / `?->` / `::` token of a call, used to position the definition at
+/// the start of the `->name(` callsite rather than the whole chain.
+fn operator_node<'a>(call: Node<'a>) -> Option<Node<'a>> {
+    let mut cursor = call.walk();
+    for child in call.children(&mut cursor) {
+        if matches!(child.kind(), "->" | "?->" | "::") {
+            return Some(child);
+        }
+    }
+    None
+}
+
+/// The expression of the `n`th positional argument, skipping the `argument`
+/// wrapper node.
+fn nth_arg_node<'a>(args: Node<'a>, n: usize) -> Option<Node<'a>> {
+    let mut cursor = args.walk();
+    let mut index = 0;
+    for child in args.children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        if index == n {
+            return child.named_child(0);
+        }
+        index += 1;
+    }
+    None
+}
+
+/// The `n`th argument when it is a string literal — the shape every route name,
+/// URI and resource name must have to be statically resolvable.
+fn nth_string_arg(args: Node, n: usize, source: &[u8]) -> Option<String> {
+    let node = nth_arg_node(args, n)?;
+    if !is_string_node(node) {
+        return None;
+    }
+    string_text(node, source)
+}
+
+fn is_string_node(node: Node) -> bool {
+    matches!(node.kind(), "string" | "encapsed_string")
+}
+
+/// Inner text of a string literal, quotes stripped.
+fn string_text(node: Node, source: &[u8]) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "string_content" {
+            return child.utf8_text(source).ok().map(str::to_string);
+        }
+    }
+    // An empty literal (`''`) has no `string_content` child.
+    node.utf8_text(source).ok().map(|raw| {
+        raw.trim_start_matches(['\'', '"'])
+            .trim_end_matches(['\'', '"'])
+            .to_string()
+    })
+}
+
+/// The element expressions of an array literal, in order.
+fn array_values<'a>(node: Node<'a>) -> Vec<Node<'a>> {
+    if node.kind() != "array_creation_expression" {
+        return Vec::new();
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor)
+        .filter(|child| child.kind() == "array_element_initializer")
+        .filter_map(|element| element.named_child(0))
+        .collect()
+}
+
+/// Every string literal in an array literal (`['store', 'update']`).
+fn string_array(node: Node, source: &[u8]) -> Vec<String> {
+    array_values(node)
+        .into_iter()
+        .filter(|value| is_string_node(*value))
+        .filter_map(|value| string_text(value, source))
+        .collect()
+}
+
+/// The `'as' => 'api.'` entry of a group's array-attribute argument.
+fn array_as_prefix(node: Node, source: &[u8]) -> Option<String> {
+    if node.kind() != "array_creation_expression" {
+        return None;
+    }
+    let mut cursor = node.walk();
+    for element in node.children(&mut cursor) {
+        if element.kind() != "array_element_initializer" {
+            continue;
+        }
+        let mut pair = element.walk();
+        let parts: Vec<Node> = element
+            .children(&mut pair)
+            .filter(|child| child.is_named())
+            .collect();
+        if parts.len() == 2
+            && is_string_node(parts[0])
+            && string_text(parts[0], source).as_deref() == Some("as")
+            && is_string_node(parts[1])
+        {
+            return string_text(parts[1], source);
+        }
+    }
+    None
+}
+
+fn is_closure_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "anonymous_function" | "anonymous_function_creation_expression" | "arrow_function"
+    )
+}
+
+/// The closure passed to a `group(...)` call, if it has one. Handles both the
+/// fluent form and the legacy `group(['as' => 'x'], function () {})` form.
+fn closure_argument<'a>(args: Node<'a>) -> Option<Node<'a>> {
+    let mut cursor = args.walk();
+    for child in args.children(&mut cursor) {
+        if child.kind() != "argument" {
+            continue;
+        }
+        if let Some(expr) = child.named_child(0) {
+            if is_closure_kind(expr.kind()) {
+                return Some(expr);
+            }
+        }
+    }
+    None
+}
+
+/// The name prefix a `group(...)` chain contributes to the routes inside it.
 ///
-/// Only matches single-quoted or double-quoted string literals. Variable
-/// arguments (`->name($var)`) are skipped because we can't resolve them
-/// statically.
+/// A chained `->name('admin.')` / `->as('admin.')` wins; otherwise the group's
+/// `['as' => 'admin.']` array attribute is used. Returns `None` for a group
+/// that sets no prefix (e.g. a bare `->middleware(...)->group(...)`), which
+/// contributes nothing to its children's names.
+fn group_prefix(links: &[ChainLink], group_index: usize, source: &[u8]) -> Option<String> {
+    // Nearest setter to the left of `group(` governs — the chain reads left to
+    // right, so a later `->name()` supersedes an earlier one.
+    let chained = links[..group_index]
+        .iter()
+        .rev()
+        .find(|link| link.method == "name" || link.method == "as")
+        .and_then(|link| nth_string_arg(link.args, 0, source));
+
+    chained.or_else(|| {
+        nth_arg_node(links[group_index].args, 0).and_then(|first| array_as_prefix(first, source))
+    })
+}
+
+/// Walk `node`, invoking `sink` once per fluent-chain root with that chain's
+/// links and the group-name prefix in force where the chain is written.
 ///
-/// `inherited_prefixes` carries name prefixes contributed by *external-file*
-/// group loads that target this file (issue #43). For each callsite, one
-/// `RouteDefinition` is emitted per inherited prefix, with the final name being
-/// `inherited_prefix + in_file_closure_prefix + leaf`. A file that is loaded
-/// both directly and via a prefixed group therefore contributes both its bare
-/// and prefixed names. Passing `&[]` (or `&["".into()]`) means "no inherited
-/// prefix" and yields byte-identical behavior to a plain direct scan.
+/// Recursion descends through every node, so chains registered inside macro
+/// bodies, service-provider methods and closures passed to arbitrary helpers
+/// are all reached — matching what the old whole-file byte scan covered. A
+/// `group(...)` closure's body is walked with the group's prefix appended;
+/// everything else keeps the prefix it inherited.
+fn walk_chains<'a, F>(node: Node<'a>, source: &'a [u8], prefix: &str, sink: &mut F)
+where
+    F: FnMut(&[ChainLink<'a>], &str),
+{
+    if is_call_kind(node.kind()) && is_chain_root(node) {
+        let links = collect_links(node, source);
+        let group_index = links.iter().position(|link| link.method == "group");
+        let nested = match group_index {
+            Some(index) => format!(
+                "{prefix}{}",
+                group_prefix(&links, index, source).unwrap_or_default()
+            ),
+            None => prefix.to_string(),
+        };
+
+        sink(&links, prefix);
+
+        for (index, link) in links.iter().enumerate() {
+            let mut cursor = link.args.walk();
+            for arg in link.args.children(&mut cursor) {
+                if arg.kind() != "argument" {
+                    continue;
+                }
+                let is_group_body = Some(index) == group_index
+                    && arg
+                        .named_child(0)
+                        .is_some_and(|e| is_closure_kind(e.kind()));
+                let inner = if is_group_body {
+                    nested.as_str()
+                } else {
+                    prefix
+                };
+                walk_chains(arg, source, inner, sink);
+            }
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_chains(child, source, prefix, sink);
+    }
+}
+
+/// Reconstruct a route's HTTP method, URI and controller action from the verb
+/// call that opens its chain. Returns a partial result when a piece is absent —
+/// a closure route still resolves method + URI.
+fn chain_metadata(links: &[ChainLink], source: &[u8]) -> RouteMetadata {
+    let Some(verb) = links
+        .iter()
+        .find(|link| HTTP_VERBS.contains(&link.method.as_str()))
+    else {
+        return RouteMetadata::default();
+    };
+
+    RouteMetadata {
+        method: Some(verb.method.clone()),
+        uri: nth_string_arg(verb.args, 0, source),
+        action: nth_arg_node(verb.args, 1).and_then(|arg| action_text(arg, source)),
+    }
+}
+
+/// Render a route's second argument as a display string:
+/// `[UserController::class, 'show']` → `UserController@show`,
+/// `DashboardController::class` → `DashboardController`, a closure →
+/// `Closure`, and any other string literal (a view name, a redirect target)
+/// verbatim.
+fn action_text(node: Node, source: &[u8]) -> Option<String> {
+    if is_closure_kind(node.kind()) {
+        return Some("Closure".to_string());
+    }
+    if node.kind() == "array_creation_expression" {
+        let values = array_values(node);
+        let (class, method) = (values.first()?, values.get(1)?);
+        if !is_string_node(*method) {
+            return None;
+        }
+        return Some(format!(
+            "{}@{}",
+            class_reference_name(*class, source)?,
+            string_text(*method, source)?
+        ));
+    }
+    if let Some(class) = class_reference_name(node, source) {
+        return Some(class);
+    }
+    if is_string_node(node) {
+        let text = string_text(node, source)?;
+        // Legacy `'Controller@method'` syntax renders with a short class name.
+        if let Some((class, method)) = text.split_once('@') {
+            return Some(format!("{}@{}", short_class_name(class), method));
+        }
+        return Some(text);
+    }
+    None
+}
+
+/// Short class name of a `Foo\Bar::class` expression.
+fn class_reference_name(node: Node, source: &[u8]) -> Option<String> {
+    let text = node.utf8_text(source).ok()?;
+    let class = text.strip_suffix("::class")?.trim();
+    Some(short_class_name(class).to_string())
+}
+
+/// The 0-based definition span of a callsite: from `anchor` to the end of
+/// `last`. Multi-line spans collapse to the anchor column, since a
+/// `RouteDefinition` addresses a single line.
+fn definition_span(anchor: Node, last: Node) -> (u32, u32, u32) {
+    let start = anchor.start_position();
+    let end = last.end_position();
+    let end_column = if end.row == start.row {
+        end.column as u32
+    } else {
+        start.column as u32
+    };
+    (start.row as u32, start.column as u32, end_column)
+}
+
+/// Extract every named route defined in `content`.
+///
+/// `inherited_prefixes` are name prefixes contributed by external-file group
+/// loads that reach this file (issue #43); the file is always scanned under the
+/// empty prefix too, so it contributes both its bare and prefixed names.
+/// Passing `&[]` means "no inherited prefix".
 pub fn extract_named_routes(
     content: &str,
     file: &Path,
     priority: u8,
     inherited_prefixes: &[String],
 ) -> Vec<(Option<String>, RouteDefinition)> {
-    let mut results = Vec::new();
-    let bytes = content.as_bytes();
+    let Ok(tree) = crate::parser::parse_php(content) else {
+        return Vec::new();
+    };
+    let source = content.as_bytes();
 
-    // Normalize inherited prefixes to a non-empty set that always contains the
-    // empty string (the file is always scanned directly too). Dedupe so a load
-    // graph that reaches this file by two equal-prefix paths doesn't duplicate.
+    // Always include the empty prefix (the file is scanned directly too), and
+    // dedupe so a load graph reaching this file twice with the same prefix
+    // doesn't duplicate its routes.
     let mut effective: Vec<&str> = vec![""];
-    for p in inherited_prefixes {
-        if !p.is_empty() && !effective.contains(&p.as_str()) {
-            effective.push(p.as_str());
+    for prefix in inherited_prefixes {
+        if !prefix.is_empty() && !effective.contains(&prefix.as_str()) {
+            effective.push(prefix.as_str());
         }
     }
 
-    // Build group-span index once per file. Each span tells us "any
-    // `->name('X')` inside body_start..body_end gets `prefix` prepended."
-    // Nested groups are handled by accumulating every span that encloses the
-    // callsite, ordered outermost-first.
-    let groups = find_route_groups(bytes);
+    let mut results = Vec::new();
+    walk_chains(tree.root_node(), source, "", &mut |links, prefix| {
+        emit_chain_routes(
+            links,
+            prefix,
+            source,
+            file,
+            priority,
+            &effective,
+            &mut results,
+        );
+    });
+    results
+}
 
-    let pattern = b"->name";
-    let mut i = 0;
+/// Emit every route definition a single fluent chain registers.
+fn emit_chain_routes(
+    links: &[ChainLink],
+    prefix: &str,
+    source: &[u8],
+    file: &Path,
+    priority: u8,
+    effective: &[&str],
+    results: &mut Vec<(Option<String>, RouteDefinition)>,
+) {
+    // A chain ending in `group(...)` configures its children; its own
+    // `->name('admin.')` is their prefix, not a route of its own.
+    if links.iter().any(|link| link.method == "group") {
+        return;
+    }
 
-    while i + pattern.len() <= bytes.len() {
-        if &bytes[i..i + pattern.len()] != pattern {
-            i += 1;
-            continue;
-        }
+    let metadata = chain_metadata(links, source);
 
-        // After "->name", skip whitespace, expect '('.
-        let mut j = i + pattern.len();
-        while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t') {
-            j += 1;
+    for link in links {
+        if link.instance && link.method == "name" {
+            emit_named_route(
+                link, prefix, source, file, priority, effective, &metadata, results,
+            );
         }
-        if j >= bytes.len() || bytes[j] != b'(' {
-            i += 1;
-            continue;
+        if link.method == "resource" || link.method == "apiResource" {
+            emit_resource_routes(
+                links, link, prefix, source, file, priority, effective, results,
+            );
         }
-        j += 1;
-        while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t') {
-            j += 1;
-        }
-        if j >= bytes.len() {
-            i += 1;
-            continue;
-        }
-        let quote = bytes[j];
-        if quote != b'\'' && quote != b'"' {
-            i += 1;
-            continue;
-        }
-        j += 1;
-        let str_start = j;
-        while j < bytes.len() && bytes[j] != quote && bytes[j] != b'\n' {
-            // Allow simple escapes — skip the next byte.
-            if bytes[j] == b'\\' && j + 1 < bytes.len() {
-                j += 2;
-            } else {
-                j += 1;
-            }
-        }
-        if j >= bytes.len() || bytes[j] != quote {
-            i += 1;
-            continue;
-        }
-        let literal_name = match std::str::from_utf8(&bytes[str_start..j]) {
-            Ok(s) => s.to_string(),
-            Err(_) => {
-                i += 1;
-                continue;
-            }
-        };
+    }
+}
 
-        // Compose the in-file portion of the name from enclosing closure-group
-        // prefixes plus the literal `->name('X')` value. Groups are pre-sorted
-        // by body_start so iterating in order yields outermost-first.
-        let mut in_file_name = String::new();
-        for grp in &groups {
-            if grp.body_start <= i && i < grp.body_end {
-                in_file_name.push_str(&grp.prefix);
-            }
-        }
-        in_file_name.push_str(&literal_name);
+#[allow(clippy::too_many_arguments)]
+fn emit_named_route(
+    link: &ChainLink,
+    prefix: &str,
+    source: &[u8],
+    file: &Path,
+    priority: u8,
+    effective: &[&str],
+    metadata: &RouteMetadata,
+    results: &mut Vec<(Option<String>, RouteDefinition)>,
+) {
+    let Some(argument) = nth_arg_node(link.args, 0).filter(|node| is_string_node(*node)) else {
+        return;
+    };
+    let Some(literal) = string_text(argument, source) else {
+        return;
+    };
 
-        let (line, column) = byte_to_line_col(bytes, i);
-        let end_column = column + (j - i + 1) as u32; // include closing quote
+    let anchor = link.operator.unwrap_or(link.name_node);
+    let (line, column, end_column) = definition_span(anchor, argument);
+    let leaf = format!("{prefix}{literal}");
 
-        // Scan backward from the `->name(` callsite to find the verb call that
-        // started this route's fluent chain. Captures HTTP method, URI, and the
-        // controller@action target for hover display.
-        let metadata = extract_route_metadata(bytes, i);
+    for inherited in effective {
+        results.push((
+            Some(format!("{inherited}{leaf}")),
+            RouteDefinition {
+                file: file.to_path_buf(),
+                line,
+                column,
+                end_column,
+                priority,
+                method: metadata.method.clone(),
+                uri: metadata.uri.clone(),
+                action: metadata.action.clone(),
+            },
+        ));
+    }
+}
 
-        // Emit one definition per inherited prefix (always including ""), so a
-        // file reachable via an external-file group load contributes both its
-        // bare and prefixed names.
-        for prefix in &effective {
-            let mut name = String::with_capacity(prefix.len() + in_file_name.len());
-            name.push_str(prefix);
-            name.push_str(&in_file_name);
+/// Expand a `resource(...)` / `apiResource(...)` registration into the named
+/// routes Laravel synthesizes for it — `photos.index`, `photos.show`, … — after
+/// applying any `->only([...])` / `->except([...])` filter on the same chain.
+///
+/// Punted (common case only): `->names([...])` overrides, `Route::resources([…])`
+/// plural registration, and shallow/nested resources.
+#[allow(clippy::too_many_arguments)]
+fn emit_resource_routes(
+    links: &[ChainLink],
+    link: &ChainLink,
+    prefix: &str,
+    source: &[u8],
+    file: &Path,
+    priority: u8,
+    effective: &[&str],
+    results: &mut Vec<(Option<String>, RouteDefinition)>,
+) {
+    let Some(raw) = nth_string_arg(link.args, 0, source) else {
+        return;
+    };
+    let resource = raw.trim_matches('/');
+    if resource.is_empty() {
+        return;
+    }
+
+    let defaults = if link.method == "apiResource" {
+        API_RESOURCE_ACTIONS
+    } else {
+        RESOURCE_ACTIONS
+    };
+    let (line, column, end_column) = definition_span(link.name_node, link.args);
+
+    for action in resource_actions(links, defaults, source) {
+        let leaf = format!("{prefix}{resource}.{action}");
+        for inherited in effective {
             results.push((
-                Some(name),
+                Some(format!("{inherited}{leaf}")),
                 RouteDefinition {
                     file: file.to_path_buf(),
                     line,
                     column,
                     end_column,
                     priority,
-                    method: metadata.method.clone(),
-                    uri: metadata.uri.clone(),
-                    action: metadata.action.clone(),
+                    // A resource registers several verbs; none of them applies
+                    // to the group as a whole.
+                    method: None,
+                    uri: Some(resource.to_string()),
+                    action: Some(action.to_string()),
                 },
             ));
         }
-
-        i = j + 1;
     }
+}
 
-    // Second pass: derive route names from `Route::resource(...)` /
-    // `Route::apiResource(...)` (and their `->resource(...)` / `->apiResource(...)`
-    // fluent forms). Laravel synthesizes one named route per CRUD action — e.g.
-    // `Route::resource('photos', PhotoController::class)` registers
-    // `photos.index`, `photos.create`, ... `photos.destroy`. We compose these
-    // leaf names with the same group/inherited prefixes as `->name()` routes.
-    extract_resource_routes(bytes, file, priority, &effective, &groups, &mut results);
+/// The action set surviving a resource registration's `->only([...])` /
+/// `->except([...])` filter. `only` wins when both are present. A non-array
+/// argument is ignored, leaving the defaults in place.
+fn resource_actions(
+    links: &[ChainLink],
+    defaults: &'static [&'static str],
+    source: &[u8],
+) -> Vec<&'static str> {
+    let array_arg = |method: &str| -> Option<Vec<String>> {
+        let link = links.iter().find(|link| link.method == method)?;
+        let node = nth_arg_node(link.args, 0)?;
+        if node.kind() != "array_creation_expression" {
+            return None;
+        }
+        Some(string_array(node, source))
+    };
 
-    results
+    if let Some(only) = array_arg("only") {
+        return defaults
+            .iter()
+            .copied()
+            .filter(|action| only.iter().any(|kept| kept == action))
+            .collect();
+    }
+    if let Some(except) = array_arg("except") {
+        return defaults
+            .iter()
+            .copied()
+            .filter(|action| !except.iter().any(|dropped| dropped == action))
+            .collect();
+    }
+    defaults.to_vec()
 }
 
 /// Default action set for `Route::resource(...)` — full CRUD.
@@ -676,245 +1060,6 @@ const RESOURCE_ACTIONS: &[&str] = &[
 /// Default action set for `Route::apiResource(...)` — no `create`/`edit` (those
 /// render forms, which an API doesn't serve).
 const API_RESOURCE_ACTIONS: &[&str] = &["index", "store", "show", "update", "destroy"];
-
-/// Append resource-derived route definitions to `results`.
-///
-/// Detects `resource(` / `apiResource(` callsites preceded by `->` or `::`,
-/// extracts the first string-literal argument (the resource URI/name), strips
-/// leading AND trailing `/`, applies any `->only([...])`/`->except([...])`
-/// filter found in the same statement, then emits one [`RouteDefinition`] per
-/// surviving action × effective prefix × enclosing closure-group prefix.
-///
-/// Punted (common case only): `->names([...])` / `->name('…')` overrides on the
-/// resource, `Route::resources([...])` plural registration, and shallow/nested
-/// resources. These are uncommon and would need substantially more parsing.
-fn extract_resource_routes(
-    bytes: &[u8],
-    file: &Path,
-    priority: u8,
-    effective: &[&str],
-    groups: &[RouteGroupSpan],
-    results: &mut Vec<(Option<String>, RouteDefinition)>,
-) {
-    // Scan for `->`/`::` connectors and read the method identifier that follows.
-    // We can't keyword-match on `resource` alone because `apiResource` spells it
-    // with a capital `R` (`api` + `Resource`); matching the connector + full
-    // identifier handles both spellings cleanly.
-    let paren_pairs = build_paren_pairs(bytes);
-    let mut i = 0usize;
-
-    while i + 2 < bytes.len() {
-        let connector = &bytes[i..i + 2];
-        if connector != b"->" && connector != b"::" {
-            i += 1;
-            continue;
-        }
-
-        // Read the identifier immediately after the connector.
-        let name_start = i + 2;
-        let mut name_end = name_start;
-        while name_end < bytes.len() && is_identifier_byte(bytes[name_end]) {
-            name_end += 1;
-        }
-        let method = match std::str::from_utf8(&bytes[name_start..name_end]) {
-            Ok(s) => s,
-            Err(_) => {
-                i += 2;
-                continue;
-            }
-        };
-        let is_api = match method {
-            "resource" => false,
-            "apiResource" => true,
-            _ => {
-                i += 2;
-                continue;
-            }
-        };
-
-        // Right boundary: an opening `(` (after optional whitespace).
-        let mut j = name_end;
-        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
-            j += 1;
-        }
-        if j >= bytes.len() || bytes[j] != b'(' {
-            i += 2;
-            continue;
-        }
-        let args_open = j;
-        let Some(&args_close) = paren_pairs.get(&args_open) else {
-            i = args_open + 1;
-            continue;
-        };
-
-        // First argument: the resource name/URI. Must be a string literal.
-        let stripped = match nth_arg_slice(bytes, args_open + 1, args_close, 0)
-            .and_then(parse_string_literal)
-        {
-            Some(name) => {
-                let trimmed = name.trim_matches('/');
-                if trimmed.is_empty() {
-                    i = args_open + 1;
-                    continue;
-                }
-                trimmed.to_string()
-            }
-            None => {
-                i = args_open + 1;
-                continue;
-            }
-        };
-
-        // Determine the action set, honoring `->only([...])` / `->except([...])`
-        // appearing anywhere in the same statement.
-        let (_stmt_start, stmt_end) = statement_containing(bytes, name_start);
-        let defaults = if is_api {
-            API_RESOURCE_ACTIONS
-        } else {
-            RESOURCE_ACTIONS
-        };
-        let actions = resource_actions_in_statement(bytes, args_open, stmt_end, defaults);
-
-        // Position of the call (for goto-definition). Point at the start of the
-        // method identifier, ending after the closing `)` of the arg list.
-        let (line, column) = byte_to_line_col(bytes, name_start);
-        let end_column = column + (args_close + 1 - name_start) as u32;
-
-        // Enclosing closure-group prefix(es) for this call's offset.
-        let mut in_file_prefix = String::new();
-        for grp in groups {
-            if grp.body_start <= name_start && name_start < grp.body_end {
-                in_file_prefix.push_str(&grp.prefix);
-            }
-        }
-
-        for action in &actions {
-            let leaf = format!("{}.{}", stripped, action);
-            for prefix in effective {
-                let mut name =
-                    String::with_capacity(prefix.len() + in_file_prefix.len() + leaf.len());
-                name.push_str(prefix);
-                name.push_str(&in_file_prefix);
-                name.push_str(&leaf);
-                results.push((
-                    Some(name),
-                    RouteDefinition {
-                        file: file.to_path_buf(),
-                        line,
-                        column,
-                        end_column,
-                        priority,
-                        // Resource routes register multiple verbs; no single
-                        // method applies, so leave it unresolved.
-                        method: None,
-                        uri: Some(stripped.clone()),
-                        action: Some((*action).to_string()),
-                    },
-                ));
-            }
-        }
-
-        i = args_open + 1;
-    }
-}
-
-/// Resolve the surviving action set for a resource registration by scanning the
-/// statement (`start..end`) for `->only([...])` then `->except([...])`. `only`
-/// wins when both are present (matching Laravel's runtime, where the last
-/// applied modifier governs, but `only` is the common explicit case). Returns a
-/// filtered, owned subset of `defaults` preserving their canonical order.
-fn resource_actions_in_statement<'a>(
-    bytes: &[u8],
-    start: usize,
-    end: usize,
-    defaults: &'a [&'a str],
-) -> Vec<&'a str> {
-    if let Some(list) = method_array_arg(bytes, start, end, b"only") {
-        return defaults
-            .iter()
-            .filter(|a| list.contains(&a.to_string()))
-            .copied()
-            .collect();
-    }
-    if let Some(list) = method_array_arg(bytes, start, end, b"except") {
-        return defaults
-            .iter()
-            .filter(|a| !list.contains(&a.to_string()))
-            .copied()
-            .collect();
-    }
-    defaults.to_vec()
-}
-
-/// Find `->{method}([ ... ])` within `start..end` and return the string-literal
-/// elements of its array argument. Returns `None` if the method isn't called.
-fn method_array_arg(bytes: &[u8], start: usize, end: usize, method: &[u8]) -> Option<Vec<String>> {
-    let mut i = start;
-    while i + method.len() < end {
-        // Match `->{method}` with a `->` connector and a word boundary after.
-        if i >= 2
-            && &bytes[i - 2..i] == b"->"
-            && i + method.len() <= end
-            && &bytes[i..i + method.len()] == method
-        {
-            let after = i + method.len();
-            let boundary_ok = after >= end || !is_identifier_byte(bytes[after]);
-            if boundary_ok {
-                let mut j = after;
-                while j < end && bytes[j].is_ascii_whitespace() {
-                    j += 1;
-                }
-                if j < end && bytes[j] == b'(' {
-                    return Some(parse_string_array(bytes, j + 1, end));
-                }
-            }
-        }
-        i += 1;
-    }
-    None
-}
-
-/// Collect string-literal elements from an array literal opening at `start`
-/// (the byte just after the `(`). Reads up to the matching `]`, returning each
-/// quoted element's inner text. Tolerant of a missing `[` (treats the call
-/// argument list as the element source).
-fn parse_string_array(bytes: &[u8], start: usize, end: usize) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut i = start;
-    while i < end && bytes[i].is_ascii_whitespace() {
-        i += 1;
-    }
-    if i < end && bytes[i] == b'[' {
-        i += 1;
-    }
-    while i < end {
-        let b = bytes[i];
-        if b == b']' || b == b')' {
-            break;
-        }
-        if b == b'\'' || b == b'"' {
-            let quote = b;
-            i += 1;
-            let lit_start = i;
-            while i < end && bytes[i] != quote {
-                if bytes[i] == b'\\' && i + 1 < end {
-                    i += 2;
-                    continue;
-                }
-                i += 1;
-            }
-            if i < end {
-                if let Ok(s) = std::str::from_utf8(&bytes[lit_start..i]) {
-                    out.push(s.to_string());
-                }
-                i += 1; // skip closing quote
-            }
-            continue;
-        }
-        i += 1;
-    }
-    out
-}
 
 /// Resolved data describing the verb call that opens a route's fluent chain.
 /// Each field can be `None` when static extraction can't pin it down — callers
@@ -944,184 +1089,6 @@ const HTTP_VERBS: &[&str] = &[
     "permanentRedirect",
 ];
 
-/// Walk forward from the start of the statement that contains `name_callsite_offset`
-/// to find the verb call that opens the fluent chain, then parse its first two
-/// arguments (URI + action).
-///
-/// Statement boundaries are detected with full string-literal and depth tracking
-/// (parens, brackets, braces) so `{user}` route parameters and closure bodies
-/// don't fool the scan. Returns a partial result whenever a piece is missing —
-/// a closure-based route still resolves method + URI.
-pub fn extract_route_metadata(bytes: &[u8], name_callsite_offset: usize) -> RouteMetadata {
-    let (stmt_start, _stmt_end) = statement_containing(bytes, name_callsite_offset);
-    let Some((method, args_start)) = find_verb_call(bytes, stmt_start, name_callsite_offset) else {
-        return RouteMetadata::default();
-    };
-
-    // Walk forward from the verb's opening `(` to grab arg 1 (URI) and arg 2
-    // (action). Both are optional — `Route::view('/x', 'view.name')` has no
-    // action, `Route::redirect(...)` has only a URI.
-    let (uri_slice, after_uri) = read_arg(bytes, args_start);
-    let uri = uri_slice.and_then(parse_string_literal);
-
-    let action = if let Some(after_uri_idx) = after_uri {
-        let (action_slice, _) = read_arg(bytes, after_uri_idx);
-        action_slice.and_then(parse_action_argument)
-    } else {
-        None
-    };
-
-    RouteMetadata {
-        method: Some(method),
-        uri,
-        action,
-    }
-}
-
-/// Return `(start, end)` of the PHP statement that contains `offset`. Walks
-/// forward from byte 0, tracking string literals and combined brace/paren/bracket
-/// depth so that `;` is only treated as a separator when depth is zero and we're
-/// not inside a string.
-fn statement_containing(bytes: &[u8], offset: usize) -> (usize, usize) {
-    let mut stmt_start = 0usize;
-    let mut depth = 0i32;
-    let mut in_string: Option<u8> = None;
-    let mut i = 0usize;
-
-    while i < bytes.len() {
-        let b = bytes[i];
-        if let Some(quote) = in_string {
-            if b == b'\\' && i + 1 < bytes.len() {
-                i += 2;
-                continue;
-            }
-            if b == quote {
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-        match b {
-            b'\'' | b'"' => in_string = Some(b),
-            b'(' | b'[' | b'{' => depth += 1,
-            b')' | b']' | b'}' => depth -= 1,
-            b';' if depth == 0 => {
-                if i >= offset {
-                    return (stmt_start, i);
-                }
-                stmt_start = i + 1;
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    (stmt_start, bytes.len())
-}
-
-/// Find the first `<receiver>-><verb>(` or `Route::<verb>(` whose verb appears
-/// in [`HTTP_VERBS`]. Returns the verb name and the byte offset of the first
-/// character inside the `(`.
-fn find_verb_call(bytes: &[u8], start: usize, end: usize) -> Option<(String, usize)> {
-    let mut i = start;
-    while i < end {
-        for &verb in HTTP_VERBS {
-            let vb = verb.as_bytes();
-            if i + vb.len() > end || &bytes[i..i + vb.len()] != vb {
-                continue;
-            }
-            // Verb must be preceded by `->` or `::` — this is the left
-            // word-boundary check (the `>` / `:` is not an identifier byte).
-            let prefix_ok = i >= 2 && (&bytes[i - 2..i] == b"->" || &bytes[i - 2..i] == b"::");
-            if !prefix_ok {
-                continue;
-            }
-            // Verb must not be followed by an identifier byte (otherwise
-            // `->getUser(` would match `get`).
-            let after_verb = i + vb.len();
-            if after_verb < end && is_identifier_byte(bytes[after_verb]) {
-                continue;
-            }
-            let mut j = after_verb;
-            while j < end && (bytes[j] == b' ' || bytes[j] == b'\t') {
-                j += 1;
-            }
-            if j < end && bytes[j] == b'(' {
-                return Some((verb.to_string(), j + 1));
-            }
-        }
-        i += 1;
-    }
-    None
-}
-
-fn is_identifier_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_'
-}
-
-/// Read a single argument starting at `start` from a (paren-balanced) argument
-/// list. Returns (`Some(slice)` of the argument bytes, `Some(idx)` of the byte
-/// after the separating comma — or `None` if the closing `)` was reached).
-fn read_arg(bytes: &[u8], start: usize) -> (Option<&[u8]>, Option<usize>) {
-    let mut depth_paren = 0i32;
-    let mut depth_bracket = 0i32;
-    let mut depth_brace = 0i32;
-    let mut in_string: Option<u8> = None;
-    let mut i = start;
-    let arg_start = i;
-    while i < bytes.len() {
-        let b = bytes[i];
-        if let Some(quote) = in_string {
-            if b == b'\\' && i + 1 < bytes.len() {
-                i += 2;
-                continue;
-            }
-            if b == quote {
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-        match b {
-            b'\'' | b'"' => in_string = Some(b),
-            b'(' => depth_paren += 1,
-            b')' => {
-                if depth_paren == 0 && depth_bracket == 0 && depth_brace == 0 {
-                    let slice = trimmed_slice(bytes, arg_start, i);
-                    return (slice, None);
-                }
-                depth_paren -= 1;
-            }
-            b'[' => depth_bracket += 1,
-            b']' => depth_bracket -= 1,
-            b'{' => depth_brace += 1,
-            b'}' => depth_brace -= 1,
-            b',' if depth_paren == 0 && depth_bracket == 0 && depth_brace == 0 => {
-                let slice = trimmed_slice(bytes, arg_start, i);
-                return (slice, Some(i + 1));
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    (None, None)
-}
-
-fn trimmed_slice(bytes: &[u8], start: usize, end: usize) -> Option<&[u8]> {
-    let mut s = start;
-    let mut e = end;
-    while s < e && bytes[s].is_ascii_whitespace() {
-        s += 1;
-    }
-    while e > s && bytes[e - 1].is_ascii_whitespace() {
-        e -= 1;
-    }
-    if s >= e {
-        None
-    } else {
-        Some(&bytes[s..e])
-    }
-}
-
 /// Decode a single-quoted or double-quoted string literal into the raw inner text.
 /// Returns `None` for non-string-literal arguments (variables, expressions, etc.).
 fn parse_string_literal(slice: &[u8]) -> Option<String> {
@@ -1149,55 +1116,6 @@ fn parse_string_literal(slice: &[u8]) -> Option<String> {
         i += 1;
     }
     Some(out)
-}
-
-/// Parse the second argument of a route registration into a human-readable
-/// `Controller@action` string. Handles the four shapes Laravel accepts plus
-/// the closure case. Returns `None` when the argument is something we can't
-/// statically resolve (e.g. a variable).
-fn parse_action_argument(slice: &[u8]) -> Option<String> {
-    let text = std::str::from_utf8(slice).ok()?.trim();
-    if text.is_empty() {
-        return None;
-    }
-
-    // Shape 1: closure literal — `function (...) { ... }` or `fn(...) => ...`
-    if text.starts_with("function") || text.starts_with("fn(") || text.starts_with("fn ") {
-        return Some("Closure".to_string());
-    }
-
-    // Shape 2: `[Controller::class, 'method']`
-    if text.starts_with('[') && text.ends_with(']') {
-        let inner = &text[1..text.len() - 1];
-        let parts: Vec<&str> = inner.splitn(2, ',').map(str::trim).collect();
-        if parts.len() == 2 {
-            let class = parts[0].trim_end_matches("::class");
-            let class_short = short_class_name(class);
-            if let Some(method) = parse_string_literal(parts[1].as_bytes()) {
-                return Some(format!("{}@{}", class_short, method));
-            }
-        }
-        return None;
-    }
-
-    // Shape 3: `Controller::class` — single-action / invokable controller
-    if let Some(class) = text.strip_suffix("::class") {
-        return Some(short_class_name(class).to_string());
-    }
-
-    // Shape 4: `'Controller@method'` — legacy string syntax
-    if let Some(s) = parse_string_literal(text.as_bytes()) {
-        if s.contains('@') {
-            // Render short class name in the @method form.
-            let mut parts = s.splitn(2, '@');
-            if let (Some(class), Some(method)) = (parts.next(), parts.next()) {
-                return Some(format!("{}@{}", short_class_name(class), method));
-            }
-        }
-        return Some(s);
-    }
-
-    None
 }
 
 /// Take the last `\`-separated segment of a PHP FQN. `App\Http\UserController` → `UserController`.
@@ -1307,268 +1225,58 @@ fn promote(seen: &mut HashMap<PathBuf, u8>, path: PathBuf, priority: u8) {
         .or_insert(priority);
 }
 
-fn byte_to_line_col(bytes: &[u8], byte_offset: usize) -> (u32, u32) {
-    let mut line = 0u32;
-    let mut last_newline: i64 = -1;
-    for (idx, b) in bytes.iter().enumerate().take(byte_offset) {
-        if *b == b'\n' {
-            line += 1;
-            last_newline = idx as i64;
-        }
-    }
-    let column = (byte_offset as i64 - last_newline - 1) as u32;
-    (line, column)
-}
-
-// ============================================================================
-// Route-group resolution — composing route names across nested groups
-// ============================================================================
-//
-// Laravel route groups contribute a name prefix to every route declared inside
-// the group's closure body:
-//
-//   Route::name('admin.')->group(function () {
-//       Route::get('/users', ...)->name('users.index');  // → "admin.users.index"
-//   });
-//
-// Groups also accept attributes in array form:
-//
-//   Route::group(['as' => 'api.'], function () {
-//       Route::get('/users', ...)->name('users.index');  // → "api.users.index"
-//   });
-//
-// Groups can nest arbitrarily. To compose the final name we:
-//   1. Find every `->group(...)` callsite, extracting its prefix contribution
-//      and the byte range of its closure body.
-//   2. When `extract_named_routes` sees a `->name('X')` callsite at offset O,
-//      concatenate every group's prefix whose body range encloses O.
-
-/// Scan `bytes` for every `->group(...)` callsite, returning the spans of
-/// those that contribute a name prefix. Forward scan produces spans ordered
-/// by `body_start` ascending, so iterating in order is outermost-first when
-/// resolving an enclosed `->name(...)`.
-fn find_route_groups(bytes: &[u8]) -> Vec<RouteGroupSpan> {
-    let paren_pairs = build_paren_pairs(bytes);
-    let mut groups = Vec::new();
-    // Look for the `group` keyword preceded by either `->` (chained: `->group(`)
-    // or `::` (facade: `Route::group(`). Both forms register route groups in
-    // Laravel; restricting to `->group` (as the first draft did) missed every
-    // `Route::group(['as' => ...], ...)` callsite.
-    let keyword = b"group";
-    let mut i = 0usize;
-
-    while i + keyword.len() < bytes.len() {
-        if &bytes[i..i + keyword.len()] != keyword {
-            i += 1;
-            continue;
-        }
-        // Word boundary BEFORE: must be `->` or `::`.
-        if i < 2 {
-            i += 1;
-            continue;
-        }
-        let connector = &bytes[i - 2..i];
-        if connector != b"->" && connector != b"::" {
-            i += 1;
-            continue;
-        }
-        // Word boundary AFTER: must not be `groupBy`, `groupName`, etc.
-        let after_g = i + keyword.len();
-        if after_g < bytes.len() && is_identifier_byte(bytes[after_g]) {
-            i = after_g;
-            continue;
-        }
-        // Find the `(` opening the group's arg list.
-        let mut j = after_g;
-        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
-            j += 1;
-        }
-        if j >= bytes.len() || bytes[j] != b'(' {
-            i = j.max(i + 1);
-            continue;
-        }
-        let args_open = j;
-        let Some(&args_close) = paren_pairs.get(&args_open) else {
-            i = args_open + 1;
-            continue;
-        };
-
-        // Prefix can come from one of:
-        //   (a) a `->name('X')` link earlier in the same fluent chain
-        //   (b) an `['as' => 'X', ...]` array literal as the first arg
-        //
-        // Use the connector position (start of `->`/`::`) so the chain walker
-        // sees this call's left edge correctly.
-        let group_offset = i - 2;
-        let chain_prefix = extract_chain_name_prefix(bytes, group_offset, &paren_pairs);
-        let array_prefix = extract_array_as_prefix(bytes, args_open + 1, args_close);
-        let prefix = chain_prefix.or(array_prefix);
-
-        // Closure body: `function (...) { ... }` between args_open+1 and args_close.
-        let body = find_function_body(bytes, args_open + 1, args_close);
-
-        if let (Some(prefix), Some((body_start, body_end))) = (prefix, body) {
-            groups.push(RouteGroupSpan {
-                prefix,
-                body_start,
-                body_end,
-            });
-        }
-
-        // Continue scanning forward — including INSIDE this group's body, so
-        // nested groups get picked up. (Skipping to args_close + 1 would lose
-        // every nested `->group(...)`.)
-        i += 1;
-    }
-
-    groups
-}
-
-/// Scan `bytes` for every `->group(...)`/`::group(...)` callsite that loads an
-/// *external file* rather than running a closure body (issue #43). A load is
-/// recorded only when the call has NO closure body and its (path) argument
-/// resolves to a file path. The own-prefix (which may be empty) is captured the
-/// same way closure groups capture theirs.
+/// Find every `->group(<path>)`/`::group(<path>)` callsite in `content` that
+/// loads an *external file* rather than running a closure body (issue #43).
+///
+/// Each load carries the complete name prefix in force at its callsite — the
+/// enclosing closure groups' prefixes plus its own — so the caller can build
+/// the load graph's edges without re-deriving group nesting.
 ///
 /// `root` is the project root (for `base_path(...)`); `loader_dir` is the
 /// directory of the file being scanned (for `__DIR__ . '...'`).
 fn find_external_group_loads(
-    bytes: &[u8],
+    content: &str,
     root: &Path,
     loader_dir: &Path,
 ) -> Vec<ExternalGroupLoad> {
-    let paren_pairs = build_paren_pairs(bytes);
+    let Ok(tree) = crate::parser::parse_php(content) else {
+        return Vec::new();
+    };
+    let source = content.as_bytes();
     let mut loads = Vec::new();
-    let keyword = b"group";
-    let mut i = 0usize;
 
-    while i + keyword.len() < bytes.len() {
-        if &bytes[i..i + keyword.len()] != keyword {
-            i += 1;
-            continue;
+    walk_chains(tree.root_node(), source, "", &mut |links, prefix| {
+        let Some(index) = links.iter().position(|link| link.method == "group") else {
+            return;
+        };
+        let group = &links[index];
+        // A closure group runs inline; only a path argument loads a file.
+        if closure_argument(group.args).is_some() {
+            return;
         }
-        if i < 2 {
-            i += 1;
-            continue;
-        }
-        let connector = &bytes[i - 2..i];
-        if connector != b"->" && connector != b"::" {
-            i += 1;
-            continue;
-        }
-        let after_g = i + keyword.len();
-        if after_g < bytes.len() && is_identifier_byte(bytes[after_g]) {
-            i = after_g;
-            continue;
-        }
-        let mut j = after_g;
-        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
-            j += 1;
-        }
-        if j >= bytes.len() || bytes[j] != b'(' {
-            i = j.max(i + 1);
-            continue;
-        }
-        let args_open = j;
-        let Some(&args_close) = paren_pairs.get(&args_open) else {
-            i = args_open + 1;
-            continue;
+
+        // With an `['as' => …]` array literal first, the path is the SECOND
+        // argument; the fluent `->as(…)->group($path)` form puts it first.
+        let array_first = nth_arg_node(group.args, 0)
+            .is_some_and(|first| first.kind() == "array_creation_expression");
+        let Some(path_node) = nth_arg_node(group.args, usize::from(array_first)) else {
+            return;
+        };
+        let Ok(text) = path_node.utf8_text(source) else {
+            return;
+        };
+        let Some(target) = resolve_path_argument(text.as_bytes(), root, loader_dir) else {
+            return;
         };
 
-        // An external load never has a closure body — skip closure groups so we
-        // don't double-handle them (they're owned by `find_route_groups`).
-        if find_function_body(bytes, args_open + 1, args_close).is_some() {
-            i += 1;
-            continue;
-        }
-
-        let group_offset = i - 2;
-        let chain_prefix = extract_chain_name_prefix(bytes, group_offset, &paren_pairs);
-        let array_prefix = extract_array_as_prefix(bytes, args_open + 1, args_close);
-
-        // Determine which argument holds the path. With an array `['as' => ...]`
-        // first arg (array form), the path is the SECOND argument; otherwise the
-        // fluent `->as(...)->group($path)` form puts it FIRST.
-        let array_first = first_arg_is_array_literal(bytes, args_open + 1, args_close);
-        let path_slice = if array_first {
-            nth_arg_slice(bytes, args_open + 1, args_close, 1)
-        } else {
-            nth_arg_slice(bytes, args_open + 1, args_close, 0)
-        };
-
-        if let Some(slice) = path_slice {
-            if let Some(target) = resolve_path_argument(slice, root, loader_dir) {
-                loads.push(ExternalGroupLoad {
-                    offset: group_offset,
-                    own_prefix: chain_prefix.or(array_prefix).unwrap_or_default(),
-                    target,
-                });
-            }
-        }
-
-        i += 1;
-    }
+        let own = group_prefix(links, index, source).unwrap_or_default();
+        loads.push(ExternalGroupLoad {
+            edge_prefix: format!("{prefix}{own}"),
+            target,
+        });
+    });
 
     loads
-}
-
-/// Does the first argument in `[start..end]` begin with a `[` array literal?
-fn first_arg_is_array_literal(bytes: &[u8], start: usize, end: usize) -> bool {
-    let mut i = start;
-    while i < end && bytes[i].is_ascii_whitespace() {
-        i += 1;
-    }
-    i < end && bytes[i] == b'['
-}
-
-/// Return the trimmed byte slice of the `n`-th (0-based) comma-separated
-/// argument inside `[start..end)`, respecting nested parens/brackets/braces and
-/// string literals. `None` if there is no such argument.
-fn nth_arg_slice(bytes: &[u8], start: usize, end: usize, n: usize) -> Option<&[u8]> {
-    let mut depth_paren = 0i32;
-    let mut depth_bracket = 0i32;
-    let mut depth_brace = 0i32;
-    let mut in_string: Option<u8> = None;
-    let mut arg_index = 0usize;
-    let mut arg_start = start;
-    let mut i = start;
-    while i < end {
-        let b = bytes[i];
-        if let Some(quote) = in_string {
-            if b == b'\\' && i + 1 < end {
-                i += 2;
-                continue;
-            }
-            if b == quote {
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-        match b {
-            b'\'' | b'"' => in_string = Some(b),
-            b'(' => depth_paren += 1,
-            b')' => depth_paren -= 1,
-            b'[' => depth_bracket += 1,
-            b']' => depth_bracket -= 1,
-            b'{' => depth_brace += 1,
-            b'}' => depth_brace -= 1,
-            b',' if depth_paren == 0 && depth_bracket == 0 && depth_brace == 0 => {
-                if arg_index == n {
-                    return trimmed_slice(bytes, arg_start, i);
-                }
-                arg_index += 1;
-                arg_start = i + 1;
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    if arg_index == n {
-        trimmed_slice(bytes, arg_start, end)
-    } else {
-        None
-    }
 }
 
 /// Resolve a `->group(...)` path argument to an absolute path. Recognized
@@ -1638,274 +1346,6 @@ pub fn normalize_path(path: &Path) -> PathBuf {
         }
     }
     out
-}
-
-/// Walk backward from a `->group(` offset through prior chain links looking
-/// for a `->name('X')` whose string argument should prefix routes in this
-/// group. Returns the prefix string (e.g. `"admin."`).
-///
-/// The walk skips over each intervening `->method(...)` link by paren-balancing
-/// — that's why we need the pre-computed paren_pairs map.
-fn extract_chain_name_prefix(
-    bytes: &[u8],
-    group_offset: usize,
-    paren_pairs: &HashMap<usize, usize>,
-) -> Option<String> {
-    let mut cursor = group_offset;
-    loop {
-        if cursor < 2 {
-            return None;
-        }
-        // The byte just before `->` should be `)` closing the previous link.
-        let mut k = cursor;
-        while k > 0 && bytes[k - 1].is_ascii_whitespace() {
-            k -= 1;
-        }
-        if k == 0 || bytes[k - 1] != b')' {
-            return None;
-        }
-        let close_paren = k - 1;
-        let open_paren = *paren_pairs
-            .iter()
-            .find(|(_, &v)| v == close_paren)
-            .map(|(k, _)| k)?;
-
-        // Walk back from `(` over the method name.
-        let mut name_end = open_paren;
-        while name_end > 0 && bytes[name_end - 1].is_ascii_whitespace() {
-            name_end -= 1;
-        }
-        let mut name_start = name_end;
-        while name_start > 0 && is_identifier_byte(bytes[name_start - 1]) {
-            name_start -= 1;
-        }
-        if name_start == name_end {
-            return None;
-        }
-        let method = std::str::from_utf8(&bytes[name_start..name_end]).ok()?;
-
-        // The 2 bytes before the method name must be `->` or `::`.
-        if name_start < 2 {
-            return None;
-        }
-        let connector = &bytes[name_start - 2..name_start];
-        if connector != b"->" && connector != b"::" {
-            return None;
-        }
-
-        // `Route::name('admin.')` and its alias `Route::as('admin.')` both set
-        // a group's name prefix.
-        if method == "name" || method == "as" {
-            // Extract the string literal first-argument from the `()`.
-            return read_first_string_literal(bytes, open_paren + 1, close_paren);
-        }
-
-        // Not a name-setter — continue walking back from the connector position.
-        cursor = name_start - 2;
-    }
-}
-
-/// Read the first string literal in `[start..end]`. Returns the unescaped
-/// inner text. Skips leading whitespace; ignores subsequent arguments.
-fn read_first_string_literal(bytes: &[u8], start: usize, end: usize) -> Option<String> {
-    let mut i = start;
-    while i < end && bytes[i].is_ascii_whitespace() {
-        i += 1;
-    }
-    if i >= end {
-        return None;
-    }
-    let quote = bytes[i];
-    if quote != b'\'' && quote != b'"' {
-        return None;
-    }
-    i += 1;
-    let mut out = String::new();
-    while i < end && bytes[i] != quote {
-        if bytes[i] == b'\\' && i + 1 < end {
-            out.push(bytes[i + 1] as char);
-            i += 2;
-            continue;
-        }
-        out.push(bytes[i] as char);
-        i += 1;
-    }
-    if i >= end {
-        return None;
-    }
-    Some(out)
-}
-
-/// Look for `['as' => 'X', ...]` in the group's first argument. Returns the
-/// value of the `as` key when found.
-fn extract_array_as_prefix(bytes: &[u8], start: usize, end: usize) -> Option<String> {
-    // First arg must start with `[`.
-    let mut i = start;
-    while i < end && bytes[i].is_ascii_whitespace() {
-        i += 1;
-    }
-    if i >= end || bytes[i] != b'[' {
-        return None;
-    }
-
-    // Scan within the array literal for `'as'` (or `"as"`) followed by `=>`
-    // and a string. Operates within the args range, ignoring nested arrays
-    // and strings via depth-tracking.
-    let patterns: [&[u8]; 2] = [b"'as'", b"\"as\""];
-    for pat in patterns {
-        let mut j = i;
-        let mut in_string: Option<u8> = None;
-        while j + pat.len() < end {
-            let b = bytes[j];
-            if let Some(q) = in_string {
-                if b == b'\\' && j + 1 < end {
-                    j += 2;
-                    continue;
-                }
-                if b == q {
-                    in_string = None;
-                }
-                j += 1;
-                continue;
-            }
-            if b == b'\'' || b == b'"' {
-                // Check if this is the start of the pattern we want
-                if j + pat.len() <= end && &bytes[j..j + pat.len()] == pat {
-                    // Look past the pattern for `=>` then a string literal.
-                    let mut k = j + pat.len();
-                    while k < end && bytes[k].is_ascii_whitespace() {
-                        k += 1;
-                    }
-                    if k + 2 <= end && &bytes[k..k + 2] == b"=>" {
-                        let value = read_first_string_literal(bytes, k + 2, end);
-                        if value.is_some() {
-                            return value;
-                        }
-                    }
-                }
-                in_string = Some(b);
-                j += 1;
-                continue;
-            }
-            j += 1;
-        }
-    }
-    None
-}
-
-/// Find the byte range of a `function (...) { ... }` body inside the group's
-/// arg list. Returns `(body_start, body_end)` — body_start points to the byte
-/// right after the opening `{`, body_end to the matching `}` byte.
-fn find_function_body(bytes: &[u8], start: usize, end: usize) -> Option<(usize, usize)> {
-    let kw = b"function";
-    let mut i = start;
-    let mut in_string: Option<u8> = None;
-    while i + kw.len() < end {
-        let b = bytes[i];
-        if let Some(q) = in_string {
-            if b == b'\\' && i + 1 < end {
-                i += 2;
-                continue;
-            }
-            if b == q {
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-        if b == b'\'' || b == b'"' {
-            in_string = Some(b);
-            i += 1;
-            continue;
-        }
-        if i + kw.len() <= end && &bytes[i..i + kw.len()] == kw {
-            let before_ok = i == 0 || !is_identifier_byte(bytes[i - 1]);
-            let after = i + kw.len();
-            let after_ok = after >= bytes.len() || !is_identifier_byte(bytes[after]);
-            if before_ok && after_ok {
-                // Walk forward to the `{`. PHP's `function () use ($x) {`
-                // and other variants all end with a `{`.
-                let mut j = after;
-                while j < end && bytes[j] != b'{' {
-                    j += 1;
-                }
-                if j >= end {
-                    return None;
-                }
-                let body_start = j + 1;
-                // Brace-balance from j to find the close.
-                let mut depth = 1i32;
-                let mut k = body_start;
-                let mut in_s: Option<u8> = None;
-                while k < bytes.len() {
-                    let bc = bytes[k];
-                    if let Some(q) = in_s {
-                        if bc == b'\\' && k + 1 < bytes.len() {
-                            k += 2;
-                            continue;
-                        }
-                        if bc == q {
-                            in_s = None;
-                        }
-                        k += 1;
-                        continue;
-                    }
-                    match bc {
-                        b'\'' | b'"' => in_s = Some(bc),
-                        b'{' => depth += 1,
-                        b'}' => {
-                            depth -= 1;
-                            if depth == 0 {
-                                return Some((body_start, k));
-                            }
-                        }
-                        _ => {}
-                    }
-                    k += 1;
-                }
-                return None;
-            }
-        }
-        i += 1;
-    }
-    None
-}
-
-/// Pre-compute open `(` → close `)` pairs across the entire file. Skips
-/// quoted strings so parens inside string literals don't mis-balance. Used
-/// for backward chain walks where naive byte scanning would get confused by
-/// nested calls.
-fn build_paren_pairs(bytes: &[u8]) -> HashMap<usize, usize> {
-    let mut pairs = HashMap::new();
-    let mut stack: Vec<usize> = Vec::new();
-    let mut in_string: Option<u8> = None;
-    let mut i = 0;
-    while i < bytes.len() {
-        let b = bytes[i];
-        if let Some(q) = in_string {
-            if b == b'\\' && i + 1 < bytes.len() {
-                i += 2;
-                continue;
-            }
-            if b == q {
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-        match b {
-            b'\'' | b'"' => in_string = Some(b),
-            b'(' => stack.push(i),
-            b')' => {
-                if let Some(open) = stack.pop() {
-                    pairs.insert(open, i);
-                }
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-    pairs
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/route_discovery.rs
+++ b/laravel-lsp/src/route_discovery.rs
@@ -968,8 +968,12 @@ fn emit_named_route(
 /// routes Laravel synthesizes for it — `photos.index`, `photos.show`, … — after
 /// applying any `->only([...])` / `->except([...])` filter on the same chain.
 ///
+/// A slashed URI contributes only its last segment to the names; the rest is a
+/// URI prefix. The full URI is still carried on each definition for display.
+///
 /// Punted (common case only): `->names([...])` overrides, `Route::resources([…])`
-/// plural registration, and shallow/nested resources.
+/// plural registration, `singleton(...)`/`apiSingleton(...)`, and shallow/nested
+/// resources.
 #[allow(clippy::too_many_arguments)]
 fn emit_resource_routes(
     links: &[ChainLink],
@@ -984,10 +988,16 @@ fn emit_resource_routes(
     let Some(raw) = nth_string_arg(link.args, 0, source) else {
         return;
     };
-    let resource = raw.trim_matches('/');
-    if resource.is_empty() {
+    let uri = raw.trim_matches('/');
+    if uri.is_empty() {
         return;
     }
+    // Everything before the last `/` is a URI prefix, not part of the route
+    // name: `Route::resource('admin/photos', …)` registers `photos.index`, not
+    // `admin/photos.index`. Laravel routes any slashed name through
+    // `ResourceRegistrar::prefixedResource`, whose `getResourcePrefix` keeps
+    // only the final segment as the resource name.
+    let resource = uri.rsplit('/').next().unwrap_or(uri);
 
     let defaults = if link.method == "apiResource" {
         API_RESOURCE_ACTIONS
@@ -1010,7 +1020,7 @@ fn emit_resource_routes(
                     // A resource registers several verbs; none of them applies
                     // to the group as a whole.
                     method: None,
-                    uri: Some(resource.to_string()),
+                    uri: Some(uri.to_string()),
                     action: Some(action.to_string()),
                 },
             ));

--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -1096,7 +1096,7 @@ fn no_indexed_resource_name_ever_starts_with_slash() {
     // Belt-and-suspenders: across a realistic mix, assert the slash bug is gone.
     let (_tmp, index) = index_routes(&[(
         "routes/web.php",
-        "<?php\nRoute::name('api.')->group(function () {\n    Route::resource('/leads', LeadController::class);\n    Route::apiResource('/photos/', PhotoController::class);\n});\nRoute::resource('/bare', BareController::class);\n",
+        "<?php\nRoute::name('api.')->group(function () {\n    Route::resource('/leads', LeadController::class);\n    Route::apiResource('/photos/', PhotoController::class);\n});\nRoute::resource('/bare', BareController::class);\nRoute::resource('/admin/account-manager/accounts', AccountsController::class);\n",
     )]);
 
     for name in index.routes.keys() {
@@ -1113,6 +1113,49 @@ fn no_indexed_resource_name_ever_starts_with_slash() {
     assert!(index.get("api.leads.index").is_some());
     assert!(index.get("api.photos.store").is_some());
     assert!(index.get("bare.show").is_some());
+    // A multi-segment URI is what actually exercises the invariant above —
+    // single-segment fixtures pass it even when interior slashes are kept.
+    assert!(index.get("accounts.index").is_some());
+}
+
+#[test]
+fn resource_with_multi_segment_uri_names_only_the_last_segment() {
+    // Laravel sends any slashed resource name through
+    // `ResourceRegistrar::prefixedResource`, which keeps only the final segment
+    // as the route name and treats the rest as a URI prefix. Indexing the whole
+    // path made every CRUD route of such a resource unresolvable.
+    let src = r#"<?php
+Route::resource('/admin/account-manager/accounts', AccountsController::class)->only(['index', 'show']);
+"#;
+    let mut names = names_of(src);
+    names.sort();
+    assert_eq!(names, vec!["accounts.index", "accounts.show"]);
+}
+
+#[test]
+fn resource_with_multi_segment_uri_keeps_the_full_uri_for_display() {
+    // The prefix is dropped from the NAME only — hover still shows the path
+    // the developer wrote.
+    let path = PathBuf::from("/fake/routes/web.php");
+    let results = extract_named_routes(
+        "<?php\nRoute::apiResource('admin/photos', PhotoController::class)->only(['index']);\n",
+        &path,
+        PRIORITY_APP,
+        &[],
+    );
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0.as_deref(), Some("photos.index"));
+    assert_eq!(results[0].1.uri.as_deref(), Some("admin/photos"));
+}
+
+#[test]
+fn resource_with_multi_segment_uri_composes_with_group_prefix() {
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    Route::resource('account-manager/users', UsersController::class)->only(['index']);
+});
+"#;
+    assert_eq!(names_of(src), vec!["admin.users.index"]);
 }
 
 #[test]

--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -1259,3 +1259,126 @@ fn folio_named_page_surfaces_in_handler_route_index() {
     assert_eq!(route.uri.as_deref(), Some("/users/{id}"));
     assert_eq!(route.method.as_deref(), Some("get"));
 }
+
+// ============================================================================
+// Comment / heredoc blindness (the byte-scan bug the AST parse retired)
+// ============================================================================
+//
+// The previous scanner matched braces, parens and quotes over raw bytes with no
+// notion of PHP comments. Real route files carry commented-out route code and
+// English prose, both of which silently corrupted every group boundary that
+// followed: a stray `{` from `// Route::get('/x', function () {` pushed a
+// group's closing brace hundreds of lines late, and a lone apostrophe in
+// "it's" opened a phantom string literal that swallowed the braces after it.
+// Routes then inherited a prefix from a group they were never inside.
+
+#[test]
+fn commented_out_route_is_not_indexed() {
+    let src = r#"<?php
+// Route::get('/ghost', [GhostController::class, 'index'])->name('ghost');
+Route::get('/real')->name('real');
+"#;
+    assert_eq!(
+        names_of(src),
+        vec!["real"],
+        "a commented-out route is not a route"
+    );
+}
+
+#[test]
+fn commented_out_resource_is_not_indexed() {
+    let src = r#"<?php
+// Route::resource('ghosts', GhostController::class);
+Route::resource('reals', RealController::class)->only(['index']);
+"#;
+    assert_eq!(names_of(src), vec!["reals.index"]);
+}
+
+#[test]
+fn commented_out_closure_brace_does_not_extend_group_body() {
+    // The decisioncloud shape: a commented-out route leaves an unmatched `{`
+    // inside the group. Byte-scanning counted it, so the group's closing brace
+    // was never found and its prefix vanished from the routes inside it.
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    // Route::get('/legacy', function () {
+    Route::get('/users')->name('users.index');
+});
+Route::name('api.')->group(function () {
+    Route::get('/posts')->name('posts.index');
+});
+"#;
+    assert_eq!(
+        names_of(src),
+        vec!["admin.users.index", "api.posts.index"],
+        "an unmatched brace in a comment must not move the group boundary"
+    );
+}
+
+#[test]
+fn apostrophe_in_comment_does_not_shift_group_boundary() {
+    // A lone `it's` opens a phantom string literal for a quote-tracking byte
+    // scanner, hiding every brace up to the next quote — here, the group's own
+    // closing `}`, which then swallowed the sibling group below it.
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    Route::get('/users')->name('users.index');
+    // the closing brace is below, it's important
+});
+Route::name('api.')->group(function () {
+    Route::get('/posts')->name('posts.index');
+});
+"#;
+    assert_eq!(
+        names_of(src),
+        vec!["admin.users.index", "api.posts.index"],
+        "a prose apostrophe must not shift the group boundary"
+    );
+}
+
+#[test]
+fn block_comment_braces_do_not_shift_group_boundary() {
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    /*
+     * Route::get('/old', function () {
+     */
+    Route::get('/users')->name('users.index');
+});
+Route::get('/login')->name('login');
+"#;
+    assert_eq!(names_of(src), vec!["admin.users.index", "login"]);
+}
+
+#[test]
+fn heredoc_braces_do_not_shift_group_boundary() {
+    // A `}` inside heredoc text closed the group early, so the route below it
+    // lost the `admin.` prefix entirely.
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    $sql = <<<'SQL'
+} this brace is data, not code
+SQL;
+    Route::get('/users')->name('users.index');
+});
+Route::get('/login')->name('login');
+"#;
+    assert_eq!(
+        names_of(src),
+        vec!["admin.users.index", "login"],
+        "heredoc content must not be parsed as code"
+    );
+}
+
+#[test]
+fn group_name_setter_is_not_itself_a_route() {
+    // `->name('admin.')` on a chain that ends in `->group(...)` configures the
+    // children's prefix; it does not register a route of its own. The byte scan
+    // indexed it as the bogus route `admin.`.
+    let src = r#"<?php
+Route::prefix('/admin')->name('admin.')->group(function () {
+    Route::get('/users')->name('users.index');
+});
+"#;
+    assert_eq!(names_of(src), vec!["admin.users.index"]);
+}


### PR DESCRIPTION
## Summary

`route('…')` reported **"Route not found in index"** for routes that `artisan route:list` resolves fine.

The route scanners in `route_discovery.rs` matched braces, parens and quotes over raw bytes with no notion of PHP comments or heredocs. Real route files carry both:

```php
// Route::get('/legacy', function () {     ← phantom `{`, brace depth never returns
// the user's session is checked below    ← phantom string opens at `user's`
```

Either one shifts every group boundary that follows. In the project where this surfaced, a `Route::prefix('/accounts')->name('accounts.')->group(…)` closure appeared to end ~160 lines late and swallowed the sibling `->name('admin.')` group, so `admin.accounts.index` was indexed as `accounts.admin.accounts.index` — and every route below it inherited a prefix from a group it was never inside.

Route names, group prefixes, resource expansion and route metadata are now read from a tree-sitter parse. **Nineteen byte scanners are deleted** (`build_paren_pairs`, `find_function_body`, `statement_containing`, `find_verb_call`, `extract_chain_name_prefix`, `find_route_groups`, …); `route_discovery.rs` drops from 1912 to 1352 lines.

Two further bugs fall out, both consequences of scanning bytes:

- a **commented-out** route was indexed as a real one;
- a group's own `->name('admin.')` registered a bogus route literally named `admin.`.

## Verified on a real project

139 route files (93.5% vendor), before → after:

| | before | after |
|---|---|---|
| `admin.accounts.index` | ❌ missing | ✅ `web.php:1232` |
| phantom `accounts.admin.*` names | 30 | 0 |
| names under `admin.` | 0 | 63 |
| names indexed | 428 | 583 |

155 names that were previously indexed under the wrong prefix are now correct.

## ⚠️ Performance — a deliberate, measured regression

This implements **option A** from [`docs/route-cache-unification.md`](docs/route-cache-unification.md), which that discovery ([#48](https://github.com/mike-bronner/zed-laravel/issues/48)) **ruled out** on benchmark numbers. The override is intentional and is recorded in the doc, along with the re-measured cost:

| Corpus | `build_route_index` before | after | ratio |
|---|---|---|---|
| 500 vendor files | 38.0 ms | 151.4 ms | 4.0× |
| 2000 vendor files | 172.8 ms | 580.0 ms | 3.4× |
| 5000 vendor files | 368.5 ms | **1.43 s** | 3.9× |

Real project: 55.9 ms → 173.7 ms (3.1×).

The realistic-path ratio exceeds the ~2.8× raw parse ratio because `build_route_index` parses each file **twice** — once to discover `->group(<path>)` load edges, once to extract routes. A third parse (the prefix graph re-scanning every file) is removed in this PR, which took the real project from 256 ms to 174 ms. Collapsing the remaining two onto one cached parse is the next optimization; the **hybrid** split described under option B in the same doc remains available if the cold-start cost proves unacceptable.

Re-run the numbers with `cargo bench --bench route_cache`.

## Test plan

- [x] `cargo test` — **2,998 pass**, 0 fail
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt`
- [x] **7 new regression tests** covering commented-out routes and resources, unmatched comment braces, prose apostrophes, block comments, heredoc braces, and the group-name-setter case
- [x] **Mutation-verified**: every one of the 7 was run against the old byte scanner and confirmed to fail there, then confirmed to pass here. (A first draft had four that passed under *both* — balanced braces and paired apostrophes — and were rewritten with genuine imbalance.)
- [x] **Parity**: all 67 pre-existing `route_discovery` tests pass under both the old and new implementations
- [x] Verified end-to-end against a real vendor-heavy Laravel project

## Notes

- Removes the unused public `extract_route_metadata` (no consumers outside the module; metadata now comes off the parsed chain).
- The vendor-file discovery pre-filter (`content_registers_named_routes`) stays a cheap byte check — it decides *whether* to parse a file, so parsing it to make that decision would defeat the point.
- `singleton(...)` / `apiSingleton(...)` share the resource prefix semantics but are not indexed at all today; they are listed with the other punted forms in the module doc rather than added here.

## Second commit — slashed resource names

`Route::resource('/admin/account-manager/accounts', …)` indexed `admin/account-manager/accounts.index`, but Laravel registers `accounts.index`: `ResourceRegistrar::register` sends any slashed name through `prefixedResource`, whose `getResourcePrefix` keeps only the final segment and treats the rest as a URI prefix. Every CRUD route of such a resource was missing from the index.

The full URI is still carried on each definition, so hover shows the path as written.

Four discriminating tests, each verified red against the unfixed code — including `no_indexed_resource_name_ever_starts_with_slash`, which asserted this invariant already but only exercised single-segment fixtures and so passed while the bug was live. On the real project: `account-manager.accounts.index` now resolves, and **no indexed name contains a slash**.

Context: [#48](https://github.com/mike-bronner/zed-laravel/issues/48)
