### PR TITLE
fix: 🐛 re-sync open buffers after the pattern-cache warm

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4332,15 +4332,23 @@ impl LaravelLanguageServer {
     }
 
     fn new(client: Client) -> Self {
+        // Bound to locals (rather than built inline in the struct literal
+        // below) so `salsa` can publish `documents` into the salsa layer
+        // right after `spawn()` — see `SalsaHandle::set_documents` for why
+        // bulk_import_patterns needs to see open buffers.
+        let documents: Arc<RwLock<HashMap<Url, (String, i32)>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+        let salsa = SalsaActor::spawn();
+        salsa.set_documents(documents.clone());
         Self {
             client,
-            documents: Arc::new(RwLock::new(HashMap::new())),
+            documents,
             root_path: Arc::new(RwLock::new(None)),
             workspace_root: Arc::new(RwLock::new(None)),
             diagnostics: Arc::new(RwLock::new(HashMap::new())),
             pending_diagnostics: Arc::new(RwLock::new(HashMap::new())),
             debounce_delay_ms: 200, // 200ms for diagnostics
-            salsa: SalsaActor::spawn(),
+            salsa,
             cache: Arc::new(RwLock::new(None)),
             pending_rescans: Arc::new(RwLock::new(HashSet::new())),
             rescan_debounce_handle: Arc::new(RwLock::new(None)),
@@ -5459,24 +5467,20 @@ impl LaravelLanguageServer {
                 }
             }
             let magic_elapsed = magic_started.elapsed();
-            // The reference indexes are built — ask the client to refresh code
-            // lenses requested while warming was still in progress (those
-            // resolved against an empty index and read 0). Fire-and-forget, so
-            // it never blocks. NOTE: Zed currently doesn't re-query already-open
-            // documents on this refresh (upstream bug, filed) — a reopen/edit
-            // refreshes them — but files opened after warm resolve correctly,
-            // and the disk cache keeps warm short.
-            let _ = client_for_warm.code_lens_refresh().await;
-            // Reference indexes are ready — the unused-symbol diagnostic may now
-            // run (it's suppressed mid-warm to avoid flagging everything while
-            // the index is empty). It surfaces on the next open/edit of a file.
-            warm_complete_for_warm.store(true, std::sync::atomic::Ordering::Relaxed);
 
-            // Re-register every open buffer's live text. The warm rebuilt
-            // pattern entries from DISK content, so a file the user has open
-            // (and possibly edited) would serve stale positions — goto/hover
-            // dead in exactly the files being worked on — until their next
-            // keystroke re-parses it. Bounded by open tabs, idempotent.
+            // Re-register every open buffer's live text BEFORE the
+            // code-lens refresh below. The `bulk_import_patterns` guard
+            // (see `SalsaHandle::bulk_import_patterns`) now skips open
+            // paths during the warm import itself, so this loop is no
+            // longer papering over a clobbered cache entry — but it's kept
+            // deliberately: it still re-registers the SourceFile input and
+            // dirties the symbol/hierarchy indexes, repairing any open file
+            // the warm's file-discovery pass touched before the buffer was
+            // opened. Running it before `code_lens_refresh()` closes a
+            // stale-lens window — the refresh triggers client lens queries
+            // gated on `warm_complete`, so those queries must see the
+            // re-synced state, not the pre-sync one. Bounded by open tabs,
+            // idempotent.
             let open_docs: Vec<(std::path::PathBuf, String, i32)> = server_for_warm
                 .documents
                 .read()
@@ -5495,6 +5499,19 @@ impl LaravelLanguageServer {
                     debug!("post-warm buffer re-sync failed for {:?}: {}", path, e);
                 }
             }
+
+            // The reference indexes are built — ask the client to refresh code
+            // lenses requested while warming was still in progress (those
+            // resolved against an empty index and read 0). Fire-and-forget, so
+            // it never blocks. NOTE: Zed currently doesn't re-query already-open
+            // documents on this refresh (upstream bug, filed) — a reopen/edit
+            // refreshes them — but files opened after warm resolve correctly,
+            // and the disk cache keeps warm short.
+            let _ = client_for_warm.code_lens_refresh().await;
+            // Reference indexes are ready — the unused-symbol diagnostic may now
+            // run (it's suppressed mid-warm to avoid flagging everything while
+            // the index is empty). It surfaces on the next open/edit of a file.
+            warm_complete_for_warm.store(true, std::sync::atomic::Ordering::Relaxed);
 
             let elapsed = started_at.elapsed();
             info!(

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -5472,6 +5472,30 @@ impl LaravelLanguageServer {
             // the index is empty). It surfaces on the next open/edit of a file.
             warm_complete_for_warm.store(true, std::sync::atomic::Ordering::Relaxed);
 
+            // Re-register every open buffer's live text. The warm rebuilt
+            // pattern entries from DISK content, so a file the user has open
+            // (and possibly edited) would serve stale positions — goto/hover
+            // dead in exactly the files being worked on — until their next
+            // keystroke re-parses it. Bounded by open tabs, idempotent.
+            let open_docs: Vec<(std::path::PathBuf, String, i32)> = server_for_warm
+                .documents
+                .read()
+                .await
+                .iter()
+                .filter_map(|(uri, (text, version))| {
+                    uri.to_file_path().ok().map(|p| (p, text.clone(), *version))
+                })
+                .collect();
+            for (path, text, version) in open_docs {
+                if let Err(e) = server_for_warm
+                    .salsa
+                    .update_file(path.clone(), version, text)
+                    .await
+                {
+                    debug!("post-warm buffer re-sync failed for {:?}: {}", path, e);
+                }
+            }
+
             let elapsed = started_at.elapsed();
             info!(
                 "🔥 Laravel: pattern cache warmed ({} newly parsed, {} from disk, total {}, in {:?}; parse {:?}, magic-resolve {:?})",

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -15,9 +15,10 @@ use salsa::Setter;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, RwLock};
+use tower_lsp::lsp_types::Url;
 use tracing::{debug, info};
 
 use crate::config::kebab_to_pascal_case;
@@ -5517,6 +5518,13 @@ pub struct SalsaHandle {
     /// handler. See the comment on `SalsaActor::pattern_cache` for why
     /// this exists.
     pattern_cache: Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>,
+    /// The server's open-document map (URI → (text, version)). `None` until
+    /// `set_documents` publishes it — every existing `spawn()` call site
+    /// (25+, mostly tests) still compiles unchanged; an unset map is
+    /// treated as "no open buffers", i.e. the pre-fix behaviour. See
+    /// `SalsaActor::documents` for the shared-allocation rationale and
+    /// `bulk_import_patterns` for the one consumer that matters.
+    documents: Arc<OnceLock<Arc<RwLock<HashMap<Url, (String, i32)>>>>>,
 }
 
 impl SalsaHandle {
@@ -5527,6 +5535,39 @@ impl SalsaHandle {
     /// instance the actor reads from in `handle_get_patterns`.
     pub fn pattern_cache(&self) -> Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>> {
         self.pattern_cache.clone()
+    }
+
+    /// Publish the server's open-document map into the salsa layer. Call
+    /// once at startup, right after `SalsaActor::spawn()` — mirrors how
+    /// `pattern_cache` above is a single shared `Arc` handed to both sides
+    /// at construction. Kept as a post-construction setter (instead of a
+    /// `spawn()` parameter) because `spawn()` has 25+ call sites, mostly
+    /// tests, that don't have a documents map to hand it. A second call is
+    /// a no-op — `OnceLock` refuses to overwrite — since only server
+    /// startup should ever publish this.
+    pub fn set_documents(&self, documents: Arc<RwLock<HashMap<Url, (String, i32)>>>) {
+        if self.documents.set(documents).is_err() {
+            debug!("SalsaHandle::set_documents called more than once; ignoring");
+        }
+    }
+
+    /// Snapshot the paths of every currently open buffer as a `HashSet`,
+    /// once, for O(1) membership checks. The sole consumer is
+    /// `bulk_import_patterns`, which must not let a disk-parsed warm entry
+    /// overwrite a path the user has open (and possibly edited) — see
+    /// there. Called from async context (the warming task that calls
+    /// `bulk_import_patterns` is itself a `tokio::spawn`ed future, not the
+    /// actor thread), so a plain `.read().await` is correct here.
+    async fn open_buffer_paths(&self) -> std::collections::HashSet<PathBuf> {
+        match self.documents.get() {
+            Some(documents) => documents
+                .read()
+                .await
+                .keys()
+                .filter_map(|uri| uri.to_file_path().ok())
+                .collect(),
+            None => std::collections::HashSet::new(),
+        }
     }
 
     /// Update or create a file in the database
@@ -5903,12 +5944,28 @@ impl SalsaHandle {
     /// Real-world cost: ~7ms for 40,589 entries (per earlier bench).
     /// The `async fn` and `Result` shape is preserved for source
     /// compatibility with the existing call sites.
+    ///
+    /// **Open buffers are skipped.** Entries here are parsed from DISK, so
+    /// unconditionally inserting would silently overwrite the pattern-cache
+    /// entry for a file the user has open with unsaved edits — goto/hover
+    /// then serve stale positions in exactly the files being worked on,
+    /// until the next keystroke re-parses it. The open path is read from
+    /// `documents` (published via `set_documents`) into a `HashSet` ONCE,
+    /// not per-entry, to stay inside the ~7ms budget above. A skipped path
+    /// simply keeps whatever's already in the cache (or nothing, forcing a
+    /// lazy re-parse from the live Salsa buffer on the next `get_patterns`
+    /// call) — its own `did_open`/`did_change` path is what keeps its entry
+    /// current.
     pub async fn bulk_import_patterns(
         &self,
         entries: Vec<(PathBuf, Arc<ParsedPatternsData>)>,
     ) -> Result<usize, &'static str> {
         let total = entries.len();
+        let open_paths = self.open_buffer_paths().await;
         for (path, data) in entries {
+            if open_paths.contains(&path) {
+                continue;
+            }
             self.pattern_cache.insert(path, (0, data));
         }
         Ok(total)
@@ -6885,6 +6942,16 @@ pub struct SalsaActor {
     /// and warming's bulk insert is negligible. ~5KB per entry × 65k cap
     /// = ~320MB worst case. Cap enforced manually on insert.
     pattern_cache: Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>,
+    /// The server's open-document map (URI → (text, version)), published
+    /// once via `SalsaHandle::set_documents` after `spawn()` returns. SAME
+    /// `Arc<OnceLock<_>>` allocation as `SalsaHandle::documents` — see there
+    /// for why this exists and why it's a `OnceLock` rather than a
+    /// constructor parameter. Read with `blocking_read()` in
+    /// `BulkImportPatterns`: this struct lives on the actor's dedicated
+    /// `std::thread::spawn` thread (`run`, below), never polled by the
+    /// tokio runtime, so a blocking read is the correct (and only
+    /// available) primitive here.
+    documents: Arc<OnceLock<Arc<RwLock<HashMap<Url, (String, i32)>>>>>,
     /// LRU cache of parsed Blade loop blocks, keyed by file path + version.
     /// Salsa already memoizes the underlying query, but caching the Arc avoids
     /// re-walking the query graph on every diagnostic / completion request.
@@ -7022,6 +7089,15 @@ impl SalsaActor {
             Arc::new(dashmap::DashMap::with_capacity(65536));
         let pattern_cache_for_actor = pattern_cache.clone();
 
+        // Published post-construction via `SalsaHandle::set_documents` (the
+        // server's `documents` map isn't available yet here — see the field
+        // doc comment on `SalsaActor::documents`). Both structs below share
+        // this SAME `Arc<OnceLock<_>>`, so a single `set()` through either
+        // handle publishes it to both at once.
+        let documents: Arc<OnceLock<Arc<RwLock<HashMap<Url, (String, i32)>>>>> =
+            Arc::new(OnceLock::new());
+        let documents_for_actor = documents.clone();
+
         std::thread::spawn(move || {
             let mut actor = SalsaActor {
                 db: LaravelDatabase::new(),
@@ -7029,6 +7105,7 @@ impl SalsaActor {
                 // Pre-allocate with reasonable capacity to avoid early reallocations
                 files: HashMap::with_capacity(64),
                 pattern_cache: pattern_cache_for_actor,
+                documents: documents_for_actor,
                 loop_blocks_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 php_assignments_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 document_symbols_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
@@ -7082,6 +7159,25 @@ impl SalsaActor {
         SalsaHandle {
             sender: tx,
             pattern_cache,
+            documents,
+        }
+    }
+
+    /// Synchronous counterpart to `SalsaHandle::open_buffer_paths`, for the
+    /// dead-fallback `BulkImportPatterns` message handler below. This runs
+    /// inside `run()`, on the actor's dedicated `std::thread::spawn` thread
+    /// — never polled by the tokio runtime — so `blocking_read()` is the
+    /// correct primitive: there's no `.await` available (this isn't an
+    /// async fn) and, unlike on a tokio worker thread, nothing here can
+    /// deadlock the runtime by blocking.
+    fn open_buffer_paths_blocking(&self) -> std::collections::HashSet<PathBuf> {
+        match self.documents.get() {
+            Some(documents) => documents
+                .blocking_read()
+                .keys()
+                .filter_map(|uri| uri.to_file_path().ok())
+                .collect(),
+            None => std::collections::HashSet::new(),
         }
     }
 
@@ -7266,9 +7362,16 @@ impl SalsaActor {
                 // pattern_cache via SalsaHandle::bulk_import_patterns
                 // (which does NOT round-trip through this actor channel).
                 // See SalsaActor::pattern_cache for the architectural why.
+                // Guarded the same way as that real path (open buffers
+                // skipped) so the two can't drift apart if this fallback
+                // ever does get exercised.
                 SalsaRequest::BulkImportPatterns { entries, reply } => {
                     let total = entries.len();
+                    let open_paths = self.open_buffer_paths_blocking();
                     for (path, data) in entries {
+                        if open_paths.contains(&path) {
+                            continue;
+                        }
                         self.pattern_cache.insert(path, (0, data));
                     }
                     let _ = reply.send(total);

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -38,6 +38,7 @@ mod livewire_tag_navigation_containment;
 mod loop_variable_resolution;
 mod macro_goto_def_handler;
 mod nested_module_root_correction;
+mod post_warm_open_buffer_guard;
 mod query_chain_completion_handler;
 mod rename_integration;
 mod route_binding_resolution;

--- a/laravel-lsp/src/tests/post_warm_open_buffer_guard.rs
+++ b/laravel-lsp/src/tests/post_warm_open_buffer_guard.rs
@@ -82,6 +82,21 @@ async fn bulk_import_skips_open_buffer_and_position_still_resolves() {
         "buffer text parses with the config() call on the shifted line"
     );
 
+    // Register the project so the actor publishes the shared pattern cache
+    // (bulk_import_patterns errors before publication — the real warm only
+    // runs after project registration, and this test mirrors that order).
+    server
+        .salsa
+        .register_project_files(
+            dir.path().to_path_buf(),
+            vec![std::path::PathBuf::from("app/Http/Controllers")],
+            vec![dir.path().join("resources/views")],
+            None,
+            std::path::PathBuf::from("routes"),
+        )
+        .await
+        .unwrap();
+
     // Simulate the warm's disk-parse step for the SAME file: parse the
     // UNEDITED disk content, exactly as `register_project_files_with_salsa`'s
     // warm task does via `parse_owned_with_hierarchy`, then hand it to the

--- a/laravel-lsp/src/tests/post_warm_open_buffer_guard.rs
+++ b/laravel-lsp/src/tests/post_warm_open_buffer_guard.rs
@@ -1,0 +1,117 @@
+//! Regression: the post-warm pattern-cache import must not clobber an open
+//! buffer's live-parsed entry with one parsed from disk.
+//!
+//! `bulk_import_patterns` bulk-inserts DISK-parsed `ParsedPatternsData` into
+//! the shared `pattern_cache` after a warm. Before the fix it did this
+//! unconditionally, so a file the user has open — with unsaved edits that
+//! shift positions relative to disk — would have its cache entry silently
+//! overwritten by the disk-parsed (differently-positioned) version. Because
+//! `pattern_cache` is checked FIRST on every `get_patterns` call (see
+//! `handle_get_patterns`), that stale entry then wins over the live buffer
+//! until the user's next edit evicts it — goto/hover dead in exactly the
+//! file being worked on.
+//!
+//! This test reproduces the sequence directly against the real
+//! `SalsaHandle` (the same layer `register_project_files_with_salsa`'s warm
+//! task drives), mirroring how `factory_goto_def_handler.rs` primes the
+//! actor without going through the full LSP open/index dance. Deterministic:
+//! no sleeps, no real warm timing — `bulk_import_patterns` is the exact unit
+//! under test.
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::salsa_impl::{ConfigReferenceData, ParsedPatternsData};
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::Url;
+use tower_lsp::LspService;
+
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+const DISK_SRC: &str = "<?php\nconfig('app.name');\n";
+
+/// Same content with an extra line prepended — every existing position
+/// shifts down by one line, exactly what an unsaved edit at the top of a
+/// file does.
+const BUFFER_SRC: &str = "<?php\n// unsaved edit\nconfig('app.name');\n";
+
+fn config_ref_at_line(data: &ParsedPatternsData, line: u32) -> Option<&ConfigReferenceData> {
+    data.config_refs
+        .iter()
+        .map(|r| r.as_ref())
+        .find(|r| r.line == line)
+}
+
+#[tokio::test]
+async fn bulk_import_skips_open_buffer_and_position_still_resolves() {
+    let dir = TempDir::new().unwrap();
+    let path: PathBuf = dir.path().join("config_probe.php");
+    std::fs::write(&path, DISK_SRC).unwrap();
+
+    let server = test_server();
+
+    // Simulate `did_open` with unsaved edits: register the buffer text with
+    // the salsa layer AND the server's `documents` map — the latter is what
+    // `bulk_import_patterns` consults via `SalsaHandle::set_documents`
+    // (wired in `LaravelLanguageServer::new`).
+    server
+        .salsa
+        .update_file(path.clone(), 1, BUFFER_SRC.to_string())
+        .await
+        .unwrap();
+    let uri = Url::from_file_path(&path).unwrap();
+    server
+        .documents
+        .write()
+        .await
+        .insert(uri, (BUFFER_SRC.to_string(), 1));
+
+    // Sanity: before any warm import, the live buffer parses with the
+    // shifted position (line 2, 0-based) — proves the fixture is set up as
+    // intended.
+    let live = server
+        .salsa
+        .get_patterns(path.clone())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        config_ref_at_line(&live, 2).is_some(),
+        "buffer text parses with the config() call on the shifted line"
+    );
+
+    // Simulate the warm's disk-parse step for the SAME file: parse the
+    // UNEDITED disk content, exactly as `register_project_files_with_salsa`'s
+    // warm task does via `parse_owned_with_hierarchy`, then hand it to the
+    // exact function under test.
+    let (disk_data, _hierarchy) =
+        laravel_lsp::pattern_indexer::parse_owned_with_hierarchy(&path, DISK_SRC);
+    assert!(
+        config_ref_at_line(&disk_data, 1).is_some(),
+        "disk text parses with the config() call one line up from the buffer"
+    );
+    server
+        .salsa
+        .bulk_import_patterns(vec![(path.clone(), disk_data)])
+        .await
+        .unwrap();
+
+    // The guard must have skipped the open path: a lookup at the buffer's
+    // (shifted) position still resolves. Without the fix,
+    // `bulk_import_patterns` would have overwritten the cache with the
+    // disk-parsed entry, and this lookup at line 2 would come back `None`
+    // (the stale entry only has the reference at line 1).
+    let after_warm = server
+        .salsa
+        .get_patterns(path.clone())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        config_ref_at_line(&after_warm, 2).is_some(),
+        "position lookup at the open buffer's line must still resolve after the warm import \
+         (would be None without the open-buffer guard)"
+    );
+}


### PR DESCRIPTION
When the pattern-cache warm finishes, it rebuilds every file's pattern entry from **disk** content — silently overwriting the entries for files the user has open. An open buffer that differs from disk (unsaved edits — the normal state while coding) then serves stale positions: goto-definition and hover go dead *in exactly the files being worked on*, while completions (which read the live buffer) keep working. Any keystroke in the file re-parses it and "fixes" the problem, which is what made this so hard to pin down — it likely underlies a class of unreproducible "goto sometimes doesn't work" reports.

Reproduction (scripted LSP session): open a file with an extra line inserted at the top (shifting all positions) before the warm completes, wait for the warm, request goto-definition on any pattern → `null`. Type one character → works.

Fix: when the warm completes, re-register every open document's live buffer text with the incremental layer. Bounded by open tabs, idempotent, runs once per warm.

Full test suite green on all targets.
