### PR TITLE
fix: 🐛 char-boundary-safe truncation of translation and config display values

### DIFF
--- a/laravel-lsp/src/display_truncate.rs
+++ b/laravel-lsp/src/display_truncate.rs
@@ -1,0 +1,23 @@
+//! Char-safe truncation for values shown in hover cards and completion docs.
+//!
+//! `s[..limit]` truncation panics whenever a multibyte character straddles
+//! the byte index — reachable via any translation or config value with a
+//! multibyte character at the cut point. Every display-truncation call site
+//! shares this one implementation so that safety property can't regress by
+//! being hand-copied somewhere byte-based again.
+
+/// Truncate strings longer than `limit` chars with a `…` ellipsis. Operates
+/// on chars (not bytes) so it never splits a multibyte character.
+///
+/// Used by config/translation dispatch code to clip long resolved values
+/// before stuffing them into a code block.
+pub fn truncate_for_display(s: &str, limit: usize) -> String {
+    if s.chars().count() <= limit {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(limit).collect();
+    format!("{}…", head)
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/display_truncate/tests.rs
+++ b/laravel-lsp/src/display_truncate/tests.rs
@@ -1,0 +1,25 @@
+use super::*;
+
+#[test]
+fn truncate_for_display_clips_long_strings() {
+    let long = "x".repeat(500);
+    let out = truncate_for_display(&long, 200);
+    assert!(out.ends_with('…'));
+    assert_eq!(out.chars().filter(|c| *c == 'x').count(), 200);
+}
+
+#[test]
+fn truncate_for_display_passes_short_strings_through() {
+    let short = "short";
+    let out = truncate_for_display(short, 200);
+    assert_eq!(out, "short");
+}
+
+#[test]
+fn truncate_for_display_handles_multibyte_chars_at_boundary() {
+    // 200 multibyte chars — make sure we count chars not bytes
+    let s: String = "日".repeat(300);
+    let out = truncate_for_display(&s, 200);
+    assert!(out.ends_with('…'));
+    assert_eq!(out.chars().count(), 201); // 200 + ellipsis
+}

--- a/laravel-lsp/src/hover.rs
+++ b/laravel-lsp/src/hover.rs
@@ -793,18 +793,5 @@ pub fn source_link(display: &str, file_url: &str, line: Option<u32>) -> String {
     }
 }
 
-/// Truncate strings longer than `limit` chars with a `…` ellipsis. Operates
-/// on chars (not bytes) so it never splits a multibyte character.
-///
-/// Used by config/translation dispatch code to clip long resolved values
-/// before stuffing them into a code block.
-pub fn truncate_for_display(s: &str, limit: usize) -> String {
-    if s.chars().count() <= limit {
-        return s.to_string();
-    }
-    let head: String = s.chars().take(limit).collect();
-    format!("{}…", head)
-}
-
 #[cfg(test)]
 mod tests;

--- a/laravel-lsp/src/hover/tests.rs
+++ b/laravel-lsp/src/hover/tests.rs
@@ -178,30 +178,6 @@ fn source_link_without_line_omits_fragment() {
     assert_eq!(link, "[app/Foo.php](file:///abs/Foo.php)");
 }
 
-#[test]
-fn truncate_for_display_clips_long_strings() {
-    let long = "x".repeat(500);
-    let out = truncate_for_display(&long, 200);
-    assert!(out.ends_with('…'));
-    assert_eq!(out.chars().filter(|c| *c == 'x').count(), 200);
-}
-
-#[test]
-fn truncate_for_display_passes_short_strings_through() {
-    let short = "short";
-    let out = truncate_for_display(short, 200);
-    assert_eq!(out, "short");
-}
-
-#[test]
-fn truncate_for_display_handles_multibyte_chars_at_boundary() {
-    // 200 multibyte chars — make sure we count chars not bytes
-    let s: String = "日".repeat(300);
-    let out = truncate_for_display(&s, 200);
-    assert!(out.ends_with('…'));
-    assert_eq!(out.chars().count(), 201); // 200 + ellipsis
-}
-
 // ============================================================================
 // magic_member_card (M6) — classification hover for Eloquent magic members
 // ============================================================================

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -64,6 +64,7 @@ pub mod config;
 pub mod config_key_locator;
 pub mod config_lookup;
 pub mod database;
+pub mod display_truncate;
 pub mod document_symbols;
 pub mod env_key_locator;
 pub mod facade_resolver;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -14569,9 +14569,12 @@ impl LaravelLanguageServer {
                 .trim_end_matches('\'')
                 .trim_end_matches('"');
 
-            // Truncate long values for display
-            if unquoted.len() > 50 {
-                format!("{}...", &unquoted[..47])
+            // Truncate long values for display. Char-based, not byte-based:
+            // a byte slice panics when index 47 lands inside a multibyte
+            // character (e.g. 'č' in a Czech catalogue).
+            if unquoted.chars().count() > 50 {
+                let truncated: String = unquoted.chars().take(47).collect();
+                format!("{truncated}...")
             } else {
                 unquoted.to_string()
             }
@@ -14722,9 +14725,12 @@ impl LaravelLanguageServer {
             // Check for env() call pattern: env('VAR_NAME') or env('VAR_NAME', 'default')
             let resolved = Self::resolve_env_value(value, env_vars);
 
-            // Truncate long values for display
-            let display_value = if resolved.len() > 50 {
-                format!("{}...", &resolved[..47])
+            // Truncate long values for display. Char-based, not byte-based:
+            // a byte slice panics when index 47 lands inside a multibyte
+            // character (e.g. 'ü' in a German config value).
+            let display_value = if resolved.chars().count() > 50 {
+                let truncated: String = resolved.chars().take(47).collect();
+                format!("{truncated}...")
             } else {
                 resolved
             };

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -14569,15 +14569,7 @@ impl LaravelLanguageServer {
                 .trim_end_matches('\'')
                 .trim_end_matches('"');
 
-            // Truncate long values for display. Char-based, not byte-based:
-            // a byte slice panics when index 47 lands inside a multibyte
-            // character (e.g. 'č' in a Czech catalogue).
-            if unquoted.chars().count() > 50 {
-                let truncated: String = unquoted.chars().take(47).collect();
-                format!("{truncated}...")
-            } else {
-                unquoted.to_string()
-            }
+            laravel_lsp::display_truncate::truncate_for_display(unquoted, 200)
         } else {
             String::new()
         }
@@ -14725,17 +14717,7 @@ impl LaravelLanguageServer {
             // Check for env() call pattern: env('VAR_NAME') or env('VAR_NAME', 'default')
             let resolved = Self::resolve_env_value(value, env_vars);
 
-            // Truncate long values for display. Char-based, not byte-based:
-            // a byte slice panics when index 47 lands inside a multibyte
-            // character (e.g. 'ü' in a German config value).
-            let display_value = if resolved.chars().count() > 50 {
-                let truncated: String = resolved.chars().take(47).collect();
-                format!("{truncated}...")
-            } else {
-                resolved
-            };
-
-            display_value
+            laravel_lsp::display_truncate::truncate_for_display(&resolved, 200)
         } else {
             String::new()
         }
@@ -20054,7 +20036,7 @@ return [
         };
         let truncated = value
             .as_deref()
-            .map(|v| laravel_lsp::hover::truncate_for_display(v, 200));
+            .map(|v| laravel_lsp::display_truncate::truncate_for_display(v, 200));
         let trailer = if value.is_none() {
             Some("*(value not found)*")
         } else {
@@ -20125,7 +20107,10 @@ return [
                 r, key, &locale, map_ref,
             ) {
                 Some(res) => Some((
-                    hover::truncate_for_display(&Self::unquote_php_literal(&res.value), 200),
+                    laravel_lsp::display_truncate::truncate_for_display(
+                        &Self::unquote_php_literal(&res.value),
+                        200,
+                    ),
                     self.source_link(&res.source_file, None).await,
                 )),
                 None => None,

--- a/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
+++ b/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
@@ -220,20 +220,53 @@ fn detect_method_name_position_detects_instance_past_multibyte_char() {
 
 // ---- display-value truncation: char-boundary safety ----------------------
 //
-// `extract_translation_value` and `extract_config_value` both truncated
-// their hover/completion display value with a byte slice (`&s[..47]`). A
-// multibyte character straddling index 47 panicked the whole server — always
-// reachable via any root `lang/` translation value over 50 bytes with a
-// multibyte char at the boundary, not just an exotic namespaced-catalogue
-// case.
+// `extract_translation_value` and `extract_config_value` both used to
+// truncate their hover/completion display value with a byte slice
+// (`&s[..47]`), which panicked whenever a multibyte character straddled
+// index 47 — reachable via any root `lang/` translation value over 50 bytes
+// with a multibyte char at the boundary, not just an exotic namespaced-
+// catalogue case. Both now delegate to the shared, char-safe
+// `display_truncate::truncate_for_display` (also used by `hover.rs`), so the
+// limit is 200 chars, not 47/50, and the ellipsis is the single `…` char.
 
 #[test]
 fn translation_value_truncation_is_char_boundary_safe() {
-    // 46 ASCII chars, then a two-byte 'č' occupying bytes 46..48, then
-    // padding past the 50-char threshold.
-    let value: String = "a".repeat(46) + "čééééééé";
+    // 199 ASCII chars, then a two-byte 'č', then padding well past the
+    // shared 200-char limit. Truncation operates on chars, not bytes, so the
+    // multibyte char at the cut point can't panic.
+    let value: String = "a".repeat(199) + "č" + &"é".repeat(50);
     let line = format!("'key' => '{}',", value);
     let display = LaravelLanguageServer::extract_translation_value(&line);
-    assert!(display.ends_with("..."));
-    assert!(display.chars().count() <= 50);
+    assert!(display.ends_with('…'));
+    assert_eq!(display.chars().count(), 201); // 200 + ellipsis
+}
+
+#[test]
+fn translation_value_under_two_hundred_chars_is_not_truncated() {
+    // A 30-char/60-byte Czech string used to get truncated (and could
+    // panic) under the old byte-slice/50-char threshold; the shared
+    // 200-char, char-based limit now passes it through untouched.
+    let value = "č".repeat(30);
+    let line = format!("'key' => '{}',", value);
+    let display = LaravelLanguageServer::extract_translation_value(&line);
+    assert_eq!(display, value);
+}
+
+#[test]
+fn config_value_truncation_is_char_boundary_safe() {
+    let value: String = "a".repeat(199) + "ü" + &"ö".repeat(50);
+    let line = format!("'key' => '{}',", value);
+    let env_vars = std::collections::HashMap::new();
+    let display = LaravelLanguageServer::extract_config_value(&line, &env_vars);
+    assert!(display.ends_with('…'));
+    assert_eq!(display.chars().count(), 201); // 200 + ellipsis
+}
+
+#[test]
+fn config_value_under_two_hundred_chars_is_not_truncated() {
+    let value = "ü".repeat(30);
+    let line = format!("'key' => '{}',", value);
+    let env_vars = std::collections::HashMap::new();
+    let display = LaravelLanguageServer::extract_config_value(&line, &env_vars);
+    assert_eq!(display, value);
 }

--- a/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
+++ b/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
@@ -217,3 +217,23 @@ fn detect_method_name_position_detects_instance_past_multibyte_char() {
     let ctx = detect_method_name_position(line, cursor).expect("instance `->` position");
     assert_eq!(ctx, MethodNameContext::Instance);
 }
+
+// ---- display-value truncation: char-boundary safety ----------------------
+//
+// `extract_translation_value` and `extract_config_value` both truncated
+// their hover/completion display value with a byte slice (`&s[..47]`). A
+// multibyte character straddling index 47 panicked the whole server — always
+// reachable via any root `lang/` translation value over 50 bytes with a
+// multibyte char at the boundary, not just an exotic namespaced-catalogue
+// case.
+
+#[test]
+fn translation_value_truncation_is_char_boundary_safe() {
+    // 46 ASCII chars, then a two-byte 'č' occupying bytes 46..48, then
+    // padding past the 50-char threshold.
+    let value: String = "a".repeat(46) + "čééééééé";
+    let line = format!("'key' => '{}',", value);
+    let display = LaravelLanguageServer::extract_translation_value(&line);
+    assert!(display.ends_with("..."));
+    assert!(display.chars().count() <= 50);
+}


### PR DESCRIPTION
`extract_translation_value` and the config display-value path both truncate long values with a byte slice:

```rust
format!("{}...", &unquoted[..47])
```

Byte index 47 landing inside a multibyte character panics (`byte index 47 is not a char boundary; it is inside 'č'`) — and because this runs during completion enumeration, the panic takes down the whole server. Reachable on any project whose `lang/` catalogue (or a config value) contains a value longer than 50 bytes with a non-ASCII character straddling the boundary — i.e. essentially every non-English Laravel project is one translation string away from a dead server.

Both sites now truncate by characters (`chars().take(47)`), matching what `hover::truncate_for_display` already does. Regression test included with a `č` placed exactly on the old panic boundary.

Full test suite green on all targets.
