### PR TITLE
fix: 🐛 capture view() references inside conditional first arguments

### DIFF
--- a/laravel-lsp/queries/php.scm
+++ b/laravel-lsp/queries/php.scm
@@ -41,6 +41,41 @@
   (#eq? @function_name "view"))
 
 ; ============================================================================
+; Pattern 1a: view($cond ? 'a' : 'b') - conditional/coalesce/match first argument
+; ============================================================================
+; Matches: view($this->template === 'button' ? 'ns::button' : 'ns::form')
+;          view($view ?? 'ns::fallback')
+;          view(match ($type) { 'a' => 'ns::a', default => 'ns::b' })
+;
+; The first argument isn't a plain string literal, so Pattern 1 above never
+; fires. Instead of enumerating every literal position (ternary nesting,
+; match arm count, etc. are unbounded), capture the whole first-argument
+; expression and let the Rust-side walker in `extract_all_php_patterns`
+; recurse into it, emitting one ViewMatch per string literal it finds.
+
+(function_call_expression
+  function: (name) @function_name
+  arguments: (arguments
+    (argument
+      (conditional_expression) @view_conditional_arg))
+  (#eq? @function_name "view"))
+
+(function_call_expression
+  function: (name) @function_name
+  arguments: (arguments
+    (argument
+      (binary_expression
+        operator: "??") @view_conditional_arg))
+  (#eq? @function_name "view"))
+
+(function_call_expression
+  function: (name) @function_name
+  arguments: (arguments
+    (argument
+      (match_expression) @view_conditional_arg))
+  (#eq? @function_name "view"))
+
+; ============================================================================
 ; Pattern 2: View::make('view.name') static method calls
 ; ============================================================================
 ; Matches: View::make('users.profile')

--- a/laravel-lsp/queries/php.scm
+++ b/laravel-lsp/queries/php.scm
@@ -41,17 +41,26 @@
   (#eq? @function_name "view"))
 
 ; ============================================================================
-; Pattern 1a: view($cond ? 'a' : 'b') - conditional/coalesce/match first argument
+; Pattern 1a: view($cond ? 'a' : 'b') - expression first argument
 ; ============================================================================
 ; Matches: view($this->template === 'button' ? 'ns::button' : 'ns::form')
 ;          view($view ?? 'ns::fallback')
 ;          view(match ($type) { 'a' => 'ns::a', default => 'ns::b' })
+;          view(($cond ? 'pages.a' : 'pages.b'))
+;          view(('pages.home')) - a parenthesized literal also hides the
+;          string from Pattern 1, which requires it as a direct child of
+;          the argument
 ;
 ; The first argument isn't a plain string literal, so Pattern 1 above never
 ; fires. Instead of enumerating every literal position (ternary nesting,
 ; match arm count, etc. are unbounded), capture the whole first-argument
 ; expression and let the Rust-side walker in `extract_all_php_patterns`
 ; recurse into it, emitting one ViewMatch per string literal it finds.
+;
+; The same four expression kinds are captured at every view entry point:
+; Pattern 2a (View::make), Pattern 3a (Route::view), Pattern 4a
+; (Volt::route). The second-argument sites use @route_view_conditional_arg
+; so the walker marks their names as route views.
 
 (function_call_expression
   function: (name) @function_name
@@ -73,6 +82,13 @@
   arguments: (arguments
     (argument
       (match_expression) @view_conditional_arg))
+  (#eq? @function_name "view"))
+
+(function_call_expression
+  function: (name) @function_name
+  arguments: (arguments
+    (argument
+      (parenthesized_expression) @view_conditional_arg))
   (#eq? @function_name "view"))
 
 ; ============================================================================
@@ -132,6 +148,87 @@
   (#eq? @method_name "make"))
 
 ; ============================================================================
+; Pattern 2a: View::make($cond ? 'a' : 'b') - expression first argument
+; ============================================================================
+; Same blind spot as Pattern 1a, same fix: capture the whole expression
+; (ternary, `??`, match, or parenthesized) and let the Rust-side walker
+; emit one ViewMatch per nested string literal.
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument
+      (conditional_expression) @view_conditional_arg))
+  (#eq? @class_name "View")
+  (#eq? @method_name "make"))
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument
+      (binary_expression
+        operator: "??") @view_conditional_arg))
+  (#eq? @class_name "View")
+  (#eq? @method_name "make"))
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument
+      (match_expression) @view_conditional_arg))
+  (#eq? @class_name "View")
+  (#eq? @method_name "make"))
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument
+      (parenthesized_expression) @view_conditional_arg))
+  (#eq? @class_name "View")
+  (#eq? @method_name "make"))
+
+(scoped_call_expression
+  scope: (qualified_name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument
+      (conditional_expression) @view_conditional_arg))
+  (#match? @class_name ".*View$")
+  (#eq? @method_name "make"))
+
+(scoped_call_expression
+  scope: (qualified_name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument
+      (binary_expression
+        operator: "??") @view_conditional_arg))
+  (#match? @class_name ".*View$")
+  (#eq? @method_name "make"))
+
+(scoped_call_expression
+  scope: (qualified_name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument
+      (match_expression) @view_conditional_arg))
+  (#match? @class_name ".*View$")
+  (#eq? @method_name "make"))
+
+(scoped_call_expression
+  scope: (qualified_name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument
+      (parenthesized_expression) @view_conditional_arg))
+  (#match? @class_name ".*View$")
+  (#eq? @method_name "make"))
+
+; ============================================================================
 ; Pattern 3: Route::view('/path', 'view.name') - Route view registration
 ; ============================================================================
 ; Matches: Route::view('/home', 'welcome')
@@ -170,6 +267,55 @@
   (#eq? @method_name "view"))
 
 ; ============================================================================
+; Pattern 3a: Route::view('/path', $cond ? 'a' : 'b') - expression second argument
+; ============================================================================
+; Same treatment as Pattern 1a for the SECOND argument. The bare (argument)
+; placeholder keeps the positional constraint - without it a ternary in the
+; route-path argument would be captured and its strings treated as view
+; names. @route_view_conditional_arg tells the walker these are route views.
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument)
+    (argument
+      (conditional_expression) @route_view_conditional_arg))
+  (#eq? @class_name "Route")
+  (#eq? @method_name "view"))
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument)
+    (argument
+      (binary_expression
+        operator: "??") @route_view_conditional_arg))
+  (#eq? @class_name "Route")
+  (#eq? @method_name "view"))
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument)
+    (argument
+      (match_expression) @route_view_conditional_arg))
+  (#eq? @class_name "Route")
+  (#eq? @method_name "view"))
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument)
+    (argument
+      (parenthesized_expression) @route_view_conditional_arg))
+  (#eq? @class_name "Route")
+  (#eq? @method_name "view"))
+
+; ============================================================================
 ; Pattern 4: Volt::route('/path', 'view.name') - Volt route registration
 ; ============================================================================
 ; Matches: Volt::route('/home', 'welcome')
@@ -198,6 +344,52 @@
     (argument
       (encapsed_string
         (string_content) @route_view_name)))
+  (#eq? @class_name "Volt")
+  (#eq? @method_name "route"))
+
+; ============================================================================
+; Pattern 4a: Volt::route('/path', $cond ? 'a' : 'b') - expression second argument
+; ============================================================================
+; Same as Pattern 3a - Volt view names are route views too.
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument)
+    (argument
+      (conditional_expression) @route_view_conditional_arg))
+  (#eq? @class_name "Volt")
+  (#eq? @method_name "route"))
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument)
+    (argument
+      (binary_expression
+        operator: "??") @route_view_conditional_arg))
+  (#eq? @class_name "Volt")
+  (#eq? @method_name "route"))
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument)
+    (argument
+      (match_expression) @route_view_conditional_arg))
+  (#eq? @class_name "Volt")
+  (#eq? @method_name "route"))
+
+(scoped_call_expression
+  scope: (name) @class_name
+  name: (name) @method_name
+  arguments: (arguments
+    (argument)
+    (argument
+      (parenthesized_expression) @route_view_conditional_arg))
   (#eq? @class_name "Volt")
   (#eq? @method_name "route"))
 

--- a/laravel-lsp/src/queries.rs
+++ b/laravel-lsp/src/queries.rs
@@ -538,13 +538,19 @@ pub fn extract_all_php_patterns<'a>(
                     is_route_view: true,
                 });
             }
-            // `view($cond ? 'a' : 'b')` / `view($x ?? 'fallback')` /
-            // `view(match (...) { ... })` — the captured node is the whole
-            // first-argument expression (see Pattern 1a in php.scm); walk it
-            // for every nested string literal, each becoming its own
-            // ViewMatch at that literal's own position.
+            // `view($cond ? 'a' : 'b')` / `View::make($x ?? 'fallback')` /
+            // `view(match (...) { ... })` / `view(('name'))` — the captured
+            // node is a whole argument expression (Patterns 1a/2a/3a/4a in
+            // php.scm); walk it for every nested string literal, each
+            // becoming its own ViewMatch at that literal's own position.
+            // `route_view_conditional_arg` is the same capture at the
+            // second-argument sites (`Route::view`, `Volt::route`), whose
+            // names are route views.
             "view_conditional_arg" => {
-                collect_nested_view_literals(node, source_bytes, &mut result.views);
+                collect_nested_view_literals(node, source_bytes, &mut result.views, false);
+            }
+            "route_view_conditional_arg" => {
+                collect_nested_view_literals(node, source_bytes, &mut result.views, true);
             }
 
             // Inertia page patterns (issue #10). `inertia_page` covers the
@@ -1312,23 +1318,23 @@ fn is_conditionally_nested(node: tree_sitter::Node, scope: tree_sitter::Node) ->
 
 /// The content of `node` if it is a plain (non-interpolated) string literal —
 /// single-quoted `string` or a double-quoted `encapsed_string` whose only
-/// named child is one `string_content`. `None` for everything else.
+/// named child is one `string_content`. `Some("")` for an empty literal,
+/// `None` for everything else. The literal check itself lives in
+/// [`plain_string_content`]; this wraps it for callers that want the value
+/// rather than the node.
 fn literal_string_value(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
     if node.kind() != "string" && node.kind() != "encapsed_string" {
         return None;
     }
-    match node.named_child_count() {
-        0 => Some(String::new()),
-        1 => {
-            let child = node.named_child(0)?;
-            if child.kind() == "string_content" {
-                Some(child.utf8_text(source).ok()?.to_string())
-            } else {
-                None
-            }
-        }
-        _ => None,
+    if node.named_child_count() == 0 {
+        return Some(String::new());
     }
+    Some(
+        plain_string_content(node)?
+            .utf8_text(source)
+            .ok()?
+            .to_string(),
+    )
 }
 
 /// The `string_content` node inside `node`, if `node` is a plain
@@ -1350,10 +1356,12 @@ fn plain_string_content(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
     (child.kind() == "string_content").then_some(child)
 }
 
-/// Collect every plain string literal nested within `node` — a `view()`
-/// call's first-argument expression captured as `view_conditional_arg` in
-/// php.scm (a ternary, `??`, or `match`) — one [`ViewMatch`] per literal at
-/// that literal's own position.
+/// Collect every plain string literal nested within `node` — a view
+/// entry point's argument expression captured as `view_conditional_arg` or
+/// `route_view_conditional_arg` in php.scm (a ternary, `??`, `match`, or
+/// parenthesized expression) — one [`ViewMatch`] per literal at that
+/// literal's own position. `is_route_view` marks names from the
+/// second-argument sites (`Route::view`, `Volt::route`) as route views.
 ///
 /// Only descends into VALUE positions, never the expression being tested:
 /// a ternary's `condition`, a `??`'s left-hand operand, and a match arm's
@@ -1365,6 +1373,7 @@ fn collect_nested_view_literals<'a>(
     node: tree_sitter::Node,
     source: &'a [u8],
     out: &mut Vec<ViewMatch<'a>>,
+    is_route_view: bool,
 ) {
     match node.kind() {
         "string" | "encapsed_string" => {
@@ -1384,7 +1393,7 @@ fn collect_nested_view_literals<'a>(
                         row: start.row,
                         column: start.column,
                         end_column: end.column,
-                        is_route_view: false,
+                        is_route_view,
                     });
                 }
             }
@@ -1393,10 +1402,10 @@ fn collect_nested_view_literals<'a>(
         // for elvis, so only `alternative` is guaranteed.
         "conditional_expression" => {
             if let Some(body) = node.child_by_field_name("body") {
-                collect_nested_view_literals(body, source, out);
+                collect_nested_view_literals(body, source, out, is_route_view);
             }
             if let Some(alternative) = node.child_by_field_name("alternative") {
-                collect_nested_view_literals(alternative, source, out);
+                collect_nested_view_literals(alternative, source, out, is_route_view);
             }
         }
         // `$x ?? 'fallback'` — only the fallback (right operand) is a
@@ -1407,31 +1416,31 @@ fn collect_nested_view_literals<'a>(
                 .is_some_and(|op| op.kind() == "??") =>
         {
             if let Some(right) = node.child_by_field_name("right") {
-                collect_nested_view_literals(right, source, out);
+                collect_nested_view_literals(right, source, out, is_route_view);
             }
         }
         "match_expression" => {
             if let Some(body) = node.child_by_field_name("body") {
-                collect_nested_view_literals(body, source, out);
+                collect_nested_view_literals(body, source, out, is_route_view);
             }
         }
         "match_block" => {
             let mut cursor = node.walk();
             for arm in node.named_children(&mut cursor) {
-                collect_nested_view_literals(arm, source, out);
+                collect_nested_view_literals(arm, source, out, is_route_view);
             }
         }
         // `'a', 'b' => 'x'` / `default => 'y'` — only `return_expression`
         // (the arm's VALUE), never `conditional_expressions` (the keys).
         "match_conditional_expression" | "match_default_expression" => {
             if let Some(value) = node.child_by_field_name("return_expression") {
-                collect_nested_view_literals(value, source, out);
+                collect_nested_view_literals(value, source, out, is_route_view);
             }
         }
         // Transparently unwrap `($cond ? 'a' : 'b')`.
         "parenthesized_expression" => {
             if let Some(inner) = node.named_child(0) {
-                collect_nested_view_literals(inner, source, out);
+                collect_nested_view_literals(inner, source, out, is_route_view);
             }
         }
         _ => {}

--- a/laravel-lsp/src/queries.rs
+++ b/laravel-lsp/src/queries.rs
@@ -538,6 +538,14 @@ pub fn extract_all_php_patterns<'a>(
                     is_route_view: true,
                 });
             }
+            // `view($cond ? 'a' : 'b')` / `view($x ?? 'fallback')` /
+            // `view(match (...) { ... })` — the captured node is the whole
+            // first-argument expression (see Pattern 1a in php.scm); walk it
+            // for every nested string literal, each becoming its own
+            // ViewMatch at that literal's own position.
+            "view_conditional_arg" => {
+                collect_nested_view_literals(node, source_bytes, &mut result.views);
+            }
 
             // Inertia page patterns (issue #10). `inertia_page` covers the
             // helper (`inertia('Page')`) and facade (`Inertia::render('Page')`)
@@ -1320,6 +1328,113 @@ fn literal_string_value(node: tree_sitter::Node, source: &[u8]) -> Option<String
             }
         }
         _ => None,
+    }
+}
+
+/// The `string_content` node inside `node`, if `node` is a plain
+/// (non-interpolated) string literal — a single-quoted `string` or
+/// double-quoted `encapsed_string` whose only named child is exactly one
+/// `string_content`. `None` for everything else, including an empty literal
+/// (`''`, no content node to position at) and an interpolated string. Unlike
+/// [`literal_string_value`], this returns the AST node rather than the
+/// value, so callers that need both text AND position read them off the
+/// same node.
+fn plain_string_content(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    if node.kind() != "string" && node.kind() != "encapsed_string" {
+        return None;
+    }
+    if node.named_child_count() != 1 {
+        return None;
+    }
+    let child = node.named_child(0)?;
+    (child.kind() == "string_content").then_some(child)
+}
+
+/// Collect every plain string literal nested within `node` — a `view()`
+/// call's first-argument expression captured as `view_conditional_arg` in
+/// php.scm (a ternary, `??`, or `match`) — one [`ViewMatch`] per literal at
+/// that literal's own position.
+///
+/// Only descends into VALUE positions, never the expression being tested:
+/// a ternary's `condition`, a `??`'s left-hand operand, and a match arm's
+/// key list (`'a', 'b' => …`) are skipped — a literal sitting there isn't a
+/// view name, it's a discriminant (`view($this->x === 'button' ? … : …)`
+/// must not capture `'button'`, and `match ($t) { 'a' => 'x', … }` must not
+/// capture `'a'`).
+fn collect_nested_view_literals<'a>(
+    node: tree_sitter::Node,
+    source: &'a [u8],
+    out: &mut Vec<ViewMatch<'a>>,
+) {
+    match node.kind() {
+        "string" | "encapsed_string" => {
+            // Recursion stops AT the string node rather than descending
+            // into it, so an interpolated fragment inside an arm
+            // (`"ns::{$x}"`) is skipped instead of yielding a garbage
+            // partial name — the same rule Pattern 1 applies to a direct
+            // `view()` argument.
+            if let Some(content) = plain_string_content(node) {
+                if let Ok(text) = content.utf8_text(source) {
+                    let start = content.start_position();
+                    let end = content.end_position();
+                    out.push(ViewMatch {
+                        view_name: text,
+                        byte_start: content.start_byte(),
+                        byte_end: content.end_byte(),
+                        row: start.row,
+                        column: start.column,
+                        end_column: end.column,
+                        is_route_view: false,
+                    });
+                }
+            }
+        }
+        // `$cond ? then : else` / elvis `$cond ?: else` — `body` is absent
+        // for elvis, so only `alternative` is guaranteed.
+        "conditional_expression" => {
+            if let Some(body) = node.child_by_field_name("body") {
+                collect_nested_view_literals(body, source, out);
+            }
+            if let Some(alternative) = node.child_by_field_name("alternative") {
+                collect_nested_view_literals(alternative, source, out);
+            }
+        }
+        // `$x ?? 'fallback'` — only the fallback (right operand) is a
+        // resolvable view name.
+        "binary_expression"
+            if node
+                .child_by_field_name("operator")
+                .is_some_and(|op| op.kind() == "??") =>
+        {
+            if let Some(right) = node.child_by_field_name("right") {
+                collect_nested_view_literals(right, source, out);
+            }
+        }
+        "match_expression" => {
+            if let Some(body) = node.child_by_field_name("body") {
+                collect_nested_view_literals(body, source, out);
+            }
+        }
+        "match_block" => {
+            let mut cursor = node.walk();
+            for arm in node.named_children(&mut cursor) {
+                collect_nested_view_literals(arm, source, out);
+            }
+        }
+        // `'a', 'b' => 'x'` / `default => 'y'` — only `return_expression`
+        // (the arm's VALUE), never `conditional_expressions` (the keys).
+        "match_conditional_expression" | "match_default_expression" => {
+            if let Some(value) = node.child_by_field_name("return_expression") {
+                collect_nested_view_literals(value, source, out);
+            }
+        }
+        // Transparently unwrap `($cond ? 'a' : 'b')`.
+        "parenthesized_expression" => {
+            if let Some(inner) = node.named_child(0) {
+                collect_nested_view_literals(inner, source, out);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/laravel-lsp/src/queries/tests/column_positions.rs
+++ b/laravel-lsp/src/queries/tests/column_positions.rs
@@ -44,6 +44,39 @@ fn view_column_positions() {
 }
 
 #[test]
+fn view_ternary_argument_column_positions() {
+    // view($x ? 'a' : 'b')
+    // Position: 0         1         2
+    //           0123456789012345678901234567
+    //           <?php view($x ? 'a' : 'b');
+    // Each ternary arm's position points at ITS OWN content, not the call
+    // or the conditional expression as a whole.
+    let php_code = "<?php view($x ? 'a' : 'b');";
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    assert_eq!(patterns.views.len(), 2, "got {:?}", patterns.views);
+
+    let a = patterns
+        .views
+        .iter()
+        .find(|v| v.view_name == "a")
+        .expect("should capture the 'then' arm");
+    assert_eq!(a.column, 17, "'a' content starts at column 17");
+    assert_eq!(a.end_column, 18, "'a' content ends at column 18");
+
+    let b = patterns
+        .views
+        .iter()
+        .find(|v| v.view_name == "b")
+        .expect("should capture the 'else' arm");
+    assert_eq!(b.column, 23, "'b' content starts at column 23");
+    assert_eq!(b.end_column, 24, "'b' content ends at column 24");
+}
+
+#[test]
 fn env_column_positions() {
     // env('APP_NAME')
     // Position: 0         1         2

--- a/laravel-lsp/src/queries/tests/php_pattern_extraction.rs
+++ b/laravel-lsp/src/queries/tests/php_pattern_extraction.rs
@@ -47,6 +47,88 @@ fn test_extract_all_php_patterns_views() {
 }
 
 #[test]
+fn test_extract_all_php_patterns_views_ternary_first_argument() {
+    // `view()`'s first argument isn't a plain string literal — Pattern 1
+    // never fires — but every arm is still a resolvable view name, so each
+    // one gets its own ViewMatch (mirrors the real fixture in
+    // GuestTestPage::render()).
+    let php_code = r#"<?php
+    return view($this->template === 'button' ? 'common-google::test-button' : 'common-google::test-form');
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    let view_names: Vec<&str> = patterns.views.iter().map(|m| m.view_name).collect();
+    assert_eq!(
+        patterns.views.len(),
+        2,
+        "both ternary arms should be captured, got {view_names:?}"
+    );
+    assert!(view_names.contains(&"common-google::test-button"));
+    assert!(view_names.contains(&"common-google::test-form"));
+    assert!(
+        patterns.views.iter().all(|v| !v.is_route_view),
+        "ternary arms of view() are not Route::view()"
+    );
+}
+
+#[test]
+fn test_extract_all_php_patterns_views_null_coalesce_first_argument() {
+    let php_code = r#"<?php
+    return view($override ?? 'pages.default');
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    assert_eq!(patterns.views.len(), 1, "got {:?}", patterns.views);
+    assert_eq!(patterns.views[0].view_name, "pages.default");
+}
+
+#[test]
+fn test_extract_all_php_patterns_views_match_first_argument() {
+    let php_code = r#"<?php
+    return view(match ($type) {
+        'a' => 'pages.a',
+        default => 'pages.b',
+    });
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    let view_names: Vec<&str> = patterns.views.iter().map(|m| m.view_name).collect();
+    assert_eq!(patterns.views.len(), 2, "got {view_names:?}");
+    assert!(view_names.contains(&"pages.a"));
+    assert!(view_names.contains(&"pages.b"));
+}
+
+#[test]
+fn test_extract_all_php_patterns_views_conditional_argument_skips_interpolated_arm() {
+    // An interpolated arm (`"ns::{$x}"`) isn't a resolvable literal — same
+    // rule Pattern 1 applies to a direct `view()` argument — so only the
+    // plain-literal arm is captured.
+    let php_code = r#"<?php
+    return view($cond ? "ns::{$dynamic}" : 'pages.fallback');
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    assert_eq!(patterns.views.len(), 1, "got {:?}", patterns.views);
+    assert_eq!(patterns.views[0].view_name, "pages.fallback");
+}
+
+#[test]
 fn test_extract_all_php_patterns_env() {
     let php_code = r#"<?php
     $name = env('APP_NAME', 'Laravel');

--- a/laravel-lsp/src/queries/tests/php_pattern_extraction.rs
+++ b/laravel-lsp/src/queries/tests/php_pattern_extraction.rs
@@ -129,6 +129,160 @@ fn test_extract_all_php_patterns_views_conditional_argument_skips_interpolated_a
 }
 
 #[test]
+fn test_extract_all_php_patterns_views_elvis_first_argument() {
+    // Elvis `$x ?: 'fallback'` parses as a conditional_expression with NO
+    // `body` field — this exercises the walker's absent-body path.
+    let php_code = r#"<?php
+    return view($x ?: 'pages.fallback');
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    assert_eq!(patterns.views.len(), 1, "got {:?}", patterns.views);
+    assert_eq!(patterns.views[0].view_name, "pages.fallback");
+}
+
+#[test]
+fn test_extract_all_php_patterns_views_parenthesized_conditional_argument() {
+    // The outer parentheses make the argument's direct child a
+    // parenthesized_expression, hiding the conditional from the bare
+    // conditional_expression capture.
+    let php_code = r#"<?php
+    return view(($cond ? 'pages.a' : 'pages.b'));
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    let view_names: Vec<&str> = patterns.views.iter().map(|m| m.view_name).collect();
+    assert_eq!(patterns.views.len(), 2, "got {view_names:?}");
+    assert!(view_names.contains(&"pages.a"));
+    assert!(view_names.contains(&"pages.b"));
+}
+
+#[test]
+fn test_extract_all_php_patterns_views_parenthesized_literal_argument() {
+    // A plain literal wrapped in parentheses is hidden from Pattern 1 too —
+    // it requires the string as a DIRECT child of the argument.
+    let php_code = r#"<?php
+    return view(('pages.home'));
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    assert_eq!(patterns.views.len(), 1, "got {:?}", patterns.views);
+    assert_eq!(patterns.views[0].view_name, "pages.home");
+    assert!(!patterns.views[0].is_route_view);
+}
+
+#[test]
+fn test_extract_all_php_patterns_view_make_ternary_first_argument() {
+    let php_code = r#"<?php
+    return View::make($compact ? 'widgets.small' : 'widgets.large');
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    let view_names: Vec<&str> = patterns.views.iter().map(|m| m.view_name).collect();
+    assert_eq!(patterns.views.len(), 2, "got {view_names:?}");
+    assert!(view_names.contains(&"widgets.small"));
+    assert!(view_names.contains(&"widgets.large"));
+    assert!(patterns.views.iter().all(|v| !v.is_route_view));
+}
+
+#[test]
+fn test_extract_all_php_patterns_view_make_qualified_null_coalesce_argument() {
+    let php_code = r#"<?php
+    return \Illuminate\Support\Facades\View::make($override ?? 'pages.default');
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    assert_eq!(patterns.views.len(), 1, "got {:?}", patterns.views);
+    assert_eq!(patterns.views[0].view_name, "pages.default");
+}
+
+#[test]
+fn test_extract_all_php_patterns_route_view_conditional_second_argument() {
+    // The ternary sits in the SECOND argument (the view name). The bare
+    // (argument) placeholder in the query keeps the route-path argument out:
+    // a ternary in the path must not be captured, so exactly two names come
+    // back and both are the view-argument arms.
+    let php_code = r#"<?php
+    Route::view($legacy ? '/old-home' : '/home', $dark ? 'home.dark' : 'home.light');
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    let view_names: Vec<&str> = patterns.views.iter().map(|m| m.view_name).collect();
+    assert_eq!(
+        patterns.views.len(),
+        2,
+        "only the view-argument arms should be captured, got {view_names:?}"
+    );
+    assert!(view_names.contains(&"home.dark"));
+    assert!(view_names.contains(&"home.light"));
+    assert!(
+        patterns.views.iter().all(|v| v.is_route_view),
+        "Route::view names are route views"
+    );
+}
+
+#[test]
+fn test_extract_all_php_patterns_route_view_parenthesized_literal_second_argument() {
+    let php_code = r#"<?php
+    Route::view('/about', ('pages.about'));
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    assert_eq!(patterns.views.len(), 1, "got {:?}", patterns.views);
+    assert_eq!(patterns.views[0].view_name, "pages.about");
+    assert!(patterns.views[0].is_route_view);
+}
+
+#[test]
+fn test_extract_all_php_patterns_volt_route_match_second_argument() {
+    let php_code = r#"<?php
+    Volt::route('/counter', match ($variant) {
+        'v2' => 'counter.v2',
+        default => 'counter.v1',
+    });
+    "#;
+
+    let tree = parse_php(php_code).expect("Should parse PHP");
+    let lang = language_php();
+    let patterns =
+        extract_all_php_patterns(&tree, php_code, &lang).expect("Should extract patterns");
+
+    let view_names: Vec<&str> = patterns.views.iter().map(|m| m.view_name).collect();
+    assert_eq!(patterns.views.len(), 2, "got {view_names:?}");
+    assert!(view_names.contains(&"counter.v2"));
+    assert!(view_names.contains(&"counter.v1"));
+    assert!(patterns.views.iter().all(|v| v.is_route_view));
+}
+
+#[test]
 fn test_extract_all_php_patterns_env() {
     let php_code = r#"<?php
     $name = env('APP_NAME', 'Laravel');


### PR DESCRIPTION
`view()` reference capture only accepts a plain string-literal first argument, so a very common Livewire/controller shape is invisible to goto/hover/diagnostics:

```php
return view($this->template === 'button' ? 'pkg::test-button' : 'pkg::test-form');
```

Neither string is clickable and neither gets a missing-view diagnostic.

Every string literal inside a conditional first argument is now captured as its own view reference with its own position: ternary arms, `??` fallbacks, and `match` arm values. The walker is structure-aware — it descends only into value positions, so the ternary's *condition* literal (`'button'` above) and `match` arm *keys* are correctly not captured as view names.

Covers both extraction paths (the parse-time path and the warming indexer) since they share the extractor. Tests pin the captured set and exact positions for all three expression shapes, including the negative cases.

Full test suite green on all targets.
