### PR TITLE
fix(lsp): recover from mutex poisoning instead of `.lock().unwrap()` on the memoization caches

### DIFF
--- a/laravel-lsp/src/class_locator.rs
+++ b/laravel-lsp/src/class_locator.rs
@@ -79,6 +79,15 @@ struct CacheEntry {
 ///
 /// Bounded `LruCache` behind a `Mutex` (lru mutates on read to reorder;
 /// `spawn_blocking` workers share it, so the lock guards the O(1) get/put only).
+///
+/// Poisoning: every `.lock()` on this cache recovers a poisoned mutex with
+/// `unwrap_or_else(|e| e.into_inner())` instead of panicking, so a panic in one
+/// worker can't permanently disable class resolution for the rest of the
+/// session. That is safe because the worst case of a half-updated entry here is
+/// a stale hit or a briefly-wrong recency ordering, never an incorrect result:
+/// a positive is revalidated on every hit with `exists()` + [`path_within_root`]
+/// and a negative expires after [`NEGATIVE_TTL`], so a stale entry costs at most
+/// one extra walk.
 type LocatorKey = (PathBuf, String, bool);
 type LocatorCache = Mutex<LruCache<LocatorKey, CacheEntry>>;
 fn locator_cache() -> &'static LocatorCache {
@@ -102,16 +111,30 @@ fn locator_cache() -> &'static LocatorCache {
 /// watched `.php` create/delete calls [`invalidate_project`]), so this full
 /// reset is only needed when the caller wants a guaranteed-clean slate.
 pub fn reset_locator_cache() {
-    locator_cache().lock().unwrap().clear();
+    locator_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
 }
 
 /// Canonicalize the project root once per process (canonicalize is a syscall;
 /// the root never changes during a session). Mirrors `ComposerAutoload`'s key
 /// normalization so both caches agree on what "this project" means.
+///
+/// `std::sync::Mutex` guards the `ROOTS` map: the critical section is one short
+/// `entry`/`or_insert_with` and is never held across an `.await`.
+///
+/// Poisoning: the `.lock()` recovers a poisoned mutex with
+/// `unwrap_or_else(|e| e.into_inner())` instead of panicking, so a panic
+/// elsewhere can't permanently break root canonicalization. That is safe
+/// because the worst case of a half-updated entry here is a stale hit — an
+/// entry the panicking thread never finished inserting, so the next call simply
+/// re-canonicalizes — never an incorrect result, since the cached value is a
+/// pure function of its key.
 fn canonical_root(root: &Path) -> PathBuf {
     static ROOTS: OnceLock<Mutex<HashMap<PathBuf, PathBuf>>> = OnceLock::new();
     let roots = ROOTS.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut map = roots.lock().expect("class_locator root cache poisoned");
+    let mut map = roots.lock().unwrap_or_else(|e| e.into_inner());
     map.entry(root.to_path_buf())
         .or_insert_with(|| root.canonicalize().unwrap_or_else(|_| root.to_path_buf()))
         .clone()
@@ -126,7 +149,12 @@ fn canonical_root(root: &Path) -> PathBuf {
 /// Composer/PSR-4 tiers live before reaching here.
 fn cached_walk(class_name: &str, root: &Path, include_vendor: bool) -> Option<PathBuf> {
     let key = (canonical_root(root), class_name.to_string(), include_vendor);
-    if let Some(hit) = locator_cache().lock().unwrap().get(&key).cloned() {
+    if let Some(hit) = locator_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&key)
+        .cloned()
+    {
         match &hit.path {
             // Positive hit — trust it only while the file still exists AND still
             // resolves inside the project root (a swapped-in symlink could now
@@ -156,13 +184,16 @@ fn walk_and_cache(
     include_vendor: bool,
 ) -> Option<PathBuf> {
     let resolved = find_php_class_file_impl(class_name, root, include_vendor);
-    locator_cache().lock().unwrap().put(
-        key.clone(),
-        CacheEntry {
-            path: resolved.clone(),
-            cached_at: std::time::Instant::now(),
-        },
-    );
+    locator_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .put(
+            key.clone(),
+            CacheEntry {
+                path: resolved.clone(),
+                cached_at: std::time::Instant::now(),
+            },
+        );
     resolved
 }
 
@@ -193,7 +224,12 @@ fn walk_and_cache(
 fn live_app_walk(class_name: &str, root: &Path) -> Option<PathBuf> {
     let key = (canonical_root(root), class_name.to_string(), false);
     // Trust a still-valid cached app-positive without re-walking.
-    if let Some(hit) = locator_cache().lock().unwrap().get(&key).cloned() {
+    if let Some(hit) = locator_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&key)
+        .cloned()
+    {
         if let Some(path) = &hit.path {
             if path.exists() && path_within_root(path, root) {
                 return Some(path.clone());
@@ -213,7 +249,7 @@ pub fn invalidate_project(project_root: &Path) {
     // `LruCache` has no `retain`; rebuild without this root's entries. The cache
     // is small (bounded) and invalidation is rare (a watched create/delete), so
     // the O(n) rebuild is fine.
-    let mut cache = locator_cache().lock().unwrap();
+    let mut cache = locator_cache().lock().unwrap_or_else(|e| e.into_inner());
     let keep: Vec<(LocatorKey, CacheEntry)> = cache
         .iter()
         .filter(|((root, _, _), _)| root != &key_root)

--- a/laravel-lsp/src/composer_autoload.rs
+++ b/laravel-lsp/src/composer_autoload.rs
@@ -363,6 +363,19 @@ impl ComposerAutoload {
     /// instance because Composer rarely changes during an editing session
     /// — when it does (e.g. `composer require ...`), the user typically
     /// restarts the editor or reloads the extension anyway.
+    ///
+    /// `std::sync::Mutex` guards the map: both critical sections are one short
+    /// `HashMap` get/insert and neither is held across the load or an `.await`.
+    ///
+    /// Poisoning: both `.lock()` calls recover a poisoned mutex with
+    /// `unwrap_or_else(|e| e.into_inner())` instead of panicking, so a panic
+    /// elsewhere can't permanently break every PSR-4 lookup. That is safe
+    /// because the worst case of a half-updated entry here is a stale hit — an
+    /// entry the panicking thread never finished inserting, so the next call
+    /// rebuilds and interns a second `&'static ComposerAutoload` for that root,
+    /// exactly the harmless duplicate the race note below already accepts —
+    /// never an incorrect result, since each interned value is immutable and
+    /// derived from the same `vendor/composer` files.
     pub fn for_project(project_root: &Path) -> &'static ComposerAutoload {
         static CACHE: OnceLock<Mutex<HashMap<PathBuf, &'static ComposerAutoload>>> =
             OnceLock::new();
@@ -374,7 +387,7 @@ impl ComposerAutoload {
 
         // Fast path: already cached.
         {
-            let map = cache.lock().expect("composer_autoload cache poisoned");
+            let map = cache.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(found) = map.get(&key) {
                 return found;
             }
@@ -384,7 +397,7 @@ impl ComposerAutoload {
         // cache lives for the entire process lifetime — leaks bounded by
         // the number of distinct projects ever opened.
         let loaded = Box::leak(Box::new(ComposerAutoload::load(project_root)));
-        let mut map = cache.lock().expect("composer_autoload cache poisoned");
+        let mut map = cache.lock().unwrap_or_else(|e| e.into_inner());
         // Race-safe: if another thread already inserted while we built,
         // drop ours and use theirs. (We can't free the leak, but a
         // duplicate static autoload is harmless.)

--- a/laravel-lsp/src/laravel_introspector/chain.rs
+++ b/laravel-lsp/src/laravel_introspector/chain.rs
@@ -120,6 +120,14 @@ struct ParsedClassFile {
 /// read (it promotes the touched entry to most-recently-used), and `analyze`
 /// runs on the parallel `spawn_blocking` index workers — the lock is held only
 /// for the O(1) get/put, never across the parse.
+///
+/// Poisoning: every `.lock()` on this cache recovers a poisoned mutex with
+/// `unwrap_or_else(|e| e.into_inner())` instead of panicking, so a panic in one
+/// index worker can't permanently disable the memo for the rest of the session.
+/// That is safe because the worst case of a half-updated entry here is a stale
+/// hit or a briefly-wrong recency ordering, never an incorrect result: every
+/// lookup re-stats the file and rebuilds on a changed [`FileStamp`], so a stale
+/// entry costs at most one extra read + parse.
 type ParsedCache = Mutex<LruCache<PathBuf, (FileStamp, Arc<ParsedClassFile>)>>;
 fn parsed_file_cache() -> &'static ParsedCache {
     static CACHE: OnceLock<ParsedCache> = OnceLock::new();
@@ -141,7 +149,10 @@ fn parsed_file_cache() -> &'static ParsedCache {
 /// rebuilds on a changed [`FileStamp`] — so this full reset is only needed
 /// when the caller wants a guaranteed-clean slate.
 pub fn reset_parsed_file_cache() {
-    parsed_file_cache().lock().unwrap().clear();
+    parsed_file_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
 }
 
 /// Read + parse `path` once (structure + use-aliases), memoized and revalidated
@@ -154,7 +165,11 @@ fn parsed_class_file(path: &Path) -> Option<Arc<ParsedClassFile>> {
     let stamp = FileStamp::of(path);
     if let Some(stamp) = stamp {
         // Scope the lock to the O(1) lookup — never held across the parse below.
-        if let Some((cached_stamp, parsed)) = parsed_file_cache().lock().unwrap().get(path) {
+        if let Some((cached_stamp, parsed)) = parsed_file_cache()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(path)
+        {
             if *cached_stamp == stamp {
                 return Some(parsed.clone());
             }
@@ -181,7 +196,7 @@ fn parsed_class_file(path: &Path) -> Option<Arc<ParsedClassFile>> {
     if let Some(stamp) = stamp {
         parsed_file_cache()
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .put(path.to_path_buf(), (stamp, parsed.clone()));
     }
     Some(parsed)

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2108,6 +2108,16 @@ struct LaravelLanguageServer {
     /// `std::sync::Mutex`, not `RwLock`: `lru` mutates on read to reorder
     /// recency, and every critical section is a short map op (same rationale
     /// as the `class_locator` cache).
+    ///
+    /// Poisoning: every `.lock()` on this cache recovers a poisoned mutex with
+    /// `unwrap_or_else(|e| e.into_inner())` instead of panicking, so a panic
+    /// anywhere else in the process can't permanently disable this cache. That
+    /// is safe because the worst case of a half-updated entry here is a stale
+    /// hit or a briefly-wrong recency ordering — a vendor path recorded whose
+    /// eviction ripple never ran, so one file's own magic-member references go
+    /// missing until the next re-open or save re-indexes it — never an
+    /// incorrect result, since the cache stores only session bookkeeping and
+    /// resolution always re-derives from Salsa.
     vendor_open_magic_lru: Arc<std::sync::Mutex<lru::LruCache<PathBuf, ()>>>,
     /// Dominant Inertia page extension (`vue` / `tsx` / `jsx` / `svelte`),
     /// detected once at startup by counting files under `resources/js/Pages/`.
@@ -6987,7 +6997,10 @@ impl LaravelLanguageServer {
     /// simply go missing again until the next re-open or save re-indexes it.
     async fn record_vendor_open_magic(&self, path: &Path) {
         let evicted = {
-            let mut lru = self.vendor_open_magic_lru.lock().unwrap();
+            let mut lru = self
+                .vendor_open_magic_lru
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             // `push` returns the displaced pair: the SAME key on a re-open
             // (a recency touch — must not evict the entries we just wrote),
             // or the LRU-oldest entry on overflow.

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -37,6 +37,7 @@ mod livewire_component_resolution;
 mod livewire_tag_navigation_containment;
 mod loop_variable_resolution;
 mod macro_goto_def_handler;
+mod mutex_poison_recovery;
 mod nested_module_root_correction;
 mod query_chain_completion_handler;
 mod rename_integration;

--- a/laravel-lsp/src/tests/mutex_poison_recovery.rs
+++ b/laravel-lsp/src/tests/mutex_poison_recovery.rs
@@ -1,0 +1,142 @@
+//! Lock-poisoning recovery for the `std::sync::Mutex`-guarded memoization
+//! caches (issue #317).
+//!
+//! Not to be confused with `cache_root_poisoning.rs`, which is about a
+//! *persisted on-disk cache* recording a hijacked project root. This module is
+//! about `std::sync::Mutex` **poisoning**: a thread that panics while holding a
+//! `MutexGuard` marks the mutex poisoned forever, so every later `.lock()`
+//! returns `Err`. Under the old `.lock().unwrap()` convention that turned one
+//! transient panic anywhere in the process into a permanently panicking cache
+//! for the rest of the LSP session.
+//!
+//! Every production site now acquires with
+//! `.lock().unwrap_or_else(|e| e.into_inner())`, which takes the guard back out
+//! of the poison error and carries on. These tests pin that behaviour on
+//! `vendor_open_magic_lru` — the only one of the six hardened caches reachable
+//! from a test, because the other five live behind module-private
+//! `OnceLock`/`LazyLock` statics (`class_locator`'s `locator_cache` and
+//! `ROOTS`, `chain`'s `parsed_file_cache`, `vendor_member_prover`'s
+//! `PACKAGE_MEMBER_READS`, `ComposerAutoload::for_project`'s `CACHE`) that hand
+//! out no `Mutex` handle to poison. `vendor_open_magic_lru` is a `Backend`
+//! field, so a test can hold its real guard and panic on it.
+//!
+//! Both tests poison the **real production mutex** (not a stand-in), then check
+//! that recovery yields a cache that still works, not merely a `.lock()` that
+//! didn't panic. The second test drives the recovery through
+//! `record_vendor_open_magic`, the production call site itself, so reverting
+//! that one line back to `.unwrap()` turns this file red.
+
+use crate::LaravelLanguageServer;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower_lsp::LspService;
+
+fn backend() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+fn poisoned_path() -> PathBuf {
+    PathBuf::from("/vendor/acme/pkg/src/PoisonedDuringWrite.php")
+}
+
+/// Poison `backend.vendor_open_magic_lru` for real: a spawned thread takes the
+/// production lock, writes one entry through the live guard, and panics with
+/// the guard still bound.
+///
+/// Returns once the panicking thread has been joined; the caller asserts on the
+/// poison state.
+fn poison_lru(backend: &LaravelLanguageServer) {
+    let lru = Arc::clone(&backend.vendor_open_magic_lru);
+    let handle = std::thread::spawn(move || {
+        let mut guard = lru.lock().expect("the cache is not poisoned yet");
+        // The mutating cache operation has to happen *through the live guard*,
+        // before the panic — that is what leaves the cache "half updated" and
+        // makes recovery meaningful rather than a no-op.
+        guard.push(poisoned_path(), ());
+        // guard still held here
+        panic!("simulated panic while the vendor-open-magic guard is live");
+    });
+
+    assert!(
+        handle.join().is_err(),
+        "the spawned thread must actually unwind — a thread that returned Ok \
+         never poisoned anything and the rest of the test would be vacuous"
+    );
+    assert!(
+        backend.vendor_open_magic_lru.is_poisoned(),
+        "a panic with the guard bound must leave the mutex poisoned — without \
+         this the recovery below would be exercising a healthy lock"
+    );
+}
+
+#[tokio::test]
+async fn poisoned_vendor_lru_is_recovered_and_still_holds_its_invariants() {
+    let backend = backend();
+    poison_lru(&backend);
+
+    // The exact expression every production site now uses.
+    let mut recovered = backend
+        .vendor_open_magic_lru
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    assert!(
+        recovered.peek(&poisoned_path()).is_some(),
+        "the entry written before the panic is still there — recovery hands \
+         back the same cache, it does not reset it"
+    );
+
+    // Not just "the lock opened": the recovered cache still behaves like an LRU.
+    let fresh = PathBuf::from("/vendor/acme/pkg/src/AfterRecovery.php");
+    assert!(
+        recovered.push(fresh.clone(), ()).is_none(),
+        "a fresh insert into the recovered cache displaces nothing"
+    );
+    assert!(
+        recovered.get(&fresh).is_some(),
+        "the freshly inserted entry is retrievable through the recovered guard"
+    );
+    assert_eq!(
+        recovered.len(),
+        2,
+        "both the pre-panic entry and the post-recovery one are counted"
+    );
+    assert!(
+        recovered.len() <= crate::VENDOR_OPEN_MAGIC_LRU_CAP,
+        "the recovered cache still respects its configured capacity"
+    );
+}
+
+#[tokio::test]
+async fn production_record_path_runs_against_a_poisoned_vendor_lru() {
+    let backend = backend();
+    poison_lru(&backend);
+
+    // `record_vendor_open_magic` is the production caller of the hardened
+    // `main.rs` site. Under `.lock().unwrap()` this call panics; under
+    // `.lock().unwrap_or_else(|e| e.into_inner())` it records normally.
+    // Two entries against a cap of 128 means no eviction, so no ripple work is
+    // triggered and this stays a pure cache assertion.
+    let opened = PathBuf::from("/vendor/acme/pkg/src/OpenedAfterPoison.php");
+    backend.record_vendor_open_magic(&opened).await;
+
+    let mut lru = backend
+        .vendor_open_magic_lru
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    assert!(
+        lru.get(&opened).is_some(),
+        "the production on-open path recorded the vendor file even though the \
+         cache mutex was poisoned"
+    );
+    assert_eq!(
+        lru.len(),
+        2,
+        "the pre-panic entry survived and the production insert was added to it"
+    );
+    assert!(
+        lru.len() <= crate::VENDOR_OPEN_MAGIC_LRU_CAP,
+        "the recovered cache still respects its configured capacity"
+    );
+}

--- a/laravel-lsp/src/vendor_member_prover.rs
+++ b/laravel-lsp/src/vendor_member_prover.rs
@@ -237,6 +237,18 @@ fn vendor_package_root(root: &Path, file: &Path) -> Option<PathBuf> {
 /// `(package root, member)`. Vendor packages don't change mid-session, and the
 /// diagnostics pass re-proves the same handful of members on every debounced
 /// edit — without this, each keystroke batch would re-walk `laravel/framework`.
+///
+/// `std::sync::Mutex`, not `RwLock` or `tokio::sync::Mutex`: the critical
+/// section is one short `HashMap` get/insert and is never held across an
+/// `.await` (the package walk runs outside the lock).
+///
+/// Poisoning: every `.lock()` on this cache recovers a poisoned mutex with
+/// `unwrap_or_else(|e| e.into_inner())` instead of panicking, so a panic
+/// elsewhere in the process can't turn every later diagnostics pass into a
+/// panic. That is safe because the worst case of a half-updated entry here is a
+/// stale hit — a verdict the panicking thread never finished inserting, so the
+/// next call re-walks the package — never an incorrect result, since a verdict
+/// is a pure re-derivation from a vendor tree that does not change mid-session.
 static PACKAGE_MEMBER_READS: LazyLock<Mutex<HashMap<(PathBuf, String), bool>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
@@ -246,7 +258,11 @@ static PACKAGE_MEMBER_READS: LazyLock<Mutex<HashMap<(PathBuf, String), bool>>> =
 /// the walk is bounded by [`MAX_PACKAGE_FILES`].
 fn package_touches_member(package_root: &Path, member: &str) -> bool {
     let key = (package_root.to_path_buf(), member.to_string());
-    if let Some(&hit) = PACKAGE_MEMBER_READS.lock().unwrap().get(&key) {
+    if let Some(&hit) = PACKAGE_MEMBER_READS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&key)
+    {
         return hit;
     }
 
@@ -279,7 +295,10 @@ fn package_touches_member(package_root: &Path, member: &str) -> bool {
         }
     }
 
-    PACKAGE_MEMBER_READS.lock().unwrap().insert(key, found);
+    PACKAGE_MEMBER_READS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(key, found);
     found
 }
 


### PR DESCRIPTION
## Summary

Implements #317.

Every production `std::sync::Mutex`-guarded memoization cache in `laravel-lsp/src/` took its guard with `.lock().unwrap()` or `.lock().expect(...)`. A panic while any of those guards was live poisons that mutex permanently, so every later acquisition panics for the remaining life of the server process — one transient bug anywhere degrades the whole LSP session. All 14 production sites now recover the guard with `.lock().unwrap_or_else(|e| e.into_inner())`.

No locking primitive changes type. Nothing under `#[cfg(test)]` is touched.

## Changes

**Sites hardened (14, across 6 caches):**

| Cache | File | Sites |
|---|---|---|
| `vendor_open_magic_lru` | `main.rs` | 1 |
| `locator_cache()` | `class_locator.rs` | 5 |
| `canonical_root()`'s `ROOTS` | `class_locator.rs` | 1 (was `.expect(...)`) |
| `parsed_file_cache()` | `laravel_introspector/chain.rs` | 3 (one split across lines by rustfmt) |
| `PACKAGE_MEMBER_READS` | `vendor_member_prover.rs` | 2 |
| `ComposerAutoload::for_project()`'s `CACHE` | `composer_autoload.rs` | 2 (were `.expect(...)`) |

The two `.expect(...)` messages are gone by design: recovery means the message could never fire again.

**Doc comments.** All six caches gained prose stating (a) that `.lock()` recovers a poisoned mutex via `into_inner()` rather than panicking, and (b) the worst-case effect of a half-updated entry in *that* cache. `PACKAGE_MEMBER_READS` and `ComposerAutoload::for_project` had no primitive rationale at all, so theirs were written from scratch (Mutex-vs-RwLock note included).

**New tests.** `laravel-lsp/src/tests/mutex_poison_recovery.rs`, declared in `laravel-lsp/src/tests/mod.rs`. Named for lock recovery, not "poisoning," and its `//!` doc opens by distinguishing it from the unrelated `cache_root_poisoning.rs` (which is about a persisted on-disk cache, not `Mutex` poisoning).

## How the sites were enumerated

Not by a single-line literal grep — rustfmt splits some of these across lines. `grep -rn '\.lock()' laravel-lsp/src/` returns 33 hits; each was classified by hand:

- **14 production, panic-on-poison** → fixed (table above).
- **7 `tokio::sync::Mutex` `.lock().await`** (`magic_batch_state` ×5 incl. one rustfmt-split at `main.rs`, `db_provider_task`) → no `PoisonError`, nothing to recover.
- **2 `member_resolver.rs` `MEMO`** → out of scope, see below.
- **6 under `#[cfg(test)]`** (`class_locator.rs`'s `mod tests`, incl. two rustfmt-split) and **4 in `src/tests/`** (`watched_files_magic.rs`, `db_provider_init_idempotency.rs`) → left untouched.

## Deliberate exclusions

**`file_exists_cache` (`main.rs:1936`)** — out of scope and untouched. It is `Arc<RwLock<HashMap<PathBuf, (bool, Instant)>>>` over `tokio::sync::RwLock`, accessed with `.read().await` / `.write().await`. A tokio lock has no `PoisonError` and therefore no `.into_inner()` recovery path to apply — there is nothing here to fix. That is true regardless of #299's merge status (#299 is not on `main` at the time of this PR, so its two lock sites do not exist yet either). Converting it to `std::sync::Mutex` to make it fit would be an unrequested primitive change, so it stays as it is.

**`member_resolver.rs`'s `auth_model_fqcn()` `MEMO` (~lines 1963-1979)** — out of scope and untouched. It already reads and writes via `if let Ok(memo) = MEMO.lock()`, so a poisoned lock never panics there. What it does instead is silently and permanently fall back to re-parsing `config/auth.php` from disk on every call. That is a *different* failure mode — perpetual cache-miss, not perpetual panic — than the one this issue hardens against. Switching it to `.unwrap_or_else(|e| e.into_inner())` would change its behaviour (it would start serving the recovered memo), not drop in equivalently, so it belongs to a separate decision.

## Why recovery, not propagation

All six caches are pure memoization, and each one's own freshness machinery already absorbs a half-updated entry:

- `locator_cache` — positives revalidated per hit with `exists()` + `path_within_root`; negatives expire after `NEGATIVE_TTL`. A stale entry costs one extra walk.
- `parsed_file_cache` — every lookup re-stats and rebuilds on a changed `FileStamp`. A stale entry costs one extra read + parse.
- `ROOTS`, `PACKAGE_MEMBER_READS`, `ComposerAutoload`'s `CACHE` — a panicking thread leaves the entry uninserted, so the next call recomputes; each value is a pure function of its key.
- `vendor_open_magic_lru` — session bookkeeping only; the worst case is one vendor file's own references going missing until the next re-open or save.

Worst case across all six is a stale hit or a briefly-wrong recency ordering. Losing an entire cache for the rest of the session is strictly worse than either.

## Test coverage, and its honest limit

`vendor_open_magic_lru` is the only one of the six reachable from a test — it is a `Backend` field, so a test can hold its real guard. The other five live behind module-private `OnceLock`/`LazyLock` statics that hand out no `Mutex` handle, so no test can poison them; the module doc says so rather than leaving the gap unexplained. The issue's AC asks for the `vendor_open_magic_lru` site at minimum for exactly this reason.

Both tests poison the **real production mutex**: a spawned thread takes the lock, `push`es an entry through the live guard, and panics with the guard still bound (`// guard still held here`). Each then asserts `join()` returned `Err` and `is_poisoned()` is `true` *before* exercising recovery.

- `poisoned_vendor_lru_is_recovered_and_still_holds_its_invariants` — re-acquires with the exact production expression and checks the cache still behaves: the pre-panic entry survives (`peek`), a fresh `push` displaces nothing and is retrievable via `get`, `len() == 2`, and `len() <= VENDOR_OPEN_MAGIC_LRU_CAP`.
- `production_record_path_runs_against_a_poisoned_vendor_lru` — drives recovery through `record_vendor_open_magic`, the production caller of the hardened `main.rs` site, then asserts the same invariants. Two entries against a cap of 128 means no eviction, so no ripple work is triggered.

Mutation-verified: reverting `main.rs`'s site to `.lock().unwrap()` turns the second test red (`1 passed; 1 failed`); reverted back, both pass.

```
$ cargo test -p laravel-lsp mutex_poison_recovery
running 2 tests
test tests::mutex_poison_recovery::production_record_path_runs_against_a_poisoned_vendor_lru ... ok
test tests::mutex_poison_recovery::poisoned_vendor_lru_is_recovered_and_still_holds_its_invariants ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 497 filtered out
```

## Acceptance Criteria

- [x] Every production call site that panics on a poisoned lock is replaced with exactly `.lock().unwrap_or_else(|e| e.into_inner())`, enumerated by hand from `grep -rn '\.lock()' laravel-lsp/src/` and classified individually (see "How the sites were enumerated"). Covers `main.rs`'s `vendor_open_magic_lru`, `class_locator.rs`'s `locator_cache()` ×5 and `canonical_root()`'s `ROOTS`, `chain.rs`'s `parsed_file_cache()` ×3 (including the rustfmt-split insert path), `vendor_member_prover.rs`'s `PACKAGE_MEMBER_READS` ×2, and `composer_autoload.rs`'s `CACHE` ×2. The two custom `.expect(...)` messages are dropped, as expected.
- [x] Every `.lock().unwrap()` under `#[cfg(test)]` is untouched — `class_locator.rs`'s `mod tests` block and `src/tests/watched_files_magic.rs`. Confirmed by diff.
- [x] `file_exists_cache` is confirmed out of scope and left alone, with the reasoning stated above (tokio `RwLock`, no `PoisonError` path; not converted).
- [x] `member_resolver.rs`'s `auth_model_fqcn()` `MEMO` is confirmed out of scope and left alone, with the reasoning stated above (already no-ops on poison; different failure mode).
- [x] No locking primitive changes type anywhere in the diff — only the `.unwrap()`/`.expect(...)` on the lock result changes.
- [x] All six caches' doc comments state both required clauses (recovery via `into_inner()`; the specific worst case), written from scratch for `PACKAGE_MEMBER_READS` and `ComposerAutoload::for_project`.
- [x] New `laravel-lsp/src/tests/mutex_poison_recovery.rs`, declared in `tests/mod.rs`, covering the `vendor_open_magic_lru` site with the full poison-then-recover-then-verify-invariants sequence, shown passing above.
- [x] `cargo clippy -p laravel-lsp --all-targets -- -D warnings` exits 0; `cargo build` succeeds; no new `#[allow(...)]` anywhere in the diff.
- [x] No other behaviour changes. `git diff -w origin/main...HEAD` shows no non-whitespace change on any line touching `LruCache::new`, `.put(`, `.get(`, capacity constants, `Instant::elapsed`, or TTL constants outside the target expressions themselves. rustfmt re-wrapped several of the patched chains, so the chained `.get(&key)` / `.put(` and their argument lines are re-indented in the raw diff — that is the target site's own formatting, no token change.

## Test Plan

- [x] `cargo build` (root workspace and `laravel-lsp`) succeeds
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -p laravel-lsp --all-targets -- -D warnings` exits 0
- [x] `cargo test` — 3019 tests pass, 0 failures (2440 lib + 499 bin + 80 integration)
- [x] `cargo test -p laravel-lsp mutex_poison_recovery` — 2 passed
- [x] Mutation check: reverting the `main.rs` site to `.unwrap()` turns the new production-path test red

Fixes #317