### PR TITLE
perf: ⚡ Pattern-cache follow-ups from the #299 review

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -1938,7 +1938,7 @@ struct LaravelLanguageServer {
     /// `vendor_open_magic_lru`) rather than a plain `HashMap`: the TTL only
     /// expires an entry's VALUE on next lookup, it never removes the key, so
     /// an unbounded map grew for every distinct path ever probed over a
-    /// session (goto/hover/diagnostics checking candidate paths that don't
+    /// session (goto/hover/completion checking candidate paths that don't
     /// exist) with nothing ever shrinking it. `std::sync::Mutex`, not
     /// `RwLock`: `lru` mutates on every read to reorder recency, so a "read"
     /// is never actually read-only.
@@ -2151,9 +2151,28 @@ const DEFAULT_SALSA_DEBOUNCE_MS: u64 = 200;
 const VENDOR_OPEN_MAGIC_LRU_CAP: usize = 128;
 
 /// Cap on `file_exists_cache`: how many distinct (path, exists, cached_at)
-/// probes stay resident at once. Generous — goto/hover/diagnostics probe many
-/// candidate paths per request, most of which don't exist — but bounded, so
-/// a long session doesn't grow the map for every path ever checked.
+/// probes stay resident at once.
+///
+/// This is a MEMORY CEILING, not a fit to a measured working set, and the
+/// distinction is worth keeping straight before anyone re-tunes it.
+///
+/// `file_exists_cached` is reached from exactly three places —
+/// `goto_definition`, `hover`, and `completion` — via the `resolve_*_file` and
+/// `create_*_location_from_salsa` helpers. All three are cursor-driven: they
+/// resolve ONE symbol, probing that symbol's handful of candidate paths.
+/// Nothing sweeps the project through here; diagnostics in particular resolve
+/// through their own path and never touch this cache. So the live set is
+/// bounded by how many distinct symbols a person navigates to, throttled
+/// further by the 5-second TTL — orders of magnitude below this cap in any
+/// plausible session.
+///
+/// The cap exists because the TTL alone never freed anything: it was only
+/// consulted on read, so a path probed once and never probed again stayed
+/// resident for the life of the process. 8192 entries is on the order of a
+/// megabyte — small enough to not care about, large enough that eviction
+/// pressure isn't a realistic concern. If it ever needs deriving from real
+/// data, measure the distinct-key count from a live session; do NOT scale it
+/// off the project's file count, which is not what keys this cache.
 const FILE_EXISTS_CACHE_CAP: usize = 8192;
 
 // NOTE: Blade directives are now dynamically discovered via get_all_blade_directives()

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4773,22 +4773,6 @@ impl LaravelLanguageServer {
 
         info!("Laravel: Project files registered with Salsa for reference finding");
 
-        // Size the shared pattern cache for this project's real file count
-        // now that `register_project_files`'s walk has discovered it — and
-        // BEFORE either of the two bulk-insert paths below (the disk-cache
-        // restore and warming's bulk import) run. Sizing here means neither
-        // one grows the table through a series of rehashes as it inserts.
-        // `list_project_files` just returns the actor's already-discovered
-        // list (no re-walk); a failure here is non-fatal — it only costs
-        // the resize's benefit, not correctness — so we log and continue.
-        match self.salsa.list_project_files().await {
-            Ok(paths) => self.salsa.resize_pattern_cache(paths.len()),
-            Err(e) => debug!(
-                "list_project_files failed, pattern cache stays at its bootstrap capacity: {}",
-                e
-            ),
-        }
-
         // Disk-cache restore. Loads previously-parsed patterns into the
         // shared pattern_cache, dropping any entry whose on-disk mtime
         // doesn't match what was cached. Anything restored here gets
@@ -4798,7 +4782,18 @@ impl LaravelLanguageServer {
         if let Some(p) = progress.as_mut() {
             p.report("Loading cached index…", Some(0), true).await;
         }
-        let pattern_cache = self.salsa.pattern_cache();
+        // Published by the actor at the end of the registration walk above,
+        // sized for the file count that walk discovered. Absent only if that
+        // registration didn't complete — in which case there's no indexed
+        // project to load a cache into or warm, so stop rather than build a
+        // second, unshared table nothing else would ever read.
+        let Some(pattern_cache) = self.salsa.pattern_cache() else {
+            debug!("Pattern cache not published; skipping disk-cache load and warming");
+            if let Some(p) = progress {
+                p.end("Project indexing unavailable.").await;
+            }
+            return;
+        };
         let root_for_load = root_path.to_path_buf();
         let cache_for_load = pattern_cache.clone();
         // The load is a sync, parallel (rayon) pass over ~40k cache
@@ -6647,17 +6642,23 @@ impl LaravelLanguageServer {
                 .map(|c| c.view_paths.clone())
                 .unwrap_or_default();
             let changed: HashSet<&str> = changed_views.iter().map(String::as_str).collect();
-            for entry in self.salsa.pattern_cache().iter() {
-                let p = entry.key();
-                if !p.to_string_lossy().ends_with(".blade.php")
-                    || p.components().any(|c| c.as_os_str() == "vendor")
-                {
-                    continue;
-                }
-                if let Some(name) = laravel_lsp::view_var_index::view_name_for_path(p, &view_paths)
-                {
-                    if changed.contains(name.as_str()) {
-                        work.insert(p.clone());
+            // No published cache means nothing has been indexed yet, so there
+            // are no Blade files to re-resolve — an empty work set, not a
+            // missed refresh.
+            if let Some(cache) = self.salsa.pattern_cache() {
+                for entry in cache.iter() {
+                    let p = entry.key();
+                    if !p.to_string_lossy().ends_with(".blade.php")
+                        || p.components().any(|c| c.as_os_str() == "vendor")
+                    {
+                        continue;
+                    }
+                    if let Some(name) =
+                        laravel_lsp::view_var_index::view_name_for_path(p, &view_paths)
+                    {
+                        if changed.contains(name.as_str()) {
+                            work.insert(p.clone());
+                        }
                     }
                 }
             }

--- a/laravel-lsp/src/pattern_indexer.rs
+++ b/laravel-lsp/src/pattern_indexer.rs
@@ -203,7 +203,12 @@ pub fn parse_owned_with_hierarchy(
         // `handle_update_file`, which removes this path's `pattern_cache`
         // entry, so the next `handle_get_patterns` re-parses the file through
         // the full (non-warming) path instead of serving this slimmed entry.
-        data.member_access_refs.clear();
+        //
+        // Assigned a fresh `Vec` rather than `.clear()`ed: clearing drops the
+        // `Arc`s (the ~110MB of `MemberAccessReferenceData`) but KEEPS the
+        // backing buffer, so the pointer array — ~560k slots on a large
+        // project — stays resident for the lifetime of the cache entry.
+        data.member_access_refs = Vec::new();
     }
 
     // Class FQCNs this file imports — Blade `@use` scanned from source, PHP

--- a/laravel-lsp/src/pattern_indexer/tests.rs
+++ b/laravel-lsp/src/pattern_indexer/tests.rs
@@ -283,6 +283,32 @@ fn vendor_member_access_refs_are_dropped_but_app_ones_kept() {
 }
 
 #[test]
+fn dropped_vendor_member_access_refs_release_their_buffer() {
+    // `is_empty()` above can't tell `.clear()` from a fresh `Vec`: clearing
+    // drops the `Arc`s but keeps the backing buffer alive for the lifetime of
+    // the cache entry (~560k pointer slots on a large project). The parse must
+    // hand back a Vec that owns no allocation at all.
+    let src = "<?php\nnamespace App\\Models;\nclass User { public function f() { return $this->email; } }\n";
+
+    // Same source on an app path proves the parse really did populate the list
+    // — so a zero capacity on the vendor path is a release, not an empty parse.
+    let app_path = PathBuf::from("/proj/app/Models/User.php");
+    let (app_data, _) = parse_owned_with_hierarchy(&app_path, src);
+    assert!(
+        app_data.member_access_refs.capacity() > 0,
+        "fixture must produce at least one member access ref"
+    );
+
+    let vendor_path = PathBuf::from("/proj/vendor/acme/pkg/src/User.php");
+    let (vendor_data, _) = parse_owned_with_hierarchy(&vendor_path, src);
+    assert_eq!(
+        vendor_data.member_access_refs.capacity(),
+        0,
+        "a dropped vendor ref list must release its buffer, not just its length"
+    );
+}
+
+#[test]
 fn parse_owned_no_context_for_pattern_free_file() {
     let path = PathBuf::from("/proj/app/Widget.php");
     let src = "<?php\nnamespace App;\nclass Widget { public function noop() {} }\n";

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -5539,70 +5539,40 @@ pub enum SalsaRequest {
 #[derive(Clone)]
 pub struct SalsaHandle {
     sender: mpsc::Sender<SalsaRequest>,
-    /// Shared concurrent pattern cache — same cell the actor holds. Reads
-    /// and writes from here NEVER go through the actor's mpsc channel,
-    /// which means they're never blocked behind a slow handler. See the
-    /// comment on `SalsaActor::pattern_cache` for why this exists, and on
-    /// `resize_pattern_cache` for why it's an `RwLock<Arc<DashMap>>`
-    /// rather than a plain `Arc<DashMap>`.
+    /// Publication slot for the shared concurrent pattern cache. Reads and
+    /// writes through it NEVER go through the actor's mpsc channel, which
+    /// means they're never blocked behind a slow handler. See the comment on
+    /// `SalsaActor::pattern_cache` for why that matters.
+    ///
+    /// Empty until the actor finishes its first project walk and publishes a
+    /// table sized for the real file count (see
+    /// `SalsaActor::size_and_publish_pattern_cache`). A `OnceLock` rather
+    /// than a plain `Arc<DashMap>` handed out at `spawn()` because the
+    /// capacity isn't knowable that early — and a `OnceLock` rather than a
+    /// swappable `RwLock<Arc<DashMap>>` because a swap would silently split
+    /// a long-lived caller (warming holds this `Arc` for minutes) from the
+    /// table the actor is writing to. Published exactly once, so an `Arc`
+    /// taken from here is the live table for the rest of the session.
     pattern_cache:
-        Arc<std::sync::RwLock<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>>>,
+        Arc<std::sync::OnceLock<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>>>,
 }
 
 impl SalsaHandle {
     /// Borrow the shared pattern cache directly. The on-disk cache module
-    /// uses this to pre-load entries before warming starts, and to read
-    /// them back out after warming completes for persistence. Returned
-    /// `Arc` is cheap to clone — the underlying `DashMap` is the same
-    /// instance the actor reads from in `handle_get_patterns`, current as
-    /// of this call (a concurrent `resize_pattern_cache` swaps the cell to
-    /// a NEW `Arc`, which this snapshot won't see — harmless in practice,
-    /// since resize only ever runs once, early, before any caller takes
-    /// this snapshot for warming or disk-cache I/O).
-    pub fn pattern_cache(&self) -> Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>> {
-        self.pattern_cache.read().unwrap().clone()
-    }
-
-    /// Re-size the shared pattern cache for a project with `expected_files`
-    /// entries, plus [`PATTERN_CACHE_CAPACITY_PADDING`] headroom.
+    /// uses this to pre-load entries before warming starts, and to read them
+    /// back out after warming completes for persistence. The returned `Arc`
+    /// is cheap to clone and points at the same `DashMap` instance the actor
+    /// reads from in `handle_get_patterns` — for the rest of the session, not
+    /// just for the moment of this call.
     ///
-    /// dashmap 6.x has no `reserve`: the only way to grow a `DashMap`'s
-    /// table is to build a new, bigger one. Callers should invoke this
-    /// EXACTLY ONCE, right after `list_project_files` reports the
-    /// project's real file count (discovered by `register_project_files`'s
-    /// walk) — and BEFORE the disk-cache load and warming's bulk import,
-    /// both of which are the actual insert volume this sizing avoids
-    /// rehashing. `+ PATTERN_CACHE_CAPACITY_PADDING` covers files that
-    /// appear after this call without an immediate rehash — a `composer
-    /// update` pulling in new vendor packages, or new app files created
-    /// mid-session.
-    ///
-    /// A handful of entries can already be in the cache when this runs
-    /// (an editor may send `didOpen` for already-open buffers before
-    /// project registration finishes) — those are migrated into the
-    /// resized table, not dropped. No-op if the cache is already at least
-    /// as large as the target, so a second call (or a re-registration)
-    /// doesn't pay for a needless rebuild.
-    ///
-    /// Honest limit: this only avoids growth for the FIRST index of a
-    /// project. There's no signal to size from before this call runs, so
-    /// a cold start (no on-disk cache yet, nothing has called this)
-    /// still grows the table organically from
-    /// [`PATTERN_CACHE_INITIAL_CAPACITY`] as warming's own inserts land —
-    /// each such rehash is a per-shard event (dashmap defaults to 16
-    /// shards), so its cost is a fraction of a full-table rehash, not the
-    /// whole thing at once.
-    pub fn resize_pattern_cache(&self, expected_files: usize) {
-        let target_capacity = expected_files.saturating_add(PATTERN_CACHE_CAPACITY_PADDING);
-        let mut current = self.pattern_cache.write().unwrap();
-        if current.capacity() >= target_capacity {
-            return;
-        }
-        let resized = dashmap::DashMap::with_capacity(target_capacity);
-        for entry in current.iter() {
-            resized.insert(entry.key().clone(), entry.value().clone());
-        }
-        *current = Arc::new(resized);
+    /// `None` until the actor has walked a project and published the table
+    /// (see `SalsaActor::size_and_publish_pattern_cache`). Callers that run
+    /// before project registration — or in a test/tooling instance that never
+    /// registers one — must handle that rather than assume a cache exists.
+    pub fn pattern_cache(
+        &self,
+    ) -> Option<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>> {
+        self.pattern_cache.get().cloned()
     }
 
     /// Update or create a file in the database
@@ -5979,12 +5949,20 @@ impl SalsaHandle {
     /// Real-world cost: ~7ms for 40,589 entries (per earlier bench).
     /// The `async fn` and `Result` shape is preserved for source
     /// compatibility with the existing call sites.
+    ///
+    /// Errors if the actor hasn't published the cache yet. Every caller is on
+    /// the warming path, which only runs after project registration, so this
+    /// should be unreachable — but dropping the batch loudly beats inserting
+    /// it into a table nothing else can see.
     pub async fn bulk_import_patterns(
         &self,
         entries: Vec<(PathBuf, Arc<ParsedPatternsData>)>,
     ) -> Result<usize, &'static str> {
+        let cache = self
+            .pattern_cache
+            .get()
+            .ok_or("pattern cache not published — no project registered yet")?;
         let total = entries.len();
-        let cache = self.pattern_cache.read().unwrap();
         for (path, data) in entries {
             cache.insert(path, (0, data));
         }
@@ -6958,24 +6936,27 @@ pub struct SalsaActor {
     /// no reason they should serialize through the actor.
     ///
     /// DashMap is lock-free for reads and uses per-shard locks for writes
-    /// (16 shards by default), so contention between the actor's read path
-    /// and warming's bulk insert is negligible. There is no cap: it holds
-    /// exactly one entry per indexed file (app + vendor), so its size is
-    /// whatever the project's file count makes it — on a large project
+    /// (`(available_parallelism * 4).next_power_of_two()` shards by default —
+    /// 64 on a typical 10-to-16-core dev machine), so contention between the
+    /// actor's read path and warming's bulk insert is negligible. There is no
+    /// cap: it holds exactly one entry per indexed file (app + vendor), so its
+    /// size is whatever the project's file count makes it — on a large project
     /// that's tens of thousands of entries, several hundred MB total. Wins
     /// like dropping vendor `member_access_refs` at parse time (see
     /// `pattern_indexer`'s vendor gate) shrink the PER-ENTRY cost; nothing
     /// here bounds the ENTRY COUNT.
     ///
-    /// Wrapped in an `RwLock` (rather than a bare `Arc<DashMap>`) so
-    /// `SalsaHandle::resize_pattern_cache` can swap in a table pre-sized
-    /// for the project's real file count once it's known — dashmap 6.x has
-    /// no `reserve`, so growing the table means building a new one and
-    /// replacing this cell. Every read/write here pays one uncontended
-    /// `RwLock::read()` (an atomic increment/decrement), which is
-    /// negligible next to a DashMap shard lock or a tree-sitter parse.
-    pattern_cache:
-        Arc<std::sync::RwLock<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>>>,
+    /// Replaced exactly once, by `size_and_publish_pattern_cache`, with a
+    /// table pre-sized for the project's real file count — dashmap 6.x has no
+    /// `reserve`, so growing the table means building a new one. That happens
+    /// before the table is ever published to a `SalsaHandle`, so no other
+    /// holder can be left pointing at the discarded one.
+    pattern_cache: Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>,
+    /// The slot every `SalsaHandle` reads `pattern_cache` out of. Filled by
+    /// `size_and_publish_pattern_cache` once the first project walk knows how
+    /// big the table should be; see `SalsaHandle::pattern_cache`.
+    pattern_cache_slot:
+        Arc<std::sync::OnceLock<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>>>,
     /// LRU cache of parsed Blade loop blocks, keyed by file path + version.
     /// Salsa already memoizes the underlying query, but caching the Arc avoids
     /// re-walking the query graph on every diagnostic / completion request.
@@ -7101,14 +7082,14 @@ pub struct SalsaActor {
     salsa_sp_root: Option<PathBuf>,
 }
 
-/// Bootstrap capacity for the shared pattern cache, used only until
-/// `SalsaHandle::resize_pattern_cache` sizes it for real (see that method
-/// and `SalsaActor::spawn`).
+/// Bootstrap capacity for the pattern cache, used only until
+/// [`SalsaActor::size_and_publish_pattern_cache`] sizes it for real (see that
+/// method and [`SalsaActor::spawn`]).
 const PATTERN_CACHE_INITIAL_CAPACITY: usize = 1024;
 
 /// Headroom added on top of the discovered file count when
-/// `SalsaHandle::resize_pattern_cache` sizes the pattern cache — covers
-/// files that appear after that call without forcing an immediate rehash
+/// [`SalsaActor::size_and_publish_pattern_cache`] sizes the pattern cache —
+/// covers files that appear afterwards without forcing an immediate rehash
 /// (a `composer update`, new app files created mid-session).
 const PATTERN_CACHE_CAPACITY_PADDING: usize = 1000;
 
@@ -7117,27 +7098,17 @@ impl SalsaActor {
     pub fn spawn() -> SalsaHandle {
         let (tx, rx) = mpsc::channel(256);
 
-        // Shared pattern cache: created here, cloned into both the actor
-        // and the SalsaHandle. Both ends use the SAME cell so writes from
-        // either side are immediately visible on the other, and so a later
-        // `resize_pattern_cache` swap (see that method) is visible to both
-        // too.
-        //
-        // `spawn()` runs before any project is known — the LSP server is
-        // constructed here, before `initialize` carries a workspace root —
-        // so there's no file count to size against yet. This modest
-        // capacity is only the bootstrap value: `register_project_files`'s
-        // caller resizes the table for real via `resize_pattern_cache` as
-        // soon as the project's file count is known, before the disk-cache
-        // load or warming insert anything into it. A short-lived
-        // test/tooling instance that never registers a project keeps this
-        // small default and never pays for a monorepo-sized table.
-        let pattern_cache: Arc<
-            std::sync::RwLock<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>>,
-        > = Arc::new(std::sync::RwLock::new(Arc::new(
-            dashmap::DashMap::with_capacity(PATTERN_CACHE_INITIAL_CAPACITY),
-        )));
-        let pattern_cache_for_actor = pattern_cache.clone();
+        // The pattern cache is published to handles through this slot rather
+        // than handed out here, because `spawn()` runs before any project is
+        // known — the LSP server is constructed at this point, before
+        // `initialize` carries a workspace root — so there's no file count to
+        // size a table against yet. `handle_register_project_files` fills the
+        // slot once its walk knows the count. A short-lived test/tooling
+        // instance that never registers a project simply never fills it.
+        let pattern_cache_slot: Arc<
+            std::sync::OnceLock<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>>,
+        > = Arc::new(std::sync::OnceLock::new());
+        let pattern_cache_slot_for_actor = pattern_cache_slot.clone();
 
         std::thread::spawn(move || {
             let mut actor = SalsaActor {
@@ -7145,7 +7116,14 @@ impl SalsaActor {
                 receiver: rx,
                 // Pre-allocate with reasonable capacity to avoid early reallocations
                 files: HashMap::with_capacity(64),
-                pattern_cache: pattern_cache_for_actor,
+                // Bootstrap table, big enough for the handful of `didOpen`
+                // buffers an editor may send before registration finishes.
+                // Replaced with a correctly-sized one — carrying those
+                // entries over — by `size_and_publish_pattern_cache`.
+                pattern_cache: Arc::new(dashmap::DashMap::with_capacity(
+                    PATTERN_CACHE_INITIAL_CAPACITY,
+                )),
+                pattern_cache_slot: pattern_cache_slot_for_actor,
                 loop_blocks_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 php_assignments_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 document_symbols_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
@@ -7198,7 +7176,7 @@ impl SalsaActor {
 
         SalsaHandle {
             sender: tx,
-            pattern_cache,
+            pattern_cache: pattern_cache_slot,
         }
     }
 
@@ -7241,7 +7219,7 @@ impl SalsaActor {
                 }
                 SalsaRequest::RemoveFile { path, reply } => {
                     self.files.remove(&path);
-                    self.pattern_cache.read().unwrap().remove(&path);
+                    self.pattern_cache.remove(&path);
                     self.loop_blocks_cache.pop(&path);
                     self.php_assignments_cache.pop(&path);
                     self.document_symbols_cache.pop(&path);
@@ -7269,7 +7247,9 @@ impl SalsaActor {
                     // pushing into HashMaps — no parsing). Clear first
                     // so we start from a known state.
                     self.symbol_index.clear();
-                    let cache = self.pattern_cache.read().unwrap().clone();
+                    // Cloned so the iteration below borrows the Arc, not `self` —
+                    // `insert_file` needs `&mut self.symbol_index` at the same time.
+                    let cache = Arc::clone(&self.pattern_cache);
                     for entry in cache.iter() {
                         let path = entry.key();
                         let (_, ref patterns) = *entry.value();
@@ -7285,7 +7265,7 @@ impl SalsaActor {
                     // it, so a stale entry would otherwise never be re-parsed.
                     // The rest are dropped so no since-deleted file's symbols,
                     // hierarchy node, or cached parse can survive the rebuild.
-                    self.pattern_cache.read().unwrap().clear();
+                    self.pattern_cache.clear();
                     self.symbol_index.clear();
                     self.class_hierarchy_index.clear();
                     self.loop_blocks_cache.clear();
@@ -7385,9 +7365,8 @@ impl SalsaActor {
                 // See SalsaActor::pattern_cache for the architectural why.
                 SalsaRequest::BulkImportPatterns { entries, reply } => {
                     let total = entries.len();
-                    let cache = self.pattern_cache.read().unwrap();
                     for (path, data) in entries {
-                        cache.insert(path, (0, data));
+                        self.pattern_cache.insert(path, (0, data));
                     }
                     let _ = reply.send(total);
                 }
@@ -7552,7 +7531,9 @@ impl SalsaActor {
                     // freshly resolved magic members. `remove_file` clears both
                     // kinds, so re-inserting literals here keeps them alive.
                     self.symbol_index.remove_file(&path);
-                    let cache = self.pattern_cache.read().unwrap();
+                    // Cloned so the lookup borrows the Arc, not `self` — `insert_file`
+                    // needs `&mut self.symbol_index` while the Ref guard is alive.
+                    let cache = Arc::clone(&self.pattern_cache);
                     if let Some(cached) = cache.get(&path) {
                         let (_, ref patterns) = *cached;
                         self.symbol_index.insert_file(&path, patterns);
@@ -7811,7 +7792,7 @@ impl SalsaActor {
     /// Handle file update - create or update the SourceFile
     fn handle_update_file(&mut self, path: PathBuf, version: i32, text: String) {
         // Invalidate caches for this file - will be recomputed on next request
-        self.pattern_cache.read().unwrap().remove(&path);
+        self.pattern_cache.remove(&path);
         self.loop_blocks_cache.pop(&path);
         self.php_assignments_cache.pop(&path);
         self.document_symbols_cache.pop(&path);
@@ -7951,15 +7932,13 @@ impl SalsaActor {
         // we don't need a Salsa SourceFile input to serve cached
         // patterns.
         //
-        // DashMap::get returns a Ref guard; clone the Arc out and drop it
-        // (plus the RwLock read guard around it) before returning, so
-        // neither is held across the caller's continued use of `self`.
-        let cache = self.pattern_cache.read().unwrap();
-        let hit = cache.get(path).map(|entry| {
+        // DashMap::get returns a Ref guard holding a shard lock; clone the
+        // Arc out and let the guard drop at the end of this statement, so
+        // it's never held across the `&mut self` work below.
+        let hit = self.pattern_cache.get(path).map(|entry| {
             let (_, cached_data) = entry.value();
             Arc::clone(cached_data)
         });
-        drop(cache);
         if let Some(data) = hit {
             debug!("✅ Cache HIT for {} ({:?})", file_name, start.elapsed());
             return Some(data);
@@ -8546,8 +8525,6 @@ impl SalsaActor {
 
         // Cache the Arc for future requests (cheap Arc::clone on cache hit)
         self.pattern_cache
-            .read()
-            .unwrap()
             .insert(path.clone(), (version, Arc::clone(&data)));
 
         let total_time = start.elapsed();
@@ -9003,6 +8980,67 @@ impl SalsaActor {
             self.livewire_files.clone(),
             self.route_files.clone(),
         ));
+
+        // The buckets above are the only file-count signal in the process,
+        // and this is the moment they're complete — size the pattern cache
+        // from them before anything bulk-inserts into it.
+        self.size_and_publish_pattern_cache();
+    }
+
+    /// Number of distinct files the project walk discovered. Supersets the
+    /// categorized buckets (`source_files` covers all non-vendor code, and the
+    /// controller/view/livewire/route lists overlap it), so the union is
+    /// deduplicated — on borrowed paths, which costs a hash per entry and no
+    /// `PathBuf` allocations.
+    fn project_file_count(&self) -> usize {
+        let mut seen: std::collections::HashSet<&Path> = std::collections::HashSet::new();
+        self.source_files
+            .iter()
+            .chain(self.controller_files.iter())
+            .chain(self.view_files.iter())
+            .chain(self.livewire_files.iter())
+            .chain(self.route_files.iter())
+            .chain(self.vendor_files.iter())
+            .filter(|p| seen.insert(p.as_path()))
+            .count()
+    }
+
+    /// Replace the bootstrap pattern cache with one sized for the project just
+    /// walked, then publish it to every [`SalsaHandle`].
+    ///
+    /// dashmap 6.x has no `reserve` — growing a `DashMap`'s table means
+    /// building a new one — so this runs BEFORE the table is shared, and only
+    /// ever once. Both halves of that matter:
+    ///
+    /// * **Before sharing.** The disk-cache load and warming's bulk import
+    ///   hold their `Arc` for the whole indexing pass; if the table could be
+    ///   swapped underneath them they'd read one map while the actor wrote to
+    ///   another. Sizing first and publishing second makes that unreachable
+    ///   rather than merely unlikely.
+    /// * **Only once.** A mid-session re-registration (a project-root change)
+    ///   leaves the existing table in place: [`PATTERN_CACHE_CAPACITY_PADDING`]
+    ///   absorbs ordinary growth, and organic per-shard rehashing beyond that
+    ///   is far cheaper than the alternative of a swap.
+    ///
+    /// Any entries already present — an editor may send `didOpen` for open
+    /// buffers before registration finishes — are migrated, not dropped.
+    fn size_and_publish_pattern_cache(&mut self) {
+        if self.pattern_cache_slot.get().is_some() {
+            return;
+        }
+
+        let target_capacity = self
+            .project_file_count()
+            .saturating_add(PATTERN_CACHE_CAPACITY_PADDING);
+        if self.pattern_cache.capacity() < target_capacity {
+            let sized = dashmap::DashMap::with_capacity(target_capacity);
+            for entry in self.pattern_cache.iter() {
+                sized.insert(entry.key().clone(), entry.value().clone());
+            }
+            self.pattern_cache = Arc::new(sized);
+        }
+
+        let _ = self.pattern_cache_slot.set(Arc::clone(&self.pattern_cache));
     }
 
     /// Ensure a file is registered with Salsa (read from disk if needed)

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -5198,43 +5198,121 @@ class P extends ServiceProvider
     );
 }
 
-// ─── SalsaHandle::resize_pattern_cache ────────────────────────────────────
+// ─── Pattern-cache sizing and publication ─────────────────────────────────
 
-#[tokio::test]
-async fn resize_pattern_cache_grows_capacity_and_keeps_existing_entries() {
-    let handle = SalsaActor::spawn();
-    let path = PathBuf::from("/proj/app/Models/User.php");
-    let data = Arc::new(ParsedPatternsData::default());
+/// A temp project of `php_files` trivial `.php` files under `app/`, registered
+/// with `handle`. Returns the `TempDir` so the caller keeps it alive.
+async fn register_temp_project(handle: &SalsaHandle, php_files: usize) -> tempfile::TempDir {
+    let dir = tempfile::TempDir::new().unwrap();
+    let app = dir.path().join("app");
+    std::fs::create_dir_all(&app).unwrap();
+    for i in 0..php_files {
+        std::fs::write(app.join(format!("F{i}.php")), "<?php\n").unwrap();
+    }
     handle
-        .bulk_import_patterns(vec![(path.clone(), data)])
+        .register_project_files(
+            dir.path().to_path_buf(),
+            vec![PathBuf::from("app/Http/Controllers")],
+            vec![dir.path().join("resources/views")],
+            None,
+            PathBuf::from("routes"),
+        )
         .await
         .unwrap();
+    dir
+}
 
-    let before = handle.pattern_cache().capacity();
-    handle.resize_pattern_cache(before + 5_000);
-    let after = handle.pattern_cache().capacity();
+#[tokio::test]
+async fn pattern_cache_is_unpublished_until_a_project_is_registered() {
+    let handle = SalsaActor::spawn();
 
     assert!(
-        after >= before + 5_000,
-        "resize must grow capacity to at least the requested target (+ padding), got {before} -> {after}"
+        handle.pattern_cache().is_none(),
+        "no project walked yet, so there is no correctly-sized table to hand out"
     );
     assert!(
-        handle.pattern_cache().contains_key(&path),
-        "an entry present before the resize must survive the table swap"
+        handle
+            .bulk_import_patterns(vec![(
+                PathBuf::from("/proj/app/Models/User.php"),
+                Arc::new(ParsedPatternsData::default()),
+            )])
+            .await
+            .is_err(),
+        "importing before publication must fail closed, not write to an unshared table"
+    );
+
+    let _project = register_temp_project(&handle, 4).await;
+    assert!(
+        handle.pattern_cache().is_some(),
+        "registration must publish the table"
     );
 }
 
 #[tokio::test]
-async fn resize_pattern_cache_is_a_no_op_once_already_big_enough() {
+async fn registration_sizes_the_pattern_cache_for_the_discovered_file_count() {
+    // Comfortably past the bootstrap table's real capacity (~1.8k regardless
+    // of shard count), so a published table that was NOT resized fails here.
+    const FILES: usize = 1_500;
     let handle = SalsaActor::spawn();
-    handle.resize_pattern_cache(10_000);
-    let grown = handle.pattern_cache().capacity();
+    let _project = register_temp_project(&handle, FILES).await;
 
-    // A smaller request must not shrink or rebuild an already-adequate table.
-    handle.resize_pattern_cache(10);
-    assert_eq!(
-        handle.pattern_cache().capacity(),
-        grown,
-        "resize must not rebuild the table when it's already big enough"
+    let cache = handle.pattern_cache().expect("registration must publish");
+    assert!(
+        cache.capacity() >= FILES + PATTERN_CACHE_CAPACITY_PADDING,
+        "table must be sized for the walk's file count plus padding, got {}",
+        cache.capacity()
+    );
+}
+
+#[tokio::test]
+async fn entries_cached_before_registration_survive_the_sizing_swap() {
+    let handle = SalsaActor::spawn();
+
+    // An editor can send `didOpen` for an already-open buffer before project
+    // registration finishes; that lands in the bootstrap table.
+    let early = tempfile::TempDir::new().unwrap();
+    let early_file = early.path().join("Early.php");
+    std::fs::write(&early_file, "<?php\nclass Early {}\n").unwrap();
+    handle.get_patterns(early_file.clone()).await.unwrap();
+
+    let _project = register_temp_project(&handle, 1_500).await;
+
+    let cache = handle.pattern_cache().expect("registration must publish");
+    assert!(
+        cache.contains_key(&early_file),
+        "a pre-registration entry must be migrated into the resized table, not dropped"
+    );
+}
+
+#[tokio::test]
+async fn re_registration_leaves_the_published_table_live() {
+    // The whole point of publishing once: a later registration must not leave
+    // the actor writing to a table that handle holders can no longer see. A
+    // mid-session project-root change re-registers with no flight guard, so
+    // this is reachable in production, not just in theory.
+    let handle = SalsaActor::spawn();
+    let _first = register_temp_project(&handle, 1_500).await;
+    let published = handle.pattern_cache().expect("registration must publish");
+
+    // Second registration, deliberately larger than the first.
+    let _second = register_temp_project(&handle, 3_000).await;
+
+    // Drive an actor-side write through `handle_get_patterns`, then look for
+    // it through the Arc taken BEFORE the re-registration.
+    let late = tempfile::TempDir::new().unwrap();
+    let late_file = late.path().join("Late.php");
+    std::fs::write(&late_file, "<?php\nclass Late {}\n").unwrap();
+    handle.get_patterns(late_file.clone()).await.unwrap();
+
+    assert!(
+        published.contains_key(&late_file),
+        "the actor must still be writing to the table it published, not a newer one"
+    );
+    assert!(
+        Arc::ptr_eq(
+            &published,
+            &handle.pattern_cache().expect("still published")
+        ),
+        "re-registration must not swap the published table"
     );
 }

--- a/laravel-lsp/src/tests/watched_files_magic.rs
+++ b/laravel-lsp/src/tests/watched_files_magic.rs
@@ -814,7 +814,23 @@ async fn incremental_batch_runs_regardless_of_project_size() {
 
     // Inflate the pattern cache past the retired 15,000-file gate with cheap
     // empty entries (no parsing — direct DashMap inserts).
-    let cache = backend.salsa.pattern_cache();
+    // Register the project so the actor publishes the shared pattern cache —
+    // `seed` only drives per-file updates, which never trigger the walk.
+    backend
+        .salsa
+        .register_project_files(
+            root.to_path_buf(),
+            vec![PathBuf::from("app/Http/Controllers")],
+            vec![root.join("resources/views")],
+            None,
+            PathBuf::from("routes"),
+        )
+        .await
+        .unwrap();
+    let cache = backend
+        .salsa
+        .pattern_cache()
+        .expect("registration publishes the pattern cache");
     for i in 0..15_001 {
         cache.insert(
             root.join(format!("app/Filler/F{i}.php")),


### PR DESCRIPTION
Follow-ups to #299, from a closer pass over the merged branch. These five were posted as an FYI on that PR before it merged.

### Release the vendor member-ref buffer

`parse_owned_with_hierarchy` dropped a vendor file's `member_access_refs` with `Vec::clear()`. That drops the `Arc`s — the ~110MB the drop exists for — but keeps the backing buffer, so the pointer array (~560k slots on a 36.7k-file project) stays resident for the lifetime of the cache entry.

The existing `vendor_member_access_refs_are_dropped_but_app_ones_kept` asserted `is_empty()`, which passes either way; a `capacity()` assertion now discriminates.

### Publish the pattern cache once instead of swapping it

Two problems, one fix.

`list_project_files()` was called twice — once in `register_project_files_with_salsa` purely to read `paths.len()`, and again moments later by the warming task for the actual work. Each call builds a deduplicated `HashSet<PathBuf>` plus a `Vec<PathBuf>` over the whole corpus: roughly 8MB of transient `PathBuf` allocation to compute one integer.

And `pattern_cache` became `Arc<RwLock<Arc<DashMap>>>` so the resize would be visible on both sides. But `SalsaHandle::pattern_cache()` hands out a snapshot `Arc` that the warming task holds for the entire indexing pass — the skip-check, the view-change scan, `build_magic_member_entries`, `save_from` — while its writes go through `bulk_import_patterns` to whatever the cell currently holds. The rustdoc's defence was that resize "only ever runs once, early"; `update_project_root` re-registers mid-session with no flight guard, so a root change during warming could split reads from writes.

The actor now sizes its own table at the end of `handle_register_project_files`, from the buckets that walk just filled, and publishes it through a `OnceLock`. Sizing happens before the table is shared, so no holder can be left pointing at a discarded one; publication happens once, so a re-registration can't strand the published table either. `pattern_cache()` returns `Option` and `bulk_import_patterns` fails closed. The `RwLock` is gone from all 12 access sites.

### Correct what feeds `file_exists_cache`

My own review claim was wrong, so this one is a doc fix rather than a code change.

I flagged `FILE_EXISTS_CACHE_CAP = 8192` as an unjustified constant that "a component-existence sweep will thrash." There is no sweep. `file_exists_cached` is reached from exactly three places — `goto_definition`, `hover`, `completion` — all cursor-driven, one symbol at a time. Diagnostics resolve through their own path and never touch it. The live set is a function of how many symbols a person navigates to, throttled by a 5-second TTL, not of project size.

8192 stands as a memory ceiling. The comment claiming diagnostics as a caller was the actual defect, and it now records how to measure properly if the number ever does need deriving.

## Verification

- 3,028 tests green, `cargo clippy --all-targets` clean, `cargo fmt --check` clean.
- The four new pattern-cache tests are mutation-verified — dropping the publish call, publishing without sizing, and removing the publish-once guard each turn the relevant test red. The last of those catches the actor writing to a table handle-holders can no longer see.
- No behaviour change intended anywhere except the two memory reductions.

## Not included

A throwaway harness was built to measure the `file_exists_cache` working set and is deliberately absent: it failed to drive the resolvers correctly across several attempts, and the useful answer came from reading the call graph instead. Sizing that cache off the project file count — the obvious-looking fix — would measure the wrong quantity, and the doc now says so.

One thing left on the table: the surviving `list_project_files()` call still clones every `PathBuf` into a `HashSet` and a `Vec`. It genuinely needs the list, so rewriting its dedup is a separate optimization rather than part of this change.
