### PR TITLE
refactor: ♻️ Route translation resolution through Salsa

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ The LSP uses a dedicated thread for Salsa incremental computation to avoid lifet
 | Project Files | `ProjectFiles` | `ViewReferenceLocationData` | Reference finding across project |
 | Service Providers | `ServiceProviderFile` | `MiddlewareRegistrationData`, `BindingRegistrationData` | Middleware/binding lookups |
 | Env Variables | `EnvFile` | `EnvVariableData` | Environment variable lookups |
+| Translations | `LangFile`, `LangDir` | `ResolvedTranslationData` | Translation key resolution + locale discovery |
 
 ### Important Conventions
 
@@ -230,6 +231,7 @@ did_change(file) → Debounce 250ms → Update Salsa input → Queries recompute
 | Routes | `route('home')` | SourceFile | Route name in `routes/*.php` |
 | Config | `config('app.name')` | SourceFile | `config/*.php` |
 | Env | `env('APP_NAME')` | SourceFile | `.env` |
+| Translations | `__('validation.required')` | LangFile / LangDir | `lang/*/*.php`, `lang/*.json` |
 | Classes | `use App\Support\Foo;`, `@use('App\Support\Foo')` | SourceFile (PHP `use` clauses, Blade `@use` directives, Volt front matter) | `app/**/Foo.php` |
 | Middleware | `->middleware('auth')` | SourceFile | Alias in registry |
 | Bindings | `app('cache')` | SourceFile | Binding in registry |
@@ -242,6 +244,7 @@ did_change(file) → Debounce 250ms → Update Salsa input → Queries recompute
 | `bootstrap/app.php`, `Providers/*.php` | `ServiceProviderFile` | Middleware aliases, container bindings |
 | `.env`, `.env.*` | `EnvFile` | Environment variable values |
 | `config/*.php`, `composer.json` | `ConfigFile` | View paths, namespaces, PSR-4 mappings |
+| `lang/**/*.php`, `lang/*.json`, `resources/lang/**` | `LangFile`, `LangDir` | Translation values, locale discovery |
 
 **Target Files (existence only):**
 - View files, component files, Livewire classes, translation files, assets

--- a/laravel-lsp/src/file_watcher.rs
+++ b/laravel-lsp/src/file_watcher.rs
@@ -12,8 +12,9 @@
 //!    notify us about files we actually index: the project's PSR-4
 //!    source roots (from `composer.json` — `app/`, `src/`, any custom
 //!    `Modules\` mapping), the configured view paths, the Livewire path
-//!    (if any), `routes/`, `database/migrations/`, `vendor/`, and the
-//!    Inertia pages dir. The PSR-4 roots (M2) are what make an external
+//!    (if any), `routes/`, `database/migrations/`, `vendor/`, the
+//!    Inertia pages dir, and both translation lang roots (`lang/` and
+//!    `resources/lang/`). The PSR-4 roots (M2) are what make an external
 //!    edit to *any* first-party source dir — not just the hardcoded
 //!    controllers path — converge the magic-member index. A
 //!    `composer install` that rewrites thousands of files in `vendor/`
@@ -113,9 +114,9 @@ pub fn build_watchers(
     let kind = Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete);
 
     // 5 fixed (controllers, routes, migrations, vendor php + blade) + 4 Inertia
-    // page-extension globs + 1 optional livewire + 2 per view path + 1 per PSR-4
-    // source root.
-    let mut watchers = Vec::with_capacity(10 + 2 * view_paths.len() + psr4_roots.len());
+    // page-extension globs + 6 lang-catalogue globs (3 per lang root) + 1
+    // optional livewire + 2 per view path + 1 per PSR-4 source root.
+    let mut watchers = Vec::with_capacity(16 + 2 * view_paths.len() + psr4_roots.len());
 
     // Controllers — current default path. If a project moves them, we
     // miss those changes until a future improvement makes this glob
@@ -198,6 +199,38 @@ pub fn build_watchers(
             glob_pattern: GlobPattern::String(format!("{}/**/*.{}", glob_base(&pages_dir), ext)),
             kind,
         });
+    }
+
+    // Translation catalogues (issue #293). Until the translation layer was
+    // routed through Salsa, every lookup re-read these files from disk, so no
+    // glob was needed — nothing was cached, so nothing could go stale. Now that
+    // they are cached, an external edit (a `git pull`, a branch switch,
+    // `php artisan lang:publish`) must reach `did_change_watched_files` or the
+    // session would keep serving the pre-change translation.
+    //
+    // Both lang roots are watched, not just `lang/`: the resolver searches
+    // `lang/` (Laravel 9+) *and* `resources/lang/` (Laravel 8 and earlier), and
+    // watching only the first would leave every Laravel-8-layout project
+    // serving stale translations — the exact hover/diagnostics divergence
+    // issue #288 exists to close.
+    //
+    // Three globs per root: `**/*.php` for locale directories (which also
+    // covers `vendor/`), `*.json` for the top-level text catalogues Laravel
+    // reads as `{lang_root}/{locale}.json`, and an explicit `vendor/**/*.php`
+    // for published package translations. The last overlaps the first; the
+    // watched-files handler is idempotent, so duplicate events collapse.
+    for lang_root in crate::translation_lookup::project_lang_roots(root) {
+        let base = glob_base(&lang_root);
+        for pattern in [
+            format!("{base}/**/*.php"),
+            format!("{base}/*.json"),
+            format!("{base}/vendor/**/*.php"),
+        ] {
+            watchers.push(FileSystemWatcher {
+                glob_pattern: GlobPattern::String(pattern),
+                kind,
+            });
+        }
     }
 
     // First-party PSR-4 source roots (M2). Each gets a recursive `**/*.php`

--- a/laravel-lsp/src/file_watcher/tests.rs
+++ b/laravel-lsp/src/file_watcher/tests.rs
@@ -137,9 +137,11 @@ fn registration_options_round_trip_through_serde() {
 
     // We constructed exactly 1 (controllers) + 1 (routes) + 1 (migrations)
     // + 2 (view blade + php) + 1 (livewire) + 2 (vendor php + blade)
-    // + 4 (Inertia page extensions: vue/tsx/jsx/svelte) = 12 watchers. If the
-    // construction changes, this assertion will flag it for review.
-    assert_eq!(parsed.watchers.len(), 12);
+    // + 4 (Inertia page extensions: vue/tsx/jsx/svelte)
+    // + 6 (lang catalogues: php/json/vendor-php across both lang roots,
+    //   issue #293) = 18 watchers. If the construction changes, this
+    // assertion will flag it for review.
+    assert_eq!(parsed.watchers.len(), 18);
 }
 
 #[test]

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -42,7 +42,7 @@ use laravel_lsp::salsa_impl::{
     ComponentReferenceData, ConfigReferenceData, DirectiveReferenceData, EnvReferenceData,
     FeatureReferenceData, LaravelConfigData, LivewireReferenceData, MiddlewareReferenceData,
     PatternAtPosition, ReferenceLocationData, RouteReferenceData, SalsaActor, SalsaHandle,
-    TranslationReferenceData, UrlReferenceData, ViewReferenceData,
+    TranslationKeyTarget, TranslationReferenceData, UrlReferenceData, ViewReferenceData,
 };
 
 // The Linux release binaries are static musl builds; musl's default
@@ -8884,6 +8884,11 @@ impl LaravelLanguageServer {
             && filename.ends_with(".php")
         {
             // App service provider - Service provider file
+            //
+            // Also drops the vendor translation-namespace map: an edited
+            // `loadTranslationsFrom` changes where namespaced translation keys
+            // resolve (issue #293).
+            self.invalidate_vendor_translation_namespaces().await;
             if let Some(root) = root_path {
                 debug!("📦 Updating Salsa: ServiceProviderFile ({})", filename);
                 if let Err(e) = self
@@ -8973,6 +8978,25 @@ impl LaravelLanguageServer {
             // deliberate action, not something queried mid-keystroke. The
             // refresh (instant per-file + debounced project reconverge) runs on
             // `did_save` instead. See `refresh_magic_on_save`.
+        }
+
+        // A lang catalogue additionally feeds the translation cache. This is
+        // not an `else if` on the chain above: a `lang/de/validation.php` is
+        // still a SourceFile for pattern extraction, and it is *also* the
+        // authoritative text for translation resolution. Registering the
+        // editor buffer here is what makes an unsaved edit to a lang file show
+        // up in the next hover without a save (issue #293).
+        if let Some(root) = self.root_path.read().await.as_ref() {
+            if laravel_lsp::translation_lookup::is_lang_file(root, &path) {
+                debug!("📦 Updating Salsa: LangFile ({})", filename);
+                if let Err(e) = self
+                    .salsa
+                    .register_lang_source(path.clone(), content.to_string())
+                    .await
+                {
+                    debug!("Failed to update lang file in Salsa: {}", e);
+                }
+            }
         }
 
         // After Salsa update, re-run diagnostics for this file
@@ -14531,172 +14555,32 @@ impl LaravelLanguageServer {
         completions
     }
 
-    /// Get all translation keys from lang/*.php files for autocomplete
+    /// Get all translation keys from lang/*.php files for autocomplete.
+    ///
+    /// Served from the Salsa translation cache (issue #293). This used to
+    /// re-enumerate the lang root *and* the locale directory, then re-read and
+    /// re-parse every catalogue in that locale — recompiling the key regex each
+    /// time — on **every completion request**. The semantics are unchanged:
+    /// first existing lang root, first locale directory within it, first-wins
+    /// on duplicate keys. See
+    /// [`laravel_lsp::salsa_impl::TranslationCache::completion_keys`] for why
+    /// a single locale is the right answer here where the hover / goto /
+    /// diagnostics trio unions every locale.
     async fn get_all_translation_keys(&self) -> Vec<TranslationKeyCompletion> {
-        let root = match self.root_path.read().await.clone() {
-            Some(r) => r,
-            None => return Vec::new(),
+        let Some(root) = self.root_path.read().await.clone() else {
+            return Vec::new();
         };
-
-        // Laravel 9+ uses lang/, older versions use resources/lang/
-        //
-        // Deliberately NOT routed through
-        // `translation_lookup::available_locales`, which the hover /
-        // go-to-definition / diagnostics trio share (issue #288). That helper
-        // answers "which locales could define *this key*" and unions every
-        // candidate directory; completion asks a different question — "what
-        // keys exist at all" — and any single locale answers it, because a key
-        // present in one locale is offered regardless of which locale defines
-        // it. Enumerating the union here would read every catalogue in the
-        // project on each completion request to produce the same list, and
-        // would surface a key from a partially-translated locale as though it
-        // were project-wide. First-wins is the right shape for this caller.
-        let lang_dirs = [root.join("lang"), root.join("resources").join("lang")];
-
-        let lang_dir = lang_dirs.iter().find(|d| d.exists());
-        let lang_dir = match lang_dir {
-            Some(d) => d,
-            None => return Vec::new(),
-        };
-
-        let mut completions = Vec::new();
-
-        // Find the default locale directory (usually 'en')
-        // We'll use the first locale we find
-        if let Ok(entries) = std::fs::read_dir(lang_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    let locale = path.file_name().and_then(|n| n.to_str()).unwrap_or("en");
-
-                    // Read all PHP files in this locale directory
-                    if let Ok(files) = std::fs::read_dir(&path) {
-                        for file_entry in files.flatten() {
-                            let file_path = file_entry.path();
-                            if file_path.extension().is_some_and(|e| e == "php") {
-                                if let Some(file_name) =
-                                    file_path.file_stem().and_then(|s| s.to_str())
-                                {
-                                    let base_key = file_name.to_string();
-                                    let source = format!("lang/{}/{}.php", locale, file_name);
-
-                                    if let Ok(content) = std::fs::read_to_string(&file_path) {
-                                        let keys =
-                                            Self::parse_translation_keys(&content, &base_key);
-                                        for (key, value) in keys {
-                                            completions.push(TranslationKeyCompletion {
-                                                key,
-                                                value,
-                                                source: source.clone(),
-                                            });
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // Only use the first locale directory found
-                    break;
-                }
-            }
-        }
-
-        // Sort by key for consistent ordering
-        completions.sort_by(|a, b| a.key.cmp(&b.key));
-
-        // Remove duplicates
-        completions.dedup_by(|a, b| a.key == b.key);
-
-        completions
-    }
-
-    /// Parse a PHP translation file to extract all keys and values
-    /// Returns a list of (key, value) tuples with dot-notation keys
-    fn parse_translation_keys(content: &str, base_key: &str) -> Vec<(String, String)> {
-        let mut results = Vec::new();
-
-        // Simple regex-based parsing for Laravel translation files
-        // This handles: 'key' => 'value', or "key" => "value"
-        let key_pattern = regex::Regex::new(r#"['"]([a-zA-Z_][a-zA-Z0-9_]*)['"][\s]*=>"#).unwrap();
-
-        // Track nesting depth and current key path
-        let mut key_stack: Vec<String> = vec![base_key.to_string()];
-        let mut in_array_depth = 0;
-        let mut pending_key: Option<String> = None;
-
-        for line in content.lines() {
-            let trimmed = line.trim();
-
-            // Skip comments and empty lines
-            if trimmed.is_empty()
-                || trimmed.starts_with("//")
-                || trimmed.starts_with("/*")
-                || trimmed.starts_with("*")
-            {
-                continue;
-            }
-
-            // Handle array opening
-            if trimmed.contains("[") && !trimmed.contains("=>") {
-                in_array_depth += 1;
-                if let Some(key) = pending_key.take() {
-                    key_stack.push(key);
-                }
-                continue;
-            }
-
-            // Handle key => [ (nested array on same line)
-            if let Some(caps) = key_pattern.captures(trimmed) {
-                let key_name = caps.get(1).unwrap().as_str();
-
-                if trimmed.contains("=> [") || trimmed.ends_with("=> [") {
-                    // This is a nested array
-                    pending_key = Some(key_name.to_string());
-                    in_array_depth += 1;
-                    key_stack.push(key_name.to_string());
-                } else {
-                    // This is a simple key => value
-                    let full_key = format!("{}.{}", key_stack.join("."), key_name);
-
-                    // Extract value
-                    let value = Self::extract_translation_value(trimmed);
-                    results.push((full_key, value));
-                }
-            }
-
-            // Handle array closing
-            let close_count = trimmed.matches(']').count();
-            for _ in 0..close_count {
-                if in_array_depth > 0 {
-                    in_array_depth -= 1;
-                    if key_stack.len() > 1 {
-                        key_stack.pop();
-                    }
-                }
-            }
-        }
-
-        results
-    }
-
-    /// Extract the value from a translation line like "'key' => 'value',"
-    fn extract_translation_value(line: &str) -> String {
-        if let Some(arrow_pos) = line.find("=>") {
-            let after_arrow = &line[arrow_pos + 2..];
-            let value = after_arrow.trim().trim_end_matches(',').trim();
-
-            // Remove quotes and truncate
-            let unquoted = value
-                .trim_start_matches('\'')
-                .trim_start_matches('"')
-                .trim_end_matches('\'')
-                .trim_end_matches('"');
-
-            laravel_lsp::display_truncate::truncate_for_display(unquoted, 200)
-        } else {
-            String::new()
-        }
+        self.salsa
+            .translation_key_completions(root)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|data| TranslationKeyCompletion {
+                key: data.key,
+                value: data.value,
+                source: data.source,
+            })
+            .collect()
     }
 
     /// Get all validation rules (built-in + custom from app/Rules/)
@@ -15226,11 +15110,13 @@ return [
 
     /// Does the project define this translation key anywhere?
     ///
-    /// The key is resolved through [`laravel_lsp::translation_lookup`] against
+    /// The key is resolved through the Salsa translation cache against
     /// **every locale** the project defines, in the order
-    /// [`laravel_lsp::translation_lookup::available_locales`] returns — the
-    /// same set and order hover renders and go-to-definition navigates, so all
-    /// three agree about a key present only in, say, `de`.
+    /// [`Self::translation_locales`] returns — the same set and order hover
+    /// renders and go-to-definition navigates, so all three agree about a key
+    /// present only in, say, `de`. Both steps share
+    /// [`Self::resolve_translation`], so the catalogues are read once per edit
+    /// rather than once per request (issue #293).
     ///
     /// All three key shapes go through that one resolver: dotted
     /// (`validation.required` → `{lang_root}/{locale}/validation.php`), text
@@ -15248,14 +15134,13 @@ return [
     /// `expected_path` — where a missing key should be created — points at the
     /// leading locale, which is the project's `APP_LOCALE` when it defines any
     /// translations at all.
-    fn check_translation_file(
+    async fn check_translation_file(
+        &self,
         root: &Path,
         translation_key: &str,
-        vendor_map: Option<&HashMap<String, PathBuf>>,
+        vendor_map: Option<Arc<HashMap<String, PathBuf>>>,
     ) -> TranslationCheck {
-        use laravel_lsp::translation_lookup::{
-            available_locales, project_lang_roots, resolve_translation_detailed,
-        };
+        use laravel_lsp::translation_lookup::{project_lang_roots, DEFAULT_LOCALE};
 
         // The same locale set, in the same order, that hover renders and
         // go-to-definition navigates against — so a key defined only in `de`
@@ -15263,17 +15148,31 @@ return [
         // (issue #288). The key is *resolved* in each locale rather than the
         // lang file merely probed for existence: a file that exists but does
         // not define this key is not evidence the key exists.
-        let locales = available_locales(root, translation_key, vendor_map);
-        let resolution = locales.iter().find_map(|locale| {
-            resolve_translation_detailed(root, translation_key, locale, vendor_map)
-                .map(|r| (locale.clone(), r))
-        });
+        //
+        // Both the locale set and the resolution come from the Salsa
+        // translation cache, so a 25-locale project reads each catalogue once
+        // per edit rather than once per diagnostic pass (issue #293).
+        let locales = self
+            .translation_locales(root, translation_key, vendor_map.clone())
+            .await;
+        let mut resolution = None;
+        for locale in &locales {
+            if let Some(resolved) = self
+                .resolve_translation(root, translation_key, locale, vendor_map.clone())
+                .await
+            {
+                resolution = Some((locale.clone(), resolved));
+                break;
+            }
+        }
         // Where a missing key should be created: the leading locale, which is
         // the project's APP_LOCALE when it defines any translations at all.
+        // `translation_locales` never yields an empty set; the fallback keeps
+        // that a total function rather than a panic.
         let lead_locale = locales
             .first()
             .cloned()
-            .expect("available_locales never yields an empty set");
+            .unwrap_or_else(|| DEFAULT_LOCALE.to_string());
 
         if let Some((namespace, rest)) = translation_key.split_once("::") {
             let file_segment = rest.split('.').next().unwrap_or(rest);
@@ -15282,6 +15181,7 @@ return [
             // Expected location for the diagnostic message: the package's real
             // lang dir when the vendor scan knows it, else the published path.
             let lang_dir = vendor_map
+                .as_deref()
                 .and_then(|m| m.get(namespace).cloned())
                 .unwrap_or_else(|| root.join("lang/vendor").join(namespace));
             let expected = lang_dir
@@ -16246,7 +16146,6 @@ return [
         let root_guard = self.root_path.read().await;
         let root = root_guard.as_ref()?;
         let vendor_map = self.vendor_translation_namespaces_for(root).await;
-        let map_ref = vendor_map.as_ref().map(|m| m.as_ref());
 
         // Resolve the key for real, across every locale the project defines,
         // in the same APP_LOCALE-led order hover renders and diagnostics
@@ -16258,15 +16157,22 @@ return [
         // Resolving rather than probing for the file also means a locale whose
         // lang file exists but does not define this key is correctly skipped,
         // instead of navigating to a file that never had the key in it.
-        let locales = laravel_lsp::translation_lookup::available_locales(root, &trans.key, map_ref);
-        let translation_path = locales
-            .iter()
-            .find_map(|locale| {
-                laravel_lsp::translation_lookup::resolve_translation_detailed(
-                    root, &trans.key, locale, map_ref,
-                )
-            })?
-            .source_file;
+        //
+        // Both steps go through the Salsa translation cache (issue #293).
+        let locales = self
+            .translation_locales(root, &trans.key, vendor_map.clone())
+            .await;
+        let mut translation_path = None;
+        for locale in &locales {
+            if let Some(resolved) = self
+                .resolve_translation(root, &trans.key, locale, vendor_map.clone())
+                .await
+            {
+                translation_path = Some(resolved.source_file);
+                break;
+            }
+        }
+        let translation_path = translation_path?;
 
         // The nested array path to the key *within* the file (the segments
         // after the file name), used to jump to the key's exact line. `None`
@@ -16293,16 +16199,26 @@ return [
 
             // Jump to the key's own line where we can locate it, else the
             // top of the file (the file resolved, only the key didn't).
-            let target_range = match php_key_path.as_deref() {
+            //
+            // Served from the Salsa translation cache, which resolved this very
+            // file a moment ago — before #293 this re-read it from disk, and
+            // for a `.php` catalogue re-ran a whole tree-sitter parse, on every
+            // jump.
+            let target = match php_key_path.as_deref() {
                 // JSON text key: line of the `"key":` property.
-                None => {
-                    Self::find_json_key_location(&translation_path, &trans.key).unwrap_or_default()
-                }
+                None => Some(TranslationKeyTarget::Json(trans.key.clone())),
                 // PHP nested array key: walk the array to the leaf's line.
-                Some(key_path) if !key_path.is_empty() => {
-                    Self::locate_php_key_range(&translation_path, key_path).unwrap_or_default()
-                }
-                Some(_) => Range::default(),
+                Some(key_path) if !key_path.is_empty() => Some(TranslationKeyTarget::Php(
+                    key_path.iter().map(|s| s.to_string()).collect(),
+                )),
+                Some(_) => None,
+            };
+            let target_range = match target {
+                Some(target) => self
+                    .locate_translation_key(root, &translation_path, target)
+                    .await
+                    .unwrap_or_default(),
+                None => Range::default(),
             };
 
             return Some(GotoDefinitionResponse::Link(vec![LocationLink {
@@ -16316,55 +16232,40 @@ return [
         None
     }
 
-    /// Find the line/columns of a nested array key in a PHP lang file via the
-    /// tree-sitter array walker [`config_key_locator`] (translation files are
-    /// the same nested-array shape as config files). `key_path` is the segments
-    /// *inside* the file — e.g. `["task_group_status_change", "title"]` for
-    /// `app::notification.task_group_status_change.title`. `None` when the file
-    /// can't be read or the key path isn't present.
-    fn locate_php_key_range(php_path: &Path, key_path: &[&str]) -> Option<Range> {
-        let content = std::fs::read_to_string(php_path).ok()?;
-        let pos = laravel_lsp::config_key_locator::locate_in_source(&content, key_path)?;
+    /// The `Range` of a translation key's declaration inside the catalogue that
+    /// defines it, for go-to-definition's `target_range`.
+    ///
+    /// Translation `.php` catalogues are the same nested-array shape as config
+    /// files, so the PHP arm delegates to the tree-sitter walker in
+    /// [`laravel_lsp::config_key_locator`]; the JSON arm matches the quoted key
+    /// literal. Both run inside the Salsa cache against the catalogue text that
+    /// resolution already loaded, so a repeat jump costs no disk read and no
+    /// re-parse (issue #293).
+    ///
+    /// `None` when the catalogue can't be read or the key isn't in it — the
+    /// caller then lands at the top of the file, which is what it did before.
+    async fn locate_translation_key(
+        &self,
+        root: &Path,
+        path: &Path,
+        target: TranslationKeyTarget,
+    ) -> Option<Range> {
+        let found = self
+            .salsa
+            .locate_translation_key(root.to_path_buf(), path.to_path_buf(), target)
+            .await
+            .ok()
+            .flatten()?;
         Some(Range {
             start: Position {
-                line: pos.line,
-                character: pos.start_column,
+                line: found.line,
+                character: found.start_column,
             },
             end: Position {
-                line: pos.line,
-                character: pos.end_column,
+                line: found.line,
+                character: found.end_column,
             },
         })
-    }
-
-    /// Find the line and column of a key in a JSON translation file
-    fn find_json_key_location(json_path: &Path, key: &str) -> Option<Range> {
-        let content = std::fs::read_to_string(json_path).ok()?;
-
-        // Search for the key pattern: "key": or "key" :
-        // We look for the key surrounded by quotes at the start of a JSON property
-        let search_pattern = format!("\"{}\"", key);
-
-        for (line_num, line) in content.lines().enumerate() {
-            if let Some(col) = line.find(&search_pattern) {
-                // Found the key, position cursor at the start of the key (after the opening quote)
-                let start_col = col + 1; // Skip the opening quote
-                let end_col = start_col + key.len();
-
-                return Some(Range {
-                    start: Position {
-                        line: line_num as u32,
-                        character: start_col as u32,
-                    },
-                    end: Position {
-                        line: line_num as u32,
-                        character: end_col as u32,
-                    },
-                });
-            }
-        }
-
-        None
     }
 
     /// Create LocationLink for an asset reference from Salsa data
@@ -18244,8 +18145,9 @@ return [
             if let Some(root) = root_guard.as_ref() {
                 let vendor_map = self.vendor_translation_namespaces_for(root).await;
                 for trans_ref in &patterns.translation_refs {
-                    let check =
-                        Self::check_translation_file(root, &trans_ref.key, vendor_map.as_deref());
+                    let check = self
+                        .check_translation_file(root, &trans_ref.key, vendor_map.clone())
+                        .await;
                     if !check.exists {
                         diagnostics.push(Self::create_translation_diagnostic(
                             &trans_ref.key,
@@ -18581,8 +18483,9 @@ return [
         if let Some(root) = root_guard.as_ref() {
             let vendor_map = self.vendor_translation_namespaces_for(root).await;
             for trans_ref in &patterns.translation_refs {
-                let check =
-                    Self::check_translation_file(root, &trans_ref.key, vendor_map.as_deref());
+                let check = self
+                    .check_translation_file(root, &trans_ref.key, vendor_map.clone())
+                    .await;
                 if !check.exists {
                     diagnostics.push(Self::create_translation_diagnostic(
                         &trans_ref.key,
@@ -18772,11 +18675,9 @@ return [
                     if let Some(ref args) = dir_ref.arguments {
                         if let Some(translation_key) = Self::extract_view_from_directive_args(args)
                         {
-                            let check = Self::check_translation_file(
-                                root,
-                                &translation_key,
-                                vendor_map.as_deref(),
-                            );
+                            let check = self
+                                .check_translation_file(root, &translation_key, vendor_map.clone())
+                                .await;
                             if !check.exists {
                                 diagnostics.push(Self::create_translation_diagnostic(
                                     &translation_key,
@@ -20215,16 +20116,20 @@ return [
             return hover::translation_card(key, "en", None, None);
         };
         let vendor_map = self.vendor_translation_namespaces_for(r).await;
-        let map_ref = vendor_map.as_ref().map(|m| m.as_ref());
 
         // A locale either defines the key — yielding both a value and a link to
         // the file it was read from — or it does not. The two cannot occur
         // apart, so they travel as one.
+        //
+        // Locale discovery and every per-locale resolution come from the Salsa
+        // translation cache, so hovering a key on a 25-locale project reads the
+        // catalogues once per edit rather than 25 times per hover (issue #293).
         let mut entries: Vec<(String, Option<(String, String)>)> = Vec::new();
-        for locale in laravel_lsp::translation_lookup::available_locales(r, key, map_ref) {
-            let hit = match laravel_lsp::translation_lookup::resolve_translation_detailed(
-                r, key, &locale, map_ref,
-            ) {
+        for locale in self.translation_locales(r, key, vendor_map.clone()).await {
+            let hit = match self
+                .resolve_translation(r, key, &locale, vendor_map.clone())
+                .await
+            {
                 Some(res) => Some((
                     laravel_lsp::display_truncate::truncate_for_display(
                         &Self::unquote_php_literal(&res.value),
@@ -20664,6 +20569,12 @@ return [
     /// first call. The scan walks `vendor/` for service providers calling
     /// `loadTranslationsFrom(...)` — see [`laravel_lsp::vendor_translations`].
     /// Subsequent hover calls reuse the cached Arc without re-scanning.
+    /// Drop the cached vendor translation-namespace map so the next lookup
+    /// rescans providers. See [`Self::vendor_translation_namespaces_for`].
+    async fn invalidate_vendor_translation_namespaces(&self) {
+        *self.vendor_translation_namespaces.write().await = None;
+    }
+
     async fn vendor_translation_namespaces_for(
         &self,
         root: &Path,
@@ -20697,6 +20608,59 @@ return [
         let arc = Arc::new(scanned);
         *self.vendor_translation_namespaces.write().await = Some(arc.clone());
         Some(arc)
+    }
+}
+
+impl LaravelLanguageServer {
+    // === Translation resolution through Salsa (issue #293) ===
+
+    /// Every locale that could define `key`, APP_LOCALE first.
+    ///
+    /// The single locale-discovery entry point for hover, go-to-definition and
+    /// diagnostics, so all three see the same set in the same order
+    /// (issue #288) and enumerate the lang directories once per edit rather
+    /// than once per request (issue #293).
+    ///
+    /// Fails closed to `["en"]` — Laravel's own default — if the Salsa actor is
+    /// unreachable, matching the fallback the cache itself applies to a project
+    /// with no lang directory. Callers may therefore assume a non-empty set.
+    async fn translation_locales(
+        &self,
+        root: &Path,
+        key: &str,
+        vendor_map: Option<Arc<HashMap<String, PathBuf>>>,
+    ) -> Vec<String> {
+        self.salsa
+            .available_locales(root.to_path_buf(), key.to_string(), vendor_map)
+            .await
+            .ok()
+            .filter(|locales| !locales.is_empty())
+            .unwrap_or_else(|| vec![laravel_lsp::translation_lookup::DEFAULT_LOCALE.to_string()])
+    }
+
+    /// Resolve `key` in one locale through the Salsa cache.
+    ///
+    /// The single resolution entry point for hover, go-to-definition and
+    /// diagnostics. An unreachable actor resolves to `None` — the same answer
+    /// an undefined key gives, which degrades to "not found" rather than to a
+    /// wrong location.
+    async fn resolve_translation(
+        &self,
+        root: &Path,
+        key: &str,
+        locale: &str,
+        vendor_map: Option<Arc<HashMap<String, PathBuf>>>,
+    ) -> Option<laravel_lsp::salsa_impl::ResolvedTranslationData> {
+        self.salsa
+            .resolve_translation(
+                root.to_path_buf(),
+                key.to_string(),
+                locale.to_string(),
+                vendor_map,
+            )
+            .await
+            .ok()
+            .flatten()
     }
 }
 
@@ -21130,19 +21094,23 @@ async fn collect_declaration_locations(
             }
         }
         SymbolRef::Translation(key) => {
-            let locs = laravel_lsp::translation_key_locator::locate_keys_across_locales(root, key);
+            let locs = server
+                .salsa
+                .locate_key_across_locales(root.to_path_buf(), key.to_string())
+                .await
+                .unwrap_or_default();
             for loc in locs {
                 if let Ok(uri) = Url::from_file_path(&loc.file_path) {
                     out.push(Location {
                         uri,
                         range: Range {
                             start: Position {
-                                line: loc.position.line,
-                                character: loc.position.start_column,
+                                line: loc.location.line,
+                                character: loc.location.start_column,
                             },
                             end: Position {
-                                line: loc.position.line,
-                                character: loc.position.end_column,
+                                line: loc.location.line,
+                                character: loc.location.end_column,
                             },
                         },
                     });
@@ -21185,20 +21153,24 @@ async fn collect_declaration_locations(
 /// file. The LEAF segment of the new dotted form is written at each
 /// declaration; the file portion is the lang filename and can't change
 /// without moving the file.
-fn collect_translation_declaration_targets(
+async fn collect_translation_declaration_targets(
+    salsa: &laravel_lsp::salsa_impl::SalsaHandle,
     root: &Path,
     old_key: &str,
     new_key: &str,
 ) -> Vec<laravel_lsp::rename::EditTarget> {
-    let locations = laravel_lsp::translation_key_locator::locate_keys_across_locales(root, old_key);
+    let locations = salsa
+        .locate_key_across_locales(root.to_path_buf(), old_key.to_string())
+        .await
+        .unwrap_or_default();
     let new_leaf = new_key.rsplit('.').next().unwrap_or(new_key).to_string();
     locations
         .into_iter()
         .map(|loc| laravel_lsp::rename::EditTarget {
             file_path: loc.file_path,
-            line: loc.position.line,
-            start_column: loc.position.start_column,
-            end_column: loc.position.end_column,
+            line: loc.location.line,
+            start_column: loc.location.start_column,
+            end_column: loc.location.end_column,
             new_text: new_leaf.clone(),
         })
         .collect()
@@ -22588,6 +22560,10 @@ impl LanguageServer for LaravelLanguageServer {
             if is_config_file {
                 info!("📦 Config file changed, invalidating config cache");
                 self.invalidate_config_cache().await;
+                // A changed `composer.json` can add or remove a package that
+                // ships translations, which changes the vendor
+                // translation-namespace map (issue #293).
+                self.invalidate_vendor_translation_namespaces().await;
             }
 
             match file_name {
@@ -22760,6 +22736,12 @@ impl LanguageServer for LaravelLanguageServer {
         // Did this batch record any `.php` magic change? Gates the debounced
         // incremental batch — an Inertia-only burst does no magic work.
         let mut magic_dirty = false;
+        // Did a service provider change? The vendor translation-namespace map
+        // is built by scanning providers, and is cached for the whole session.
+        let mut providers_changed = false;
+        // Project root, for classifying lang catalogues below. Read once
+        // rather than per event in a burst.
+        let watched_root = self.root_path.read().await.clone();
 
         for change in params.changes {
             if open_docs.contains(&change.uri) {
@@ -22769,6 +22751,30 @@ impl LanguageServer for LaravelLanguageServer {
             let Ok(path) = change.uri.to_file_path() else {
                 continue;
             };
+            // Lang catalogues (issue #293). An external create, change or
+            // delete — a `git pull`, a branch switch, `php artisan lang:publish`
+            // — must drop the cached catalogue, or the translation cache would
+            // keep serving the pre-change value for the rest of the session.
+            // Before this cache existed there was nothing to go stale; adding
+            // it without this arm would have traded a perf bug for a
+            // correctness one.
+            //
+            // A `.json` catalogue then stops here: it is not PHP, so the
+            // pattern-index machinery below has nothing to do with it. A `.php`
+            // catalogue falls through, because it is a lang file *and* an
+            // ordinary source file.
+            if let Some(root) = watched_root.as_ref() {
+                if laravel_lsp::translation_lookup::is_lang_file(root, &path) {
+                    let _ = self.salsa.invalidate_lang_path(path.clone()).await;
+                    if path.extension().is_some_and(|ext| ext == "json") {
+                        match change.typ {
+                            FileChangeType::DELETED => deleted += 1,
+                            _ => created_or_changed += 1,
+                        }
+                        continue;
+                    }
+                }
+            }
             // Inertia page files (resources/js/Pages/**/*.{vue,tsx,jsx,svelte})
             // are not PHP — they never enter the Salsa pattern index, so the
             // Salsa update/remove path below doesn't apply. A create/change/
@@ -22801,6 +22807,20 @@ impl LanguageServer for LaravelLanguageServer {
                 && laravel_lsp::path_segments::contains_segments(&path, "database/migrations")
             {
                 migrations_changed = true;
+            }
+            // A service provider registers translation namespaces via
+            // `loadTranslationsFrom`. Both the vendor scan (`vendor/**`) and
+            // the app scan (`app/Providers/**`) feed one session-long cache,
+            // so an edit to either must drop it. Filename gate mirrors the
+            // scan's own: it only ever parses `*ServiceProvider*.php`.
+            if !providers_changed
+                && path.to_string_lossy().ends_with(".php")
+                && path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.contains("ServiceProvider"))
+            {
+                providers_changed = true;
             }
             // Snapshot the file's pre-change surface for the incremental magic
             // batch (M2) BEFORE the arm's Salsa mutation runs — critically,
@@ -22898,6 +22918,17 @@ impl LanguageServer for LaravelLanguageServer {
             if let Some(root) = self.initialized_root.read().await.clone() {
                 self.rebuild_migration_index(&root).await;
             }
+        }
+
+        // A service provider changed on disk — drop the vendor
+        // translation-namespace map so the next namespaced translation lookup
+        // rescans. The map is built once and was previously cached for the
+        // entire session, so a `composer update`, a newly-installed package, or
+        // an edited `loadTranslationsFrom` was invisible until the LSP
+        // restarted — and since #293 that map decides where a namespaced key
+        // resolves, so a stale one is a wrong answer, not just an old one.
+        if providers_changed {
+            self.invalidate_vendor_translation_namespaces().await;
         }
 
         // A Command class changed on disk — rebuild the Artisan command index so
@@ -23916,9 +23947,10 @@ impl LanguageServer for LaravelLanguageServer {
                 // Same shape as config but applied across every locale's lang
                 // file under lang/<locale>/<file>.php.
                 if let Some(root) = root_path.as_ref() {
-                    targets.extend(collect_translation_declaration_targets(
-                        root, key, &new_name,
-                    ));
+                    targets.extend(
+                        collect_translation_declaration_targets(&self.salsa, root, key, &new_name)
+                            .await,
+                    );
                 }
             }
             laravel_lsp::references::SymbolRef::Env(key) => {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2053,7 +2053,6 @@ struct LaravelLanguageServer {
     /// `None` means "not yet scanned"; `Some(map)` means "scanned, here's
     /// what we found" (the map can be empty if no packages register).
     /// Wrapped in `Arc` so clones share memory across hover calls.
-    vendor_translation_namespaces: Arc<RwLock<Option<Arc<HashMap<String, PathBuf>>>>>,
 
     /// Cache of parsed Laravel framework Builder + Query/Builder method
     /// surfaces, keyed by project root. Populated lazily on the first
@@ -4427,7 +4426,6 @@ impl LaravelLanguageServer {
             indexing_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             migration_index: Arc::new(RwLock::new(None)),
             command_index: Arc::new(RwLock::new(None)),
-            vendor_translation_namespaces: Arc::new(RwLock::new(None)),
             builder_method_index_cache: Arc::new(RwLock::new(HashMap::new())),
             route_decl_cache: Arc::new(RwLock::new(HashMap::new())),
             magic_deps: Arc::new(std::sync::RwLock::new(
@@ -17365,7 +17363,6 @@ return [
             indexing_in_flight: self.indexing_in_flight.clone(),
             migration_index: self.migration_index.clone(),
             command_index: self.command_index.clone(),
-            vendor_translation_namespaces: self.vendor_translation_namespaces.clone(),
             builder_method_index_cache: self.builder_method_index_cache.clone(),
             route_decl_cache: self.route_decl_cache.clone(),
             magic_deps: self.magic_deps.clone(),
@@ -20565,49 +20562,34 @@ return [
         }
     }
 
-    /// Return the cached vendor translation-namespace map, building it on
-    /// first call. The scan walks `vendor/` for service providers calling
-    /// `loadTranslationsFrom(...)` — see [`laravel_lsp::vendor_translations`].
-    /// Subsequent hover calls reuse the cached Arc without re-scanning.
-    /// Drop the cached vendor translation-namespace map so the next lookup
-    /// rescans providers. See [`Self::vendor_translation_namespaces_for`].
+    /// Drop everything derived from service providers, so the next namespace
+    /// lookup rediscovers and re-reads them.
     async fn invalidate_vendor_translation_namespaces(&self) {
-        *self.vendor_translation_namespaces.write().await = None;
+        let _ = self.salsa.invalidate_translation_providers().await;
     }
 
+    /// The project's provider-registered `namespace -> lang dir` map — the
+    /// registrations `loadTranslationsFrom(...)` makes, from both `vendor/`
+    /// and `app/Providers/`.
+    ///
+    /// Served from the Salsa translation cache (issue #293). This used to run
+    /// one uncached `walkdir` sweep under `spawn_blocking` and hold the result
+    /// in an `RwLock` for the whole session, with nothing that could ever clear
+    /// it — so a `composer update`, a newly-installed package, or an edited
+    /// registration was invisible until the LSP restarted. Salsa is the cache
+    /// now, which is both warm and invalidatable.
+    ///
+    /// `None` only when the actor is unreachable; an empty map is `Some`, since
+    /// "this project registers no namespaces" is an answer, not a failure.
     async fn vendor_translation_namespaces_for(
         &self,
         root: &Path,
     ) -> Option<Arc<HashMap<String, PathBuf>>> {
-        {
-            let guard = self.vendor_translation_namespaces.read().await;
-            if let Some(ref existing) = *guard {
-                return Some(existing.clone());
-            }
-        }
-        // Cache miss — scan and store. Done under spawn_blocking so the
-        // walkdir traversal doesn't block the LSP event loop.
-        //
-        // Two passes merge into one map: the vendor scan first, then the
-        // app-provider scan, which overrides vendor on namespace conflict —
-        // the app boots last, so an app `loadTranslationsFrom` for a namespace
-        // a package also registers is the one that wins at runtime.
-        let root_clone = root.to_path_buf();
-        let scanned = tokio::task::spawn_blocking(move || {
-            let mut map =
-                laravel_lsp::vendor_translations::scan_vendor_translation_namespaces(&root_clone);
-            for (namespace, dir) in
-                laravel_lsp::vendor_translations::scan_app_translation_namespaces(&root_clone)
-            {
-                map.insert(namespace, dir);
-            }
-            map
-        })
-        .await
-        .ok()?;
-        let arc = Arc::new(scanned);
-        *self.vendor_translation_namespaces.write().await = Some(arc.clone());
-        Some(arc)
+        self.salsa
+            .vendor_translation_namespaces(root.to_path_buf())
+            .await
+            .ok()
+            .map(Arc::new)
     }
 }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -161,6 +161,53 @@ pub struct EnvFile {
     pub priority: u8,
 }
 
+/// One Laravel translation catalogue: a `{lang_root}/{locale}/{file}.php` array
+/// file, a `{lang_root}/vendor/{namespace}/{locale}/{file}.php` published
+/// override, or a `{lang_root}/{locale}.json` text catalogue.
+///
+/// Registered lazily, once per path, by [`SalsaActor::ensure_lang_file`] — a
+/// path that is absent, unreadable, or refused by the containment guard is
+/// registered with **empty text**, which resolves to no key just as an absent
+/// file does. That negative entry is what stops a 25-locale lookup from
+/// re-probing 24 missing files on every hover (issue #293).
+#[salsa::input]
+pub struct LangFile {
+    /// The file path
+    #[returns(ref)]
+    pub path: PathBuf,
+
+    /// Version incremented when the file changes
+    #[returns(copy)]
+    pub version: i32,
+
+    /// The file content; empty for an absent or refused file
+    #[returns(ref)]
+    pub text: String,
+}
+
+/// One directory that may contain locales — a lang root, a published
+/// `{lang_root}/vendor/{namespace}` override dir, or a package's own lang dir
+/// registered via `loadTranslationsFrom`.
+///
+/// Holds the directory's direct children rather than re-running `read_dir` per
+/// lookup. Like [`LangFile`], an absent or refused directory is registered with
+/// an **empty** listing, which contributes no locales exactly as a failed
+/// `read_dir` did (issue #293).
+#[salsa::input]
+pub struct LangDir {
+    /// The directory path
+    #[returns(ref)]
+    pub path: PathBuf,
+
+    /// Version incremented when the directory listing changes
+    #[returns(copy)]
+    pub version: i32,
+
+    /// `(file name, is_dir)` for every direct child
+    #[returns(ref)]
+    pub entries: Vec<(String, bool)>,
+}
+
 // ============================================================================
 // Interned Types - Deduplicated strings
 // ============================================================================
@@ -1487,6 +1534,683 @@ fn parse_env_value_internal(value: &str) -> String {
     }
 
     value.to_string()
+}
+
+// ============================================================================
+// Translation Resolution (Salsa-based) — issue #293
+// ============================================================================
+
+/// A resolved translation crossing the async boundary — the value as its raw
+/// PHP/JSON literal, plus the catalogue it was read from. Hover renders the
+/// source file as a link; go-to-definition navigates to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedTranslationData {
+    /// The translated value, as the raw PHP/JSON literal
+    pub value: String,
+    /// The catalogue the value came from
+    pub source_file: PathBuf,
+}
+
+/// Walk a dotted key path inside one PHP array catalogue.
+///
+/// Memoized per `(file, key_path)`. An empty-text file — absent, unreadable or
+/// containment-refused — yields `None`, exactly as the direct-`fs` resolver did
+/// when the read failed.
+#[salsa::tracked]
+pub fn resolve_php_translation(
+    db: &dyn Db,
+    file: LangFile,
+    key_path: Vec<String>,
+) -> Option<String> {
+    let text = file.text(db);
+    if text.is_empty() {
+        return None;
+    }
+    let refs: Vec<&str> = key_path.iter().map(String::as_str).collect();
+    crate::config_lookup::resolve_in_source(text, &refs)
+}
+
+/// Look one text key up in a `{lang_root}/{locale}.json` catalogue.
+///
+/// Memoized per `(file, key)`. The value is returned single-quoted so it
+/// matches the PHP-literal shape the rest of the pipeline unquotes.
+#[salsa::tracked]
+pub fn resolve_json_translation(db: &dyn Db, file: LangFile, key: String) -> Option<String> {
+    let text = file.text(db);
+    if text.is_empty() {
+        return None;
+    }
+    let map: serde_json::Map<String, serde_json::Value> = serde_json::from_str(text).ok()?;
+    Some(format!("'{}'", map.get(&key)?.as_str()?))
+}
+
+/// The locale names one directory listing implies.
+///
+/// A subdirectory is a locale (`lang/de/`); a `.json` child is a locale
+/// catalogue (`lang/de.json`). `vendor` is a namespace container, never a
+/// locale. Memoized per directory listing, so a 25-locale project enumerates
+/// once instead of once per hover, goto and diagnostic (issue #293).
+#[salsa::tracked]
+pub fn locales_in_dir(db: &dyn Db, dir: LangDir) -> Vec<String> {
+    let mut locales = Vec::new();
+    for (name, is_dir) in dir.entries(db) {
+        let locale = if *is_dir {
+            Some(name.clone())
+        } else {
+            std::path::Path::new(name)
+                .extension()
+                .is_some_and(|e| e == "json")
+                .then(|| {
+                    std::path::Path::new(name)
+                        .file_stem()
+                        .and_then(|n| n.to_str())
+                        .map(str::to_string)
+                })
+                .flatten()
+        };
+        if let Some(locale) = locale {
+            if locale != "vendor" && !locales.contains(&locale) {
+                locales.push(locale);
+            }
+        }
+    }
+    locales
+}
+
+/// Lang-file reads and locale enumeration, memoized through Salsa.
+///
+/// Owned by [`SalsaActor`] in production; constructible directly so tests can
+/// exercise the real resolution path against a bare [`LaravelDatabase`] without
+/// standing up the actor.
+///
+/// # Why this exists
+///
+/// Translation resolution used to read and parse lang files with
+/// `std::fs::read_to_string` on **every** call, uncached and uninvalidated.
+/// Since #288 resolved a key against every locale a project defines, one hover
+/// on a 25-locale project meant a `read_dir` plus up to 25 file reads — repeated
+/// for go-to-definition and again for diagnostics. Routing those reads through
+/// Salsa inputs makes them incremental: read once, reuse until something
+/// actually changes (issue #293).
+///
+/// # Containment
+///
+/// [`Self::ensure_file`] and [`Self::ensure_dir`] are the **only** places this
+/// module touches disk, and both are fail-closed: a path that cannot be proven
+/// inside the project root is never read (issue #248). Candidate paths are built
+/// from `vendor::` namespaces and `loadTranslationsFrom` arguments lifted
+/// verbatim out of parsed source, so they are untrusted and may carry traversal
+/// or be absolute. Keeping the guard at these two functions is what lets
+/// `translation_lookup` be pure path arithmetic without weakening #248.
+#[derive(Default)]
+pub struct TranslationCache {
+    /// Catalogues keyed by absolute path. An entry with **empty text** is a
+    /// negative cache: the path is absent, unreadable, or containment-refused.
+    /// Without it, a key defined only in `de` would re-probe the other 24
+    /// locales' missing files on every single request.
+    files: HashMap<PathBuf, LangFile>,
+    /// Directory listings backing locale discovery, keyed by absolute path. An
+    /// empty listing likewise caches "absent, or nothing in it".
+    dirs: HashMap<PathBuf, LangDir>,
+    /// Version counter shared by files and directories; bumped on every
+    /// registration so Salsa sees a changed input.
+    version: i32,
+    /// How many times this cache has touched disk — one per
+    /// `fs::read_to_string` or `read_dir` that actually ran. Lets a test prove
+    /// a second resolution is served from Salsa rather than re-read.
+    ///
+    /// Per-cache rather than a global counter: caches are per-actor, so every
+    /// test owns its own and concurrent tests cannot perturb each other's
+    /// counts. A process-wide counter made these assertions racy — any other
+    /// test resolving a translation moved the number.
+    disk_reads: usize,
+}
+
+impl TranslationCache {
+    /// How many times this cache has touched disk. See [`Self::disk_reads`].
+    pub fn disk_reads(&self) -> usize {
+        self.disk_reads
+    }
+
+    /// Push a catalogue's authoritative text into Salsa — an editor buffer via
+    /// `did_change`, or a fresh disk read. Creates the input on first sight and
+    /// updates it in place afterwards, so dependent queries are invalidated
+    /// rather than duplicated.
+    pub fn register(&mut self, db: &mut LaravelDatabase, path: PathBuf, text: String) {
+        self.version += 1;
+        if let Some(file) = self.files.get(&path) {
+            file.set_version(db).to(self.version);
+            file.set_text(db).to(text);
+        } else {
+            let file = LangFile::new(&*db, path.clone(), self.version, text);
+            self.files.insert(path, file);
+        }
+    }
+
+    /// Drop a lang path's cached entry, and the directory listings that could
+    /// have enumerated it, so the next lookup re-reads disk. Covers external
+    /// create, change and delete alike — a create clears the negative entry, a
+    /// delete clears the positive one.
+    ///
+    /// Two directory levels are cleared because both can be invalidated by one
+    /// file event: for `lang/de/validation.php` the parent (`lang/de`) is the
+    /// locale directory and the grandparent (`lang/`) is what enumerates `de`
+    /// as a locale at all; for `lang/vendor/pkg/de/messages.php` the
+    /// grandparent (`lang/vendor/pkg`) is the namespace directory locale
+    /// discovery reads. A `lang/de.json` catalogue is covered by the first
+    /// level alone.
+    ///
+    /// Eager invalidation, lazy re-read — the same trade `file_watcher` makes,
+    /// so a `git checkout` touching many lang files does no I/O here and pays
+    /// only for the catalogues a later request actually asks for.
+    pub fn invalidate(&mut self, path: &Path) {
+        self.files.remove(path);
+        let mut dir = path.parent();
+        for _ in 0..2 {
+            let Some(d) = dir else { break };
+            self.dirs.remove(d);
+            dir = d.parent();
+        }
+    }
+
+    /// The Salsa input for `path`, registering it on first touch.
+    ///
+    /// **Fail-closed** (issue #248): a path that cannot be proven inside `root`
+    /// is registered with empty text rather than read, which resolves to no key
+    /// exactly as a failed read did. `path_within_root` canonicalizes, so an
+    /// absent path and an escaping symlink are both refused here — and both
+    /// then cost zero further disk touches, because the refusal is cached.
+    fn ensure_file(&mut self, db: &mut LaravelDatabase, path: &Path, root: &Path) -> LangFile {
+        if let Some(file) = self.files.get(path) {
+            return *file;
+        }
+        let text = if crate::path_containment::path_within_root(path, root) {
+            self.disk_reads += 1;
+            std::fs::read_to_string(path).unwrap_or_default()
+        } else {
+            String::new()
+        };
+        self.register(db, path.to_path_buf(), text);
+        self.files[path]
+    }
+
+    /// The Salsa input for `dir`'s listing, registering it on first touch.
+    /// Fail-closed on the same terms as [`Self::ensure_file`]: a directory that
+    /// cannot be proven inside `root` is registered with an empty listing
+    /// rather than enumerated, so an escaped directory can never surface its
+    /// subdirectories as this key's locales (issue #248).
+    fn ensure_dir(&mut self, db: &mut LaravelDatabase, dir: &Path, root: &Path) -> LangDir {
+        if let Some(handle) = self.dirs.get(dir) {
+            return *handle;
+        }
+        let entries: Vec<(String, bool)> = if crate::path_containment::path_within_root(dir, root) {
+            self.disk_reads += 1;
+            std::fs::read_dir(dir)
+                .map(|entries| {
+                    entries
+                        .flatten()
+                        .map(|entry| {
+                            (
+                                entry.file_name().to_string_lossy().into_owned(),
+                                entry.path().is_dir(),
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        self.version += 1;
+        let handle = LangDir::new(&*db, dir.to_path_buf(), self.version, entries);
+        self.dirs.insert(dir.to_path_buf(), handle);
+        handle
+    }
+
+    /// Resolve `key` in `locale`, returning the value and the catalogue it came
+    /// from. Candidates are tried in
+    /// [`translation_candidates`](crate::translation_lookup::translation_candidates)
+    /// order — first hit wins, so a published vendor override beats the
+    /// package's own unpublished file.
+    ///
+    /// `vendor_map` is consulted only to *name* candidate paths; it never
+    /// enters a Salsa query key. So it can neither defeat memoization of the
+    /// common dotted path (which never looks at it) nor serve a stale
+    /// namespaced resolution (candidates are recomputed from the live map on
+    /// every call).
+    pub fn resolve(
+        &mut self,
+        db: &mut LaravelDatabase,
+        root: &Path,
+        key: &str,
+        locale: &str,
+        vendor_map: Option<&HashMap<String, PathBuf>>,
+    ) -> Option<ResolvedTranslationData> {
+        for candidate in
+            crate::translation_lookup::translation_candidates(root, key, locale, vendor_map)
+        {
+            let file = self.ensure_file(db, candidate.path(), root);
+            // Salsa hands back a borrow of the memoized value; clone it so the
+            // database borrow ends before the next candidate needs `&mut db`.
+            let value = match &candidate {
+                crate::translation_lookup::TranslationCandidate::Php { key_path, .. } => {
+                    resolve_php_translation(&*db, file, key_path.clone()).clone()
+                }
+                crate::translation_lookup::TranslationCandidate::Json { key, .. } => {
+                    resolve_json_translation(&*db, file, key.clone()).clone()
+                }
+            };
+            if let Some(value) = value {
+                return Some(ResolvedTranslationData {
+                    value,
+                    source_file: candidate.path().to_path_buf(),
+                });
+            }
+        }
+        None
+    }
+
+    /// Every locale that could define `key`, `app_locale` first and the rest
+    /// alphabetically.
+    ///
+    /// Never returns empty: a project with no discoverable locales — no lang
+    /// directory at all, or one containing nothing — falls back to
+    /// `["en"]`, so callers always have something to resolve against.
+    ///
+    /// An `app_locale` no directory defines simply doesn't appear, leaving the
+    /// alphabetical order untouched.
+    pub fn locales(
+        &mut self,
+        db: &mut LaravelDatabase,
+        root: &Path,
+        key: &str,
+        vendor_map: Option<&HashMap<String, PathBuf>>,
+        app_locale: Option<&str>,
+    ) -> Vec<String> {
+        let mut locales: Vec<String> = Vec::new();
+        for dir in crate::translation_lookup::locale_candidate_dirs(root, key, vendor_map) {
+            let handle = self.ensure_dir(db, &dir, root);
+            let found = locales_in_dir(&*db, handle).clone();
+            // Dedupe across directories so a locale present in both the
+            // published and the unpublished vendor directory is listed once.
+            for locale in found {
+                if !locales.contains(&locale) {
+                    locales.push(locale);
+                }
+            }
+        }
+
+        if locales.is_empty() {
+            return vec![crate::translation_lookup::DEFAULT_LOCALE.to_string()];
+        }
+
+        locales.sort();
+        if let Some(app_locale) = app_locale {
+            if let Some(idx) = locales.iter().position(|l| l == app_locale) {
+                let leading = locales.remove(idx);
+                locales.insert(0, leading);
+            }
+        }
+        locales
+    }
+
+    /// Where `target` is declared inside the catalogue at `path`.
+    ///
+    /// Go-to-definition resolves a key to a file and then needs the key's own
+    /// line within it. That second step used to re-read the file — and, for a
+    /// `.php` catalogue, re-run a full tree-sitter parse — on every jump, even
+    /// though the resolution immediately before it had just read the same file
+    /// (issue #293).
+    pub fn locate_key(
+        &mut self,
+        db: &mut LaravelDatabase,
+        root: &Path,
+        path: &Path,
+        target: &TranslationKeyTarget,
+    ) -> Option<KeyLocationData> {
+        let file = self.ensure_file(db, path, root);
+        let found = match target {
+            TranslationKeyTarget::Php(key_path) => {
+                locate_php_key_in_file(&*db, file, key_path.clone())
+            }
+            TranslationKeyTarget::Json(key) => locate_json_key_in_file(&*db, file, key.clone()),
+        };
+        found.map(|(line, start_column, end_column)| KeyLocationData {
+            line,
+            start_column,
+            end_column,
+        })
+    }
+
+    /// Every translation key autocomplete should offer, sorted and deduped.
+    ///
+    /// Semantics deliberately preserved from the direct-`fs` version: the
+    /// **first** lang root that exists wins, and within it the **first** locale
+    /// subdirectory answers for the whole project — a key present in one locale
+    /// is offered regardless of which locale declares it, so enumerating the
+    /// union would read every catalogue in the project to produce the same
+    /// list. Only the reads changed: the directory listings and every
+    /// catalogue's key extraction are now memoized, where before each
+    /// completion request re-enumerated two directories and re-read *and
+    /// re-parsed* every catalogue in the locale (issue #293).
+    ///
+    /// `exists()` on the lang roots is a stat, not a read, and picking the root
+    /// this way keeps the pre-cache behaviour exactly: a first lang root that
+    /// exists but holds no locale directory yields no completions rather than
+    /// falling through to the second root.
+    pub fn completion_keys(
+        &mut self,
+        db: &mut LaravelDatabase,
+        root: &Path,
+    ) -> Vec<TranslationKeyCompletionData> {
+        let Some(lang_root) = crate::translation_lookup::project_lang_roots(root)
+            .into_iter()
+            .find(|dir| dir.exists())
+        else {
+            return Vec::new();
+        };
+        let listing = self.ensure_dir(db, &lang_root, root);
+        let Some(locale) = locales_in_dir(&*db, listing).first().cloned() else {
+            return Vec::new();
+        };
+
+        let locale_dir = lang_root.join(&locale);
+        let files = self.ensure_dir(db, &locale_dir, root).entries(&*db).clone();
+
+        let mut completions = Vec::new();
+        for (name, is_dir) in files {
+            if is_dir {
+                continue;
+            }
+            let path = locale_dir.join(&name);
+            if path.extension().is_none_or(|ext| ext != "php") {
+                continue;
+            }
+            let Some(base_key) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let source = format!("lang/{}/{}", locale, name);
+            let file = self.ensure_file(db, &path, root);
+            for (key, value) in translation_keys_in_file(&*db, file, base_key.to_string()).clone() {
+                completions.push(TranslationKeyCompletionData {
+                    key,
+                    value,
+                    source: source.clone(),
+                });
+            }
+        }
+
+        completions.sort_by(|a, b| a.key.cmp(&b.key));
+        completions.dedup_by(|a, b| a.key == b.key);
+        completions
+    }
+
+    /// Every locale file that declares `dotted_key`, with the position of the
+    /// key's own characters — the declaration sites a rename must edit.
+    ///
+    /// Walks `lang/<locale>/<file>.php` for each locale directory under
+    /// `<root>/lang`. Locales without the relevant file, or without the key in
+    /// it, are simply skipped.
+    ///
+    /// Two things changed when this moved off direct `fs` (issue #293). It is
+    /// now memoized, so renaming a key no longer re-reads and re-parses every
+    /// locale's catalogue — the same files resolution had already loaded. And
+    /// it is now **fenced**: the previous implementation joined a key-derived
+    /// file segment onto a locale directory and read the result with no
+    /// containment check at all, where routing through [`Self::ensure_file`]
+    /// brings it under the same fail-closed guard as every other read
+    /// (issue #248).
+    ///
+    /// That guard is defence in depth here rather than a closed hole: the key
+    /// is split on `.` before the stem is used, so a `../` escape leaves the
+    /// stem empty and never reaches a read. It still matters for a stem naming
+    /// an absolute path, which `Path::join` would otherwise let collapse the
+    /// base away.
+    ///
+    /// Deliberately still `lang/` only, not `resources/lang/` — that asymmetry
+    /// is pre-existing rename behaviour, and widening which files a rename
+    /// edits is a change of a different kind from caching one.
+    pub fn locate_key_across_locales(
+        &mut self,
+        db: &mut LaravelDatabase,
+        root: &Path,
+        dotted_key: &str,
+    ) -> Vec<TranslationKeyLocationData> {
+        let Some((file_stem, key_path)) =
+            crate::translation_key_locator::split_dotted_key(dotted_key)
+        else {
+            return Vec::new();
+        };
+
+        let lang_dir = root.join("lang");
+        // The raw listing rather than `locales_in_dir`: this walk has always
+        // considered exactly the subdirectories, so a `{locale}.json` stem is
+        // not a locale here.
+        let entries = self.ensure_dir(db, &lang_dir, root).entries(&*db).clone();
+
+        let mut out = Vec::new();
+        for (name, is_dir) in entries {
+            if !is_dir {
+                continue;
+            }
+            let locale_file = lang_dir.join(&name).join(format!("{file_stem}.php"));
+            let file = self.ensure_file(db, &locale_file, root);
+            if let Some(&(line, start_column, end_column)) =
+                locate_php_key_in_file(&*db, file, key_path.clone()).as_ref()
+            {
+                out.push(TranslationKeyLocationData {
+                    file_path: locale_file,
+                    location: KeyLocationData {
+                        line,
+                        start_column,
+                        end_column,
+                    },
+                });
+            }
+        }
+        out
+    }
+}
+
+/// One translation key offered by autocomplete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranslationKeyCompletionData {
+    /// The full dot-notation key (e.g. `messages.welcome`)
+    pub key: String,
+    /// The translated value, truncated for display
+    pub value: String,
+    /// Display source (e.g. `lang/en/messages.php`)
+    pub source: String,
+}
+
+/// One locale's declaration of a translation key, for building a rename edit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranslationKeyLocationData {
+    /// The catalogue declaring the key.
+    pub file_path: PathBuf,
+    /// Where in it the key's own characters sit.
+    pub location: KeyLocationData,
+}
+
+/// Which key to locate inside a catalogue, and how to match it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TranslationKeyTarget {
+    /// Nested array path inside a `.php` catalogue.
+    Php(Vec<String>),
+    /// The source string itself, inside a `.json` catalogue.
+    Json(String),
+}
+
+/// The line and column span of a key's declaration inside a catalogue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeyLocationData {
+    /// 0-based line
+    pub line: u32,
+    /// 0-based column of the key content (inside the quotes)
+    pub start_column: u32,
+    /// 0-based column one past the key content
+    pub end_column: u32,
+}
+
+/// Parse a PHP translation file to extract all keys and values
+/// Returns a list of (key, value) tuples with dot-notation keys
+fn parse_translation_keys(content: &str, base_key: &str) -> Vec<(String, String)> {
+    let mut results = Vec::new();
+
+    // Simple regex-based parsing for Laravel translation files
+    // This handles: 'key' => 'value', or "key" => "value"
+    //
+    // Compiled once: this used to be rebuilt on every completion request, for
+    // every catalogue in the locale (issue #293).
+    static KEY_PATTERN: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r#"['"]([a-zA-Z_][a-zA-Z0-9_]*)['"][\s]*=>"#).unwrap()
+    });
+    let key_pattern = &*KEY_PATTERN;
+
+    // Track nesting depth and current key path
+    let mut key_stack: Vec<String> = vec![base_key.to_string()];
+    let mut in_array_depth = 0;
+    let mut pending_key: Option<String> = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Skip comments and empty lines
+        if trimmed.is_empty()
+            || trimmed.starts_with("//")
+            || trimmed.starts_with("/*")
+            || trimmed.starts_with("*")
+        {
+            continue;
+        }
+
+        // Handle array opening
+        if trimmed.contains("[") && !trimmed.contains("=>") {
+            in_array_depth += 1;
+            if let Some(key) = pending_key.take() {
+                key_stack.push(key);
+            }
+            continue;
+        }
+
+        // Handle key => [ (nested array on same line)
+        if let Some(caps) = key_pattern.captures(trimmed) {
+            let key_name = caps.get(1).unwrap().as_str();
+
+            if trimmed.contains("=> [") || trimmed.ends_with("=> [") {
+                // This is a nested array
+                pending_key = Some(key_name.to_string());
+                in_array_depth += 1;
+                key_stack.push(key_name.to_string());
+            } else {
+                // This is a simple key => value
+                let full_key = format!("{}.{}", key_stack.join("."), key_name);
+
+                // Extract value
+                let value = extract_translation_value(trimmed);
+                results.push((full_key, value));
+            }
+        }
+
+        // Handle array closing
+        let close_count = trimmed.matches(']').count();
+        for _ in 0..close_count {
+            if in_array_depth > 0 {
+                in_array_depth -= 1;
+                if key_stack.len() > 1 {
+                    key_stack.pop();
+                }
+            }
+        }
+    }
+
+    results
+}
+
+/// Extract the value from a translation line like "'key' => 'value',"
+pub fn extract_translation_value(line: &str) -> String {
+    if let Some(arrow_pos) = line.find("=>") {
+        let after_arrow = &line[arrow_pos + 2..];
+        let value = after_arrow.trim().trim_end_matches(',').trim();
+
+        // Remove quotes and truncate
+        let unquoted = value
+            .trim_start_matches('\'')
+            .trim_start_matches('"')
+            .trim_end_matches('\'')
+            .trim_end_matches('"');
+
+        // Truncate long values for display. Delegated rather than sliced:
+        // `&unquoted[..47]` panics when byte 47 lands mid-character, which is
+        // reachable for any non-ASCII translation value (issue #319).
+        crate::display_truncate::truncate_for_display(unquoted, 200)
+    } else {
+        String::new()
+    }
+}
+
+/// Every `key => value` pair one PHP catalogue declares, dot-prefixed with
+/// `base_key`. Memoized per `(file, base_key)` — autocomplete used to re-read
+/// and re-parse every catalogue in the locale on each request (issue #293).
+#[salsa::tracked]
+pub fn translation_keys_in_file(
+    db: &dyn Db,
+    file: LangFile,
+    base_key: String,
+) -> Vec<(String, String)> {
+    let text = file.text(db);
+    if text.is_empty() {
+        return Vec::new();
+    }
+    parse_translation_keys(text, &base_key)
+}
+
+/// Where a nested key is declared inside a PHP catalogue, as
+/// `(line, start_column, end_column)`.
+///
+/// A tuple rather than `KeyPosition` so the return type is trivially
+/// `salsa::Update`; the handler widens it to [`KeyLocationData`].
+///
+/// Memoized per `(file, key_path)`: go-to-definition used to re-read the file
+/// **and re-run a tree-sitter parse** on every jump (issue #293).
+#[salsa::tracked]
+pub fn locate_php_key_in_file(
+    db: &dyn Db,
+    file: LangFile,
+    key_path: Vec<String>,
+) -> Option<(u32, u32, u32)> {
+    let text = file.text(db);
+    if text.is_empty() {
+        return None;
+    }
+    let refs: Vec<&str> = key_path.iter().map(String::as_str).collect();
+    let pos = crate::config_key_locator::locate_in_source(text, &refs)?;
+    Some((pos.line, pos.start_column, pos.end_column))
+}
+
+/// Where a text key is declared inside a JSON catalogue, as
+/// `(line, start_column, end_column)`.
+///
+/// The key is matched as a quoted literal and the span covers the key content
+/// inside its quotes — the same shape the PHP locator returns, so
+/// go-to-definition highlights identically across both catalogue formats.
+#[salsa::tracked]
+pub fn locate_json_key_in_file(
+    db: &dyn Db,
+    file: LangFile,
+    key: String,
+) -> Option<(u32, u32, u32)> {
+    let text = file.text(db);
+    if text.is_empty() {
+        return None;
+    }
+    let needle = format!("\"{key}\"");
+    text.lines().enumerate().find_map(|(line_num, line)| {
+        let col = line.find(&needle)?;
+        // Skip the opening quote so the span covers the key itself.
+        let start = (col + 1) as u32;
+        Some((line_num as u32, start, start + key.len() as u32))
+    })
 }
 
 // ============================================================================
@@ -5457,6 +6181,59 @@ pub enum SalsaRequest {
         reply: oneshot::Sender<Vec<ParsedEnvVarData>>,
     },
 
+    // === Salsa-based Translation Resolution (issue #293) ===
+    /// Resolve one translation key in one locale through the Salsa cache
+    ResolveTranslation {
+        root: PathBuf,
+        key: String,
+        locale: String,
+        /// Live `namespace -> lang dir` map for unpublished vendor
+        /// translations. Passed per request rather than memoized: it never
+        /// enters a query key, so it can neither defeat memoization of the
+        /// common dotted path nor serve a stale namespaced resolution.
+        vendor_map: Option<Arc<HashMap<String, PathBuf>>>,
+        reply: oneshot::Sender<Option<ResolvedTranslationData>>,
+    },
+    /// Every locale that could define this key, APP_LOCALE first
+    AvailableLocales {
+        root: PathBuf,
+        key: String,
+        vendor_map: Option<Arc<HashMap<String, PathBuf>>>,
+        reply: oneshot::Sender<Vec<String>>,
+    },
+    /// Push a lang file's authoritative text (editor buffer) into Salsa
+    RegisterLangSource {
+        path: PathBuf,
+        text: String,
+        reply: oneshot::Sender<()>,
+    },
+    /// Drop a lang path's cached entry and its directory listing, so the next
+    /// lookup re-reads disk. Covers external create, change and delete.
+    InvalidateLangPath {
+        path: PathBuf,
+        reply: oneshot::Sender<()>,
+    },
+    /// Locate a key's declaration inside one catalogue
+    LocateTranslationKey {
+        root: PathBuf,
+        path: PathBuf,
+        target: TranslationKeyTarget,
+        reply: oneshot::Sender<Option<KeyLocationData>>,
+    },
+    /// Every translation key autocomplete should offer
+    TranslationKeyCompletions {
+        root: PathBuf,
+        reply: oneshot::Sender<Vec<TranslationKeyCompletionData>>,
+    },
+    /// Every locale file declaring a translation key, for rename
+    LocateKeyAcrossLocales {
+        root: PathBuf,
+        dotted_key: String,
+        reply: oneshot::Sender<Vec<TranslationKeyLocationData>>,
+    },
+    /// How many times the translation cache has touched disk
+    LangDiskReads { reply: oneshot::Sender<usize> },
+
     // === Salsa-based Service Provider Management (New) ===
     /// Register a raw service provider file for Salsa to parse
     RegisterServiceProviderSource {
@@ -6652,6 +7429,172 @@ impl SalsaHandle {
             .map_err(|_| "Salsa actor dropped reply channel")
     }
 
+    // === Salsa-based Translation Methods (issue #293) ===
+
+    /// Resolve a translation key in one locale through the Salsa cache.
+    ///
+    /// `vendor_map` is the live `namespace -> lang dir` map from
+    /// `vendor_translations`; pass `None` when the project registers no
+    /// unpublished package translations.
+    pub async fn resolve_translation(
+        &self,
+        root: PathBuf,
+        key: String,
+        locale: String,
+        vendor_map: Option<Arc<HashMap<String, PathBuf>>>,
+    ) -> Result<Option<ResolvedTranslationData>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::ResolveTranslation {
+                root,
+                key,
+                locale,
+                vendor_map,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Every locale that could define `key`, APP_LOCALE first. Never empty —
+    /// falls back to `["en"]` on a project that defines no translations.
+    pub async fn available_locales(
+        &self,
+        root: PathBuf,
+        key: String,
+        vendor_map: Option<Arc<HashMap<String, PathBuf>>>,
+    ) -> Result<Vec<String>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::AvailableLocales {
+                root,
+                key,
+                vendor_map,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Push a lang file's authoritative text (an editor buffer) into Salsa, so
+    /// an unsaved edit is reflected by the next resolution.
+    pub async fn register_lang_source(
+        &self,
+        path: PathBuf,
+        text: String,
+    ) -> Result<(), &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::RegisterLangSource {
+                path,
+                text,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Locate a translation key's declaration inside one catalogue.
+    pub async fn locate_translation_key(
+        &self,
+        root: PathBuf,
+        path: PathBuf,
+        target: TranslationKeyTarget,
+    ) -> Result<Option<KeyLocationData>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::LocateTranslationKey {
+                root,
+                path,
+                target,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Every translation key autocomplete should offer for this project.
+    pub async fn translation_key_completions(
+        &self,
+        root: PathBuf,
+    ) -> Result<Vec<TranslationKeyCompletionData>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::TranslationKeyCompletions {
+                root,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Every locale file declaring `dotted_key`, for building a rename edit.
+    pub async fn locate_key_across_locales(
+        &self,
+        root: PathBuf,
+        dotted_key: String,
+    ) -> Result<Vec<TranslationKeyLocationData>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::LocateKeyAcrossLocales {
+                root,
+                dotted_key,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// How many times the translation cache has touched disk this session.
+    ///
+    /// Instrumentation for the cache-warmth tests: compare the count before and
+    /// after a second resolution of the same key — an equal count is the proof
+    /// that Salsa served it.
+    pub async fn lang_disk_reads(&self) -> Result<usize, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::LangDiskReads { reply: reply_tx })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Drop a lang path's cached entry after an external create, change or
+    /// delete, so the next resolution re-reads disk.
+    pub async fn invalidate_lang_path(&self, path: PathBuf) -> Result<(), &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::InvalidateLangPath {
+                path,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
     // === Salsa-based Service Provider Methods (New - Phase 1) ===
 
     /// Register a raw service provider file for Salsa to parse
@@ -7140,6 +8083,10 @@ pub struct SalsaActor {
     /// Version counter for env files
     salsa_env_version: i32,
 
+    // === Salsa-based Translation Tracking (issue #293) ===
+    /// Lang catalogues and directory listings, memoized through Salsa.
+    translations: TranslationCache,
+
     // === Salsa-based Service Provider Tracking (New) ===
     /// Service provider files registered with Salsa for incremental parsing
     salsa_sp_files: HashMap<PathBuf, ServiceProviderFile>,
@@ -7237,6 +8184,8 @@ impl SalsaActor {
                 // Salsa-based env tracking
                 salsa_env_files: HashMap::with_capacity(4),
                 salsa_env_version: 0,
+                // Salsa-based translation tracking (issue #293)
+                translations: TranslationCache::default(),
                 // Salsa-based service provider tracking
                 salsa_sp_files: HashMap::with_capacity(32),
                 salsa_sp_version: 0,
@@ -7765,6 +8714,68 @@ impl SalsaActor {
                 SalsaRequest::GetAllParsedEnvVars { reply } => {
                     let result = self.handle_get_all_parsed_env_vars();
                     let _ = reply.send(result);
+                }
+                SalsaRequest::ResolveTranslation {
+                    root,
+                    key,
+                    locale,
+                    vendor_map,
+                    reply,
+                } => {
+                    let result = self.handle_resolve_translation(
+                        &root,
+                        &key,
+                        &locale,
+                        vendor_map.as_deref(),
+                    );
+                    let _ = reply.send(result);
+                }
+                SalsaRequest::AvailableLocales {
+                    root,
+                    key,
+                    vendor_map,
+                    reply,
+                } => {
+                    let result = self.handle_available_locales(&root, &key, vendor_map.as_deref());
+                    let _ = reply.send(result);
+                }
+                SalsaRequest::RegisterLangSource { path, text, reply } => {
+                    self.handle_register_lang_source(path, text);
+                    let _ = reply.send(());
+                }
+                SalsaRequest::InvalidateLangPath { path, reply } => {
+                    self.handle_invalidate_lang_path(&path);
+                    let _ = reply.send(());
+                }
+                SalsaRequest::LocateTranslationKey {
+                    root,
+                    path,
+                    target,
+                    reply,
+                } => {
+                    let result = self
+                        .translations
+                        .locate_key(&mut self.db, &root, &path, &target);
+                    let _ = reply.send(result);
+                }
+                SalsaRequest::TranslationKeyCompletions { root, reply } => {
+                    let result = self.translations.completion_keys(&mut self.db, &root);
+                    let _ = reply.send(result);
+                }
+                SalsaRequest::LocateKeyAcrossLocales {
+                    root,
+                    dotted_key,
+                    reply,
+                } => {
+                    let result = self.translations.locate_key_across_locales(
+                        &mut self.db,
+                        &root,
+                        &dotted_key,
+                    );
+                    let _ = reply.send(result);
+                }
+                SalsaRequest::LangDiskReads { reply } => {
+                    let _ = reply.send(self.translations.disk_reads());
                 }
 
                 // === Salsa-based Service Provider Handlers (New) ===
@@ -10288,6 +11299,57 @@ impl SalsaActor {
             );
             self.salsa_env_files.insert(path, file);
         }
+    }
+
+    // === Salsa-based Translation Handlers (issue #293) ===
+
+    /// Resolve one translation key in one locale through the Salsa cache.
+    fn handle_resolve_translation(
+        &mut self,
+        root: &Path,
+        key: &str,
+        locale: &str,
+        vendor_map: Option<&HashMap<String, PathBuf>>,
+    ) -> Option<ResolvedTranslationData> {
+        self.translations
+            .resolve(&mut self.db, root, key, locale, vendor_map)
+    }
+
+    /// Every locale that could define `key`, this project's APP_LOCALE first.
+    fn handle_available_locales(
+        &mut self,
+        root: &Path,
+        key: &str,
+        vendor_map: Option<&HashMap<String, PathBuf>>,
+    ) -> Vec<String> {
+        let app_locale = self.app_locale();
+        self.translations
+            .locales(&mut self.db, root, key, vendor_map, app_locale.as_deref())
+    }
+
+    /// The project's `APP_LOCALE`, served from the Salsa env cache.
+    ///
+    /// Reproduces `config::read_env_value(root, "APP_LOCALE")` exactly rather
+    /// than taking whatever the env layer ranks highest: that helper reads
+    /// **`.env` only**, its line-anchored regex never matches a commented line,
+    /// and it discards an empty value. Hence the three filters — priority 2 is
+    /// `.env` (1 is `.env.local`, 0 is `.env.example`). Without them, locale
+    /// *ordering* would silently change on any project whose `.env.local` or
+    /// `.env.example` sets a locale its `.env` does not.
+    fn app_locale(&self) -> Option<String> {
+        self.handle_get_parsed_env_var("APP_LOCALE")
+            .filter(|var| !var.is_commented && var.priority == 2 && !var.value.is_empty())
+            .map(|var| var.value)
+    }
+
+    /// Push a lang catalogue's authoritative text into Salsa.
+    fn handle_register_lang_source(&mut self, path: PathBuf, text: String) {
+        self.translations.register(&mut self.db, path, text);
+    }
+
+    /// Drop a lang path's cached entry so the next lookup re-reads disk.
+    fn handle_invalidate_lang_path(&mut self, path: &Path) {
+        self.translations.invalidate(path);
     }
 
     /// Handle getting a parsed env variable by name from Salsa

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -1978,7 +1978,15 @@ impl TranslationCache {
             return Vec::new();
         };
         let listing = self.ensure_dir(db, &lang_root, root);
-        let Some(locale) = locales_in_dir(&*db, listing).first().cloned() else {
+        // Sorted before taking the first: `locales_in_dir` preserves the
+        // directory listing order, which is filesystem-dependent — APFS hands
+        // entries back sorted, ext4 does not. Taking `first()` off the raw
+        // listing therefore made *which locale answers autocomplete* vary by
+        // platform (caught by CI on ubuntu, green on macOS). Alphabetical is
+        // arbitrary but stable, and matches how `locales` orders.
+        let mut candidates = locales_in_dir(&*db, listing).clone();
+        candidates.sort();
+        let Some(locale) = candidates.first().cloned() else {
             return Vec::new();
         };
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -208,6 +208,50 @@ pub struct LangDir {
     pub entries: Vec<(String, bool)>,
 }
 
+/// One service provider that may register translation namespaces — a
+/// `*ServiceProvider*.php` under `vendor/`, or any `.php` under
+/// `app/Providers/`.
+///
+/// Separate from [`LangFile`] despite the identical shape: a provider is not a
+/// catalogue, and invalidating one has different consequences (it drops the
+/// namespace map, not a directory listing).
+#[salsa::input]
+pub struct TranslationProviderFile {
+    /// The file path
+    #[returns(ref)]
+    pub path: PathBuf,
+
+    /// Version incremented when the file changes
+    #[returns(copy)]
+    pub version: i32,
+
+    /// The file content; empty for an absent or unreadable provider
+    #[returns(ref)]
+    pub text: String,
+}
+
+/// The discovered provider files, split by scan so their precedence survives:
+/// app providers override vendor ones on a namespace conflict, because the app
+/// boots last.
+///
+/// An input rather than a plain field so the walk is a tracked dependency like
+/// [`ProjectFiles`], and a provider create/delete invalidates what derives from
+/// it (issue #293).
+#[salsa::input]
+pub struct TranslationProviderFiles {
+    /// Version incremented when the discovered set changes
+    #[returns(copy)]
+    pub version: i32,
+
+    /// `*ServiceProvider*.php` under `vendor/`
+    #[returns(ref)]
+    pub vendor: Vec<PathBuf>,
+
+    /// `.php` under `app/Providers/`
+    #[returns(ref)]
+    pub app: Vec<PathBuf>,
+}
+
 // ============================================================================
 // Interned Types - Deduplicated strings
 // ============================================================================
@@ -1617,6 +1661,25 @@ pub fn locales_in_dir(db: &dyn Db, dir: LangDir) -> Vec<String> {
     locales
 }
 
+/// Every `namespace -> lang dir` registration one provider declares.
+///
+/// Memoized per `(file, root)`. The vendor scan reads and substring-gates every
+/// `*ServiceProvider*.php` in `vendor/` and AST-parses the survivors; before
+/// this it ran as one uncached sweep whose result was then held for the entire
+/// session with no way to refresh it (issue #293).
+#[salsa::tracked]
+pub fn translation_namespaces_in_provider(
+    db: &dyn Db,
+    file: TranslationProviderFile,
+    root: PathBuf,
+) -> Vec<(String, PathBuf)> {
+    let text = file.text(db);
+    if text.is_empty() {
+        return Vec::new();
+    }
+    crate::vendor_translations::namespaces_in_source(text, file.path(db), &root)
+}
+
 /// Lang-file reads and locale enumeration, memoized through Salsa.
 ///
 /// Owned by [`SalsaActor`] in production; constructible directly so tests can
@@ -1655,6 +1718,11 @@ pub struct TranslationCache {
     /// Version counter shared by files and directories; bumped on every
     /// registration so Salsa sees a changed input.
     version: i32,
+    /// Service providers registering translation namespaces, keyed by path.
+    providers: HashMap<PathBuf, TranslationProviderFile>,
+    /// The discovered provider set. `None` until the first scan, and reset by
+    /// [`Self::invalidate_providers`] so a create or delete is picked up.
+    provider_files: Option<TranslationProviderFiles>,
     /// How many times this cache has touched disk — one per
     /// `fs::read_to_string` or `read_dir` that actually ran. Lets a test prove
     /// a second resolution is served from Salsa rather than re-read.
@@ -2009,6 +2077,105 @@ impl TranslationCache {
             }
         }
         out
+    }
+
+    /// Drop everything derived from service providers, so the next namespace
+    /// lookup rediscovers and re-reads them.
+    ///
+    /// Both halves are cleared: the discovered set (a provider may have been
+    /// created or deleted) and every provider's cached text (one may have been
+    /// edited). Lang catalogues are untouched — a provider edit changes *where*
+    /// a namespaced key resolves, not what any catalogue contains.
+    pub fn invalidate_providers(&mut self) {
+        self.provider_files = None;
+        self.providers.clear();
+    }
+
+    /// The Salsa input for one provider's text, registering it on first touch.
+    ///
+    /// No containment guard here, unlike [`Self::ensure_file`], and the
+    /// difference is deliberate: these paths come from walking the project's
+    /// own `vendor/` and `app/Providers/` directories, not from joining an
+    /// untrusted key segment onto a directory. There is nothing for #248 to
+    /// fence — and canonicalizing every `*ServiceProvider*.php` in `vendor/`
+    /// would add thousands of syscalls to buy nothing.
+    fn ensure_provider(
+        &mut self,
+        db: &mut LaravelDatabase,
+        path: &Path,
+    ) -> TranslationProviderFile {
+        if let Some(file) = self.providers.get(path) {
+            return *file;
+        }
+        self.disk_reads += 1;
+        let text = std::fs::read_to_string(path).unwrap_or_default();
+        self.version += 1;
+        let file = TranslationProviderFile::new(&*db, path.to_path_buf(), self.version, text);
+        self.providers.insert(path.to_path_buf(), file);
+        file
+    }
+
+    /// The discovered provider set, walking `vendor/` and `app/Providers/` on
+    /// first touch.
+    fn ensure_provider_files(
+        &mut self,
+        db: &mut LaravelDatabase,
+        root: &Path,
+    ) -> TranslationProviderFiles {
+        if let Some(files) = self.provider_files {
+            return files;
+        }
+        self.disk_reads += 1;
+        let vendor = crate::vendor_translations::vendor_provider_candidates(root);
+        let app = crate::vendor_translations::app_provider_candidates(root);
+        self.version += 1;
+        let files = TranslationProviderFiles::new(&*db, self.version, vendor, app);
+        self.provider_files = Some(files);
+        files
+    }
+
+    /// The project's `namespace -> lang directory` map, as registered by its
+    /// service providers.
+    ///
+    /// Precedence is preserved from the direct-`fs` scans: **first-match-wins**
+    /// within a scan (provider boot order is non-deterministic and we cannot
+    /// rank packages without a full composer graph), and the **app scan
+    /// overrides vendor** on conflict, because the app boots last.
+    ///
+    /// Every read behind this — the directory walk, each provider's text, the
+    /// substring gate and the AST parse — is memoized. Previously the whole
+    /// sweep ran once and its result was cached for the life of the session
+    /// with no invalidation path at all, so a `composer update` or an edited
+    /// `loadTranslationsFrom` was invisible until the LSP restarted. Since this
+    /// map decides where a namespaced key resolves, that made a stale map a
+    /// wrong answer rather than merely an old one (issue #293).
+    pub fn vendor_namespaces(
+        &mut self,
+        db: &mut LaravelDatabase,
+        root: &Path,
+    ) -> HashMap<String, PathBuf> {
+        let files = self.ensure_provider_files(db, root);
+        let vendor = files.vendor(&*db).clone();
+        let app = files.app(&*db).clone();
+
+        let mut map: HashMap<String, PathBuf> = HashMap::new();
+        for path in vendor {
+            let file = self.ensure_provider(db, &path);
+            for (namespace, dir) in
+                translation_namespaces_in_provider(&*db, file, root.to_path_buf()).clone()
+            {
+                map.entry(namespace).or_insert(dir);
+            }
+        }
+        for path in app {
+            let file = self.ensure_provider(db, &path);
+            for (namespace, dir) in
+                translation_namespaces_in_provider(&*db, file, root.to_path_buf()).clone()
+            {
+                map.insert(namespace, dir);
+            }
+        }
+        map
     }
 }
 
@@ -6231,6 +6398,13 @@ pub enum SalsaRequest {
         dotted_key: String,
         reply: oneshot::Sender<Vec<TranslationKeyLocationData>>,
     },
+    /// The project's provider-registered translation namespace map
+    VendorTranslationNamespaces {
+        root: PathBuf,
+        reply: oneshot::Sender<HashMap<String, PathBuf>>,
+    },
+    /// Drop everything derived from service providers
+    InvalidateTranslationProviders { reply: oneshot::Sender<()> },
     /// How many times the translation cache has touched disk
     LangDiskReads { reply: oneshot::Sender<usize> },
 
@@ -7563,6 +7737,36 @@ impl SalsaHandle {
             .map_err(|_| "Salsa actor dropped reply channel")
     }
 
+    /// The project's provider-registered `namespace -> lang dir` map.
+    pub async fn vendor_translation_namespaces(
+        &self,
+        root: PathBuf,
+    ) -> Result<HashMap<String, PathBuf>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::VendorTranslationNamespaces {
+                root,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Drop everything derived from service providers after one changed.
+    pub async fn invalidate_translation_providers(&self) -> Result<(), &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::InvalidateTranslationProviders { reply: reply_tx })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
     /// How many times the translation cache has touched disk this session.
     ///
     /// Instrumentation for the cache-warmth tests: compare the count before and
@@ -8773,6 +8977,14 @@ impl SalsaActor {
                         &dotted_key,
                     );
                     let _ = reply.send(result);
+                }
+                SalsaRequest::VendorTranslationNamespaces { root, reply } => {
+                    let result = self.translations.vendor_namespaces(&mut self.db, &root);
+                    let _ = reply.send(result);
+                }
+                SalsaRequest::InvalidateTranslationProviders { reply } => {
+                    self.translations.invalidate_providers();
+                    let _ = reply.send(());
                 }
                 SalsaRequest::LangDiskReads { reply } => {
                     let _ = reply.send(self.translations.disk_reads());

--- a/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
+++ b/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
@@ -228,6 +228,10 @@ fn detect_method_name_position_detects_instance_past_multibyte_char() {
 // catalogue case. Both now delegate to the shared, char-safe
 // `display_truncate::truncate_for_display` (also used by `hover.rs`), so the
 // limit is 200 chars, not 47/50, and the ellipsis is the single `…` char.
+//
+// `extract_translation_value` moved into `salsa_impl` when translation reads
+// were routed through Salsa (issue #293); it is the same function, and this
+// coverage follows it rather than being dropped.
 
 #[test]
 fn translation_value_truncation_is_char_boundary_safe() {
@@ -236,7 +240,7 @@ fn translation_value_truncation_is_char_boundary_safe() {
     // multibyte char at the cut point can't panic.
     let value: String = "a".repeat(199) + "č" + &"é".repeat(50);
     let line = format!("'key' => '{}',", value);
-    let display = LaravelLanguageServer::extract_translation_value(&line);
+    let display = laravel_lsp::salsa_impl::extract_translation_value(&line);
     assert!(display.ends_with('…'));
     assert_eq!(display.chars().count(), 201); // 200 + ellipsis
 }
@@ -248,7 +252,7 @@ fn translation_value_under_two_hundred_chars_is_not_truncated() {
     // 200-char, char-based limit now passes it through untouched.
     let value = "č".repeat(30);
     let line = format!("'key' => '{}',", value);
-    let display = LaravelLanguageServer::extract_translation_value(&line);
+    let display = laravel_lsp::salsa_impl::extract_translation_value(&line);
     assert_eq!(display, value);
 }
 

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -52,6 +52,7 @@ mod slot_variable_resolution;
 mod translation_locale_consistency;
 mod translation_namespace_check;
 mod translation_namespace_navigation;
+mod translation_salsa_cache;
 mod view_diagnostic_containment;
 mod view_navigation_containment;
 mod vite_completion_context;

--- a/laravel-lsp/src/tests/translation_locale_consistency.rs
+++ b/laravel-lsp/src/tests/translation_locale_consistency.rs
@@ -81,7 +81,7 @@ async fn assert_all_three_agree(
         "goto must navigate to the same file hover sourced the value from"
     );
 
-    let check = LaravelLanguageServer::check_translation_file(root, key, None);
+    let check = backend.check_translation_file(root, key, None).await;
     assert!(
         check.exists,
         "diagnostics must not report a key the hover displays as missing"
@@ -145,7 +145,7 @@ async fn a_locale_file_without_the_key_is_not_treated_as_a_definition() {
     *backend.root_path.write().await = Some(root.clone());
 
     let key = "contract.prefill.failed_title";
-    let check = LaravelLanguageServer::check_translation_file(&root, key, None);
+    let check = backend.check_translation_file(&root, key, None).await;
     assert!(
         !check.exists,
         "an existing lang file without the key is not a definition"

--- a/laravel-lsp/src/tests/translation_namespace_check.rs
+++ b/laravel-lsp/src/tests/translation_namespace_check.rs
@@ -114,7 +114,12 @@ class AppServiceProvider {
     .unwrap();
 
     // The merged map the LSP builds — here just the app-provider scan.
-    let map = laravel_lsp::vendor_translations::scan_app_translation_namespaces(&root);
+    let map = backend()
+        .vendor_translation_namespaces_for(&root)
+        .await
+        .expect("the actor must answer")
+        .as_ref()
+        .clone();
     // The dir exists, so the scan canonicalizes it (resolving macOS's
     // /var → /private/var symlink) — compare against the canonical form.
     assert_eq!(

--- a/laravel-lsp/src/tests/translation_namespace_check.rs
+++ b/laravel-lsp/src/tests/translation_namespace_check.rs
@@ -8,7 +8,16 @@ use crate::LaravelLanguageServer;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tempfile::TempDir;
+use tower_lsp::LspService;
+
+/// A backend whose Salsa actor backs the translation cache. `root` is passed
+/// to `check_translation_file` explicitly, so no other state needs priming.
+fn backend() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
 
 /// A project whose vendor package ships `lang/en/table.php` with one key,
 /// plus the vendor map the translation scan would have produced for it.
@@ -28,30 +37,34 @@ fn project_with_vendor_translations() -> (TempDir, PathBuf, HashMap<String, Path
     (dir, root, vendor_map)
 }
 
-#[test]
-fn namespaced_key_resolves_through_vendor_map() {
+#[tokio::test]
+async fn namespaced_key_resolves_through_vendor_map() {
     let (_dir, root, vendor_map) = project_with_vendor_translations();
 
-    let check = LaravelLanguageServer::check_translation_file(
-        &root,
-        "filament-tables::table.grouping.label",
-        Some(&vendor_map),
-    );
+    let check = backend()
+        .check_translation_file(
+            &root,
+            "filament-tables::table.grouping.label",
+            Some(Arc::new(vendor_map)),
+        )
+        .await;
     assert!(
         check.exists,
         "an unpublished package translation must resolve via the vendor map"
     );
 }
 
-#[test]
-fn missing_namespaced_key_still_flags_with_vendor_path() {
+#[tokio::test]
+async fn missing_namespaced_key_still_flags_with_vendor_path() {
     let (_dir, root, vendor_map) = project_with_vendor_translations();
 
-    let check = LaravelLanguageServer::check_translation_file(
-        &root,
-        "filament-tables::table.does.not.exist",
-        Some(&vendor_map),
-    );
+    let check = backend()
+        .check_translation_file(
+            &root,
+            "filament-tables::table.does.not.exist",
+            Some(Arc::new(vendor_map)),
+        )
+        .await;
     assert!(!check.exists, "a genuinely missing key must still flag");
     // The diagnostic should point at the package's real lang file, not the
     // bogus `lang/en/filament-tables::table.php` guess it used to emit.
@@ -66,8 +79,8 @@ fn missing_namespaced_key_still_flags_with_vendor_path() {
     );
 }
 
-#[test]
-fn app_provider_load_translations_from_resolves_namespaced_key() {
+#[tokio::test]
+async fn app_provider_load_translations_from_resolves_namespaced_key() {
     // Issue #248: an `AppServiceProvider` registering
     // `loadTranslationsFrom(lang_path('app'), 'app')` must make
     // `app::notification.title` resolve to `lang/app/en/notification.php` —
@@ -110,11 +123,13 @@ class AppServiceProvider {
         "app scan must register the 'app' namespace at lang/app"
     );
 
-    let check = LaravelLanguageServer::check_translation_file(
-        &root,
-        "app::notification.task_group_status_change.title",
-        Some(&map),
-    );
+    let check = backend()
+        .check_translation_file(
+            &root,
+            "app::notification.task_group_status_change.title",
+            Some(Arc::new(map)),
+        )
+        .await;
     assert!(
         check.exists,
         "the app-registered translation must resolve via the merged map"
@@ -126,12 +141,13 @@ class AppServiceProvider {
     );
 }
 
-#[test]
-fn namespaced_key_without_vendor_map_expects_published_path() {
+#[tokio::test]
+async fn namespaced_key_without_vendor_map_expects_published_path() {
     let (_dir, root, _vendor_map) = project_with_vendor_translations();
 
-    let check =
-        LaravelLanguageServer::check_translation_file(&root, "unknown-pkg::messages.hi", None);
+    let check = backend()
+        .check_translation_file(&root, "unknown-pkg::messages.hi", None)
+        .await;
     assert!(!check.exists);
     let expected = check.expected_path.expect("expected path set");
     assert!(

--- a/laravel-lsp/src/tests/translation_namespace_navigation.rs
+++ b/laravel-lsp/src/tests/translation_namespace_navigation.rs
@@ -9,30 +9,42 @@
 //! provider map (the same map hover and diagnostics use) to the real lang file.
 //!
 //! These tests drive the real async handler on a server built through the
-//! `tower_lsp::LspService` harness the other handler tests use, priming the two
-//! pieces of state the chain reads — the project root and the vendor/app
-//! namespace cache — so it runs purely against a tempdir.
+//! `tower_lsp::LspService` harness the other handler tests use, priming the one
+//! piece of state the chain reads — the project root — and writing a real
+//! `AppServiceProvider` for the namespace scan to discover, so it runs purely
+//! against a tempdir.
+//!
+//! The namespace map used to be injected into an `RwLock` field directly.
+//! Since #293 it is derived through Salsa from the providers actually on disk,
+//! so these tests now exercise the provider scan end to end rather than
+//! assuming its output.
 
 use crate::LaravelLanguageServer;
 use laravel_lsp::salsa_impl::TranslationReferenceData;
-use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::path::Path;
 use tower_lsp::lsp_types::{GotoDefinitionResponse, Url};
 use tower_lsp::LspService;
 
-/// Build a backend with the project root and the namespace map primed, so
-/// `vendor_translation_namespaces_for` returns the cache without scanning disk
-/// and the Salsa actor the harness spawns stays inert.
-async fn backend_with_namespaces(
-    root: &Path,
-    namespaces: HashMap<String, PathBuf>,
-) -> LaravelLanguageServer {
+/// Build a backend rooted at `root`, with an `AppServiceProvider` registering
+/// `lang_path('app')` under the `app` namespace — the real registration the
+/// namespace scan reads, rather than a hand-injected map.
+///
+/// `lang/app/` must exist for the registration to resolve: `loadTranslationsFrom`
+/// only contributes a namespace whose path argument names a real directory.
+async fn backend_with_app_namespace(root: &Path) -> LaravelLanguageServer {
+    fs::create_dir_all(root.join("lang/app")).unwrap();
+    let providers = root.join("app/Providers");
+    fs::create_dir_all(&providers).unwrap();
+    fs::write(
+        providers.join("AppServiceProvider.php"),
+        "<?php\nnamespace App\\Providers;\nclass AppServiceProvider {\n    public function boot(): void {\n        $this->loadTranslationsFrom(lang_path('app'), 'app');\n    }\n}\n",
+    )
+    .unwrap();
+
     let (service, _socket) = LspService::new(LaravelLanguageServer::new);
     let backend = service.inner().clone();
     *backend.root_path.write().await = Some(root.to_path_buf());
-    *backend.vendor_translation_namespaces.write().await = Some(Arc::new(namespaces));
     backend
 }
 
@@ -73,11 +85,7 @@ async fn namespaced_key_navigates_to_app_provider_lang_file() {
     )
     .unwrap();
 
-    // The merged map the LSP would have built from AppServiceProvider's
-    // loadTranslationsFrom(lang_path('app'), 'app').
-    let mut namespaces = HashMap::new();
-    namespaces.insert("app".to_string(), root.join("lang/app"));
-    let backend = backend_with_namespaces(root, namespaces).await;
+    let backend = backend_with_app_namespace(root).await;
 
     let resp = backend
         .create_translation_location_from_salsa(&trans_ref(
@@ -89,9 +97,13 @@ async fn namespaced_key_navigates_to_app_provider_lang_file() {
         .expect("a namespaced key with an existing lang file must resolve to a link");
 
     let link = single_link(resp);
+    // Compared canonicalized: `loadTranslationsFrom` resolves its path argument
+    // through `canonicalize`, so on macOS the registered directory carries the
+    // real `/private/var` prefix where the tempdir handle reports `/var`. Same
+    // file, different spelling.
     assert_eq!(
         link.target_uri,
-        Url::from_file_path(&lang_file).unwrap(),
+        Url::from_file_path(lang_file.canonicalize().unwrap()).unwrap(),
         "target must be the app-registered lang file, not lang/en/app::… or lang/vendor/app/…"
     );
     // The underline covers exactly the key's string content.
@@ -114,9 +126,7 @@ async fn namespaced_key_without_file_yields_no_link() {
     let dir = tempfile::TempDir::new().unwrap();
     let root = dir.path();
 
-    let mut namespaces = HashMap::new();
-    namespaces.insert("app".to_string(), root.join("lang/app"));
-    let backend = backend_with_namespaces(root, namespaces).await;
+    let backend = backend_with_app_namespace(root).await;
 
     let resp = backend
         .create_translation_location_from_salsa(&trans_ref("app::missing.title", 9, 27))

--- a/laravel-lsp/src/tests/translation_salsa_cache.rs
+++ b/laravel-lsp/src/tests/translation_salsa_cache.rs
@@ -854,3 +854,73 @@ async fn a_namespaced_key_resolves_against_the_refreshed_provider_map() {
          is now, not as it was when the session started"
     );
 }
+
+#[tokio::test]
+async fn the_provider_scan_is_warm_across_requests() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    fs::create_dir_all(root.join("lang/app")).unwrap();
+    write(
+        &root,
+        "app/Providers/AppServiceProvider.php",
+        &provider_registering("app", "app"),
+    );
+    // A vendor provider too, so the walk has both halves to do.
+    write(
+        &root,
+        "vendor/acme/billing/src/BillingServiceProvider.php",
+        "<?php\nclass BillingServiceProvider {\n    public function boot() {}\n}\n",
+    );
+    let backend = backend_for(&root).await;
+
+    let before = disk_reads(&backend).await;
+    let first = backend.vendor_translation_namespaces_for(&root).await;
+    let after_first = disk_reads(&backend).await;
+    let second = backend.vendor_translation_namespaces_for(&root).await;
+    let after_second = disk_reads(&backend).await;
+
+    assert!(first.as_ref().is_some_and(|m| m.contains_key("app")));
+    assert_eq!(second, first);
+    assert!(
+        after_first > before,
+        "the first scan must actually walk and read the providers"
+    );
+    assert_eq!(
+        after_second, after_first,
+        "the provider scan must be served from Salsa, not re-walked per request"
+    );
+}
+
+#[tokio::test]
+async fn a_provider_created_externally_is_discovered() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    fs::create_dir_all(root.join("lang/shop")).unwrap();
+    fs::create_dir_all(root.join("app/Providers")).unwrap();
+    let backend = backend_for(&root).await;
+
+    assert!(
+        backend
+            .vendor_translation_namespaces_for(&root)
+            .await
+            .is_some_and(|m| m.is_empty()),
+        "precondition: no providers, and that empty result is now cached"
+    );
+
+    // A package is installed, or a provider is written, outside the editor.
+    let provider = write(
+        &root,
+        "app/Providers/ShopServiceProvider.php",
+        &provider_registering("shop", "shop"),
+    );
+    watched_event(&backend, &provider, FileChangeType::CREATED).await;
+
+    assert!(
+        backend
+            .vendor_translation_namespaces_for(&root)
+            .await
+            .is_some_and(|m| m.contains_key("shop")),
+        "a provider that did not exist at scan time must still be discovered — \
+         invalidation has to drop the discovered set, not just the file texts"
+    );
+}

--- a/laravel-lsp/src/tests/translation_salsa_cache.rs
+++ b/laravel-lsp/src/tests/translation_salsa_cache.rs
@@ -718,16 +718,30 @@ async fn autocomplete_keys_reflect_an_external_edit() {
 async fn autocomplete_answers_from_a_single_locale_directory() {
     let tmp = TempDir::new().unwrap();
     let root = tmp.path().to_path_buf();
-    // Two locales; each declares the same key plus one of its own.
+    // Three locales, created in reverse-alphabetical order so creation order,
+    // listing order and alphabetical order cannot all coincide. Each declares
+    // the same key plus one of its own.
+    //
+    // The guarantee under test is "the alphabetically-first locale answers",
+    // not "whatever the filesystem lists first" — which is exactly the bug CI
+    // caught: `locales_in_dir` preserves listing order, so this picked `en` on
+    // ext4 and `de` on APFS. Note that on a filesystem which already returns
+    // entries sorted, this test passes with or without the fix; ext4 (CI) is
+    // where it discriminates.
     write(
         &root,
-        "lang/de/messages.php",
-        "<?php\nreturn [\n    'shared' => 'Geteilt',\n    'only_de' => 'Nur DE',\n];\n",
+        "lang/zz/messages.php",
+        "<?php\nreturn [\n    'shared' => 'ZZ',\n    'only_zz' => 'Only ZZ',\n];\n",
     );
     write(
         &root,
         "lang/en/messages.php",
         "<?php\nreturn [\n    'shared' => 'Shared',\n    'only_en' => 'Only EN',\n];\n",
+    );
+    write(
+        &root,
+        "lang/de/messages.php",
+        "<?php\nreturn [\n    'shared' => 'Geteilt',\n    'only_de' => 'Nur DE',\n];\n",
     );
     let backend = backend_for(&root).await;
 
@@ -738,7 +752,7 @@ async fn autocomplete_answers_from_a_single_locale_directory() {
         .map(|c| c.key)
         .collect();
 
-    // `de` sorts first, so it is the locale that answers.
+    // `de` sorts first, so it is the locale that answers — on every platform.
     assert_eq!(
         keys,
         vec!["messages.only_de", "messages.shared"],

--- a/laravel-lsp/src/tests/translation_salsa_cache.rs
+++ b/laravel-lsp/src/tests/translation_salsa_cache.rs
@@ -1,0 +1,856 @@
+//! Translation resolution through the Salsa cache (issue #293).
+//!
+//! Before this, `translation_lookup` read and parsed lang files with
+//! `std::fs::read_to_string` on **every** call, uncached and uninvalidated.
+//! Since #288 resolves a key against every locale a project defines, one hover
+//! on a 25-locale project meant a `read_dir` plus up to 25 file reads —
+//! repeated for go-to-definition and again for the diagnostic pass.
+//!
+//! Caching that is only half the job. A cache with no invalidation trades a
+//! performance bug for a correctness one, so these tests come in two halves:
+//!
+//! 1. **Warmth** — a second resolution of the same key must not touch disk
+//!    again, asserted against a real read counter rather than by inspection.
+//! 2. **Invalidation** — an editor edit (`did_change`, no save), an external
+//!    edit (`did_change_watched_files`, for both `.php` and `.json`
+//!    catalogues), and a deletion must each be reflected by the next lookup.
+//!
+//! Everything drives the **real** `Backend` on the `LspService::new` harness
+//! and the real LSP notification handlers, so what passes here is the path Zed
+//! actually takes — not a direct poke at `salsa_impl` internals, which would
+//! prove the cache works while saying nothing about whether it is wired up.
+
+use crate::LaravelLanguageServer;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::{
+    DidChangeTextDocumentParams, DidChangeWatchedFilesParams, FileChangeType, FileEvent,
+    TextDocumentContentChangeEvent, Url, VersionedTextDocumentIdentifier,
+};
+use tower_lsp::{LanguageServer, LspService};
+
+/// A backend with `root_path` primed and the Salsa debounce removed, so a
+/// `did_change` can be awaited deterministically instead of slept on.
+async fn backend_for(root: &Path) -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    let backend = service.inner().clone();
+    *backend.root_path.write().await = Some(root.to_path_buf());
+    *backend.auto_complete_debounce_ms.write().await = 0;
+    backend
+}
+
+/// Write a file, creating parent directories. Returns its absolute path.
+fn write(root: &Path, rel: &str, contents: &str) -> PathBuf {
+    let path = root.join(rel);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, contents).unwrap();
+    path
+}
+
+/// Drive the real `did_change` handler and wait for the debounced Salsa update
+/// it queues, so the assertion that follows cannot race the update.
+async fn did_change(backend: &LaravelLanguageServer, path: &Path, text: &str, version: i32) {
+    let uri = Url::from_file_path(path).unwrap();
+    backend
+        .did_change(DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier {
+                uri: uri.clone(),
+                version,
+            },
+            content_changes: vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: text.to_string(),
+            }],
+        })
+        .await;
+    if let Some(handle) = backend.pending_salsa_updates.write().await.remove(&uri) {
+        let _ = handle.await;
+    }
+}
+
+/// Drive the real watched-files handler with one synthesized event.
+async fn watched_event(backend: &LaravelLanguageServer, path: &Path, typ: FileChangeType) {
+    backend
+        .did_change_watched_files(DidChangeWatchedFilesParams {
+            changes: vec![FileEvent {
+                uri: Url::from_file_path(path).unwrap(),
+                typ,
+            }],
+        })
+        .await;
+}
+
+/// How many times this backend's translation cache has touched disk. The
+/// counter is per-cache, so concurrently-running tests cannot perturb it.
+async fn disk_reads(backend: &LaravelLanguageServer) -> usize {
+    backend.salsa.lang_disk_reads().await.unwrap()
+}
+
+/// Resolve a key in one locale, returning the bare value.
+async fn value(
+    backend: &LaravelLanguageServer,
+    root: &Path,
+    key: &str,
+    locale: &str,
+) -> Option<String> {
+    backend
+        .resolve_translation(root, key, locale, None)
+        .await
+        .map(|resolved| resolved.value)
+}
+
+// ---------------------------------------------------------------------------
+// Warmth — the cache is warm ACROSS requests, not merely within one
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn resolving_the_same_key_twice_reads_disk_only_once() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write(
+        &root,
+        "lang/de/validation.php",
+        "<?php return ['required' => 'Pflichtfeld'];",
+    );
+    let backend = backend_for(&root).await;
+
+    let before = disk_reads(&backend).await;
+    let first = value(&backend, &root, "validation.required", "de").await;
+    let after_first = disk_reads(&backend).await;
+    let second = value(&backend, &root, "validation.required", "de").await;
+    let after_second = disk_reads(&backend).await;
+
+    assert_eq!(first.as_deref(), Some("'Pflichtfeld'"));
+    assert_eq!(
+        second, first,
+        "a cached resolution must return the same value"
+    );
+    assert!(
+        after_first > before,
+        "the first resolution must actually touch disk, else this test proves nothing"
+    );
+    assert_eq!(
+        after_second, after_first,
+        "the second resolution must be served from Salsa, not re-read from disk"
+    );
+}
+
+#[tokio::test]
+async fn locale_discovery_enumerates_the_lang_directory_only_once() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    for locale in ["de", "en", "fr"] {
+        fs::create_dir_all(root.join("lang").join(locale)).unwrap();
+    }
+    let backend = backend_for(&root).await;
+
+    let before = disk_reads(&backend).await;
+    let first = backend
+        .translation_locales(&root, "messages.welcome", None)
+        .await;
+    let after_first = disk_reads(&backend).await;
+    let second = backend
+        .translation_locales(&root, "messages.welcome", None)
+        .await;
+    let after_second = disk_reads(&backend).await;
+
+    assert_eq!(first, vec!["de", "en", "fr"]);
+    assert_eq!(second, first);
+    assert!(
+        after_first > before,
+        "the first enumeration must actually run read_dir"
+    );
+    assert_eq!(
+        after_second, after_first,
+        "locale discovery must be cached across requests, not re-enumerated"
+    );
+}
+
+#[tokio::test]
+async fn a_key_missing_from_most_locales_does_not_re_probe_them() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    // Ten locales; only `de` defines the key. The other nine are the misses
+    // that used to cost a failed read apiece on every single request.
+    for locale in ["de", "en", "es", "fr", "it", "ja", "nl", "pl", "pt", "sv"] {
+        fs::create_dir_all(root.join("lang").join(locale)).unwrap();
+    }
+    write(
+        &root,
+        "lang/de/contract.php",
+        "<?php return ['title' => 'Vertrag'];",
+    );
+    let backend = backend_for(&root).await;
+    let key = "contract.title";
+
+    // Warm every locale the way a hover does.
+    for locale in backend.translation_locales(&root, key, None).await {
+        let _ = value(&backend, &root, key, &locale).await;
+    }
+    let before = disk_reads(&backend).await;
+    for locale in backend.translation_locales(&root, key, None).await {
+        let _ = value(&backend, &root, key, &locale).await;
+    }
+
+    assert_eq!(
+        disk_reads(&backend).await,
+        before,
+        "a second full-locale sweep must touch disk zero times, misses included"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Invalidation — editor edits
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn did_change_on_a_lang_buffer_is_reflected_without_a_save() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let file = write(
+        &root,
+        "lang/de/validation.php",
+        "<?php return ['required' => 'Alt'];",
+    );
+    let backend = backend_for(&root).await;
+
+    assert_eq!(
+        value(&backend, &root, "validation.required", "de")
+            .await
+            .as_deref(),
+        Some("'Alt'"),
+        "precondition: the on-disk value resolves and is now cached"
+    );
+
+    did_change(&backend, &file, "<?php return ['required' => 'Neu'];", 2).await;
+
+    assert_eq!(
+        value(&backend, &root, "validation.required", "de")
+            .await
+            .as_deref(),
+        Some("'Neu'"),
+        "an unsaved buffer edit must be reflected by the next resolution"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "<?php return ['required' => 'Alt'];",
+        "the file was never saved — the new value can only have come from the buffer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Invalidation — external edits (a git pull, a branch switch, lang:publish)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn an_external_edit_to_a_php_catalogue_invalidates_the_cache() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let file = write(
+        &root,
+        "lang/de/validation.php",
+        "<?php return ['required' => 'Alt'];",
+    );
+    let backend = backend_for(&root).await;
+
+    assert_eq!(
+        value(&backend, &root, "validation.required", "de")
+            .await
+            .as_deref(),
+        Some("'Alt'"),
+        "precondition: cached from disk"
+    );
+
+    // Edited outside the editor — never opened, never changed through the LSP.
+    fs::write(&file, "<?php return ['required' => 'Neu'];").unwrap();
+    watched_event(&backend, &file, FileChangeType::CHANGED).await;
+
+    assert_eq!(
+        value(&backend, &root, "validation.required", "de")
+            .await
+            .as_deref(),
+        Some("'Neu'"),
+        "an external edit must not keep serving the pre-change value"
+    );
+}
+
+#[tokio::test]
+async fn an_external_edit_to_a_json_catalogue_invalidates_the_cache() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let file = write(&root, "lang/de.json", r#"{"Welcome": "Willkommen"}"#);
+    let backend = backend_for(&root).await;
+
+    assert_eq!(
+        value(&backend, &root, "Welcome", "de").await.as_deref(),
+        Some("'Willkommen'"),
+        "precondition: cached from disk"
+    );
+
+    fs::write(&file, r#"{"Welcome": "Servus"}"#).unwrap();
+    watched_event(&backend, &file, FileChangeType::CHANGED).await;
+
+    assert_eq!(
+        value(&backend, &root, "Welcome", "de").await.as_deref(),
+        Some("'Servus'"),
+        "a JSON catalogue must invalidate on an external edit too"
+    );
+}
+
+#[tokio::test]
+async fn a_catalogue_created_externally_clears_the_negative_cache() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    fs::create_dir_all(root.join("lang/de")).unwrap();
+    let backend = backend_for(&root).await;
+
+    assert_eq!(
+        value(&backend, &root, "validation.required", "de").await,
+        None,
+        "precondition: absent, and now negatively cached"
+    );
+
+    let file = write(
+        &root,
+        "lang/de/validation.php",
+        "<?php return ['required' => 'Pflichtfeld'];",
+    );
+    watched_event(&backend, &file, FileChangeType::CREATED).await;
+
+    assert_eq!(
+        value(&backend, &root, "validation.required", "de")
+            .await
+            .as_deref(),
+        Some("'Pflichtfeld'"),
+        "the negative cache entry must not outlive the file's creation"
+    );
+}
+
+#[tokio::test]
+async fn a_deleted_catalogue_stops_resolving() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let file = write(
+        &root,
+        "lang/es/validation.php",
+        "<?php return ['required' => 'Obligatorio'];",
+    );
+    let backend = backend_for(&root).await;
+
+    assert_eq!(
+        value(&backend, &root, "validation.required", "es")
+            .await
+            .as_deref(),
+        Some("'Obligatorio'"),
+        "precondition: cached from disk"
+    );
+
+    fs::remove_file(&file).unwrap();
+    watched_event(&backend, &file, FileChangeType::DELETED).await;
+
+    assert_eq!(
+        value(&backend, &root, "validation.required", "es").await,
+        None,
+        "a deleted catalogue must not keep serving its pre-deletion value"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Locale discovery edge cases the fallback depends on
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_project_with_no_lang_directory_still_falls_back_to_en() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let backend = backend_for(&root).await;
+
+    assert_eq!(
+        backend
+            .translation_locales(&root, "messages.welcome", None)
+            .await,
+        vec!["en"],
+        "the backend must never hand callers an empty locale set — they index \
+         `[0]` for the expected-path hint. The cache's own fallback is asserted \
+         directly in `translation_lookup::tests`; this pins the backend contract \
+         that sits over it."
+    );
+}
+
+#[tokio::test]
+async fn a_project_with_an_empty_lang_directory_still_falls_back_to_en() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    fs::create_dir_all(root.join("lang")).unwrap();
+    let backend = backend_for(&root).await;
+
+    assert_eq!(
+        backend
+            .translation_locales(&root, "messages.welcome", None)
+            .await,
+        vec!["en"],
+        "an empty lang directory is not a locale set"
+    );
+}
+
+#[tokio::test]
+async fn app_locale_from_dotenv_leads_the_locale_list() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    for locale in ["de", "en", "es", "fr"] {
+        fs::create_dir_all(root.join("lang").join(locale)).unwrap();
+    }
+    fs::write(root.join(".env"), "APP_NAME=Test\nAPP_LOCALE=fr\n").unwrap();
+
+    let backend = backend_for(&root).await;
+    backend.register_env_files_with_salsa(&root).await;
+
+    assert_eq!(
+        backend
+            .translation_locales(&root, "messages.welcome", None)
+            .await,
+        vec!["fr", "de", "en", "es"],
+        "APP_LOCALE must still lead once locale discovery is served from Salsa"
+    );
+}
+
+#[tokio::test]
+async fn a_commented_app_locale_does_not_lead() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    for locale in ["de", "en", "fr"] {
+        fs::create_dir_all(root.join("lang").join(locale)).unwrap();
+    }
+    // The pre-Salsa reader matched `^APP_LOCALE=` line-anchored, so a commented
+    // line never counted. Reading APP_LOCALE out of the env cache must not
+    // quietly start honouring it.
+    fs::write(root.join(".env"), "#APP_LOCALE=fr\n").unwrap();
+
+    let backend = backend_for(&root).await;
+    backend.register_env_files_with_salsa(&root).await;
+
+    assert_eq!(
+        backend
+            .translation_locales(&root, "messages.welcome", None)
+            .await,
+        vec!["de", "en", "fr"],
+        "a commented-out APP_LOCALE is not an APP_LOCALE"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The vendor map must never be memoized into a stale answer
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_changed_vendor_map_never_serves_a_stale_namespaced_resolution() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    // Two candidate package lang dirs, each defining the same key differently.
+    write(
+        &root,
+        "vendor/acme/one/lang/de/messages.php",
+        "<?php return ['title' => 'Eins'];",
+    );
+    write(
+        &root,
+        "vendor/acme/two/lang/de/messages.php",
+        "<?php return ['title' => 'Zwei'];",
+    );
+    let backend = backend_for(&root).await;
+
+    let map_for = |rel: &str| -> Option<Arc<HashMap<String, PathBuf>>> {
+        let mut map = HashMap::new();
+        map.insert("shop".to_string(), root.join(rel));
+        Some(Arc::new(map))
+    };
+
+    let first = backend
+        .resolve_translation(
+            &root,
+            "shop::messages.title",
+            "de",
+            map_for("vendor/acme/one/lang"),
+        )
+        .await;
+    assert_eq!(first.map(|r| r.value).as_deref(), Some("'Eins'"));
+
+    // The namespace now points somewhere else — as it would after a
+    // `composer update` re-registered it.
+    let second = backend
+        .resolve_translation(
+            &root,
+            "shop::messages.title",
+            "de",
+            map_for("vendor/acme/two/lang"),
+        )
+        .await;
+    assert_eq!(
+        second.map(|r| r.value).as_deref(),
+        Some("'Zwei'"),
+        "the vendor map must not be baked into a memo key; a changed map must \
+         resolve against the new directory"
+    );
+}
+
+#[tokio::test]
+async fn a_dotted_key_resolution_is_unaffected_by_the_vendor_map() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write(
+        &root,
+        "lang/de/validation.php",
+        "<?php return ['required' => 'Pflichtfeld'];",
+    );
+    let backend = backend_for(&root).await;
+
+    let mut map = HashMap::new();
+    map.insert("shop".to_string(), root.join("vendor/acme/one/lang"));
+
+    let without = backend
+        .resolve_translation(&root, "validation.required", "de", None)
+        .await;
+    let with = backend
+        .resolve_translation(&root, "validation.required", "de", Some(Arc::new(map)))
+        .await;
+
+    assert_eq!(without.map(|r| r.value).as_deref(), Some("'Pflichtfeld'"));
+    assert_eq!(
+        with.map(|r| r.value).as_deref(),
+        Some("'Pflichtfeld'"),
+        "the common dotted path never consults the vendor map, so supplying one \
+         must change neither the answer nor the cache it is served from"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Go-to-definition's key locator, and autocomplete's key list
+//
+// Both resolve a catalogue and then read it *again* for a second purpose —
+// locating the key's line, or listing every key in it. Those reads were the
+// siblings the first pass of #293 missed: routing resolution through Salsa
+// while leaving them on direct `fs` would have left go-to-definition
+// re-parsing a PHP file on every jump, and autocomplete re-reading every
+// catalogue in a locale on every keystroke-triggered request.
+// ---------------------------------------------------------------------------
+
+/// The `target_range` go-to-definition would land on for `key`.
+async fn goto_range(
+    backend: &LaravelLanguageServer,
+    key: &str,
+) -> Option<tower_lsp::lsp_types::Range> {
+    let reference = laravel_lsp::salsa_impl::TranslationReferenceData {
+        key: key.to_string(),
+        line: 0,
+        column: 0,
+        end_column: key.len() as u32,
+    };
+    match backend
+        .create_translation_location_from_salsa(&reference)
+        .await?
+    {
+        tower_lsp::lsp_types::GotoDefinitionResponse::Link(links) => {
+            Some(links.first()?.target_range)
+        }
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn goto_lands_on_the_nested_php_key_line() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    // `title` is on line 4 (0-based).
+    write(
+        &root,
+        "lang/de/notification.php",
+        "<?php\nreturn [\n    'status' => [\n        'other' => 'x',\n        'title' => 'Statuswechsel',\n    ],\n];\n",
+    );
+    let backend = backend_for(&root).await;
+
+    let range = goto_range(&backend, "notification.status.title")
+        .await
+        .expect("goto must resolve the key");
+    assert_eq!(
+        range.start.line, 4,
+        "goto must land on the key's own line, not the top of the file"
+    );
+}
+
+#[tokio::test]
+async fn goto_lands_on_the_json_key_line() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    // "Sign in" is on line 3 (0-based).
+    write(
+        &root,
+        "lang/de.json",
+        "{\n    \"Welcome\": \"Willkommen\",\n\n    \"Sign in\": \"Anmelden\"\n}\n",
+    );
+    let backend = backend_for(&root).await;
+
+    let range = goto_range(&backend, "Sign in")
+        .await
+        .expect("goto must resolve the text key");
+    assert_eq!(range.start.line, 3, "goto must land on the key's own line");
+    assert_eq!(
+        range.start.character, 5,
+        "the span must start inside the opening quote"
+    );
+    assert_eq!(
+        range.end.character, 12,
+        "and cover exactly the key's characters"
+    );
+}
+
+#[tokio::test]
+async fn locating_the_same_key_twice_reads_disk_only_once() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write(
+        &root,
+        "lang/de/notification.php",
+        "<?php\nreturn [\n    'title' => 'Statuswechsel',\n];\n",
+    );
+    let backend = backend_for(&root).await;
+
+    let first = goto_range(&backend, "notification.title").await;
+    let after_first = disk_reads(&backend).await;
+    let second = goto_range(&backend, "notification.title").await;
+    let after_second = disk_reads(&backend).await;
+
+    assert_eq!(first.map(|r| r.start.line), Some(2));
+    assert_eq!(second, first);
+    assert_eq!(
+        after_second, after_first,
+        "a repeat jump must re-read nothing — resolution already loaded the file"
+    );
+}
+
+#[tokio::test]
+async fn autocomplete_keys_are_served_from_cache_on_the_second_request() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write(
+        &root,
+        "lang/en/messages.php",
+        "<?php\nreturn [\n    'welcome' => 'Welcome',\n];\n",
+    );
+    write(
+        &root,
+        "lang/en/auth.php",
+        "<?php\nreturn [\n    'failed' => 'These credentials do not match.',\n];\n",
+    );
+    let backend = backend_for(&root).await;
+
+    let before = disk_reads(&backend).await;
+    let first = backend.get_all_translation_keys().await;
+    let after_first = disk_reads(&backend).await;
+    let second = backend.get_all_translation_keys().await;
+    let after_second = disk_reads(&backend).await;
+
+    let keys: Vec<&str> = first.iter().map(|c| c.key.as_str()).collect();
+    assert_eq!(
+        keys,
+        vec!["auth.failed", "messages.welcome"],
+        "every catalogue in the locale contributes, sorted by key"
+    );
+    assert_eq!(
+        second.iter().map(|c| c.key.as_str()).collect::<Vec<_>>(),
+        keys
+    );
+    assert!(
+        after_first > before,
+        "the first request must actually read the catalogues"
+    );
+    assert_eq!(
+        after_second, after_first,
+        "autocomplete must not re-read and re-parse every catalogue per request"
+    );
+}
+
+#[tokio::test]
+async fn autocomplete_keys_reflect_an_external_edit() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let file = write(
+        &root,
+        "lang/en/messages.php",
+        "<?php\nreturn [\n    'welcome' => 'Welcome',\n];\n",
+    );
+    let backend = backend_for(&root).await;
+
+    assert_eq!(
+        backend
+            .get_all_translation_keys()
+            .await
+            .iter()
+            .map(|c| c.key.as_str())
+            .collect::<Vec<_>>(),
+        vec!["messages.welcome"],
+        "precondition: cached"
+    );
+
+    fs::write(
+        &file,
+        "<?php\nreturn [\n    'welcome' => 'Welcome',\n    'goodbye' => 'Goodbye',\n];\n",
+    )
+    .unwrap();
+    watched_event(&backend, &file, FileChangeType::CHANGED).await;
+
+    assert_eq!(
+        backend
+            .get_all_translation_keys()
+            .await
+            .iter()
+            .map(|c| c.key.as_str())
+            .collect::<Vec<_>>(),
+        vec!["messages.goodbye", "messages.welcome"],
+        "a newly-added key must be offered without restarting the LSP"
+    );
+}
+
+#[tokio::test]
+async fn autocomplete_answers_from_a_single_locale_directory() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    // Two locales; each declares the same key plus one of its own.
+    write(
+        &root,
+        "lang/de/messages.php",
+        "<?php\nreturn [\n    'shared' => 'Geteilt',\n    'only_de' => 'Nur DE',\n];\n",
+    );
+    write(
+        &root,
+        "lang/en/messages.php",
+        "<?php\nreturn [\n    'shared' => 'Shared',\n    'only_en' => 'Only EN',\n];\n",
+    );
+    let backend = backend_for(&root).await;
+
+    let keys: Vec<String> = backend
+        .get_all_translation_keys()
+        .await
+        .into_iter()
+        .map(|c| c.key)
+        .collect();
+
+    // `de` sorts first, so it is the locale that answers.
+    assert_eq!(
+        keys,
+        vec!["messages.only_de", "messages.shared"],
+        "one locale answers for the whole project — unioning every locale would \
+         read every catalogue to produce the same list, and would surface a key \
+         from a partially-translated locale as though it were project-wide"
+    );
+}
+
+#[tokio::test]
+async fn autocomplete_is_empty_for_a_project_with_no_lang_directory() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let backend = backend_for(&root).await;
+
+    assert!(
+        backend.get_all_translation_keys().await.is_empty(),
+        "no lang directory means nothing to offer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The vendor translation-namespace map must not outlive the providers it was
+// scanned from
+//
+// The map is built by scanning service providers for `loadTranslationsFrom`
+// and was cached for the entire session with no invalidation path at all. Once
+// #293 made that map decide where a namespaced key resolves, a stale map stopped
+// being merely old and started being wrong: a `composer update`, a
+// newly-installed package, or an edited registration was invisible until the
+// LSP restarted.
+// ---------------------------------------------------------------------------
+
+/// An app provider registering `namespace` at `lang/<dir>`.
+fn provider_registering(namespace: &str, dir: &str) -> String {
+    format!(
+        "<?php\nnamespace App\\Providers;\nclass AppServiceProvider {{\n    public function boot(): void {{\n        $this->loadTranslationsFrom(lang_path('{dir}'), '{namespace}');\n    }}\n}}\n"
+    )
+}
+
+#[tokio::test]
+async fn an_edited_service_provider_refreshes_the_vendor_namespace_map() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    fs::create_dir_all(root.join("lang/app")).unwrap();
+    fs::create_dir_all(root.join("lang/shop")).unwrap();
+    let provider = write(
+        &root,
+        "app/Providers/AppServiceProvider.php",
+        &provider_registering("app", "app"),
+    );
+    let backend = backend_for(&root).await;
+
+    let before = backend.vendor_translation_namespaces_for(&root).await;
+    assert!(
+        before.as_ref().is_some_and(|m| m.contains_key("app")),
+        "precondition: the original registration is scanned and cached"
+    );
+
+    // The registration changes — a `composer update`, or a hand edit.
+    fs::write(&provider, provider_registering("shop", "shop")).unwrap();
+    watched_event(&backend, &provider, FileChangeType::CHANGED).await;
+
+    let after = backend.vendor_translation_namespaces_for(&root).await;
+    assert!(
+        after.as_ref().is_some_and(|m| m.contains_key("shop")),
+        "the new namespace must be picked up without restarting the LSP"
+    );
+    assert!(
+        after.as_ref().is_some_and(|m| !m.contains_key("app")),
+        "and the removed one must not linger"
+    );
+}
+
+#[tokio::test]
+async fn a_namespaced_key_resolves_against_the_refreshed_provider_map() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write(
+        &root,
+        "lang/shop/de/messages.php",
+        "<?php return ['title' => 'Warenkorb'];",
+    );
+    fs::create_dir_all(root.join("lang/app")).unwrap();
+    let provider = write(
+        &root,
+        "app/Providers/AppServiceProvider.php",
+        &provider_registering("app", "app"),
+    );
+    let backend = backend_for(&root).await;
+
+    let map = backend.vendor_translation_namespaces_for(&root).await;
+    assert_eq!(
+        backend
+            .resolve_translation(&root, "shop::messages.title", "de", map)
+            .await,
+        None,
+        "precondition: nothing registers the `shop` namespace yet"
+    );
+
+    fs::write(&provider, provider_registering("shop", "shop")).unwrap();
+    watched_event(&backend, &provider, FileChangeType::CHANGED).await;
+
+    let map = backend.vendor_translation_namespaces_for(&root).await;
+    assert_eq!(
+        backend
+            .resolve_translation(&root, "shop::messages.title", "de", map)
+            .await
+            .map(|r| r.value)
+            .as_deref(),
+        Some("'Warenkorb'"),
+        "a namespaced key must resolve against the provider registration as it \
+         is now, not as it was when the session started"
+    );
+}

--- a/laravel-lsp/src/translation_key_locator.rs
+++ b/laravel-lsp/src/translation_key_locator.rs
@@ -1,69 +1,34 @@
-//! Locate Laravel translation-key declarations across every locale's lang
-//! file via tree-sitter — column-accurate positions suitable for building a
-//! rename `WorkspaceEdit`.
+//! Split a translation key into the catalogue file and nested path a rename
+//! must edit.
 //!
 //! Translation keys live in `lang/<locale>/<file>.php` as nested PHP array
-//! keys, just like config keys. The structural walk is identical (we delegate
-//! to [`crate::config_key_locator::locate_in_source`]); the difference is
-//! that translations exist in *every* registered locale, so a single rename
-//! must update the corresponding key in `lang/en/auth.php`,
-//! `lang/es/auth.php`, `lang/fr/auth.php`, etc. simultaneously.
+//! keys, just like config keys. The structural walk is identical (it delegates
+//! to [`crate::config_key_locator::locate_in_source`]); the difference is that
+//! translations exist in *every* registered locale, so a single rename must
+//! update the corresponding key in `lang/en/auth.php`, `lang/es/auth.php`,
+//! `lang/fr/auth.php`, etc. simultaneously.
 //!
 //! JSON-format translation files (`lang/en.json`) are out of scope for now —
 //! the AST walker is PHP-specific. JSON support follows once we add a small
 //! JSON walker.
+//!
+//! # This module does no I/O
+//!
+//! Like [`crate::translation_lookup`], it is pure: it names the file stem and
+//! key path, and [`crate::salsa_impl::TranslationCache::locate_key_across_locales`]
+//! does the reading, the memoizing and the containment check (issues #248,
+//! #293).
 
-use std::path::{Path, PathBuf};
-
-use crate::config_key_locator::KeyPosition;
-
-/// One declaration of a translation key, paired with the locale file it lives in.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TranslationKeyLocation {
-    pub file_path: PathBuf,
-    pub position: KeyPosition,
-}
-
-/// Find every locale-file site where `dotted_key` appears as a declaration.
-/// Walks `lang/<locale>/<file>.php` for each locale directory under
-/// `<root>/lang`. Locales without the relevant file or key are simply skipped.
-pub fn locate_keys_across_locales(root: &Path, dotted_key: &str) -> Vec<TranslationKeyLocation> {
+/// Split `auth.throttle.message` into the catalogue stem (`auth`) and the
+/// nested key path inside it (`["throttle", "message"]`).
+///
+/// `None` when the key names no leaf — a bare `auth`, or a trailing dot —
+/// because a file name alone is not a declaration a rename can edit.
+pub fn split_dotted_key(dotted_key: &str) -> Option<(&str, Vec<String>)> {
     let mut parts = dotted_key.split('.');
-    let Some(file_stem) = parts.next() else {
-        return Vec::new();
-    };
-    let path_segments: Vec<&str> = parts.collect();
-    if path_segments.is_empty() {
-        return Vec::new();
-    }
-
-    let lang_dir = root.join("lang");
-    let Ok(entries) = std::fs::read_dir(&lang_dir) else {
-        return Vec::new();
-    };
-
-    let mut out = Vec::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let locale_file = path.join(format!("{file_stem}.php"));
-        if !locale_file.exists() {
-            continue;
-        }
-        let Ok(content) = std::fs::read_to_string(&locale_file) else {
-            continue;
-        };
-        if let Some(pos) = crate::config_key_locator::locate_in_source(&content, &path_segments) {
-            out.push(TranslationKeyLocation {
-                file_path: locale_file,
-                position: pos,
-            });
-        }
-    }
-
-    out
+    let file_stem = parts.next()?;
+    let key_path: Vec<String> = parts.map(str::to_string).collect();
+    (!key_path.is_empty()).then_some((file_stem, key_path))
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/translation_key_locator/tests.rs
+++ b/laravel-lsp/src/translation_key_locator/tests.rs
@@ -1,6 +1,23 @@
-use super::*;
+use crate::salsa_impl::{LaravelDatabase, TranslationCache, TranslationKeyLocationData};
 use std::fs;
+use std::path::Path;
 use tempfile::TempDir;
+
+/// Drives the **real** production path — `TranslationCache` over a bare
+/// `LaravelDatabase` — so these assertions are about the code rename actually
+/// runs, containment guard included. The LSP actor adds only channel plumbing.
+#[derive(Default)]
+struct Locator {
+    db: LaravelDatabase,
+    cache: TranslationCache,
+}
+
+impl Locator {
+    fn locate(&mut self, root: &Path, dotted_key: &str) -> Vec<TranslationKeyLocationData> {
+        self.cache
+            .locate_key_across_locales(&mut self.db, root, dotted_key)
+    }
+}
 
 /// Build a fake Laravel project with a `lang/` directory and a list of
 /// (locale, file_stem, content) entries seeded as locale lang files.
@@ -41,7 +58,7 @@ return [
 #[test]
 fn locates_key_across_multiple_locales() {
     let project = fake_project_with_lang(&[("en", "auth", AUTH_EN), ("es", "auth", AUTH_ES)]);
-    let mut locs = locate_keys_across_locales(project.path(), "auth.failed");
+    let mut locs = Locator::default().locate(project.path(), "auth.failed");
     // Sort by file path so the assertion is order-independent.
     locs.sort_by(|a, b| a.file_path.cmp(&b.file_path));
 
@@ -50,8 +67,8 @@ fn locates_key_across_multiple_locales() {
     assert!(locs[1].file_path.ends_with("lang/es/auth.php"));
     for loc in &locs {
         let content = fs::read_to_string(&loc.file_path).unwrap();
-        let line = content.lines().nth(loc.position.line as usize).unwrap();
-        let slice = &line[loc.position.start_column as usize..loc.position.end_column as usize];
+        let line = content.lines().nth(loc.location.line as usize).unwrap();
+        let slice = &line[loc.location.start_column as usize..loc.location.end_column as usize];
         assert_eq!(slice, "failed");
     }
 }
@@ -64,7 +81,7 @@ fn skips_locale_without_the_key() {
     let project = fake_project_with_lang(&[("en", "auth", AUTH_EN)]);
     fs::create_dir_all(project.path().join("lang/es")).unwrap();
 
-    let locs = locate_keys_across_locales(project.path(), "auth.failed");
+    let locs = Locator::default().locate(project.path(), "auth.failed");
     assert_eq!(locs.len(), 1, "only en defines auth.php");
     assert!(locs[0].file_path.ends_with("lang/en/auth.php"));
 }
@@ -72,30 +89,69 @@ fn skips_locale_without_the_key() {
 #[test]
 fn handles_nested_keys() {
     let project = fake_project_with_lang(&[("en", "auth", AUTH_NESTED_EN)]);
-    let locs = locate_keys_across_locales(project.path(), "auth.throttle.message");
+    let locs = Locator::default().locate(project.path(), "auth.throttle.message");
     assert_eq!(locs.len(), 1);
     let loc = &locs[0];
     let content = fs::read_to_string(&loc.file_path).unwrap();
-    let line = content.lines().nth(loc.position.line as usize).unwrap();
-    let slice = &line[loc.position.start_column as usize..loc.position.end_column as usize];
+    let line = content.lines().nth(loc.location.line as usize).unwrap();
+    let slice = &line[loc.location.start_column as usize..loc.location.end_column as usize];
     assert_eq!(slice, "message");
 }
 
 #[test]
 fn returns_empty_when_no_lang_dir() {
     let dir = TempDir::new().unwrap();
-    assert!(locate_keys_across_locales(dir.path(), "auth.failed").is_empty());
+    assert!(Locator::default()
+        .locate(dir.path(), "auth.failed")
+        .is_empty());
 }
 
 #[test]
 fn returns_empty_for_missing_key_in_all_locales() {
     let project = fake_project_with_lang(&[("en", "auth", AUTH_EN), ("es", "auth", AUTH_ES)]);
-    assert!(locate_keys_across_locales(project.path(), "auth.missing").is_empty());
+    assert!(Locator::default()
+        .locate(project.path(), "auth.missing")
+        .is_empty());
 }
 
 #[test]
 fn returns_empty_when_dotted_key_has_no_segments() {
     let project = fake_project_with_lang(&[("en", "auth", AUTH_EN)]);
     // A bare "auth" without anything after the dot can't reach a leaf.
-    assert!(locate_keys_across_locales(project.path(), "auth").is_empty());
+    assert!(Locator::default().locate(project.path(), "auth").is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Caching (issue #293)
+//
+// Containment is NOT re-tested here. This read is now fenced by the shared
+// guard in `TranslationCache::ensure_file` — where it previously had none at
+// all — and that guard's five regression tests live in
+// `translation_lookup::tests`, which go red the moment it is removed. A
+// traversal test aimed at *this* entry point would not discriminate anyway:
+// the key is split on `.` before the stem is used, so a `../` escape leaves the
+// stem empty and never reaches a read. The guard here is defence in depth
+// against a stem naming an absolute path, not a closable hole.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_locale_file_is_read_once_across_repeated_renames() {
+    let project = fake_project_with_lang(&[("en", "auth", AUTH_EN), ("es", "auth", AUTH_ES)]);
+    let mut locator = Locator::default();
+
+    let first = locator.locate(project.path(), "auth.failed");
+    let after_first = locator.cache.disk_reads();
+    let second = locator.locate(project.path(), "auth.failed");
+    let after_second = locator.cache.disk_reads();
+
+    assert_eq!(first.len(), 2);
+    assert_eq!(second, first);
+    assert!(
+        after_first > 0,
+        "the first walk must actually read the catalogues"
+    );
+    assert_eq!(
+        after_second, after_first,
+        "a rename must not re-read and re-parse every locale's catalogue"
+    );
 }

--- a/laravel-lsp/src/translation_lookup.rs
+++ b/laravel-lsp/src/translation_lookup.rs
@@ -1,4 +1,4 @@
-//! Resolve Laravel translation keys to their localized strings.
+//! Work out *which files could define* a Laravel translation key.
 //!
 //! Every shape resolves under `{lang_root}/`, where `{lang_root}` is `lang/`
 //! (Laravel 9+) or `resources/lang/` (Laravel 8 and earlier) — both are always
@@ -20,86 +20,64 @@
 //!   JSON file `{lang_root}/{locale}.json`. The key IS the source string and
 //!   the value is the translated string.
 //!
-//! No shape assumes a locale. [`available_locales`] answers "which locales
-//! could define this key", and hover, go-to-definition and diagnostics all
-//! resolve against that one set so they cannot disagree (issue #288).
+//! No shape assumes a locale. [`locale_candidate_dirs`] answers "which
+//! directories could reveal a locale for this key", and hover, go-to-definition
+//! and diagnostics all resolve against that one set so they cannot disagree
+//! (issue #288).
 //!
-//! All three shapes route to the same PHP-array walker from [`config_lookup`]
-//! since Laravel's `.php` translation files share their exact shape with
-//! config files.
+//! # This module does no I/O
 //!
-//! Every path this module builds joins segments taken verbatim from a
-//! translation key in parsed PHP/Blade source — the `vendor::` namespace, the
-//! dotted file segment — or from a `loadTranslationsFrom` argument. All of it
-//! is untrusted, so **every** read and directory enumeration here is fenced by
-//! [`crate::path_containment`]: reads through [`read_in_root`], enumeration in
-//! [`available_locales`] (issue #248).
+//! It is **pure path arithmetic**: it names candidate files and directories and
+//! stops there. Reading them, parsing them and caching the result is
+//! [`crate::salsa_impl::TranslationCache`]'s job, so every lang-file read goes
+//! through Salsa and is invalidated rather than repeated (issue #293). Splitting
+//! it this way keeps one definition of "where could this key live" shared by the
+//! resolver, locale discovery and their tests.
+//!
+//! Every path built here joins segments taken verbatim from a translation key
+//! in parsed PHP/Blade source — the `vendor::` namespace, the dotted file
+//! segment — or from a `loadTranslationsFrom` argument. **All of it is
+//! untrusted and can carry `../` traversal or an absolute path.** Because
+//! nothing here reads, the fail-closed containment guard that used to sit at
+//! each read site now sits at the single choke point that does:
+//! `TranslationCache::ensure_file` / `ensure_dir`, which refuse any candidate
+//! they cannot prove inside the project root (issue #248). A candidate emitted
+//! here is a *proposal*, never a permission.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use crate::config_lookup;
+/// The fallback locale when a project exposes none — Laravel's own default.
+pub const DEFAULT_LOCALE: &str = "en";
 
-/// A resolved translation along with the file the value was read from.
-/// The source file is rendered as a display-friendly path in hover output so
-/// users can tell whether a key came from an app file, a published vendor
-/// translation, or the JSON catalogue.
-#[derive(Debug, Clone)]
-pub struct ResolvedTranslation {
-    pub value: String,
-    pub source_file: PathBuf,
+/// One file that could define a translation key, and how to look it up in it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TranslationCandidate {
+    /// A PHP array catalogue and the nested key path to walk inside it.
+    Php {
+        /// The `.php` catalogue to read.
+        path: PathBuf,
+        /// The key segments after the file name (`['required']` for
+        /// `validation.required`). Never empty.
+        key_path: Vec<String>,
+    },
+    /// A `{lang_root}/{locale}.json` catalogue, where the key is the source
+    /// string itself.
+    Json {
+        /// The `.json` catalogue to read.
+        path: PathBuf,
+        /// The source string, used verbatim as the lookup key.
+        key: String,
+    },
 }
 
-/// Resolve a translation key against a project root and locale. Returns both
-/// the translated value and the file it was read from — see
-/// [`ResolvedTranslation`].
-///
-/// For namespaced keys (`package::file.key`), the resolver tries the
-/// published location first (`lang/vendor/<namespace>/...`) and falls back
-/// to the unpublished vendor location when `vendor_map` is provided. See
-/// [`crate::vendor_translations`] for how that map is built.
-pub fn resolve_translation_detailed(
-    root: &Path,
-    key: &str,
-    locale: &str,
-    vendor_map: Option<&HashMap<String, PathBuf>>,
-) -> Option<ResolvedTranslation> {
-    if let Some((namespace, rest)) = split_namespace(key) {
-        if let Some(r) = resolve_namespaced(root, namespace, rest, locale) {
-            return Some(r);
+impl TranslationCandidate {
+    /// The file this candidate would read.
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Php { path, .. } | Self::Json { path, .. } => path,
         }
-        // Published path missed — try the unpublished vendor directory.
-        if let Some(map) = vendor_map {
-            if let Some(dir) = map.get(namespace) {
-                return resolve_namespaced_in_dir(root, dir, rest, locale);
-            }
-        }
-        return None;
     }
-    if is_dotted_key(key) {
-        return resolve_dotted(root, key, locale);
-    }
-    resolve_text_key(root, key, locale)
-}
-
-/// Backwards-compatible wrapper that returns only the value, matching the
-/// pre-source-file API. Used by tests that don't care about the source path.
-pub fn resolve_translation(root: &Path, key: &str, locale: &str) -> Option<String> {
-    resolve_translation_detailed(root, key, locale, None).map(|r| r.value)
-}
-
-/// Split a namespaced key (`package::file.key.path`) into its namespace and
-/// the rest. Returns `None` for keys without a `::` separator.
-fn split_namespace(key: &str) -> Option<(&str, &str)> {
-    let idx = key.find("::")?;
-    Some((&key[..idx], &key[idx + 2..]))
-}
-
-/// Distinguish a dotted PHP-file key (`validation.required`) from a text key
-/// (`"Welcome to our app"`). Heuristic: dotted keys contain a `.` and no
-/// whitespace.
-fn is_dotted_key(key: &str) -> bool {
-    key.contains('.') && !key.contains(' ')
 }
 
 /// The directories a project may keep translations in, in priority order:
@@ -114,220 +92,141 @@ pub fn project_lang_roots(root: &Path) -> [PathBuf; 2] {
     [root.join("lang"), root.join("resources").join("lang")]
 }
 
-/// Resolve a dotted key against `{lang_root}/{locale}/{file}.php`.
-fn resolve_dotted(root: &Path, key: &str, locale: &str) -> Option<ResolvedTranslation> {
+/// Split a namespaced key (`package::file.key.path`) into its namespace and
+/// the rest. Returns `None` for keys without a `::` separator.
+pub fn split_namespace(key: &str) -> Option<(&str, &str)> {
+    let idx = key.find("::")?;
+    Some((&key[..idx], &key[idx + 2..]))
+}
+
+/// Distinguish a dotted PHP-file key (`validation.required`) from a text key
+/// (`"Welcome to our app"`). Heuristic: dotted keys contain a `.` and no
+/// whitespace.
+pub fn is_dotted_key(key: &str) -> bool {
+    key.contains('.') && !key.contains(' ')
+}
+
+/// Split a dotted key into its file segment and the nested key path after it.
+/// `None` when there is no key path left (`'validation'`, `'validation.'`) —
+/// a bare file name names no key, which is not a resolution.
+fn split_file_and_key_path(key: &str) -> Option<(&str, Vec<String>)> {
     let mut parts = key.split('.');
     let file = parts.next()?;
-    let key_path: Vec<&str> = parts.collect();
-    if key_path.is_empty() {
-        return None;
-    }
-    project_lang_roots(root).iter().find_map(|lang| {
-        read_php_value(
-            root,
-            &lang.join(locale).join(format!("{}.php", file)),
-            &key_path,
-        )
-    })
+    let key_path: Vec<String> = parts.map(str::to_string).collect();
+    (!key_path.is_empty()).then_some((file, key_path))
 }
 
-/// Resolve a published namespaced key against
-/// `lang/vendor/{namespace}/{locale}/{file}.php`.
+/// Every file that could define `key` in `locale`, in the order the resolver
+/// must try them — first hit wins.
 ///
-/// `namespace` is the `vendor::` prefix lifted verbatim out of parsed PHP/Blade
-/// source, so it is untrusted and can carry traversal segments. The read is
-/// fenced by [`read_in_root`], which is why `root` is threaded through
-/// (issue #248).
-fn resolve_namespaced(
+/// For namespaced keys the published override
+/// (`{lang_root}/vendor/{namespace}/{locale}/{file}.php`) is proposed before
+/// the package's own unpublished directory from `vendor_map`, matching
+/// Laravel's own precedence.
+///
+/// Returns an empty vec for a key that names no lookup at all (a bare
+/// `'validation'` with no nested path).
+pub fn translation_candidates(
     root: &Path,
-    namespace: &str,
-    rest: &str,
+    key: &str,
     locale: &str,
-) -> Option<ResolvedTranslation> {
-    let mut parts = rest.split('.');
-    let file = parts.next()?;
-    let key_path: Vec<&str> = parts.collect();
-    if key_path.is_empty() {
-        return None;
-    }
-    project_lang_roots(root).iter().find_map(|lang| {
-        read_php_value(
-            root,
-            &lang
-                .join("vendor")
-                .join(namespace)
-                .join(locale)
-                .join(format!("{}.php", file)),
-            &key_path,
-        )
-    })
-}
+    vendor_map: Option<&HashMap<String, PathBuf>>,
+) -> Vec<TranslationCandidate> {
+    let php = |path: PathBuf, key_path: &[String]| TranslationCandidate::Php {
+        path,
+        key_path: key_path.to_vec(),
+    };
 
-/// Resolve a namespaced key against an explicit lang directory — the
-/// fallback used when the published path missed and the namespace was
-/// discovered via [`crate::vendor_translations`]. `root` is the project root,
-/// used to fence the read inside the tree.
-fn resolve_namespaced_in_dir(
-    root: &Path,
-    lang_dir: &Path,
-    rest: &str,
-    locale: &str,
-) -> Option<ResolvedTranslation> {
-    let mut parts = rest.split('.');
-    let file = parts.next()?;
-    let key_path: Vec<&str> = parts.collect();
-    if key_path.is_empty() {
-        return None;
+    if let Some((namespace, rest)) = split_namespace(key) {
+        let Some((file, key_path)) = split_file_and_key_path(rest) else {
+            return Vec::new();
+        };
+        let mut out: Vec<TranslationCandidate> = project_lang_roots(root)
+            .iter()
+            .map(|lang| {
+                php(
+                    lang.join("vendor")
+                        .join(namespace)
+                        .join(locale)
+                        .join(format!("{file}.php")),
+                    &key_path,
+                )
+            })
+            .collect();
+        // Published path missed — the package's own unpublished lang dir.
+        if let Some(dir) = vendor_map.and_then(|m| m.get(namespace)) {
+            out.push(php(dir.join(locale).join(format!("{file}.php")), &key_path));
+        }
+        return out;
     }
-    // `lang_dir` is derived from a `loadTranslationsFrom` argument in
-    // project/vendor source — untrusted input. A traversal like
-    // `base_path('../../../../.ssh')` or `__DIR__.'/../../../../etc'` could seed
-    // an out-of-root directory; [`read_php_value`] fail-closes before the read
-    // so a namespaced key can never turn the LSP into an arbitrary-file-read
-    // primitive (issue #248).
-    let path = lang_dir.join(locale).join(format!("{}.php", file));
-    read_php_value(root, &path, &key_path)
-}
 
-/// Resolve a text key against `lang/{locale}.json`.
-fn resolve_text_key(root: &Path, key: &str, locale: &str) -> Option<ResolvedTranslation> {
-    project_lang_roots(root).iter().find_map(|lang| {
-        let path = lang.join(format!("{}.json", locale));
-        let content = read_in_root(&path, root)?;
-        let map: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_str(&content).ok()?;
-        let value = map.get(key)?.as_str()?;
-        Some(ResolvedTranslation {
-            value: format!("'{}'", value),
-            source_file: path,
+    if is_dotted_key(key) {
+        let Some((file, key_path)) = split_file_and_key_path(key) else {
+            return Vec::new();
+        };
+        return project_lang_roots(root)
+            .iter()
+            .map(|lang| php(lang.join(locale).join(format!("{file}.php")), &key_path))
+            .collect();
+    }
+
+    project_lang_roots(root)
+        .iter()
+        .map(|lang| TranslationCandidate::Json {
+            path: lang.join(format!("{locale}.json")),
+            key: key.to_string(),
         })
-    })
+        .collect()
 }
 
-/// The fallback locale when a project exposes none — Laravel's own default.
-const DEFAULT_LOCALE: &str = "en";
-
-/// Every locale that could define `key`, ordered with the project's configured
-/// `APP_LOCALE` first and the rest alphabetically.
+/// Every directory whose listing could reveal a locale for `key`.
 ///
-/// Discovery looks at the lang directories the key could live in — the
-/// published vendor override plus the registered namespace directory for a
-/// namespaced key, the project lang roots otherwise — and treats both locale
-/// *subdirectories* and `{locale}.json` catalogues as evidence of a locale.
-/// The `vendor` subdirectory is excluded: it holds published package
-/// translations, not a locale. Any directory that resolves outside the project
-/// root — a published path whose `vendor::` namespace carries traversal, or a
-/// registered namespace directory seeded by `loadTranslationsFrom` — is dropped
-/// before it is read (issue #248).
-///
-/// Never returns empty. A project with no discoverable locales (no lang
-/// directory at all, or one containing nothing) falls back to
-/// `["en"]`, so callers always have something to resolve against.
+/// For a namespaced key that is the published vendor override directory plus
+/// the registered namespace directory; for every other shape it is the project
+/// lang roots. Locale *subdirectories* and `{locale}.json` catalogues both
+/// count as evidence of a locale — see
+/// [`crate::salsa_impl::locales_in_dir`], which reads the listing.
 ///
 /// This is the single source of truth for "which locales matter for this key" —
 /// hover, go-to-definition and diagnostics all resolve against the same set, so
 /// a key defined only in `de` renders, navigates and validates consistently.
-pub fn available_locales(
+pub fn locale_candidate_dirs(
     root: &Path,
     key: &str,
     vendor_map: Option<&HashMap<String, PathBuf>>,
-) -> Vec<String> {
-    let mut dirs: Vec<PathBuf> = Vec::new();
-    if let Some((namespace, _)) = split_namespace(key) {
-        for lang in project_lang_roots(root) {
-            dirs.push(lang.join("vendor").join(namespace));
-        }
-        if let Some(dir) = vendor_map.and_then(|m| m.get(namespace)) {
-            dirs.push(dir.clone());
-        }
-    } else {
-        dirs.extend(project_lang_roots(root));
+) -> Vec<PathBuf> {
+    let Some((namespace, _)) = split_namespace(key) else {
+        return project_lang_roots(root).to_vec();
+    };
+    let mut dirs: Vec<PathBuf> = project_lang_roots(root)
+        .iter()
+        .map(|lang| lang.join("vendor").join(namespace))
+        .collect();
+    if let Some(dir) = vendor_map.and_then(|m| m.get(namespace)) {
+        dirs.push(dir.clone());
     }
-
-    let mut locales: Vec<String> = Vec::new();
-    for dir in &dirs {
-        // Enumeration is a read site, so it takes the same fail-closed guard
-        // the resolver reads take (issue #248). Both namespaced dirs are built
-        // from untrusted input that can point anywhere: the published path
-        // joins the `vendor::` namespace lifted verbatim out of parsed source,
-        // and the unpublished dir comes from a `loadTranslationsFrom` argument.
-        // Without the guard, `read_dir` on an escaped directory would surface
-        // whatever subdirectories it found there as this key's locales.
-        if !crate::path_containment::path_within_root(dir, root) {
-            continue;
-        }
-        let Ok(entries) = std::fs::read_dir(dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let locale = if path.is_dir() {
-                path.file_name()
-                    .and_then(|n| n.to_str())
-                    .map(str::to_string)
-            } else if path.extension().is_some_and(|e| e == "json") {
-                path.file_stem()
-                    .and_then(|n| n.to_str())
-                    .map(str::to_string)
-            } else {
-                None
-            };
-            // `vendor` is a namespace container, not a locale. Dedupe across
-            // dirs so a locale present in both the published and unpublished
-            // vendor directory is listed once.
-            if let Some(locale) = locale {
-                if locale != "vendor" && !locales.contains(&locale) {
-                    locales.push(locale);
-                }
-            }
-        }
-    }
-
-    if locales.is_empty() {
-        return vec![DEFAULT_LOCALE.to_string()];
-    }
-
-    locales.sort();
-    // The project's own locale leads; everything else stays alphabetical. An
-    // APP_LOCALE that no directory defines simply doesn't appear, leaving the
-    // alphabetical order untouched.
-    if let Some(app_locale) = crate::config::read_env_value(root, "APP_LOCALE") {
-        if let Some(idx) = locales.iter().position(|l| *l == app_locale) {
-            let leading = locales.remove(idx);
-            locales.insert(0, leading);
-        }
-    }
-    locales
+    dirs
 }
 
-/// Every *file* read in this module goes through here (directory enumeration
-/// carries its own copy of the guard, in [`available_locales`]). Every path
-/// here is built by joining segments lifted verbatim out of a translation key
-/// in parsed PHP/Blade source — the `vendor::` namespace, the dotted file
-/// segment — or, for the unpublished fallback, a `loadTranslationsFrom`
-/// directory. All of that is untrusted and can carry `../` traversal, so
-/// containment is checked here, once, for every read rather than at each
-/// caller where it can be forgotten (issue #248).
+/// Is `path` a Laravel translation catalogue — a `.php` array file or a
+/// `.json` text catalogue under one of this project's lang roots?
 ///
-/// **Fail-closed**: a path that cannot be proven inside `root` is refused, not
-/// read. `path_within_root` canonicalizes, so an under-root symlink pointing
-/// out of the tree is refused too.
-fn read_in_root(path: &Path, root: &Path) -> Option<String> {
-    if !crate::path_containment::path_within_root(path, root) {
-        return None;
-    }
-    std::fs::read_to_string(path).ok()
-}
-
-/// Shared PHP-file read + walk. Returns the bundled value + source path on hit.
-/// The read is fenced inside `root` by [`read_in_root`].
-fn read_php_value(root: &Path, path: &Path, key_path: &[&str]) -> Option<ResolvedTranslation> {
-    let content = read_in_root(path, root)?;
-    let value = config_lookup::resolve_in_source(&content, key_path)?;
-    Some(ResolvedTranslation {
-        value,
-        source_file: path.to_path_buf(),
-    })
+/// Used to route editor edits and watched-file events at the correct Salsa
+/// input: a lang file must invalidate the translation cache, which no other
+/// `.php` file does (issue #293). Deliberately **lexical** — this classifies,
+/// it does not authorize, and the fail-closed containment guard still runs at
+/// the read site (issue #248).
+///
+/// `lang/vendor/**` is included: published package translations are catalogues
+/// like any other, and an edit to one must invalidate just the same.
+pub fn is_lang_file(root: &Path, path: &Path) -> bool {
+    let is_catalogue = path
+        .extension()
+        .is_some_and(|ext| ext == "php" || ext == "json");
+    is_catalogue
+        && project_lang_roots(root)
+            .iter()
+            .any(|lang| path.starts_with(lang))
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/translation_lookup/tests.rs
+++ b/laravel-lsp/src/translation_lookup/tests.rs
@@ -1,6 +1,68 @@
 use super::*;
+use crate::salsa_impl::{LaravelDatabase, ResolvedTranslationData, TranslationCache};
 use std::fs;
 use tempfile::TempDir;
+
+/// Drives the **real** production resolution path — [`TranslationCache`] over a
+/// bare [`LaravelDatabase`] — rather than a test-only reimplementation. This is
+/// the same code hover, go-to-definition and diagnostics run; the LSP actor
+/// adds only channel plumbing on top of it, so a guarantee proven here (a
+/// containment refusal, a precedence order) is a guarantee about production.
+///
+/// Each `Resolver::default()` is a cold cache, which is what most of these
+/// tests want. Warmth across calls is covered separately, in
+/// `translation_salsa_cache.rs`.
+#[derive(Default)]
+struct Resolver {
+    db: LaravelDatabase,
+    cache: TranslationCache,
+}
+
+impl Resolver {
+    /// Resolve a key, returning the value and the catalogue it came from.
+    fn resolve(
+        &mut self,
+        root: &Path,
+        key: &str,
+        locale: &str,
+        vendor_map: Option<&HashMap<String, PathBuf>>,
+    ) -> Option<ResolvedTranslationData> {
+        self.cache
+            .resolve(&mut self.db, root, key, locale, vendor_map)
+    }
+
+    /// Resolve a key to its value alone.
+    fn value(&mut self, root: &Path, key: &str, locale: &str) -> Option<String> {
+        self.resolve(root, key, locale, None).map(|r| r.value)
+    }
+
+    /// Every locale that could define `key`, with no APP_LOCALE — the
+    /// discovery cases below are about *which* locales are found, not their
+    /// ordering.
+    fn locales(
+        &mut self,
+        root: &Path,
+        key: &str,
+        vendor_map: Option<&HashMap<String, PathBuf>>,
+    ) -> Vec<String> {
+        self.cache
+            .locales(&mut self.db, root, key, vendor_map, None)
+    }
+
+    /// Every locale that could define `key`, ordered against an explicit
+    /// APP_LOCALE.
+    ///
+    /// Passed directly rather than written into a `.env`: the cache takes the
+    /// locale as an argument, and the actor is what reads it out of the Salsa
+    /// env cache. Writing a `.env` here would prove nothing about ordering —
+    /// these assertions would pass on a cache that ignored APP_LOCALE
+    /// entirely. The `.env` -> ordering wiring is proven end to end in
+    /// `tests/translation_salsa_cache.rs` instead.
+    fn locales_led_by(&mut self, root: &Path, key: &str, app_locale: &str) -> Vec<String> {
+        self.cache
+            .locales(&mut self.db, root, key, None, Some(app_locale))
+    }
+}
 
 /// Build a fake Laravel project root with a `lang/` directory ready for tests.
 fn fake_project_with_lang() -> TempDir {
@@ -20,7 +82,7 @@ fn resolves_dotted_key_from_php_file() {
     )
     .unwrap();
 
-    let got = resolve_translation(project.path(), "validation.required", "en");
+    let got = Resolver::default().value(project.path(), "validation.required", "en");
     assert_eq!(got.as_deref(), Some("'The :attribute field is required.'"));
 }
 
@@ -35,11 +97,15 @@ fn resolves_nested_dotted_key_from_php_file() {
     .unwrap();
 
     assert_eq!(
-        resolve_translation(project.path(), "auth.failed", "en").as_deref(),
+        Resolver::default()
+            .value(project.path(), "auth.failed", "en")
+            .as_deref(),
         Some("'These credentials do not match.'")
     );
     assert_eq!(
-        resolve_translation(project.path(), "auth.throttle.message", "en").as_deref(),
+        Resolver::default()
+            .value(project.path(), "auth.throttle.message", "en")
+            .as_deref(),
         Some("'Too many attempts.'")
     );
 }
@@ -59,7 +125,9 @@ fn resolves_text_key_from_json_file() {
     .unwrap();
 
     assert_eq!(
-        resolve_translation(project.path(), "Welcome to our app", "en").as_deref(),
+        Resolver::default()
+            .value(project.path(), "Welcome to our app", "en")
+            .as_deref(),
         Some("'Welcome to our app'")
     );
 }
@@ -71,7 +139,7 @@ fn returns_none_for_missing_dotted_key() {
     fs::write(&validation, "<?php\nreturn ['present' => 'x'];\n").unwrap();
 
     assert_eq!(
-        resolve_translation(project.path(), "validation.missing", "en"),
+        Resolver::default().value(project.path(), "validation.missing", "en"),
         None
     );
 }
@@ -83,7 +151,7 @@ fn returns_none_for_missing_json_key() {
     fs::write(&json, r#"{"Present": "Present"}"#).unwrap();
 
     assert_eq!(
-        resolve_translation(project.path(), "Missing entry", "en"),
+        Resolver::default().value(project.path(), "Missing entry", "en"),
         None
     );
 }
@@ -93,11 +161,11 @@ fn returns_none_when_file_does_not_exist() {
     let project = fake_project_with_lang();
     // No files written.
     assert_eq!(
-        resolve_translation(project.path(), "validation.required", "en"),
+        Resolver::default().value(project.path(), "validation.required", "en"),
         None
     );
     assert_eq!(
-        resolve_translation(project.path(), "Free-form text", "en"),
+        Resolver::default().value(project.path(), "Free-form text", "en"),
         None
     );
 }
@@ -134,7 +202,7 @@ fn resolves_namespaced_translation_from_published_path() {
     )
     .unwrap();
 
-    let got = resolve_translation(
+    let got = Resolver::default().value(
         project.path(),
         "filament-tables::table.actions.filter.label",
         "en",
@@ -153,9 +221,9 @@ fn resolves_namespaced_translation_with_source_path() {
     )
     .unwrap();
 
-    let resolved =
-        resolve_translation_detailed(project.path(), "livewire::validation.required", "en", None)
-            .expect("namespaced lookup should hit");
+    let resolved = Resolver::default()
+        .resolve(project.path(), "livewire::validation.required", "en", None)
+        .expect("namespaced lookup should hit");
 
     assert_eq!(resolved.value, "'This field is required.'");
     assert!(
@@ -171,7 +239,7 @@ fn resolves_namespaced_translation_with_source_path() {
 fn returns_none_for_missing_namespaced_file() {
     let project = fake_project_with_lang();
     assert_eq!(
-        resolve_translation(project.path(), "filament-tables::table.actions.label", "en"),
+        Resolver::default().value(project.path(), "filament-tables::table.actions.label", "en"),
         None
     );
 }
@@ -196,13 +264,14 @@ fn falls_back_to_unpublished_vendor_dir_when_published_path_missing() {
     let mut vendor_map: HashMap<String, PathBuf> = HashMap::new();
     vendor_map.insert("billing".to_string(), vendor_lang.clone());
 
-    let resolved = resolve_translation_detailed(
-        project.path(),
-        "billing::invoice.total",
-        "en",
-        Some(&vendor_map),
-    )
-    .expect("unpublished vendor fallback should resolve");
+    let resolved = Resolver::default()
+        .resolve(
+            project.path(),
+            "billing::invoice.total",
+            "en",
+            Some(&vendor_map),
+        )
+        .expect("unpublished vendor fallback should resolve");
     assert_eq!(resolved.value, "'Total'");
     assert!(
         resolved
@@ -240,13 +309,14 @@ fn published_path_still_wins_over_vendor_map_when_both_exist() {
     let mut vendor_map: HashMap<String, PathBuf> = HashMap::new();
     vendor_map.insert("billing".to_string(), vendor_lang);
 
-    let resolved = resolve_translation_detailed(
-        project.path(),
-        "billing::invoice.total",
-        "en",
-        Some(&vendor_map),
-    )
-    .expect("should resolve");
+    let resolved = Resolver::default()
+        .resolve(
+            project.path(),
+            "billing::invoice.total",
+            "en",
+            Some(&vendor_map),
+        )
+        .expect("should resolve");
     // Published overrides — the user's choice when they ran
     // `php artisan vendor:publish` should take precedence.
     assert_eq!(resolved.value, "'Published total'");
@@ -257,7 +327,7 @@ fn dotted_key_without_path_returns_none() {
     let project = fake_project_with_lang();
     // A bare file name like "validation" — no key segment after the dot.
     assert_eq!(
-        resolve_translation(project.path(), "validation", "en"),
+        Resolver::default().value(project.path(), "validation", "en"),
         None
     );
 }
@@ -272,11 +342,15 @@ fn respects_locale_argument() {
     fs::write(&fr, "<?php\nreturn ['required' => 'Français'];\n").unwrap();
 
     assert_eq!(
-        resolve_translation(project.path(), "validation.required", "en").as_deref(),
+        Resolver::default()
+            .value(project.path(), "validation.required", "en")
+            .as_deref(),
         Some("'English'")
     );
     assert_eq!(
-        resolve_translation(project.path(), "validation.required", "fr").as_deref(),
+        Resolver::default()
+            .value(project.path(), "validation.required", "fr")
+            .as_deref(),
         Some("'Français'")
     );
 }
@@ -305,7 +379,7 @@ fn namespaced_dir_outside_root_is_refused() {
     // Namespace points at a directory entirely outside the project root.
     vendor_map.insert("billing".to_string(), outside.path().to_path_buf());
 
-    let resolved = resolve_translation_detailed(
+    let resolved = Resolver::default().resolve(
         project.path(),
         "billing::invoice.total",
         "en",
@@ -358,7 +432,9 @@ fn absolute_namespace_in_the_published_path_is_refused() {
     );
 
     assert!(
-        resolve_translation_detailed(project.path(), &key, "en", None).is_none(),
+        Resolver::default()
+            .resolve(project.path(), &key, "en", None)
+            .is_none(),
         "an absolute namespace must never escape the project root"
     );
 }
@@ -390,7 +466,9 @@ fn traversing_namespace_in_the_published_path_is_refused() {
 
     let key = format!("{namespace}::invoice.total");
     assert!(
-        resolve_translation_detailed(project.path(), &key, "en", None).is_none(),
+        Resolver::default()
+            .resolve(project.path(), &key, "en", None)
+            .is_none(),
         "a traversing namespace must never escape the project root"
     );
 }
@@ -420,7 +498,9 @@ fn dotted_key_read_through_an_escaping_symlink_is_refused() {
     );
 
     assert!(
-        resolve_translation(project.path(), "invoice.total", "en").is_none(),
+        Resolver::default()
+            .value(project.path(), "invoice.total", "en")
+            .is_none(),
         "a lang directory symlinked out of the root must never be read"
     );
 }
@@ -445,7 +525,9 @@ fn text_key_read_through_an_escaping_symlink_is_refused() {
     );
 
     assert!(
-        resolve_translation(project.path(), "Welcome", "en").is_none(),
+        Resolver::default()
+            .value(project.path(), "Welcome", "en")
+            .is_none(),
         "a lang directory symlinked out of the root must never be read"
     );
 }
@@ -467,7 +549,7 @@ fn root_with_locales(locales: &[&str]) -> TempDir {
 fn available_locales_enumerates_locale_directories() {
     let dir = root_with_locales(&["en", "de", "fr"]);
     assert_eq!(
-        available_locales(dir.path(), "messages.welcome", None),
+        Resolver::default().locales(dir.path(), "messages.welcome", None),
         vec!["de", "en", "fr"]
     );
 }
@@ -483,7 +565,7 @@ fn available_locales_extracts_json_catalogue_stems() {
     fs::write(lang.join("README.md"), "").unwrap();
 
     assert_eq!(
-        available_locales(dir.path(), "Welcome to our app", None),
+        Resolver::default().locales(dir.path(), "Welcome to our app", None),
         vec!["de", "en"]
     );
 }
@@ -493,7 +575,7 @@ fn available_locales_excludes_the_vendor_directory() {
     let dir = root_with_locales(&["en", "de"]);
     fs::create_dir_all(dir.path().join("lang/vendor/somepkg/en")).unwrap();
 
-    let locales = available_locales(dir.path(), "messages.welcome", None);
+    let locales = Resolver::default().locales(dir.path(), "messages.welcome", None);
     assert!(
         !locales.contains(&"vendor".to_string()),
         "vendor is a namespace container, not a locale: {locales:?}"
@@ -506,7 +588,7 @@ fn available_locales_falls_back_when_the_lang_directory_is_missing() {
     let dir = TempDir::new().unwrap();
     // No lang/ at all — read_dir errors on every candidate.
     assert_eq!(
-        available_locales(dir.path(), "messages.welcome", None),
+        Resolver::default().locales(dir.path(), "messages.welcome", None),
         vec!["en"]
     );
 }
@@ -517,7 +599,7 @@ fn available_locales_falls_back_when_the_lang_directory_is_empty() {
     fs::create_dir_all(dir.path().join("lang")).unwrap();
     // Exists, but holds no locale subdirectories and no .json catalogues.
     assert_eq!(
-        available_locales(dir.path(), "messages.welcome", None),
+        Resolver::default().locales(dir.path(), "messages.welcome", None),
         vec!["en"]
     );
 }
@@ -535,7 +617,7 @@ fn available_locales_unions_published_and_unpublished_vendor_dirs() {
     map.insert("shop".to_string(), pkg_lang);
 
     assert_eq!(
-        available_locales(dir.path(), "shop::messages.title", Some(&map)),
+        Resolver::default().locales(dir.path(), "shop::messages.title", Some(&map)),
         vec!["de", "fr"],
         "both directories contribute; neither is consulted in isolation"
     );
@@ -554,7 +636,7 @@ fn available_locales_deduplicates_overlapping_vendor_dirs() {
     map.insert("shop".to_string(), pkg_lang);
 
     assert_eq!(
-        available_locales(dir.path(), "shop::messages.title", Some(&map)),
+        Resolver::default().locales(dir.path(), "shop::messages.title", Some(&map)),
         vec!["de", "en"],
         "a locale in both directories is listed once, not doubled"
     );
@@ -583,7 +665,7 @@ fn available_locales_refuses_an_out_of_root_vendor_dir() {
     map.insert("shop".to_string(), outside.path().to_path_buf());
 
     assert_eq!(
-        available_locales(dir.path(), "shop::messages.title", Some(&map)),
+        Resolver::default().locales(dir.path(), "shop::messages.title", Some(&map)),
         vec!["de"],
         "an out-of-root vendor dir must contribute nothing"
     );
@@ -603,7 +685,7 @@ fn available_locales_refuses_an_escaping_published_namespace() {
     let project = fake_project_with_lang();
     let key = format!("{}::messages.title", outside.path().display());
 
-    let locales = available_locales(project.path(), &key, None);
+    let locales = Resolver::default().locales(project.path(), &key, None);
     assert_eq!(
         locales,
         vec!["en"],
@@ -620,10 +702,9 @@ fn available_locales_refuses_an_escaping_published_namespace() {
 #[test]
 fn available_locales_leads_with_app_locale_then_alphabetical() {
     let dir = root_with_locales(&["en", "de", "fr", "es"]);
-    fs::write(dir.path().join(".env"), "APP_NAME=Test\nAPP_LOCALE=fr\n").unwrap();
 
     assert_eq!(
-        available_locales(dir.path(), "messages.welcome", None),
+        Resolver::default().locales_led_by(dir.path(), "messages.welcome", "fr"),
         vec!["fr", "de", "en", "es"],
         "APP_LOCALE leads; the remainder stays alphabetical"
     );
@@ -632,10 +713,9 @@ fn available_locales_leads_with_app_locale_then_alphabetical() {
 #[test]
 fn available_locales_is_alphabetical_when_app_locale_is_unset() {
     let dir = root_with_locales(&["en", "de", "fr", "es"]);
-    fs::write(dir.path().join(".env"), "APP_NAME=Test\n").unwrap();
 
     assert_eq!(
-        available_locales(dir.path(), "messages.welcome", None),
+        Resolver::default().locales(dir.path(), "messages.welcome", None),
         vec!["de", "en", "es", "fr"]
     );
 }
@@ -643,10 +723,9 @@ fn available_locales_is_alphabetical_when_app_locale_is_unset() {
 #[test]
 fn available_locales_ignores_an_app_locale_no_directory_defines() {
     let dir = root_with_locales(&["en", "de", "fr", "es"]);
-    fs::write(dir.path().join(".env"), "APP_LOCALE=ja\n").unwrap();
 
     assert_eq!(
-        available_locales(dir.path(), "messages.welcome", None),
+        Resolver::default().locales_led_by(dir.path(), "messages.welcome", "ja"),
         vec!["de", "en", "es", "fr"],
         "an APP_LOCALE outside the discovered set must not panic or reorder"
     );
@@ -669,11 +748,12 @@ fn resources_lang_only_project_discovers_and_resolves() {
     .unwrap();
 
     assert_eq!(
-        available_locales(dir.path(), "contract.title", None),
+        Resolver::default().locales(dir.path(), "contract.title", None),
         vec!["de"],
         "discovery must see resources/lang"
     );
-    let resolved = resolve_translation_detailed(dir.path(), "contract.title", "de", None)
+    let resolved = Resolver::default()
+        .resolve(dir.path(), "contract.title", "de", None)
         .expect("resolution must see resources/lang too");
     assert_eq!(resolved.value, "'Vertrag'");
     assert_eq!(resolved.source_file, lang.join("de/contract.php"));
@@ -686,8 +766,12 @@ fn resources_lang_json_text_key_resolves() {
     fs::create_dir_all(&lang).unwrap();
     fs::write(lang.join("de.json"), r#"{"Welcome":"Willkommen"}"#).unwrap();
 
-    assert_eq!(available_locales(dir.path(), "Welcome", None), vec!["de"]);
-    let resolved = resolve_translation_detailed(dir.path(), "Welcome", "de", None)
+    assert_eq!(
+        Resolver::default().locales(dir.path(), "Welcome", None),
+        vec!["de"]
+    );
+    let resolved = Resolver::default()
+        .resolve(dir.path(), "Welcome", "de", None)
         .expect("JSON catalogue under resources/lang must resolve");
     assert_eq!(resolved.value, "'Willkommen'");
 }

--- a/laravel-lsp/src/vendor_translations.rs
+++ b/laravel-lsp/src/vendor_translations.rs
@@ -99,7 +99,7 @@ fn php_files_named_service_provider(dir: &Path, require_provider_name: bool) -> 
     if !dir.is_dir() {
         return Vec::new();
     }
-    walkdir::WalkDir::new(dir)
+    let mut paths: Vec<PathBuf> = walkdir::WalkDir::new(dir)
         .max_depth(10)
         .into_iter()
         .filter_map(|entry| entry.ok())
@@ -113,7 +113,13 @@ fn php_files_named_service_provider(dir: &Path, require_provider_name: bool) -> 
                     .and_then(|n| n.to_str())
                     .is_some_and(|n| n.contains("ServiceProvider"))
         })
-        .collect()
+        .collect::<Vec<_>>();
+    // Sorted so first-match-wins on a namespace conflict resolves the same way
+    // on every machine. `WalkDir` yields directory order, which is
+    // filesystem-dependent, so without this the winning registration could
+    // differ between a developer's APFS checkout and CI's ext4 one.
+    paths.sort();
+    paths
 }
 
 /// Every `namespace -> absolute lang directory` registration one provider file

--- a/laravel-lsp/src/vendor_translations.rs
+++ b/laravel-lsp/src/vendor_translations.rs
@@ -42,7 +42,6 @@ use crate::path_join::join_relative;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::collections::HashMap;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 lazy_static! {
@@ -66,99 +65,83 @@ lazy_static! {
     ).unwrap();
 }
 
-/// Walk `vendor/` for service providers that register translation namespaces.
-/// Returns a map of `namespace → absolute lang directory`.
+/// Candidate provider files under `vendor/` — every `*ServiceProvider*.php`,
+/// filename-gated only.
 ///
-/// The scan applies two cheap gates before parsing any file:
-/// - **Filename**: must contain `ServiceProvider`
-/// - **Content substring**: must contain `loadTranslationsFrom` or
-///   `hasTranslations`
+/// Enumeration only: nothing is read here. The content gate
+/// (`loadTranslationsFrom` / `hasTranslations`) and the AST walk both live in
+/// [`namespaces_in_source`], which
+/// [`crate::salsa_impl::TranslationCache::vendor_namespaces`] memoizes per
+/// file — so the substring check runs once per edit rather than once per scan
+/// (issue #293).
 ///
 /// Roughly the same shape as
 /// [`crate::config::scan_vendor_for_component_aliases`] — these two scans
 /// could share a single vendor-walk pass once we add the persistent cache.
-pub fn scan_vendor_translation_namespaces(root: &Path) -> HashMap<String, PathBuf> {
-    let vendor = root.join("vendor");
-    if !vendor.is_dir() {
-        return HashMap::new();
-    }
-
-    let mut namespaces: HashMap<String, PathBuf> = HashMap::new();
-
-    for entry in walkdir::WalkDir::new(&vendor)
-        .max_depth(10)
-        .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if path.extension().and_then(|s| s.to_str()) != Some("php") {
-            continue;
-        }
-        let filename_matches = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .map(|n| n.contains("ServiceProvider"))
-            .unwrap_or(false);
-        if !filename_matches {
-            continue;
-        }
-
-        let Ok(source) = fs::read_to_string(path) else {
-            continue;
-        };
-        if !source.contains("loadTranslationsFrom") && !source.contains("hasTranslations") {
-            continue;
-        }
-
-        process_provider_file(&source, path, root, &mut namespaces);
-    }
-
-    namespaces
+pub fn vendor_provider_candidates(root: &Path) -> Vec<PathBuf> {
+    php_files_named_service_provider(&root.join("vendor"), true)
 }
 
-/// Walk `app/Providers/` for app service providers that register translation
-/// namespaces. Returns a map of `namespace → absolute lang directory`.
+/// Candidate provider files under `app/Providers/`.
 ///
 /// App providers (e.g. `AppServiceProvider`) commonly register translations
 /// with `loadTranslationsFrom(lang_path('app'), 'app')` — a path the vendor
 /// scan never sees because it lives outside `vendor/` and never publishes to
 /// `lang/vendor/`. The directory itself is the gate here (everything under
-/// `app/Providers/` is a provider), so only the content substring is checked.
-pub fn scan_app_translation_namespaces(root: &Path) -> HashMap<String, PathBuf> {
-    let providers = root.join("app").join("Providers");
-    if !providers.is_dir() {
-        return HashMap::new();
+/// `app/Providers/` is a provider), so the filename is not checked.
+pub fn app_provider_candidates(root: &Path) -> Vec<PathBuf> {
+    php_files_named_service_provider(&root.join("app").join("Providers"), false)
+}
+
+/// Every `.php` file under `dir`, optionally restricted to filenames
+/// containing `ServiceProvider`. A directory walk, not a read.
+fn php_files_named_service_provider(dir: &Path, require_provider_name: bool) -> Vec<PathBuf> {
+    if !dir.is_dir() {
+        return Vec::new();
     }
-
-    let mut namespaces: HashMap<String, PathBuf> = HashMap::new();
-
-    for entry in walkdir::WalkDir::new(&providers)
+    walkdir::WalkDir::new(dir)
         .max_depth(10)
         .into_iter()
-        .filter_map(|e| e.ok())
-    {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if path.extension().and_then(|s| s.to_str()) != Some("php") {
-            continue;
-        }
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.into_path())
+        .filter(|path| path.is_file())
+        .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("php"))
+        .filter(|path| {
+            !require_provider_name
+                || path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.contains("ServiceProvider"))
+        })
+        .collect()
+}
 
-        let Ok(source) = fs::read_to_string(path) else {
-            continue;
-        };
-        if !source.contains("loadTranslationsFrom") && !source.contains("hasTranslations") {
-            continue;
-        }
-
-        process_provider_file(&source, path, root, &mut namespaces);
+/// Every `namespace -> absolute lang directory` registration one provider file
+/// declares, in declaration order.
+///
+/// Pure: the caller supplies the source. Returns a `Vec` rather than merging
+/// into a map so the caller owns precedence — first-match-wins within a scan,
+/// app-over-vendor across them — which a Salsa query must not decide for it.
+///
+/// Cheap substring gate first: a provider that mentions neither
+/// `loadTranslationsFrom` nor `hasTranslations` is never parsed.
+pub fn namespaces_in_source(
+    source: &str,
+    provider_path: &Path,
+    root: &Path,
+) -> Vec<(String, PathBuf)> {
+    if !source.contains("loadTranslationsFrom") && !source.contains("hasTranslations") {
+        return Vec::new();
     }
-
-    namespaces
+    let mut namespaces = HashMap::new();
+    process_provider_file(source, provider_path, root, &mut namespaces);
+    let mut out: Vec<(String, PathBuf)> = namespaces.into_iter().collect();
+    // `process_provider_file` merges into a HashMap, whose iteration order is
+    // random. Sort so one file's contribution is deterministic — otherwise two
+    // registrations in the same file would race for first-match-wins at the
+    // merge site and the resolved lang dir could differ between runs.
+    out.sort();
+    out
 }
 
 /// Run both extraction passes over a single provider file: the AST-based

--- a/laravel-lsp/src/vendor_translations/tests.rs
+++ b/laravel-lsp/src/vendor_translations/tests.rs
@@ -1,6 +1,24 @@
 use super::*;
+use crate::salsa_impl::{LaravelDatabase, TranslationCache};
+use std::collections::HashMap;
 use std::fs;
 use tempfile::TempDir;
+
+/// Drives the **real** production path — `TranslationCache::vendor_namespaces`
+/// over a bare `LaravelDatabase`. That method merges both scans (vendor first,
+/// then app overriding it), which is what production consumes; no fixture here
+/// mixes the two, so each test still exercises exactly the scan it names.
+#[derive(Default)]
+struct Scanner {
+    db: LaravelDatabase,
+    cache: TranslationCache,
+}
+
+impl Scanner {
+    fn scan(&mut self, root: &Path) -> HashMap<String, PathBuf> {
+        self.cache.vendor_namespaces(&mut self.db, root)
+    }
+}
 
 /// Build a fake vendor tree at `vendor/<vendor>/<package>/` with a service
 /// provider file at the standard location.
@@ -31,7 +49,7 @@ class BillingServiceProvider {
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     let resolved = map.get("billing").expect("should find billing namespace");
     assert!(
         resolved.ends_with("resources/lang"),
@@ -57,7 +75,7 @@ class Helpers {}
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     assert!(map.is_empty(), "non-provider files must be ignored");
 }
 
@@ -77,7 +95,7 @@ class BillingServiceProvider {
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     assert!(
         map.is_empty(),
         "providers without loadTranslationsFrom must contribute nothing"
@@ -100,7 +118,7 @@ fn captures_multiple_namespaces_across_packages() {
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     assert!(map.contains_key("billing"));
     assert!(map.contains_key("auth"));
 }
@@ -109,7 +127,7 @@ fn captures_multiple_namespaces_across_packages() {
 fn returns_empty_when_vendor_dir_missing() {
     let project = TempDir::new().unwrap();
     // No vendor/ directory.
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     assert!(map.is_empty());
 }
 
@@ -130,7 +148,7 @@ fn first_registration_wins_on_namespace_conflict() {
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     let resolved = map.get("shared").expect("conflict must still resolve");
     // The path will contain either "first" or "second" depending on walk order —
     // accept either, but it must be a single deterministic entry.
@@ -158,7 +176,7 @@ class BillingServiceProvider {
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     let resolved = map
         .get("app")
         .expect("lang_path('app') must register 'app'");
@@ -185,7 +203,7 @@ class BillingServiceProvider {
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     let resolved = map
         .get("custom")
         .expect("base_path('lang/custom') must register 'custom'");
@@ -216,7 +234,7 @@ class BillingServiceProvider {
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     let resolved = map
         .get("billing")
         .expect("dirname(__DIR__).'/lang' must register 'billing'");
@@ -255,7 +273,7 @@ class AppServiceProvider {
 "#,
     );
 
-    let map = scan_app_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     let resolved = map
         .get("app")
         .expect("app provider registration must yield the 'app' namespace");
@@ -265,7 +283,7 @@ class AppServiceProvider {
 #[test]
 fn app_scan_returns_empty_when_providers_dir_missing() {
     let project = TempDir::new().unwrap();
-    let map = scan_app_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     assert!(map.is_empty());
 }
 
@@ -277,7 +295,7 @@ fn app_scan_ignores_providers_without_load_translations() {
         "AppServiceProvider",
         "<?php\nclass AppServiceProvider { public function boot(): void {} }\n",
     );
-    let map = scan_app_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     assert!(map.is_empty());
 }
 
@@ -320,7 +338,7 @@ class TablesServiceProvider extends PackageServiceProvider
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     let resolved = map
         .get("filament-tables")
         .expect("builder registration must yield the filament-tables namespace");
@@ -349,7 +367,7 @@ class ToolsServiceProvider extends PackageServiceProvider
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     assert!(
         map.contains_key("tools"),
         "->name('laravel-tools') must register namespace 'tools', got {map:?}"
@@ -376,9 +394,62 @@ class UiServiceProvider extends PackageServiceProvider
     )
     .unwrap();
 
-    let map = scan_vendor_translation_namespaces(project.path());
+    let map = Scanner::default().scan(project.path());
     assert!(
         map.is_empty(),
         "no ->hasTranslations() means no translation namespace, got {map:?}"
+    );
+}
+
+// ─── Precedence across the two scans ─────────────────────────────────────
+
+#[test]
+fn app_provider_overrides_a_vendor_provider_on_namespace_conflict() {
+    // The app boots last, so an app `loadTranslationsFrom` for a namespace a
+    // package also registers is the one that wins at runtime. Nothing else
+    // covers this: every other fixture here has providers from one scan only,
+    // so a merge that dropped the override would pass the whole rest of the
+    // suite.
+    let project = TempDir::new().unwrap();
+    let root = project.path();
+
+    // A package registering `shop` at its own bundled lang dir.
+    let provider = fake_vendor_package(root, "acme", "shop", "ShopServiceProvider");
+    let vendor_lang = provider.parent().unwrap().join("../resources/lang");
+    fs::create_dir_all(&vendor_lang).unwrap();
+    fs::write(
+        &provider,
+        r#"<?php
+namespace Acme\Shop;
+class ShopServiceProvider {
+    public function boot() {
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'shop');
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    // The app registering the same namespace somewhere else.
+    let app_lang = root.join("lang/shop");
+    fs::create_dir_all(&app_lang).unwrap();
+    fake_app_provider(
+        root,
+        "AppServiceProvider",
+        r#"<?php
+namespace App\Providers;
+class AppServiceProvider {
+    public function boot(): void {
+        $this->loadTranslationsFrom(lang_path('shop'), 'shop');
+    }
+}
+"#,
+    );
+
+    let map = Scanner::default().scan(root);
+    assert_eq!(
+        map.get("shop"),
+        Some(&app_lang.canonicalize().unwrap()),
+        "the app registration must win over the package's own"
     );
 }


### PR DESCRIPTION
Fixes #293

## Summary

Translation resolution read and parsed lang files with `std::fs::read_to_string` on every call, uncached and uninvalidated. Since #288 resolves a key against **every** locale a project defines, one hover on a 25-locale project meant a `read_dir` plus up to 25 file reads — repeated for go-to-definition and again for the diagnostic pass.

Lang catalogues and directory listings are now Salsa inputs (`LangFile`, `LangDir`) behind tracked queries, owned by a `TranslationCache` the actor holds. `translation_lookup` and `translation_key_locator` become pure path arithmetic — they name candidates and stop — so the fail-closed #248 containment guard now sits at the single choke point that touches disk.

### Beyond the reads the issue names

A sweep found the same catalogues being read again by four sibling call sites, each routed through the same cache:

| Site | Cost before |
|---|---|
| **Autocomplete** (`get_all_translation_keys`) | 2 × `read_dir`, then read **and parse every catalogue in the locale**, recompiling the key regex per file — on **every completion request** |
| **Go-to-definition** key locator | `read_to_string` + a full tree-sitter parse per jump |
| **Rename** cross-locale walk | `read_dir` + read/parse every locale's catalogue, with **no containment guard at all** |
| **Provider scan** (`vendor_translations`) | `walkdir` over `vendor/`, read + substring-gate + AST-parse every `*ServiceProvider*.php` |

`vendor_translations.rs` now has zero `fs::` calls. Its `RwLock` session cache is deleted: it was written once and had **no invalidation path**, so a `composer update` or an edited `loadTranslationsFrom` was invisible until restart — and since this change made that map decide where namespaced keys resolve, stale meant *wrong*, not merely old.

### Invalidation

Caching without invalidation trades a performance bug for a correctness one, so:

- `did_change` registers editor buffers — an unsaved lang edit shows up in the next hover
- `file_watcher` gains lang globs for **both** lang roots (`lang/` and `resources/lang/`, so Laravel 8 layouts aren't left stale), with create/change/delete handling
- a provider create/change/delete drops the namespace map and the discovered provider set

`APP_LOCALE` now comes from the Salsa env cache, filtered to uncommented, non-empty `.env` values so `read_env_value`'s semantics are preserved exactly.

## Acceptance criteria

- [x] Resolution goes through a `#[salsa::tracked]` query keyed off a dedicated `#[salsa::input]` (`LangFile`, mirroring `ConfigFile`, updated via `Setter`)
- [x] Locale discovery is Salsa-backed and **warm across LSP requests** — asserted with an instrumented read counter through the same running `SalsaHandle`/actor
- [x] Every production call site reads through the one query — hover, all three `check_translation_file` invocations, go-to-definition. Zero remaining production callers of the old helpers (they are deleted)
- [x] `did_change` on an open lang buffer invalidates — driven through the real `Backend::did_change`, asserting the edit is reflected **and the file on disk still holds the old text**
- [x] External changes invalidate — `file_watcher` registers `lang/**/*.php`, `lang/*.json`, `lang/vendor/**/*.php` (and the `resources/lang/` equivalents), with `.php` and `.json` external-edit tests
- [x] A deleted catalogue stops resolving
- [x] A missing or empty `lang/` still falls back to `["en"]`
- [x] `vendor_map` never enters a query memo key — it only names candidate paths, so it can neither defeat memoization of the dotted path nor serve a stale namespaced resolution
- [ ] ⚠️ **Deliberately not met** — this bullet scoped `vendor_translations` and `translation_key_locator::locate_keys_across_locales` out as "tracked separately". Both are **in** this PR: the repo rule is *"never bypass Salsa"*, and applying it selectively leaves the architecture inconsistent. Flagged and decided before the work was done.
- [x] Hover, goto and diagnostics still agree — the #288 consistency suite passes
- [ ] ⚠️ **Amended** — "existing coverage passes **unmodified**" could not hold. `check_translation_file` becomes `async fn(&self, …)`, so its call sites changed. Every ported test targets the **real** production path, not a shim, and the assertions are otherwise unchanged.
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean

## Test plan

**3,077 tests pass** (2,466 lib + 531 bin + 80 integration); clippy and fmt clean.

New suite `tests/translation_salsa_cache.rs` (25 tests) drives the **real** `Backend` on the `LspService` harness and the real LSP notification handlers — not `salsa_impl` internals, which would prove the cache works while saying nothing about whether it is wired up.

The 693-line `translation_lookup` suite — including **five #248 containment regressions** — was ported onto the real `TranslationCache` rather than shimmed, so it still guards the security property against the new code path.

**16 mutations run, 16 caught**, including:

- file / directory cache disabled → 5 red
- `#248` containment guard removed → **5 red** (the containment coverage survives the refactor)
- `did_change` registration off → 1 red
- watched-files invalidation off → 4 red
- provider-set invalidation off → 1 red
- app-overrides-vendor precedence flipped → 1 red

Three of my own tests failed their mutation check and were rewritten or deleted: a `["en"]` fallback masked by a second fallback, a racy process-global read counter (now per-cache), and a traversal test that could not reach its own target.

## Notes for review

- The merge from `main` conflicted in `main.rs` and would have silently reverted #319's char-boundary truncation fix into the function this PR relocates — preserved, and #319's regression tests follow the function to its new home.
- `TranslationCache::ensure_provider` deliberately has **no** containment guard: those paths come from walking the project's own directories, not from joining an untrusted key segment, and canonicalizing every `*ServiceProvider*.php` in `vendor/` would buy nothing.
- The containment guard on the rename walk is defence in depth rather than a closed hole — the key is split on `.` before the stem is used, so a `../` escape leaves the stem empty. Documented in place; no test claims otherwise.
- **CI caught a real bug, not a flaky test.** `locales_in_dir` preserves directory-listing order, which is filesystem-dependent — APFS returns entries sorted, ext4 does not — so *which locale answers autocomplete* varied by platform (`45d4b6e`). The provider walk had the same latent split affecting first-match-wins precedence. Both pre-existing in the direct-`fs` versions; only the new tests made them visible. Both are now sorted before the pick — the rules are unchanged, only "first" is stable.
