### PR TITLE
fix: 🐛 Resolve directive view names by argument position (#327)

### DIFF
--- a/laravel-lsp/src/directive_args.rs
+++ b/laravel-lsp/src/directive_args.rs
@@ -1,0 +1,188 @@
+//! Argument-list parsing for Blade directives.
+//!
+//! A directive's arguments are PHP expressions, and the view name a directive
+//! points at is identified by its *position* in the argument list — not by
+//! being the first quoted string in it. Condition-first directives
+//! (`@includeWhen`, `@includeUnless`) put a boolean expression first, and
+//! that expression frequently contains a string literal of its own:
+//!
+//! ```text
+//! @includeWhen($type === 'admin', 'pages.admin')
+//! ```
+//!
+//! A "first quoted string wins" scan answers `admin` there — a wrong
+//! goto-definition target and a wrong outline label. Splitting the list at
+//! its first *top-level* comma — one that is not inside a quoted string, a
+//! nested `(...)`, or a `[...]` array literal — and reading the argument at
+//! the position the directive actually uses answers `pages.admin`.
+//!
+//! Bracket tracking is load-bearing rather than defensive:
+//! `@includeWhen(in_array($k, ['a', 'b']), 'pages.list')` carries two commas
+//! inside its condition, and any split that ignores nesting picks one of them.
+
+/// Directives whose first argument is a condition, putting the view name in
+/// the *second*.
+///
+/// Single-sourced because three independent call sites need this list —
+/// goto-definition (`main.rs`), find-references (`references.rs`), and the
+/// document outline (`document_symbols.rs`) — and drift between private
+/// copies is exactly how `@includeUnless` came to be handled by
+/// goto-definition while find-references never recognised it at all.
+pub fn is_condition_first(directive: &str) -> bool {
+    matches!(directive, "includeWhen" | "includeUnless")
+}
+
+/// The string literal at top-level argument position `index`.
+///
+/// `None` when that argument is absent, is not a string literal (`$view`,
+/// `$a ?: $b`, `'partials.' . $name`), or is the empty literal — an empty
+/// name resolves to no file, so it is reported absent rather than passed on.
+pub fn nth_literal(args: &str, index: usize) -> Option<String> {
+    quoted_literal(split_top_level(args).get(index)?).map(str::to_string)
+}
+
+/// The first string literal anywhere in `args`, at any nesting depth.
+///
+/// The rule for directives that are *not* condition-first, whose name is
+/// routinely nested inside an array literal rather than sitting at a
+/// top-level argument position: `@props(['title', 'count' => 0])` and
+/// `@includeFirst(['custom.layout', 'default.layout'])` both carry it one
+/// level down.
+pub fn first_literal(args: &str) -> Option<String> {
+    let mut scan = ArgScanner::default();
+    let mut start = 0usize;
+    for (i, ch) in args.char_indices() {
+        let was_open = scan.in_string();
+        scan.step(ch);
+        match (was_open, scan.in_string()) {
+            (false, true) => start = i + ch.len_utf8(),
+            (true, false) => {
+                let literal = &args[start..i];
+                return (!literal.is_empty()).then(|| literal.to_string());
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Split an argument list into its top-level arguments, with surrounding
+/// whitespace trimmed from each.
+///
+/// The directive-call parentheses are removed first when present. Always
+/// returns at least one element, so an empty list yields `[""]`.
+fn split_top_level(args: &str) -> Vec<&str> {
+    let inner = unwrap_parens(args);
+    let mut scan = ArgScanner::default();
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    for (i, ch) in inner.char_indices() {
+        let top = scan.at_top_level();
+        scan.step(ch);
+        if top && ch == ',' {
+            out.push(inner[start..i].trim());
+            start = i + ch.len_utf8();
+        }
+    }
+    out.push(inner[start..].trim());
+    out
+}
+
+/// The contents of `arg` when it is exactly a quoted string literal.
+///
+/// Anything trailing the closing quote disqualifies it: `'partials.' . $name`
+/// is a concatenation whose value is not knowable from source, and reporting
+/// its first fragment as a name — which the loose quote-trimming this
+/// replaced did — produces a target that can never resolve.
+fn quoted_literal(arg: &str) -> Option<&str> {
+    let trimmed = arg.trim();
+    let mut chars = trimmed.chars();
+    let quote = chars.next().filter(|c| *c == '\'' || *c == '"')?;
+    let rest = chars.as_str();
+
+    let mut scan = ArgScanner::default();
+    scan.step(quote);
+    for (i, ch) in rest.char_indices() {
+        scan.step(ch);
+        if !scan.in_string() {
+            let literal = &rest[..i];
+            return rest[i + ch.len_utf8()..]
+                .trim()
+                .is_empty()
+                .then_some(literal)
+                .filter(|l| !l.is_empty());
+        }
+    }
+    None
+}
+
+/// The argument list with the directive-call parentheses removed.
+///
+/// `queries.rs` documents both shapes reaching the extractors — `('view')`
+/// and a bare `'view'` — so the wrapper is detected rather than assumed: a
+/// leading `(` only wraps the list when its match is the final character.
+fn unwrap_parens(args: &str) -> &str {
+    let trimmed = args.trim();
+    let Some(body) = trimmed.strip_prefix('(') else {
+        return trimmed;
+    };
+    let mut scan = ArgScanner::default();
+    for (i, ch) in body.char_indices() {
+        let top = scan.at_top_level();
+        scan.step(ch);
+        if top && ch == ')' {
+            return if body[i + ch.len_utf8()..].trim().is_empty() {
+                &body[..i]
+            } else {
+                trimmed
+            };
+        }
+    }
+    // Unclosed args — everything after the opening paren is the list.
+    body
+}
+
+/// Tracks whether a scan position sits inside a string literal or inside
+/// nested brackets, so that commas and parens belonging to sub-expressions
+/// are not mistaken for structure of the outer argument list.
+#[derive(Default)]
+struct ArgScanner {
+    depth: usize,
+    quote: Option<char>,
+    escaped: bool,
+}
+
+impl ArgScanner {
+    /// Advance over one character.
+    fn step(&mut self, ch: char) {
+        if let Some(quote) = self.quote {
+            if self.escaped {
+                self.escaped = false;
+            } else if ch == '\\' {
+                self.escaped = true;
+            } else if ch == quote {
+                self.quote = None;
+            }
+            return;
+        }
+        match ch {
+            '\'' | '"' => self.quote = Some(ch),
+            '(' | '[' => self.depth += 1,
+            // `saturating_sub` rather than `-`: half-typed source reaches the
+            // parser constantly, and a stray closer must not panic the server.
+            ')' | ']' => self.depth = self.depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+
+    fn in_string(&self) -> bool {
+        self.quote.is_some()
+    }
+
+    fn at_top_level(&self) -> bool {
+        self.quote.is_none() && self.depth == 0
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/directive_args/tests.rs
+++ b/laravel-lsp/src/directive_args/tests.rs
@@ -1,0 +1,155 @@
+use super::*;
+
+/// The bug from #327: a condition that compares a string donated its own
+/// literal as the "view name". Every row here is a real Blade shape.
+#[test]
+fn second_argument_is_read_after_the_top_level_comma() {
+    let cases = [
+        ("($cond, 'view')", Some("view")),
+        (
+            "($boolean, 'view.name', ['status' => 'complete'])",
+            Some("view.name"),
+        ),
+        (
+            "($cond, \"double.quoted\", ['a' => $b])",
+            Some("double.quoted"),
+        ),
+        ("($type === 'admin', 'pages.admin')", Some("pages.admin")),
+        (
+            "($user->role == 'editor', 'panels.editor', ['x' => 1])",
+            Some("panels.editor"),
+        ),
+        ("($cond)", None),
+        ("($cond, '')", None),
+        ("($cond1, $cond2)", None),
+    ];
+    for (args, expected) in cases {
+        assert_eq!(nth_literal(args, 1).as_deref(), expected, "args: {args}");
+    }
+}
+
+/// Bracket tracking is load-bearing: `in_array($k, ['a', 'b'])` puts two
+/// commas inside the condition, both of them before the real split point.
+#[test]
+fn nested_brackets_do_not_supply_the_split_comma() {
+    assert_eq!(
+        nth_literal("(in_array($k, ['a', 'b']), 'pages.list')", 1).as_deref(),
+        Some("pages.list")
+    );
+    assert_eq!(
+        nth_literal("(match_it($a, $b), 'pages.match')", 1).as_deref(),
+        Some("pages.match")
+    );
+}
+
+/// A comma living inside the condition's own string literal is not
+/// structure. Without quote suppression the split lands inside `'a,b'` and
+/// argument one becomes the fragment `b'`.
+#[test]
+fn a_comma_inside_a_string_literal_is_not_the_split_point() {
+    assert_eq!(
+        nth_literal("($status === 'a,b', 'view.name')", 1).as_deref(),
+        Some("view.name")
+    );
+}
+
+/// A closing paren inside a string literal must not end the argument list
+/// early — `unwrap_parens` would otherwise treat the args as unwrapped and
+/// hand the whole raw string back.
+#[test]
+fn a_paren_inside_a_string_literal_does_not_close_the_argument_list() {
+    assert_eq!(
+        nth_literal("($label === \"a)b\", 'view.name')", 1).as_deref(),
+        Some("view.name")
+    );
+}
+
+/// PHP escapes its quote characters, and a mis-tracked `\'` flips the
+/// scanner's in-string state for the rest of the list — after which the real
+/// top-level comma looks like it is inside a string and is never found.
+#[test]
+fn an_escaped_quote_does_not_end_the_condition_string() {
+    assert_eq!(
+        nth_literal(r"($label === 'it\'s', 'view.name')", 1).as_deref(),
+        Some("view.name")
+    );
+}
+
+/// `queries.rs` documents both shapes reaching these extractors: wrapped in
+/// the directive-call parens, and bare.
+#[test]
+fn arguments_parse_with_or_without_the_wrapping_parens() {
+    assert_eq!(nth_literal("$cond, 'view'", 1).as_deref(), Some("view"));
+    assert_eq!(nth_literal("'view'", 0).as_deref(), Some("view"));
+    // A condition that is itself parenthesised must not be mistaken for the
+    // call's own wrapper — stripping it would leave the list malformed.
+    assert_eq!(
+        nth_literal("(($a || $b), 'view.name')", 1).as_deref(),
+        Some("view.name")
+    );
+}
+
+/// Half-typed source reaches the parser on every keystroke.
+#[test]
+fn unbalanced_arguments_still_yield_what_was_typed() {
+    assert_eq!(nth_literal("('view'", 0).as_deref(), Some("view"));
+    assert_eq!(nth_literal("($cond, 'view'", 1).as_deref(), Some("view"));
+    assert_eq!(nth_literal("(", 0), None);
+    assert_eq!(nth_literal("", 0), None);
+}
+
+/// Argument zero is read with the same strictness as argument one: the
+/// argument must *be* a literal. The loose quote-trimming this replaced
+/// reported `$view` and `partials.` as names — targets that never resolve.
+#[test]
+fn a_non_literal_argument_is_not_a_name() {
+    assert_eq!(nth_literal("('view')", 0).as_deref(), Some("view"));
+    assert_eq!(nth_literal("($view)", 0), None);
+    assert_eq!(nth_literal("('partials.' . $name)", 0), None);
+    assert_eq!(nth_literal("($a ?: $b)", 0), None);
+    assert_eq!(nth_literal("('')", 0), None);
+    assert_eq!(
+        nth_literal("('view', ['a' => 1])", 0).as_deref(),
+        Some("view")
+    );
+}
+
+/// The outline label for directives that are not condition-first: the name
+/// sits inside an array literal, one level below any top-level argument.
+#[test]
+fn first_literal_reaches_into_nested_array_literals() {
+    assert_eq!(
+        first_literal("(['title', 'count' => 0])").as_deref(),
+        Some("title")
+    );
+    assert_eq!(
+        first_literal("(['custom.layout', 'default.layout'])").as_deref(),
+        Some("custom.layout")
+    );
+    assert_eq!(first_literal("('content')").as_deref(), Some("content"));
+    assert_eq!(first_literal("($variable)"), None);
+    assert_eq!(first_literal("('')"), None);
+    assert_eq!(first_literal("()"), None);
+}
+
+/// The condition-first list is what routes a directive to argument one. It
+/// is asserted member by member: a set that is correct today but unpinned
+/// degrades silently the next time someone edits it.
+#[test]
+fn condition_first_directives_are_exactly_include_when_and_include_unless() {
+    assert!(is_condition_first("includeWhen"));
+    assert!(is_condition_first("includeUnless"));
+    for other in [
+        "include",
+        "includeIf",
+        "includeFirst",
+        "extends",
+        "component",
+        "each",
+        "livewire",
+        "props",
+        "section",
+    ] {
+        assert!(!is_condition_first(other), "directive: {other}");
+    }
+}

--- a/laravel-lsp/src/document_symbols.rs
+++ b/laravel-lsp/src/document_symbols.rs
@@ -34,6 +34,7 @@
 //! All positions are 0-based to match the LSP and the rest of this codebase
 //! (see `CLAUDE.md` § Position Indexing Convention).
 
+use crate::directive_args;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::path::Path;
@@ -344,7 +345,8 @@ fn extract_blade_symbols(content: &str) -> Vec<SymbolEntry> {
             .get(1)
             .map(|m| m.as_str().to_string())
             .unwrap_or_default();
-        let (arg, end_pos) = parse_directive_args(content, full.end());
+        let (raw_args, end_pos) = parse_directive_args(content, full.end());
+        let arg = raw_args.and_then(|a| directive_label(&directive, a));
         matches.push(BladeMatch::Directive {
             directive,
             arg,
@@ -573,18 +575,37 @@ fn blade_directive_label(directive: &str, arg: Option<&str>) -> String {
     }
 }
 
-/// Scan a Blade directive's `(...)` argument list with brace-aware balanced
-/// paren tracking. Returns `(first_string, end_of_directive)`:
-///   - `first_string` is the first quoted string literal anywhere in the
-///     args (`'title'` from `@props(['title', ...])`, or
-///     `'partial'` from `@includeWhen($x->y(), 'partial')`).
+/// The label fragment shown after the directive name in the outline.
+///
+/// Condition-first directives put a boolean expression in argument zero, and
+/// that expression routinely contains a string literal of its own — so the
+/// name has to be read at argument one rather than wherever the first quote
+/// happens to fall. Every other directive carries its name inside an array
+/// literal (`@props(['title', 'count' => 0])`, `@includeFirst(['a', 'b'])`)
+/// or as its sole argument, both of which the first-literal scan reaches.
+fn directive_label(directive: &str, args: &str) -> Option<String> {
+    if directive_args::is_condition_first(directive) {
+        directive_args::nth_literal(args, 1)
+    } else {
+        directive_args::first_literal(args)
+    }
+}
+
+/// Scan a Blade directive's `(...)` argument list with balanced paren
+/// tracking. Returns `(arguments, end_of_directive)`:
+///   - `arguments` is the raw text between the directive's own parens, with
+///     those parens removed — `['title', 'count' => 0]` from
+///     `@props(['title', 'count' => 0])`. `None` when the directive has no
+///     parenthesised argument list. Interpreting it is
+///     [`directive_label`]'s job, because the position of the name inside it
+///     depends on the directive.
 ///   - `end_of_directive` is the byte offset just past the matching close
 ///     paren, or `after_directive` if there are no parens. Used as the
 ///     symbol's end position.
 ///
 /// Handles nested parens (so `$user->method()` inside args doesn't truncate
 /// the search early) and quoted-string escape sequences.
-fn parse_directive_args(content: &str, after_directive: usize) -> (Option<String>, usize) {
+fn parse_directive_args(content: &str, after_directive: usize) -> (Option<&str>, usize) {
     let bytes = content.as_bytes();
     let mut i = after_directive;
 
@@ -597,12 +618,11 @@ fn parse_directive_args(content: &str, after_directive: usize) -> (Option<String
         return (None, after_directive);
     }
     i += 1; // step past the `(`
+    let start = i;
 
     let mut depth: u32 = 0;
-    let mut first_string: Option<String> = None;
     let mut in_string = false;
     let mut string_quote = b' ';
-    let mut string_start = 0usize;
 
     while i < bytes.len() {
         let c = bytes[i];
@@ -615,11 +635,6 @@ fn parse_directive_args(content: &str, after_directive: usize) -> (Option<String
                 continue;
             }
             if c == string_quote {
-                if first_string.is_none() {
-                    if let Ok(s) = std::str::from_utf8(&bytes[string_start..i]) {
-                        first_string = Some(s.to_string());
-                    }
-                }
                 in_string = false;
             }
         } else {
@@ -627,14 +642,13 @@ fn parse_directive_args(content: &str, after_directive: usize) -> (Option<String
                 b'(' => depth += 1,
                 b')' => {
                     if depth == 0 {
-                        return (first_string, i + 1);
+                        return (content.get(start..i), i + 1);
                     }
                     depth -= 1;
                 }
                 b'\'' | b'"' => {
                     in_string = true;
                     string_quote = c;
-                    string_start = i + 1;
                 }
                 _ => {}
             }
@@ -642,8 +656,8 @@ fn parse_directive_args(content: &str, after_directive: usize) -> (Option<String
         i += 1;
     }
 
-    // Unclosed args — return whatever we found, ending at EOF.
-    (first_string, bytes.len())
+    // Unclosed args — return what was typed, ending at EOF.
+    (content.get(start..), bytes.len())
 }
 
 /// One frame on the Blade open-block stack — the directive that opened it

--- a/laravel-lsp/src/document_symbols/tests.rs
+++ b/laravel-lsp/src/document_symbols/tests.rs
@@ -222,6 +222,29 @@ fn extracts_blade_includes() {
     );
 }
 
+/// The outline label for a condition-first directive is argument one. A
+/// condition that compares a string used to donate its own literal to the
+/// label (`@includeWhen($type === 'admin', ...)` rendered `@includeWhen
+/// admin`), and a condition carrying an array literal donated the array's
+/// first element.
+#[test]
+fn condition_first_includes_label_from_their_second_argument() {
+    let content = r#"@includeWhen($type === 'admin', 'pages.admin')
+@includeUnless(in_array($k, ['a', 'b']), 'pages.list')
+@includeWhen($cond, 'pages.plain', ['status' => 'complete'])
+"#;
+    let symbols = extract_blade_symbols(content);
+    let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "@includeWhen pages.admin",
+            "@includeUnless pages.list",
+            "@includeWhen pages.plain",
+        ]
+    );
+}
+
 #[test]
 fn blade_outline_for_component_file() {
     // A typical Blade component file: props + slot + child components.

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -64,6 +64,7 @@ pub mod config;
 pub mod config_key_locator;
 pub mod config_lookup;
 pub mod database;
+pub mod directive_args;
 pub mod display_truncate;
 pub mod document_symbols;
 pub mod env_key_locator;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -15922,34 +15922,16 @@ return [
         }]))
     }
 
-    /// Extract the second string argument from directive args
-    /// For @includeWhen($condition, 'view.name', $data)
+    /// Extract the view name from a condition-first directive's arguments.
+    /// For `@includeWhen($condition, 'view.name', $data)`.
     fn extract_second_string_arg(arguments: &str) -> Option<String> {
-        // Condition-first directives (`@includeWhen($cond, 'view', [...])`,
-        // `@includeUnless(...)`) put a boolean EXPRESSION first — it is not
-        // a quoted string. The name is therefore the FIRST quoted string in
-        // the args. The previous version skipped one quoted string on the
-        // assumption argument one was quoted: the two-argument form then
-        // resolved nothing, and the three-argument form returned the data
-        // array's first key — a wrong goto target and a false missing-view
-        // diagnostic.
-        let mut in_string = false;
-        let mut quote_char = ' ';
-        let mut result = String::new();
-
-        for ch in arguments.chars() {
-            if !in_string {
-                if ch == '\'' || ch == '"' {
-                    in_string = true;
-                    quote_char = ch;
-                }
-            } else if ch == quote_char {
-                return (!result.is_empty()).then_some(result);
-            } else {
-                result.push(ch);
-            }
-        }
-        None
+        // Condition-first directives (`@includeWhen`, `@includeUnless`) put a
+        // boolean EXPRESSION first, so the name is argument *one* — reached by
+        // splitting at the first top-level comma, not by taking the first
+        // quoted string in the list. A condition that compares a string
+        // (`$type === 'admin'`) donates its own literal to a first-string-wins
+        // scan, which then resolves the wrong view. See `directive_args`.
+        laravel_lsp::directive_args::nth_literal(arguments, 1)
     }
 
     /// Extract array of string arguments from directive args

--- a/laravel-lsp/src/references.rs
+++ b/laravel-lsp/src/references.rs
@@ -7,6 +7,7 @@
 //! "follow the instance chain" rule that distinguishes this from a global
 //! grep-and-rename.
 
+use crate::directive_args;
 use crate::salsa_impl::{ParsedPatternsData, PatternAtPosition, SymbolRefData};
 
 /// Classified symbol under the cursor. Mirrors [`SymbolRefData`] but stays on
@@ -105,7 +106,7 @@ pub fn classify_pattern_at_cursor(
             // a Livewire symbol so rename / find-references / goto match
             // the `<livewire:...>` tag form.
             if d.name == "livewire" {
-                let name = directive_first_string_arg(args)?;
+                let name = directive_args::nth_literal(args, 0)?;
                 return Some(SymbolRef::Livewire(name));
             }
             // @include('users.profile') and friends carry the view name in the
@@ -135,31 +136,27 @@ pub fn classify_pattern_at_cursor(
 /// Extract the view name carried by a Blade directive that takes a view
 /// argument (`@include`, `@extends`, `@component`, `@each`, plus the
 /// conditional variants). Returns `None` for directives that don't reference
-/// views or whose argument couldn't be parsed as a single string literal.
+/// views, and for a view argument that isn't a string literal — `@include($v)`
+/// and `@include('partials.' . $n)` name no view this parser can resolve.
 fn directive_view_name(name: &str, args: &str) -> Option<String> {
     if !matches!(
         name,
-        "include" | "extends" | "component" | "each" | "includeIf" | "includeWhen"
+        "include"
+            | "extends"
+            | "component"
+            | "each"
+            | "includeIf"
+            | "includeWhen"
+            | "includeUnless"
     ) {
         return None;
     }
-    directive_first_string_arg(args)
-}
-
-/// Extract the first string argument from a directive's parenthesized
-/// argument list. Handles `@livewire('counter')`, `@include('view')`, etc.
-/// Returns `None` when the args can't be parsed as a single quoted
-/// string at the head position.
-fn directive_first_string_arg(args: &str) -> Option<String> {
-    let trimmed = args.trim().trim_matches('(').trim_matches(')').trim();
-    // First comma-separated argument; trim quotes.
-    let first = trimmed.split(',').next()?.trim();
-    let unquoted = first.trim_matches('\'').trim_matches('"');
-    if unquoted.is_empty() {
-        None
-    } else {
-        Some(unquoted.to_string())
-    }
+    // `@includeWhen` / `@includeUnless` are condition-first, so their view
+    // name is argument one. Reading argument zero surfaced the condition
+    // expression itself as a "view" — a symbol that can never match another
+    // reference. `@includeUnless` was missing from the list outright, so
+    // find-references skipped it entirely.
+    directive_args::nth_literal(args, usize::from(directive_args::is_condition_first(name)))
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/references/tests.rs
+++ b/laravel-lsp/src/references/tests.rs
@@ -230,6 +230,65 @@ fn classifies_each_directive_first_arg_as_view() {
     assert_eq!(got, Some(SymbolRef::View("view.row".into())));
 }
 
+/// Classify the directive at the cursor from its raw argument text. The span
+/// is deliberately wide so column 3 always lands inside it.
+fn classify_directive(name: &str, args: &str) -> Option<SymbolRef> {
+    let mut p = empty_patterns();
+    p.directives.push(Arc::new(DirectiveReferenceData {
+        name: name.to_string(),
+        arguments: Some(args.to_string()),
+        line: 0,
+        column: 0,
+        end_column: 200,
+        string_column: 0,
+        string_end_column: 0,
+    }));
+    p.build_position_index();
+    classify_pattern_at_cursor(&p, 0, 3)
+}
+
+/// `@includeWhen` / `@includeUnless` are condition-first, so the view name is
+/// argument one. Reading argument zero surfaced the condition expression
+/// itself as a "view" — and `@includeUnless` was absent from the directive
+/// list outright, so find-references skipped it entirely.
+#[test]
+fn classifies_condition_first_directives_at_their_second_argument() {
+    assert_eq!(
+        classify_directive("includeWhen", "($type === 'admin', 'pages.admin')"),
+        Some(SymbolRef::View("pages.admin".into()))
+    );
+    assert_eq!(
+        classify_directive("includeUnless", "($guest, 'partials.user-nav')"),
+        Some(SymbolRef::View("partials.user-nav".into()))
+    );
+    assert_eq!(
+        classify_directive("includeUnless", "(in_array($k, ['a', 'b']), 'pages.list')"),
+        Some(SymbolRef::View("pages.list".into()))
+    );
+}
+
+/// A view argument that isn't a string literal names no view this parser can
+/// resolve. The loose quote-trimming this replaced classified `$view` and
+/// `partials.` as View symbols — names no other reference can ever match.
+#[test]
+fn a_non_literal_directive_argument_classifies_nothing() {
+    assert_eq!(classify_directive("include", "($view)"), None);
+    assert_eq!(classify_directive("include", "('partials.' . $name)"), None);
+    assert_eq!(classify_directive("extends", "($layout)"), None);
+    assert_eq!(classify_directive("livewire", "($component)"), None);
+    assert_eq!(classify_directive("includeWhen", "($cond, $view)"), None);
+}
+
+/// The `@livewire('counter')` directive form still classifies as Livewire —
+/// it reads argument zero, which the strictness change must not disturb.
+#[test]
+fn classifies_livewire_directive_form() {
+    assert_eq!(
+        classify_directive("livewire", "('counter')"),
+        Some(SymbolRef::Livewire("counter".into()))
+    );
+}
+
 #[test]
 fn returns_none_when_cursor_misses_all_patterns() {
     // Empty pattern set + any cursor position → nothing classified.

--- a/laravel-lsp/src/tests/directive_navigation_containment.rs
+++ b/laravel-lsp/src/tests/directive_navigation_containment.rs
@@ -245,13 +245,15 @@ fn directive_first_string_extraction_survives_data_arguments() {
 }
 
 /// Regression for the condition-first extractor: `@includeWhen` /
-/// `@includeUnless` put a boolean EXPRESSION first, so the view name is the
-/// FIRST quoted string in the args. The previous version skipped one quoted
-/// string — the two-argument form resolved nothing, and the three-argument
-/// form returned the data array's first key as the "view name" (wrong goto
-/// target, false missing-view diagnostic).
+/// `@includeUnless` put a boolean EXPRESSION first, so the view name is
+/// argument ONE — found by splitting the list at its first *top-level* comma,
+/// one that is not inside a quoted string, a nested `(...)`, or a `[...]`
+/// array literal. A first-quoted-string-wins scan resolved the condition's
+/// own literal (`$type === 'admin'` → `admin`) as the view name, and the
+/// version before that skipped one literal and returned the data array's
+/// first key. Both produced a wrong goto-definition target.
 #[test]
-fn second_arg_extraction_takes_the_first_quoted_string() {
+fn second_arg_extraction_splits_at_top_level_comma() {
     let cases = [
         ("($cond, 'view')", Some("view")),
         (
@@ -264,6 +266,22 @@ fn second_arg_extraction_takes_the_first_quoted_string() {
         ),
         ("($cond)", None),
         ("($cond, '')", None),
+        // A condition that compares a string — the bug this fixes.
+        ("($type === 'admin', 'pages.admin')", Some("pages.admin")),
+        (
+            "($user->role == 'editor', 'panels.editor', ['x' => 1])",
+            Some("panels.editor"),
+        ),
+        // Two commas inside the condition's own array literal, both before
+        // the real split point: bracket tracking is load-bearing here.
+        (
+            "(in_array($k, ['a', 'b']), 'pages.list')",
+            Some("pages.list"),
+        ),
+        // A comma inside the condition's own string is not structure.
+        ("($status === 'a,b', 'view.name')", Some("view.name")),
+        // A top-level comma exists, but neither argument is a literal.
+        ("($cond1, $cond2)", None),
     ];
     for (args, expected) in cases {
         assert_eq!(


### PR DESCRIPTION
Fixes #327

## Summary

`@includeWhen` and `@includeUnless` put a boolean expression in argument zero. Three separate parsers each identified the view name as *"the first quoted string in the argument list"* — a rule that holds only while the condition contains no string literal of its own:

| Blade | Resolved | Should be |
| --- | --- | --- |
| `@includeWhen($type === 'admin', 'pages.admin')` | `admin` | `pages.admin` |
| `@includeWhen($u->role == 'editor', 'panels.editor', ['x' => 1])` | `editor` | `panels.editor` |
| `@includeWhen(in_array($k, ['a', 'b']), 'pages.list')` | `a` | `pages.list` |

Argument lists are now split at the first **top-level** comma — one outside any quoted string, nested `(...)`, or `[...]` array literal — and the name read at the position the directive actually uses. Bracket tracking is load-bearing rather than defensive: the `in_array` row above carries two commas before the real split point.

## Why all three parsers, not just `extract_second_string_arg`

The issue scopes itself to `extract_second_string_arg`, and #325 holds the wider redesign. But the same rule had been hand-written three times and the copies had drifted, so fixing one and leaving two identical bugs in place seemed the worse trade. Called out explicitly because it is scope beyond the AC:

| Call site | Was | Now |
| --- | --- | --- |
| `main.rs::extract_second_string_arg` (goto-definition) | first quoted string anywhere | argument one |
| `references.rs::directive_view_name` (find-references) | argument zero, loosely quote-trimmed; **`@includeUnless` absent from the directive list entirely** | argument one for condition-first directives |
| `document_symbols.rs::parse_directive_args` (outline label) | first quoted string anywhere | argument one for condition-first, first-literal-anywhere otherwise |

The shared rule now lives in one new module, `laravel-lsp/src/directive_args.rs`, including the condition-first directive list — drift between private copies is precisely how `@includeUnless` came to be handled by goto-definition and invisible to find-references.

## Two deliberate deviations from the acceptance criteria

**1. Strict argument index, not a scan of the remainder.** The AC specifies "the first quoted string found in the remainder after that comma". This reads argument *one* specifically. Every AC assertion passes either way, but remainder-scanning re-opens the original bug one argument over — `@includeWhen($c, $viewVar, ['a' => 1])` would answer `a`. Argument-index is also symmetric with the existing `extract_view_from_directive_args`, which already requires argument zero to *be* a literal.

**2. Argument zero is now strict too.** Routing `references.rs` through the shared helper tightens its first-argument read as a side effect: an argument must *be* a string literal. Previously `trim_matches('\'')` classified `@include($view)` and `@include('partials.' . $n)` as View symbols literally named `$view` and `partials.` — names no other reference can ever match. This is a behaviour change outside #327's stated scope, agreed in advance rather than filed as a follow-up.

## Acceptance criteria

- [x] `extract_second_string_arg` splits at the first top-level comma, with quote-tracking suppressing comma/bracket/paren detection inside string literals
- [x] Returns `None` with no top-level comma, no quoted string in the remainder, or an empty quoted string
- [x] All ten AC test cases assert exact values as literal `assert_eq!` cases; no case from the previous suite dropped
- [x] `second_arg_extraction_takes_the_first_quoted_string` renamed to `second_arg_extraction_splits_at_top_level_comma`; no test with the old name remains
- [x] `extract_second_string_arg` still has exactly one caller — the `view_directives_second_arg` branch of `create_directive_location_from_salsa`. No missing-view diagnostic exists for these directives and none was added
- [x] `cargo test` run before and after: every previously passing test still passes
- [ ] "the diff touches only `extract_second_string_arg`, its call site, and `directive_navigation_containment.rs`" — **deliberately not met**, see the two deviations above

## Test plan

- **Before:** 3077 passing (2466 lib / 531 bin / 80 integration). **After:** 3091 passing. No test removed, none newly ignored.
- `cargo fmt --check` clean; `cargo clippy --all-targets` silent.
- **Mutation-verified: 12 mutants planted, 12 killed.** Each guard was individually broken and the suite confirmed red — bracket depth tracking, quote suppression, escape tracking, trailing-text rejection, empty-literal rejection, paren unwrapping, the condition-first directive list, and the argument index at each of the three call sites. No test stayed green against its own mutant.
- Coverage beyond the AC table: escaped quotes inside the condition (`'it\'s'`), a `)` inside a string literal, a parenthesised condition (`(($a || $b), 'view')`), argument lists arriving both wrapped and bare (`queries.rs` documents both shapes reaching these extractors), and half-typed unbalanced input.
