### PR TITLE
fix: 🐛 Truncate completion detail and documentation independently

### DIFF
--- a/laravel-lsp/src/completion_display.rs
+++ b/laravel-lsp/src/completion_display.rs
@@ -1,0 +1,107 @@
+//! Length-split rendering for config and translation completion items.
+//!
+//! A completion item shows its value in two places that want two different
+//! lengths:
+//!
+//! - `CompletionItem.detail` — a **single line** rendered inline beside the
+//!   label in the completion list. Long values blow the line out, or the
+//!   editor clips them at a width this server can't see.
+//! - `CompletionItem.documentation` — the **markdown panel** beside the
+//!   list. It has room for a full sentence, and clipping there throws away
+//!   space that was already paid for.
+//!
+//! Both used to read one already-truncated string, so a single limit had to
+//! serve both surfaces and served neither (issue #326). Laravel's own
+//! validation and auth messages run 80–150 characters, which is exactly the
+//! band where the two surfaces disagree: too long for the line, comfortably
+//! inside the panel.
+//!
+//! The fix is to keep the full value on the completion struct and truncate
+//! at each render site instead — [`COMPLETION_DETAIL_LIMIT`] for the line,
+//! [`COMPLETION_DOC_LIMIT`] for the panel. Every truncation still routes
+//! through [`crate::display_truncate::truncate_for_display`], so the
+//! char-boundary safety won in #319 holds at both new cut points.
+
+use crate::completion_format::{CodeBlock, CompletionDoc};
+use crate::display_truncate::truncate_for_display;
+
+/// Char budget for the inline `detail` line beside a completion label.
+///
+/// Deliberately short: `detail` competes for horizontal space with the label
+/// and the editor's own chrome, and a value that overflows is either wrapped
+/// or silently clipped by the client.
+pub const COMPLETION_DETAIL_LIMIT: usize = 50;
+
+/// Char budget for the markdown `documentation` panel.
+///
+/// Four times [`COMPLETION_DETAIL_LIMIT`], which clears the 80–150 char band
+/// Laravel's stock validation and auth messages occupy, so those render in
+/// full. Still bounded — the value is attacker-adjacent only in the sense
+/// that it comes off disk, but an unbounded panel is a hostile popup for
+/// anyone with a long string in a catalogue.
+pub const COMPLETION_DOC_LIMIT: usize = 200;
+
+/// The whole point of issue #326 is that these two are *different*. A future
+/// tidy-up that collapses them back to one value reproduces the bug, so make
+/// it a build failure rather than something a reviewer has to notice.
+const _: () = assert!(COMPLETION_DETAIL_LIMIT < COMPLETION_DOC_LIMIT);
+
+/// The inline `detail` line: the value, then its source file in parens.
+///
+/// Shared by the config and translation branches — the two rendered
+/// identically before this split and still do, so one function keeps them
+/// from drifting apart when the limit is tuned.
+///
+/// An empty value degrades to the source alone rather than rendering a
+/// leading space and an orphan paren.
+pub fn completion_detail(value: &str, source: &str) -> String {
+    if value.is_empty() {
+        format!("({})", source)
+    } else {
+        format!(
+            "{} ({})",
+            truncate_for_display(value, COMPLETION_DETAIL_LIMIT),
+            source
+        )
+    }
+}
+
+/// The `documentation` panel for a config key: the key, the value as a PHP
+/// `return` statement, and the file it came from.
+///
+/// Truncates `value` independently of [`completion_detail`] — it is handed
+/// the same raw value, never that function's already-clipped output.
+pub fn config_documentation(key: &str, value: &str, source: &str) -> CompletionDoc {
+    let mut doc = CompletionDoc::new().header(key);
+    if !value.is_empty() {
+        doc = doc.code(CodeBlock::new(
+            "php",
+            format!(
+                "return {};",
+                truncate_for_display(value, COMPLETION_DOC_LIMIT)
+            ),
+        ));
+    }
+    doc.section(format!("Source: {}", source))
+}
+
+/// The `documentation` panel for a translation key: the key, the translated
+/// string as the summary, and the catalogue it came from.
+///
+/// Truncates `value` independently of [`completion_detail`], for the same
+/// reason. A key with no extractable value falls back to a generic summary
+/// rather than an empty panel.
+pub fn translation_documentation(key: &str, value: &str, source: &str) -> CompletionDoc {
+    let summary = if value.is_empty() {
+        "Translation key.".to_string()
+    } else {
+        truncate_for_display(value, COMPLETION_DOC_LIMIT)
+    };
+    CompletionDoc::new()
+        .header(key)
+        .summary(summary)
+        .section(format!("Source: {}", source))
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/completion_display/tests.rs
+++ b/laravel-lsp/src/completion_display/tests.rs
@@ -1,0 +1,219 @@
+//! Issue #326: `detail` and `documentation` truncate independently.
+//!
+//! These drive the same functions the completion handler calls, so a
+//! regression that re-introduced an ad-hoc `format!` + truncate inside the
+//! handler closures would leave these tests asserting about dead code — the
+//! handler branches are three-line delegations with nothing left to drift.
+
+use super::*;
+
+/// The panel's markdown, which is what the editor actually renders.
+fn panel(doc: CompletionDoc) -> String {
+    doc.render()
+}
+
+/// The value portion of a `detail` line — everything before the trailing
+/// ` (source)`. `detail` is `"<value> (<source>)"`, so assertions about the
+/// truncated value have to look past the source suffix.
+fn detail_value<'a>(detail: &'a str, source: &str) -> &'a str {
+    detail
+        .strip_suffix(&format!(" ({})", source))
+        .unwrap_or_else(|| panic!("detail {detail:?} must end with the source in parens"))
+}
+
+// ---- the reported bug: one limit cannot serve both surfaces --------------
+
+/// 80 chars is the band Laravel's own validation and auth messages sit in:
+/// past the 50-char line budget, comfortably inside the 200-char panel. Under
+/// the old shared limit both surfaces showed the same string; now the line
+/// clips and the panel does not.
+#[test]
+fn config_eighty_char_value_clips_in_detail_and_survives_in_documentation() {
+    let value = "v".repeat(80);
+    let detail = completion_detail(&value, "config/app.php");
+    let doc = panel(config_documentation("app.name", &value, "config/app.php"));
+
+    let clipped = detail_value(&detail, "config/app.php");
+    assert!(clipped.ends_with('…'), "the line must show it was cut");
+    assert_eq!(clipped.chars().count(), COMPLETION_DETAIL_LIMIT + 1);
+
+    assert!(
+        doc.contains(&value),
+        "the panel had room for all 80 chars and must show them"
+    );
+    assert!(!doc.contains('…'), "the panel must not have been cut");
+}
+
+#[test]
+fn translation_eighty_char_value_clips_in_detail_and_survives_in_documentation() {
+    let value = "v".repeat(80);
+    let detail = completion_detail(&value, "lang/en/auth.php");
+    let doc = panel(translation_documentation(
+        "auth.failed",
+        &value,
+        "lang/en/auth.php",
+    ));
+
+    let clipped = detail_value(&detail, "lang/en/auth.php");
+    assert!(clipped.ends_with('…'));
+    assert_eq!(clipped.chars().count(), COMPLETION_DETAIL_LIMIT + 1);
+
+    assert!(doc.contains(&value));
+    assert!(!doc.contains('…'));
+}
+
+/// A value inside the line budget is untouched on both surfaces — the split
+/// must not have introduced a cut where there was none.
+#[test]
+fn short_values_are_untouched_on_both_surfaces() {
+    let value = "Welcome";
+    assert_eq!(
+        completion_detail(value, "lang/en/messages.php"),
+        "Welcome (lang/en/messages.php)"
+    );
+    assert!(panel(config_documentation("app.name", value, "config/app.php")).contains("Welcome"));
+    assert!(panel(translation_documentation(
+        "messages.welcome",
+        value,
+        "lang/en/messages.php"
+    ))
+    .contains("Welcome"));
+}
+
+// ---- char-boundary safety at both new cut points -------------------------
+//
+// The old single cut point was 200. Splitting it added a *second* place a
+// byte slice could land mid-character, so both cutoffs need proving, on both
+// branches. `€` is three bytes, so byte offset 50 falls at char 16.67 and
+// byte offset 200 at char 66.67 — squarely inside a character, exactly the
+// index a `&s[..n]` slice would panic on.
+
+#[test]
+fn config_detail_cut_lands_on_a_multibyte_char_without_panicking() {
+    let value = "€".repeat(60);
+    let source = "config/app.php";
+    let detail = completion_detail(&value, source);
+    let clipped = detail_value(&detail, source);
+
+    assert_eq!(clipped, format!("{}…", "€".repeat(COMPLETION_DETAIL_LIMIT)));
+}
+
+#[test]
+fn config_documentation_cut_lands_on_a_multibyte_char_without_panicking() {
+    let value = "€".repeat(220);
+    let doc = panel(config_documentation("app.name", &value, "config/app.php"));
+
+    assert!(doc.contains(&format!("return {}…;", "€".repeat(COMPLETION_DOC_LIMIT))));
+}
+
+#[test]
+fn translation_detail_cut_lands_on_a_multibyte_char_without_panicking() {
+    let value = "€".repeat(60);
+    let source = "lang/en/auth.php";
+    let detail = completion_detail(&value, source);
+    let clipped = detail_value(&detail, source);
+
+    assert_eq!(clipped, format!("{}…", "€".repeat(COMPLETION_DETAIL_LIMIT)));
+}
+
+#[test]
+fn translation_documentation_cut_lands_on_a_multibyte_char_without_panicking() {
+    let value = "€".repeat(220);
+    let doc = panel(translation_documentation(
+        "auth.failed",
+        &value,
+        "lang/en/auth.php",
+    ));
+
+    assert!(doc.contains(&format!("{}…", "€".repeat(COMPLETION_DOC_LIMIT))));
+}
+
+// ---- the panel is bounded, not merely longer ----------------------------
+//
+// The failure mode this split invites: now that the struct carries the full
+// value, forgetting to truncate in the panel ships an *unbounded* popup —
+// worse than the bug being fixed.
+
+#[test]
+fn config_documentation_is_bounded_at_the_doc_limit() {
+    let value = "v".repeat(5_000);
+    let doc = panel(config_documentation("app.name", &value, "config/app.php"));
+
+    assert!(doc.contains('…'), "a 5,000-char value must be cut");
+    assert!(
+        doc.chars().count() < COMPLETION_DOC_LIMIT + 200,
+        "the panel must be bounded by the doc limit, not by the value length"
+    );
+}
+
+#[test]
+fn translation_documentation_is_bounded_at_the_doc_limit() {
+    let value = "v".repeat(5_000);
+    let doc = panel(translation_documentation(
+        "auth.failed",
+        &value,
+        "lang/en/auth.php",
+    ));
+
+    assert!(doc.contains('…'));
+    assert!(doc.chars().count() < COMPLETION_DOC_LIMIT + 200);
+}
+
+#[test]
+fn detail_is_bounded_at_the_detail_limit() {
+    let value = "v".repeat(5_000);
+    let source = "config/app.php";
+    let detail = completion_detail(&value, source);
+
+    assert_eq!(
+        detail_value(&detail, source).chars().count(),
+        COMPLETION_DETAIL_LIMIT + 1
+    );
+}
+
+// ---- the empty-value fallbacks survive the refactor ----------------------
+
+#[test]
+fn an_empty_value_renders_the_source_alone_in_detail() {
+    assert_eq!(completion_detail("", "config/app.php"), "(config/app.php)");
+    assert_eq!(
+        completion_detail("", "lang/en/auth.php"),
+        "(lang/en/auth.php)"
+    );
+}
+
+#[test]
+fn an_empty_config_value_omits_the_code_block() {
+    let doc = panel(config_documentation("app.name", "", "config/app.php"));
+
+    assert!(!doc.contains("```"), "no value means no PHP block: {doc:?}");
+    assert!(doc.contains("**app.name**"));
+    assert!(doc.contains("Source: config/app.php"));
+}
+
+#[test]
+fn an_empty_translation_value_falls_back_to_a_generic_summary() {
+    let doc = panel(translation_documentation(
+        "auth.failed",
+        "",
+        "lang/en/auth.php",
+    ));
+
+    assert!(doc.contains("Translation key."));
+    assert!(doc.contains("**auth.failed**"));
+    assert!(doc.contains("Source: lang/en/auth.php"));
+}
+
+// ---- the two limits are actually different ------------------------------
+
+/// Every test above is written against the constants rather than literals, so
+/// that retuning a limit doesn't require editing eleven assertions. That makes
+/// this the one place the actual numbers are pinned — without it, a limit
+/// could be changed to anything and the suite would stay green.
+///
+/// Their *ordering* is enforced at compile time in the module itself.
+#[test]
+fn the_two_budgets_are_the_tuned_values() {
+    assert_eq!(COMPLETION_DETAIL_LIMIT, 50);
+    assert_eq!(COMPLETION_DOC_LIMIT, 200);
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -56,6 +56,7 @@ pub mod command_call_locator;
 pub mod command_disk_cache;
 pub mod command_index;
 pub mod command_signature;
+pub mod completion_display;
 pub mod completion_format;
 pub mod component_completion;
 pub mod component_declaration_locator;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -188,7 +188,10 @@ struct ConfigCheck {
 struct ConfigKeyCompletion {
     /// The full dot-notation key (e.g., "app.name")
     key: String,
-    /// The value (truncated for display)
+    /// The resolved value at **full length**, untruncated. Each render site
+    /// clips it to its own budget via
+    /// `completion_display::{COMPLETION_DETAIL_LIMIT, COMPLETION_DOC_LIMIT}`
+    /// (issue #326).
     value: String,
     /// Source file (e.g., "config/app.php")
     source: String,
@@ -258,7 +261,10 @@ struct ModelPropertyCompletion {
 struct TranslationKeyCompletion {
     /// The full dot-notation key (e.g., "messages.welcome")
     key: String,
-    /// The translated value (for display)
+    /// The translated value at **full length**, untruncated. Each render site
+    /// clips it to its own budget via
+    /// `completion_display::{COMPLETION_DETAIL_LIMIT, COMPLETION_DOC_LIMIT}`
+    /// (issue #326).
     value: String,
     /// Source file (e.g., "lang/en/messages.php")
     source: String,
@@ -14712,6 +14718,11 @@ impl LaravelLanguageServer {
 
     /// Extract the value from a config line like "'key' => value,"
     /// Resolves env() references using the provided env_vars map
+    ///
+    /// Returns the value at full length. Truncation happens at each render
+    /// site instead, because the completion list line and the documentation
+    /// panel want different budgets and one shared cut served neither
+    /// (issue #326) — see `laravel_lsp::completion_display`.
     fn extract_config_value(
         line: &str,
         env_vars: &std::collections::HashMap<String, String>,
@@ -14721,9 +14732,7 @@ impl LaravelLanguageServer {
             let value = after_arrow.trim().trim_end_matches(',').trim();
 
             // Check for env() call pattern: env('VAR_NAME') or env('VAR_NAME', 'default')
-            let resolved = Self::resolve_env_value(value, env_vars);
-
-            laravel_lsp::display_truncate::truncate_for_display(&resolved, 200)
+            Self::resolve_env_value(value, env_vars)
         } else {
             String::new()
         }
@@ -25268,23 +25277,12 @@ impl LanguageServer for LaravelLanguageServer {
                     .into_iter()
                     .filter(|c| c.key.starts_with(&config_ctx.prefix))
                     .map(|c| {
-                        let detail = if c.value.is_empty() {
-                            format!("({})", c.source)
-                        } else {
-                            format!("{} ({})", c.value, c.source)
-                        };
-
-                        let doc = {
-                            let mut d = CompletionDoc::new().header(&c.key);
-                            if !c.value.is_empty() {
-                                d = d.code(laravel_lsp::completion_format::CodeBlock::new(
-                                    "php",
-                                    format!("return {};", c.value),
-                                ));
-                            }
-                            d.section(format!("Source: {}", c.source))
-                                .into_documentation()
-                        };
+                        let detail =
+                            laravel_lsp::completion_display::completion_detail(&c.value, &c.source);
+                        let doc = laravel_lsp::completion_display::config_documentation(
+                            &c.key, &c.value, &c.source,
+                        )
+                        .into_documentation();
                         CompletionItem {
                             label: c.key.clone(),
                             kind: Some(CompletionItemKind::CONSTANT),
@@ -26202,22 +26200,12 @@ impl LanguageServer for LaravelLanguageServer {
                     .into_iter()
                     .filter(|t| t.key.starts_with(&trans_ctx.prefix))
                     .map(|t| {
-                        let detail = if t.value.is_empty() {
-                            format!("({})", t.source)
-                        } else {
-                            format!("{} ({})", t.value, t.source)
-                        };
-
-                        let doc = {
-                            let mut d = CompletionDoc::new().header(&t.key);
-                            if !t.value.is_empty() {
-                                d = d.summary(&t.value);
-                            } else {
-                                d = d.summary("Translation key.");
-                            }
-                            d.section(format!("Source: {}", t.source))
-                                .into_documentation()
-                        };
+                        let detail =
+                            laravel_lsp::completion_display::completion_detail(&t.value, &t.source);
+                        let doc = laravel_lsp::completion_display::translation_documentation(
+                            &t.key, &t.value, &t.source,
+                        )
+                        .into_documentation();
                         CompletionItem {
                             label: t.key.clone(),
                             kind: Some(CompletionItemKind::TEXT),

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2192,7 +2192,10 @@ impl TranslationCache {
 pub struct TranslationKeyCompletionData {
     /// The full dot-notation key (e.g. `messages.welcome`)
     pub key: String,
-    /// The translated value, truncated for display
+    /// The translated value at **full length**, untruncated. Each render
+    /// site clips it to its own budget via
+    /// `completion_display::{COMPLETION_DETAIL_LIMIT, COMPLETION_DOC_LIMIT}`
+    /// (issue #326).
     pub value: String,
     /// Display source (e.g. `lang/en/messages.php`)
     pub source: String,
@@ -2302,23 +2305,25 @@ fn parse_translation_keys(content: &str, base_key: &str) -> Vec<(String, String)
     results
 }
 
-/// Extract the value from a translation line like "'key' => 'value',"
+/// Extract the value from a translation line like "'key' => 'value',".
+///
+/// Returns the value at full length — see `completion_display` for why the
+/// truncation lives at the render sites rather than here.
 pub fn extract_translation_value(line: &str) -> String {
     if let Some(arrow_pos) = line.find("=>") {
         let after_arrow = &line[arrow_pos + 2..];
         let value = after_arrow.trim().trim_end_matches(',').trim();
 
-        // Remove quotes and truncate
-        let unquoted = value
+        // Remove the surrounding quotes; the value is returned at full
+        // length. Truncation happens at each render site instead, because
+        // the completion list line and the documentation panel want
+        // different budgets and one shared cut served neither (issue #326).
+        value
             .trim_start_matches('\'')
             .trim_start_matches('"')
             .trim_end_matches('\'')
-            .trim_end_matches('"');
-
-        // Truncate long values for display. Delegated rather than sliced:
-        // `&unquoted[..47]` panics when byte 47 lands mid-character, which is
-        // reachable for any non-ASCII translation value (issue #319).
-        crate::display_truncate::truncate_for_display(unquoted, 200)
+            .trim_end_matches('"')
+            .to_string()
     } else {
         String::new()
     }

--- a/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
+++ b/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
@@ -218,16 +218,29 @@ fn detect_method_name_position_detects_instance_past_multibyte_char() {
     assert_eq!(ctx, MethodNameContext::Instance);
 }
 
-// ---- display-value truncation: char-boundary safety ----------------------
+// ---- display-value extraction: no truncation, at any length --------------
 //
 // `extract_translation_value` and `extract_config_value` both used to
 // truncate their hover/completion display value with a byte slice
 // (`&s[..47]`), which panicked whenever a multibyte character straddled
 // index 47 — reachable via any root `lang/` translation value over 50 bytes
 // with a multibyte char at the boundary, not just an exotic namespaced-
-// catalogue case. Both now delegate to the shared, char-safe
-// `display_truncate::truncate_for_display` (also used by `hover.rs`), so the
-// limit is 200 chars, not 47/50, and the ellipsis is the single `…` char.
+// catalogue case. #319 replaced that with the shared, char-safe
+// `display_truncate::truncate_for_display` at a 200-char limit.
+//
+// #326 moved the cut out of these two functions entirely: the completion
+// list line and the documentation panel want different budgets, so each
+// render site now truncates the full value itself (see
+// `completion_display`). The char-boundary property is still pinned — at
+// the render sites, in `completion_display::tests` — while these four
+// assert the property that replaced it here: **whatever the length, and
+// whatever the encoding, the value comes back exactly as written**. An
+// inequality would pass with truncation quietly reinstated, so these are
+// exact-equality against multibyte inputs well past the old 200 limit.
+//
+// The four names below are kept verbatim from #319 so this coverage stays
+// traceable to the panic it guards, even though what they now assert is the
+// *absence* of a cut rather than a safe one.
 //
 // `extract_translation_value` moved into `salsa_impl` when translation reads
 // were routed through Salsa (issue #293); it is the same function, and this
@@ -235,21 +248,18 @@ fn detect_method_name_position_detects_instance_past_multibyte_char() {
 
 #[test]
 fn translation_value_truncation_is_char_boundary_safe() {
-    // 199 ASCII chars, then a two-byte 'č', then padding well past the
-    // shared 200-char limit. Truncation operates on chars, not bytes, so the
-    // multibyte char at the cut point can't panic.
+    // 199 ASCII chars, then a two-byte 'č', then padding well past the old
+    // 200-char limit — the cut point the byte slice used to panic on.
     let value: String = "a".repeat(199) + "č" + &"é".repeat(50);
     let line = format!("'key' => '{}',", value);
     let display = laravel_lsp::salsa_impl::extract_translation_value(&line);
-    assert!(display.ends_with('…'));
-    assert_eq!(display.chars().count(), 201); // 200 + ellipsis
+    assert_eq!(display, value, "the extractor must not truncate at all");
 }
 
 #[test]
 fn translation_value_under_two_hundred_chars_is_not_truncated() {
     // A 30-char/60-byte Czech string used to get truncated (and could
-    // panic) under the old byte-slice/50-char threshold; the shared
-    // 200-char, char-based limit now passes it through untouched.
+    // panic) under the old byte-slice/50-char threshold.
     let value = "č".repeat(30);
     let line = format!("'key' => '{}',", value);
     let display = laravel_lsp::salsa_impl::extract_translation_value(&line);
@@ -262,8 +272,7 @@ fn config_value_truncation_is_char_boundary_safe() {
     let line = format!("'key' => '{}',", value);
     let env_vars = std::collections::HashMap::new();
     let display = LaravelLanguageServer::extract_config_value(&line, &env_vars);
-    assert!(display.ends_with('…'));
-    assert_eq!(display.chars().count(), 201); // 200 + ellipsis
+    assert_eq!(display, value, "the extractor must not truncate at all");
 }
 
 #[test]
@@ -273,4 +282,25 @@ fn config_value_under_two_hundred_chars_is_not_truncated() {
     let env_vars = std::collections::HashMap::new();
     let display = LaravelLanguageServer::extract_config_value(&line, &env_vars);
     assert_eq!(display, value);
+}
+
+#[test]
+fn a_five_thousand_char_translation_value_survives_extraction_whole() {
+    let value = "ž".repeat(5_000);
+    let line = format!("'key' => '{}',", value);
+    assert_eq!(
+        laravel_lsp::salsa_impl::extract_translation_value(&line),
+        value
+    );
+}
+
+#[test]
+fn a_five_thousand_char_config_value_survives_extraction_whole() {
+    let value = "ö".repeat(5_000);
+    let line = format!("'key' => '{}',", value);
+    let env_vars = std::collections::HashMap::new();
+    assert_eq!(
+        LaravelLanguageServer::extract_config_value(&line, &env_vars),
+        value
+    );
 }

--- a/laravel-lsp/src/tests/completion_value_pipeline.rs
+++ b/laravel-lsp/src/tests/completion_value_pipeline.rs
@@ -1,0 +1,95 @@
+//! The untruncated value survives the whole completion pipeline (issue #326).
+//!
+//! `completion_display::tests` proves the two render sites clip to their own
+//! budgets, and `byte_offset_panic_hardening` proves the two extractors no
+//! longer clip at all. Neither says anything about what happens *between*
+//! them — and the value crosses a lot of ground in between: a regex parse, a
+//! Salsa query and its memoized `Vec<(String, String)>`, an actor round trip
+//! over a oneshot channel, and a struct conversion.
+//!
+//! Truncation reinstated anywhere along that path would leave every other
+//! test in this change green while the panel silently went back to showing a
+//! clipped string. So these drive the real `get_all_config_keys` /
+//! `get_all_translation_keys` against a real project on disk and assert the
+//! completion struct's `value` is exactly as long as what was written.
+
+use crate::LaravelLanguageServer;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use tower_lsp::LspService;
+
+/// A backend with `root_path` primed at `root`.
+async fn backend_for(root: &Path) -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    let backend = service.inner().clone();
+    *backend.root_path.write().await = Some(root.to_path_buf());
+    *backend.auto_complete_debounce_ms.write().await = 0;
+    backend
+}
+
+/// Write a file, creating parent directories. Returns its absolute path.
+fn write(root: &Path, rel: &str, contents: &str) -> PathBuf {
+    let path = root.join(rel);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, contents).unwrap();
+    path
+}
+
+/// Well past the 200-char panel budget, and multibyte throughout so a
+/// byte-based reinstatement panics rather than merely shortening.
+fn long_value() -> String {
+    "ä".repeat(5_000)
+}
+
+#[tokio::test]
+async fn a_config_value_reaches_the_completion_struct_untruncated() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let value = long_value();
+    write(
+        &root,
+        "config/app.php",
+        &format!("<?php\nreturn [\n    'name' => '{}',\n];\n", value),
+    );
+    let backend = backend_for(&root).await;
+
+    let keys = backend.get_all_config_keys().await;
+    let entry = keys
+        .iter()
+        .find(|c| c.key == "app.name")
+        .expect("the config key must be discovered at all");
+
+    assert_eq!(
+        entry.value.chars().count(),
+        value.chars().count(),
+        "the completion struct must carry the full value, not a clipped copy"
+    );
+    assert_eq!(entry.value, value);
+}
+
+#[tokio::test]
+async fn a_translation_value_reaches_the_completion_struct_untruncated() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let value = long_value();
+    write(
+        &root,
+        "lang/en/messages.php",
+        &format!("<?php\nreturn [\n    'welcome' => '{}',\n];\n", value),
+    );
+    let backend = backend_for(&root).await;
+
+    let keys = backend.get_all_translation_keys().await;
+    let entry = keys
+        .iter()
+        .find(|t| t.key == "messages.welcome")
+        .expect("the translation key must be discovered at all");
+
+    assert_eq!(
+        entry.value.chars().count(),
+        value.chars().count(),
+        "the completion struct must carry the full value, not a clipped copy"
+    );
+    assert_eq!(entry.value, value);
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod cast_type_context;
 mod class_locator_and_properties;
 mod code_action_create_containment;
 mod code_lens_opt_in;
+mod completion_value_pipeline;
 mod component_file_navigation_containment;
 mod component_navigation_containment;
 mod composer_autoload_containment;


### PR DESCRIPTION
Fixes #326

## Problem

`CompletionItem.detail` (the inline line beside the label) and
`CompletionItem.documentation` (the markdown panel) read the same
already-truncated `value`, so one limit had to serve two surfaces with
different budgets. At 200 the line blows out; at 50 the panel throws away
room it had. Laravel's own validation and auth messages run 80–150 chars —
squarely the band where the two disagree.

The truncation happened too early: `extract_config_value` /
`extract_translation_value` clipped before the value ever reached a render
site, so neither site could ask for a different length.

## Change

Carry the untruncated value; truncate at each render site.

- New `laravel-lsp/src/completion_display.rs` owns
  `COMPLETION_DETAIL_LIMIT = 50` and `COMPLETION_DOC_LIMIT = 200`, defined
  once, plus the three render functions both completion branches call.
- `extract_config_value` (`main.rs`) and `extract_translation_value`
  (`salsa_impl.rs`) no longer truncate at all.
- Both cuts still route through the char-safe
  `display_truncate::truncate_for_display` from #319, so the panic hardening
  won there holds at both new cut points.
- `const _: () = assert!(COMPLETION_DETAIL_LIMIT < COMPLETION_DOC_LIMIT);`
  makes a future "tidy-up" that collapses the limits a **build failure**
  rather than something a reviewer has to notice.

The config and translation `detail` lines were byte-identical, so they share
one `completion_detail` function. That is stronger than two parallel copies
referencing a shared constant — it makes drift impossible rather than merely
detectable. The two `documentation` builders genuinely differ (PHP code block
vs. prose summary) and stay separate.

Also updated `TranslationKeyCompletionData.value`'s doc comment in
`salsa_impl.rs`, which the acceptance criteria missed — it also read
"truncated for display" and would have gone stale.

## Memory footprint — measured

The issue asks to measure before committing to holding full values. Ran the
real extractors over real catalogues:

| Corpus | Values | Full | 200-capped | Delta |
| --- | --- | --- | --- | --- |
| Laravel framework `lang/en` (auth, validation, passwords, pagination) | 147 | 7,427 B | 7,427 B | **0 B** — longest value 87 chars |
| `test-project/config` | 291 | 2,949 B | 2,949 B | **0 B** — longest 68 chars |
| Every `'k' => 'v'` line under `vendor/` (absurd worst case) | 149,361 | 4,231,182 B | 4,197,127 B | **34 KB / 0.81%** |

The old cap was saving nothing on real data — not one value in Laravel's
stock English catalogue exceeded 200 chars. Even a synthetic sweep ~500×
larger than any real project's retained set costs under 1%. Accepted as-is;
no mitigation warranted.

## Tests

**14 new** in `completion_display/tests.rs`, **2 new** in
`tests/completion_value_pipeline.rs`, **4 updated + 2 new** in
`tests/byte_offset_panic_hardening.rs`.

- **Differential (the reported bug)** — an 80-char value, both branches:
  `detail`'s value portion ends with `…` at 51 chars; `documentation`
  contains all 80 chars verbatim with no ellipsis.
- **Char-boundary safety at both new cut points**, four distinct fixtures
  (config × 50, config × 200, translation × 50, translation × 200), using
  3-byte `€` so byte offsets 50 and 200 land mid-character — the exact index
  a `&s[..n]` slice panics on.
- **The panel is bounded, not merely longer.** The failure mode this split
  invites is forgetting to truncate the panel now that the field is
  unbounded, which would be worse than the original bug.
- **Whole-pipeline survival** — a 5,000-char multibyte value driven through
  the real `get_all_config_keys` / `get_all_translation_keys` against a
  project on disk, crossing the regex parse, the Salsa memo, the actor
  channel, and the struct conversion.
- **Empty-value fallbacks pinned** — `"(source)"` for `detail`, no code
  block for config, `"Translation key."` for translations.
- The four `byte_offset_panic_hardening` tests now assert **exact equality**
  against the full input, not a threshold — a `>= 200` check would stay green
  with truncation quietly reinstated at exactly 200.

### Mutation-verified — nine mutations, nine caught

| Mutation | Result |
| --- | --- |
| Collapse the two limits to one value | **compile error**, plus 5 red |
| `completion_detail` stops truncating | 5 red |
| `translation_documentation` bare pass-through | 2 red |
| `config_documentation` stops truncating | 2 red |
| Truncation reinstated in both extractors | 6 red, incl. both pipeline tests |
| `detail`'s empty-value branch removed | 1 red |
| Config doc always emits the code block | 1 red |
| `"Translation key."` fallback removed | 1 red |

## Verification

- `cargo test` — **3,109 passed, 0 failed, 0 ignored**, zero new `#[ignore]`
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean

## Note on the acceptance criteria

Two bullets are met in substance but not to the letter, deliberately:

1. **"four usage sites"** — three render functions, not four, because the two
   `detail` builders were identical. The bullet's stated purpose (the limits
   stay in sync when tuned) is satisfied more strongly by sharing the
   function than by duplicating it.
2. **"`detail` ends with `…` and is ≤ 51 chars"** — `detail` is
   `"<value> (<source>)"`, so it ends with the source. The tests assert the
   *value portion* ends with `…` at exactly 51 chars, and pin the full line
   shape separately.
