### PR TITLE
feat: ✨ Index Route::singleton and apiSingleton route names

### DIFF
--- a/laravel-lsp/src/route_discovery.rs
+++ b/laravel-lsp/src/route_discovery.rs
@@ -516,6 +516,10 @@ struct ChainLink<'a> {
     name_node: Node<'a>,
     /// The `->` / `?->` / `::` operator node — anchors named-route definitions.
     operator: Option<Node<'a>>,
+    /// The call's receiver — the `Route` of `Route::singleton(…)`, the
+    /// `$this->app` of `$this->app->singleton(…)`. Read lazily; only the
+    /// chain-opening link's receiver is ever consulted.
+    receiver: Option<Node<'a>>,
     /// True for `$obj->method(...)`, false for `Class::method(...)`.
     instance: bool,
 }
@@ -562,6 +566,9 @@ fn collect_links<'a>(chain: Node<'a>, source: &[u8]) -> Vec<ChainLink<'a>> {
                     args,
                     name_node,
                     operator: operator_node(node),
+                    receiver: node
+                        .child_by_field_name("scope")
+                        .or_else(|| node.child_by_field_name("object")),
                     instance: node.kind() != "scoped_call_expression",
                 });
             }
@@ -573,6 +580,16 @@ fn collect_links<'a>(chain: Node<'a>, source: &[u8]) -> Vec<ChainLink<'a>> {
 
     links.reverse();
     links
+}
+
+/// True when a chain's receiver is Laravel's router, and not some other object
+/// that happens to expose a same-named method. Deliberately an allow-list: an
+/// unrecognised receiver fails closed (no routes indexed) rather than emitting
+/// names that were never registered.
+fn is_router_receiver(receiver: &str) -> bool {
+    matches!(receiver, "Route" | "Router" | "$router" | "$this->router")
+        || receiver.ends_with("\\Route")
+        || receiver.ends_with("\\Router")
 }
 
 /// The `->` / `?->` / `::` token of a call, used to position the definition at
@@ -917,7 +934,22 @@ fn emit_chain_routes(
                 link, prefix, source, file, priority, effective, &metadata, results,
             );
         }
-        if link.method == "resource" || link.method == "apiResource" {
+        // `singleton(...)` is also the service container's binding method, so
+        // — unlike `resource(...)`, which collides with nothing — the singleton
+        // forms register routes only when the chain opens on the router itself.
+        // Without this, `$this->app->singleton('cache.limiter', …)` in a
+        // provider that also declares a named route indexes the phantom names
+        // `cache.limiter.show`/`.edit`/`.update`.
+        let registers_resource = match link.method.as_str() {
+            "resource" | "apiResource" => true,
+            "singleton" | "apiSingleton" => links
+                .first()
+                .and_then(|first| first.receiver)
+                .and_then(|node| node.utf8_text(source).ok())
+                .is_some_and(is_router_receiver),
+            _ => false,
+        };
+        if registers_resource {
             emit_resource_routes(
                 links, link, prefix, source, file, priority, effective, results,
             );
@@ -964,16 +996,20 @@ fn emit_named_route(
     }
 }
 
-/// Expand a `resource(...)` / `apiResource(...)` registration into the named
-/// routes Laravel synthesizes for it — `photos.index`, `photos.show`, … — after
-/// applying any `->only([...])` / `->except([...])` filter on the same chain.
+/// Expand a resource registration into the named routes Laravel synthesizes for
+/// it — `photos.index`, `photos.show`, … — after applying any `->only([...])` /
+/// `->except([...])` filter on the same chain.
+///
+/// Covers all four forms Laravel's `ResourceRegistrar` handles: `resource(...)`,
+/// `apiResource(...)`, `singleton(...)` and `apiSingleton(...)`. They differ only
+/// in their default action set; everything downstream of that is shared.
 ///
 /// A slashed URI contributes only its last segment to the names; the rest is a
 /// URI prefix. The full URI is still carried on each definition for display.
 ///
-/// Punted (common case only): `->names([...])` overrides, `Route::resources([…])`
-/// plural registration, `singleton(...)`/`apiSingleton(...)`, and shallow/nested
-/// resources.
+/// Punted (common case only): `->names([...])` overrides, the plural
+/// `Route::resources([…])` / `Route::singletons([…])` registrations, and
+/// shallow/nested resources.
 #[allow(clippy::too_many_arguments)]
 fn emit_resource_routes(
     links: &[ChainLink],
@@ -999,14 +1035,15 @@ fn emit_resource_routes(
     // only the final segment as the resource name.
     let resource = uri.rsplit('/').next().unwrap_or(uri);
 
-    let defaults = if link.method == "apiResource" {
-        API_RESOURCE_ACTIONS
-    } else {
-        RESOURCE_ACTIONS
+    let defaults = match link.method.as_str() {
+        "apiResource" => API_RESOURCE_ACTIONS.to_vec(),
+        "singleton" => singleton_actions(links, false),
+        "apiSingleton" => singleton_actions(links, true),
+        _ => RESOURCE_ACTIONS.to_vec(),
     };
     let (line, column, end_column) = definition_span(link.name_node, link.args);
 
-    for action in resource_actions(links, defaults, source) {
+    for action in resource_actions(links, &defaults, source) {
         let leaf = format!("{prefix}{resource}.{action}");
         for inherited in effective {
             results.push((
@@ -1033,7 +1070,7 @@ fn emit_resource_routes(
 /// argument is ignored, leaving the defaults in place.
 fn resource_actions(
     links: &[ChainLink],
-    defaults: &'static [&'static str],
+    defaults: &[&'static str],
     source: &[u8],
 ) -> Vec<&'static str> {
     let array_arg = |method: &str| -> Option<Vec<String>> {
@@ -1061,6 +1098,43 @@ fn resource_actions(
     }
     defaults.to_vec()
 }
+
+/// The default action set a `singleton(...)` / `apiSingleton(...)` registration
+/// starts from, before the chain's own `->only([...])` / `->except([...])` filter.
+///
+/// `->creatable()` widens the defaults with `create`/`store`/`destroy`;
+/// `->destroyable()` adds `destroy` alone. `creatable` wins when both are on the
+/// chain — it already implies `destroy`, so the two can't duplicate it, and
+/// neither ordering drops an action.
+///
+/// `apiSingleton` is not a separate default set: `Router::apiSingleton` registers
+/// an ordinary singleton with an implicit `only => [...]`, which
+/// `getResourceMethods` intersects with the (possibly widened) defaults above.
+/// That single mechanism is why a bare `apiSingleton` yields just `show`+`update`
+/// while `store`/`destroy` surface only alongside `creatable`/`destroyable` — and
+/// why `create`/`edit`, which render forms, can never appear on the API form.
+fn singleton_actions(links: &[ChainLink], api: bool) -> Vec<&'static str> {
+    let has = |method: &str| links.iter().any(|link| link.method == method);
+
+    let mut actions: Vec<&'static str> = match (has("creatable"), has("destroyable")) {
+        (true, _) => [&["create", "store"][..], SINGLETON_ACTIONS, &["destroy"]].concat(),
+        (false, true) => [SINGLETON_ACTIONS, &["destroy"][..]].concat(),
+        (false, false) => SINGLETON_ACTIONS.to_vec(),
+    };
+    if api {
+        actions.retain(|action| API_SINGLETON_ONLY.contains(action));
+    }
+    actions
+}
+
+/// Default action set for `Route::singleton(...)` — a single resource with no
+/// index and no identifier, so no `index`/`create`/`store`/`destroy`.
+/// Mirrors `ResourceRegistrar::$singletonResourceDefaults`.
+const SINGLETON_ACTIONS: &[&str] = &["show", "edit", "update"];
+
+/// The implicit `only => [...]` filter `Router::apiSingleton(...)` applies on top
+/// of the singleton defaults.
+const API_SINGLETON_ONLY: &[&str] = &["store", "show", "update", "destroy"];
 
 /// Default action set for `Route::resource(...)` — full CRUD.
 const RESOURCE_ACTIONS: &[&str] = &[

--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -1428,3 +1428,480 @@ Route::prefix('/admin')->name('admin.')->group(function () {
 "#;
     assert_eq!(names_of(src), vec!["admin.users.index"]);
 }
+
+// ============================================================================
+// Singleton route derivation (Route::singleton / Route::apiSingleton)
+// ============================================================================
+
+/// Route names from a direct extraction, sorted so asserts don't depend on
+/// emission order. Sorting also makes a duplicated name visible as an extra
+/// element rather than silently collapsing.
+fn sorted_names_of(src: &str) -> Vec<String> {
+    let mut names = names_of(src);
+    names.sort();
+    names
+}
+
+#[test]
+fn singleton_yields_show_edit_update() {
+    let src = r#"<?php
+Route::singleton('profile', ProfileController::class);
+"#;
+    assert_eq!(
+        sorted_names_of(src),
+        vec!["profile.edit", "profile.show", "profile.update"],
+        "a bare singleton registers exactly show/edit/update"
+    );
+}
+
+#[test]
+fn singleton_creatable_adds_create_store_destroy() {
+    let src = r#"<?php
+Route::singleton('profile', ProfileController::class)->creatable();
+"#;
+    assert_eq!(
+        sorted_names_of(src),
+        vec![
+            "profile.create",
+            "profile.destroy",
+            "profile.edit",
+            "profile.show",
+            "profile.store",
+            "profile.update",
+        ],
+        "creatable() adds create/store/destroy to the singleton defaults"
+    );
+}
+
+#[test]
+fn singleton_destroyable_adds_only_destroy() {
+    let src = r#"<?php
+Route::singleton('profile', ProfileController::class)->destroyable();
+"#;
+    let names = sorted_names_of(src);
+    assert_eq!(
+        names,
+        vec![
+            "profile.destroy",
+            "profile.edit",
+            "profile.show",
+            "profile.update",
+        ],
+        "destroyable() adds destroy and nothing else"
+    );
+    // The create/store pair belongs to creatable() alone.
+    assert!(!names.iter().any(|n| n == "profile.create"));
+    assert!(!names.iter().any(|n| n == "profile.store"));
+}
+
+#[test]
+fn singleton_creatable_and_destroyable_union_without_duplicates() {
+    // creatable() already implies destroy; stacking destroyable() on top must
+    // not emit it twice, and neither chain order may drop an action.
+    let expected = vec![
+        "profile.create",
+        "profile.destroy",
+        "profile.edit",
+        "profile.show",
+        "profile.store",
+        "profile.update",
+    ];
+    let creatable_first = r#"<?php
+Route::singleton('profile', ProfileController::class)->creatable()->destroyable();
+"#;
+    let destroyable_first = r#"<?php
+Route::singleton('profile', ProfileController::class)->destroyable()->creatable();
+"#;
+    assert_eq!(sorted_names_of(creatable_first), expected);
+    assert_eq!(sorted_names_of(destroyable_first), expected);
+}
+
+#[test]
+fn api_singleton_yields_show_and_update_only() {
+    let src = r#"<?php
+Route::apiSingleton('profile', ProfileController::class);
+"#;
+    let names = sorted_names_of(src);
+    assert_eq!(
+        names,
+        vec!["profile.show", "profile.update"],
+        "a bare apiSingleton registers exactly show/update"
+    );
+    // `edit` renders a form — an API singleton never registers it.
+    assert!(!names.iter().any(|n| n == "profile.edit"));
+}
+
+#[test]
+fn api_singleton_creatable_adds_store_and_destroy_but_never_create() {
+    let src = r#"<?php
+Route::apiSingleton('profile', ProfileController::class)->creatable();
+"#;
+    let names = sorted_names_of(src);
+    assert_eq!(
+        names,
+        vec![
+            "profile.destroy",
+            "profile.show",
+            "profile.store",
+            "profile.update",
+        ],
+        "apiSingleton()->creatable() adds store/destroy only"
+    );
+    // Both form-rendering actions stay out of the API set.
+    assert!(!names.iter().any(|n| n == "profile.create"));
+    assert!(!names.iter().any(|n| n == "profile.edit"));
+}
+
+#[test]
+fn api_singleton_destroyable_adds_destroy() {
+    let src = r#"<?php
+Route::apiSingleton('profile', ProfileController::class)->destroyable();
+"#;
+    assert_eq!(
+        sorted_names_of(src),
+        vec!["profile.destroy", "profile.show", "profile.update"],
+    );
+}
+
+#[test]
+fn singleton_only_and_except_filter_the_bare_action_set() {
+    let only = r#"<?php
+Route::singleton('profile', ProfileController::class)->only(['show', 'update']);
+"#;
+    assert_eq!(
+        sorted_names_of(only),
+        vec!["profile.show", "profile.update"]
+    );
+
+    let except = r#"<?php
+Route::singleton('profile', ProfileController::class)->except(['edit']);
+"#;
+    assert_eq!(
+        sorted_names_of(except),
+        vec!["profile.show", "profile.update"]
+    );
+}
+
+#[test]
+fn api_singleton_only_and_except_filter_the_bare_action_set() {
+    let only = r#"<?php
+Route::apiSingleton('profile', ProfileController::class)->only(['show']);
+"#;
+    assert_eq!(sorted_names_of(only), vec!["profile.show"]);
+
+    let except = r#"<?php
+Route::apiSingleton('profile', ProfileController::class)->except(['update']);
+"#;
+    assert_eq!(sorted_names_of(except), vec!["profile.show"]);
+}
+
+#[test]
+fn singleton_only_filters_against_the_expanded_not_the_bare_action_set() {
+    // `create` exists only once creatable() has widened the set. Filtering for
+    // it without creatable() must yield nothing — proof that only() runs
+    // against the expanded set rather than a base set with extras appended
+    // after the filter.
+    let bare = r#"<?php
+Route::singleton('profile', ProfileController::class)->only(['create']);
+"#;
+    assert!(
+        sorted_names_of(bare).is_empty(),
+        "create is not in the bare singleton set, so only(['create']) yields nothing"
+    );
+
+    let creatable = r#"<?php
+Route::singleton('profile', ProfileController::class)->creatable()->only(['create', 'destroy']);
+"#;
+    assert_eq!(
+        sorted_names_of(creatable),
+        vec!["profile.create", "profile.destroy"],
+    );
+
+    let destroyable = r#"<?php
+Route::singleton('profile', ProfileController::class)->destroyable()->only(['destroy']);
+"#;
+    assert_eq!(sorted_names_of(destroyable), vec!["profile.destroy"]);
+}
+
+#[test]
+fn singleton_except_filters_against_the_expanded_not_the_bare_action_set() {
+    let creatable = r#"<?php
+Route::singleton('profile', ProfileController::class)->creatable()->except(['create', 'store', 'edit']);
+"#;
+    assert_eq!(
+        sorted_names_of(creatable),
+        vec!["profile.destroy", "profile.show", "profile.update"],
+    );
+
+    let destroyable = r#"<?php
+Route::singleton('profile', ProfileController::class)->destroyable()->except(['destroy']);
+"#;
+    assert_eq!(
+        sorted_names_of(destroyable),
+        vec!["profile.edit", "profile.show", "profile.update"],
+        "excepting destroy must undo destroyable(), not be ignored"
+    );
+}
+
+#[test]
+fn api_singleton_only_filters_against_the_expanded_not_the_bare_action_set() {
+    let bare = r#"<?php
+Route::apiSingleton('profile', ProfileController::class)->only(['store']);
+"#;
+    assert!(
+        sorted_names_of(bare).is_empty(),
+        "store is not in the bare apiSingleton set"
+    );
+
+    let creatable = r#"<?php
+Route::apiSingleton('profile', ProfileController::class)->creatable()->only(['store', 'destroy']);
+"#;
+    assert_eq!(
+        sorted_names_of(creatable),
+        vec!["profile.destroy", "profile.store"],
+    );
+
+    let destroyable = r#"<?php
+Route::apiSingleton('profile', ProfileController::class)->destroyable()->only(['destroy']);
+"#;
+    assert_eq!(sorted_names_of(destroyable), vec!["profile.destroy"]);
+}
+
+#[test]
+fn api_singleton_except_filters_against_the_expanded_not_the_bare_action_set() {
+    let creatable = r#"<?php
+Route::apiSingleton('profile', ProfileController::class)->creatable()->except(['store']);
+"#;
+    assert_eq!(
+        sorted_names_of(creatable),
+        vec!["profile.destroy", "profile.show", "profile.update"],
+    );
+
+    let destroyable = r#"<?php
+Route::apiSingleton('profile', ProfileController::class)->destroyable()->except(['destroy']);
+"#;
+    assert_eq!(
+        sorted_names_of(destroyable),
+        vec!["profile.show", "profile.update"],
+    );
+}
+
+#[test]
+fn singleton_with_multi_segment_uri_names_only_the_last_segment() {
+    // Laravel detours a slashed singleton name through `prefixedSingleton`,
+    // whose `getResourcePrefix` keeps only the final segment as the name.
+    let src = r#"<?php
+Route::singleton('admin/profile', ProfileController::class);
+Route::apiSingleton('admin/settings/theme', ThemeController::class);
+"#;
+    let names = sorted_names_of(src);
+    assert!(
+        names.contains(&"profile.show".to_string()),
+        "expected profile.show, got {names:?}"
+    );
+    assert!(
+        names.contains(&"theme.show".to_string()),
+        "expected theme.show, got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| n.contains('/')),
+        "no singleton name may carry a slash, got {names:?}"
+    );
+}
+
+#[test]
+fn singleton_with_multi_segment_uri_keeps_the_full_uri_for_display() {
+    let src = r#"<?php
+Route::singleton('admin/profile', ProfileController::class)->only(['show']);
+"#;
+    let path = PathBuf::from("/fake/routes/web.php");
+    let routes = extract_named_routes(src, &path, PRIORITY_APP, &[]);
+    let (name, definition) = routes
+        .into_iter()
+        .find(|(n, _)| n.as_deref() == Some("profile.show"))
+        .expect("profile.show must be indexed");
+    assert_eq!(name.as_deref(), Some("profile.show"));
+    assert_eq!(definition.uri.as_deref(), Some("admin/profile"));
+}
+
+#[test]
+fn singleton_inside_name_group_composes_the_prefix() {
+    let src = r#"<?php
+Route::name('admin.')->group(function () {
+    Route::singleton('profile', ProfileController::class);
+});
+"#;
+    assert_eq!(
+        sorted_names_of(src),
+        vec![
+            "admin.profile.edit",
+            "admin.profile.show",
+            "admin.profile.update",
+        ],
+    );
+}
+
+#[test]
+fn singleton_skips_non_string_and_empty_names() {
+    for src in [
+        "<?php\nRoute::singleton($name, ProfileController::class);\n",
+        "<?php\nRoute::singleton('', ProfileController::class);\n",
+        "<?php\nRoute::singleton('/', ProfileController::class);\n",
+        "<?php\nRoute::apiSingleton($name, ProfileController::class);\n",
+        "<?php\nRoute::apiSingleton('', ProfileController::class);\n",
+        "<?php\nRoute::apiSingleton('/', ProfileController::class);\n",
+    ] {
+        assert!(
+            names_of(src).is_empty(),
+            "unresolvable singleton name must be skipped: {src:?}"
+        );
+    }
+}
+
+#[test]
+fn resource_forms_are_unaffected_by_the_singleton_code_path() {
+    // Regression guard: adding singleton/apiSingleton to the dispatch must not
+    // shift what resource/apiResource emit.
+    let resource = r#"<?php
+Route::resource('photos', PhotoController::class);
+"#;
+    assert_eq!(
+        sorted_names_of(resource),
+        vec![
+            "photos.create",
+            "photos.destroy",
+            "photos.edit",
+            "photos.index",
+            "photos.show",
+            "photos.store",
+            "photos.update",
+        ],
+    );
+
+    let api_resource = r#"<?php
+Route::apiResource('photos', PhotoController::class);
+"#;
+    assert_eq!(
+        sorted_names_of(api_resource),
+        vec![
+            "photos.destroy",
+            "photos.index",
+            "photos.show",
+            "photos.store",
+            "photos.update",
+        ],
+    );
+
+    // `creatable()`/`destroyable()` are not valid on a resource chain, but the
+    // shared dispatch makes them a plausible copy-paste. They must be inert.
+    let stray = r#"<?php
+Route::resource('photos', PhotoController::class)->creatable()->destroyable();
+Route::apiResource('videos', VideoController::class)->creatable();
+"#;
+    let names = sorted_names_of(stray);
+    assert_eq!(
+        names,
+        vec![
+            "photos.create",
+            "photos.destroy",
+            "photos.edit",
+            "photos.index",
+            "photos.show",
+            "photos.store",
+            "photos.update",
+            "videos.destroy",
+            "videos.index",
+            "videos.show",
+            "videos.store",
+            "videos.update",
+        ],
+        "stray singleton modifiers must not alter a resource action set"
+    );
+}
+
+#[test]
+fn container_singleton_is_not_indexed_as_a_route() {
+    // `singleton(...)` is the service container's binding method too. A package
+    // provider that binds into the container *and* registers a named route
+    // passes the file-discovery gate, so without a receiver check every binding
+    // key was indexed as a phantom `<key>.show`/`.edit`/`.update` route.
+    let src = r#"<?php
+class TelescopeServiceProvider extends ServiceProvider {
+    public function register(): void
+    {
+        $this->app->singleton('telescope.limiter', fn ($app) => new Limiter($app));
+        $app->singleton('flare.logger', fn ($app) => new Logger($app));
+        App::singleton('metrics.recorder', fn ($app) => new Recorder($app));
+        Container::singleton('audit.trail', fn ($app) => new Trail($app));
+    }
+    public function boot(): void
+    {
+        Route::get('/health', HealthController::class)->name('health');
+    }
+}
+"#;
+    assert!(
+        content_registers_named_routes(src),
+        "this file must reach extraction — the gate is not what protects us here"
+    );
+    assert_eq!(
+        names_of(src),
+        vec!["health"],
+        "container bindings must contribute no route names"
+    );
+}
+
+#[test]
+fn router_receivers_other_than_the_route_facade_index_singletons() {
+    // The allow-list is not "static calls on `Route`" — Laravel registers
+    // routes through a router instance in provider `map()` methods, and through
+    // the fully-qualified facade in files without a `use` import.
+    let cases = [
+        (
+            "<?php\n$router->singleton('profile', ProfileController::class);\n",
+            "$router",
+        ),
+        (
+            "<?php\n$this->router->singleton('profile', ProfileController::class);\n",
+            "$this->router",
+        ),
+        (
+            "<?php\n\\Illuminate\\Support\\Facades\\Route::singleton('profile', ProfileController::class);\n",
+            "fully-qualified facade",
+        ),
+        (
+            "<?php\nRoute::middleware('auth')->singleton('profile', ProfileController::class);\n",
+            "receiver behind a chained router call",
+        ),
+    ];
+    for (src, label) in cases {
+        assert_eq!(
+            sorted_names_of(src),
+            vec!["profile.edit", "profile.show", "profile.update"],
+            "{label} must still index singleton routes"
+        );
+    }
+}
+
+#[test]
+fn resource_forms_do_not_require_a_router_receiver() {
+    // The receiver gate is scoped to the singleton forms, where a real name
+    // collision exists. `resource(...)` collides with nothing, so gating it
+    // would risk dropping registrations that index correctly today.
+    let src = r#"<?php
+$this->app->resource('photos', PhotoController::class);
+"#;
+    assert_eq!(
+        sorted_names_of(src),
+        vec![
+            "photos.create",
+            "photos.destroy",
+            "photos.edit",
+            "photos.index",
+            "photos.show",
+            "photos.store",
+            "photos.update",
+        ],
+        "resource() must keep its current receiver-agnostic behavior",
+    );
+}


### PR DESCRIPTION
Fixes #316

## Summary

`route_discovery.rs` expanded only `Route::resource(...)` / `Route::apiResource(...)` into the names Laravel synthesizes, so `route('profile.show')` backed by a `Route::singleton('profile', …)` registration drew a false `Route not found in index`. `route_chain.rs`'s `ROUTE_VERBS` already listed both singleton forms, so the outline and rename walkers surfaced them — only the index side was blind.

### One mechanism, not four action tables

`apiSingleton` is not a separate default set. `Router::apiSingleton` registers an ordinary singleton with an implicit `only => ['store','show','update','destroy']`, which `getResourceMethods` intersects with the (possibly widened) singleton defaults. Modelling it that way collapses all six rows of the issue's table into one code path:

| Form | Actions |
|---|---|
| `singleton` | `show`, `edit`, `update` |
| `…->creatable()` | + `create`, `store`, `destroy` |
| `…->destroyable()` | + `destroy` |
| `apiSingleton` | `show`, `update` |
| `apiSingleton(…)->creatable()` | `show`, `update`, `store`, `destroy` |
| `apiSingleton(…)->destroyable()` | `show`, `update`, `destroy` |

`creatable` wins over `destroyable` when both are on the chain — it already implies `destroy` — so neither chain order duplicates or drops an action. Everything downstream of the default set (slash-stripping to the last segment, full-URI display, group-name composition, the `->only()`/`->except()` filter, the non-literal/empty-name guards) is the machinery #315 already built, reused unchanged.

### A defect found and fixed during implementation

`singleton(...)` is also the service container's binding method, and `route_discovery` gates emission on method name alone — it never checked the chain's receiver. A package service provider that binds into the container *and* registers a named route passes the file-discovery gate, so the first draft indexed phantom routes:

```php
$this->app->singleton('telescope.limiter', fn ($app) => new Limiter($app));
Route::get('/health', HealthController::class)->name('health');
```
```
names = ["telescope.limiter.show", "telescope.limiter.edit", "telescope.limiter.update", "health"]
```

Fixed with an allow-list receiver gate (`Route`, `Router`, `$router`, `$this->router`, and namespace-qualified forms) that fails closed on an unrecognised receiver. Scoped to the singleton forms only: `resource(...)` collides with nothing, and gating it would risk turning a known false-positive into an unknown false-negative on a surface with no reported bug. The receiver-gate inconsistency across the family is filed separately rather than widened into this PR.

## Red → green verification

Every new test was written and run against `route_discovery.rs` as it stood, with the dispatch still gated to `"resource" || "apiResource"`. 16 of the 18 behavior tests failed there:

```
failures:
    route_discovery::tests::api_singleton_creatable_adds_store_and_destroy_but_never_create
    route_discovery::tests::api_singleton_destroyable_adds_destroy
    route_discovery::tests::api_singleton_except_filters_against_the_expanded_not_the_bare_action_set
    route_discovery::tests::api_singleton_only_and_except_filter_the_bare_action_set
    route_discovery::tests::api_singleton_only_filters_against_the_expanded_not_the_bare_action_set
    route_discovery::tests::api_singleton_yields_show_and_update_only
    route_discovery::tests::singleton_creatable_adds_create_store_destroy
    route_discovery::tests::singleton_creatable_and_destroyable_union_without_duplicates
    route_discovery::tests::singleton_destroyable_adds_only_destroy
    route_discovery::tests::singleton_except_filters_against_the_expanded_not_the_bare_action_set
    route_discovery::tests::singleton_inside_name_group_composes_the_prefix
    route_discovery::tests::singleton_only_and_except_filter_the_bare_action_set
    route_discovery::tests::singleton_only_filters_against_the_expanded_not_the_bare_action_set
    route_discovery::tests::singleton_with_multi_segment_uri_keeps_the_full_uri_for_display
    route_discovery::tests::singleton_with_multi_segment_uri_names_only_the_last_segment
    route_discovery::tests::singleton_yields_show_edit_update

test result: FAILED. 79 passed; 16 failed; 0 ignored; 0 measured; 2417 filtered out
```

The two that were green from the start assert *absence* (guard clauses, cross-contamination), so a red baseline proves nothing about them — the trap `no_indexed_resource_name_ever_starts_with_slash` fell into in #315. Those, plus the three receiver-gate tests, were mutation-tested instead: the guarded code was broken and each test confirmed to go red.

| Mutation | Test that went red |
|---|---|
| `if uri.is_empty()` → `if false` | `singleton_skips_non_string_and_empty_names` |
| `resource` routed through `singleton_actions` | `resource_forms_are_unaffected_by_the_singleton_code_path` |
| Receiver gate removed | `container_singleton_is_not_indexed_as_a_route` |
| Allow-list narrowed to bare `Route` | `router_receivers_other_than_the_route_facade_index_singletons` |
| Gate extended to `resource`/`apiResource` | `resource_forms_do_not_require_a_router_receiver` |

After the change: **3,130 tests pass**, `cargo clippy --all-targets` clean, `cargo fmt --check` clean.

## Acceptance criteria

- [x] `Route::singleton(...)` indexes exactly `profile.show`, `profile.edit`, `profile.update`
- [x] `->creatable()` additionally indexes `create`, `store`, `destroy` (six total)
- [x] `->destroyable()` additionally indexes `destroy` only (four total)
- [x] `->creatable()->destroyable()` and the reversed order both yield the six-action union exactly once each
- [x] `Route::apiSingleton(...)` indexes exactly `show` + `update`; `edit` never appears
- [x] `apiSingleton()->creatable()` indexes `show`, `update`, `store`, `destroy` — no `create`, no `edit`
- [x] `apiSingleton()->destroyable()` indexes `show`, `update`, `destroy`
- [x] `->only()`/`->except()` filter both bare forms through the existing `resource_actions` mechanism (4 cases)
- [x] `->only()`/`->except()` filter against the *expanded* set, not the bare set, combined with both modifiers on both forms (8 cases)
- [x] `Route::singleton('admin/profile', …)` indexes by last segment only; the full URI is kept for display
- [x] `Route::name('admin.')->group(...)` composes onto every emitted singleton name
- [x] `resource`/`apiResource` action sets unchanged, including with stray `creatable`/`destroyable` links on the chain
- [x] Non-literal and empty/slash-only names emit nothing, for both singleton forms
- [x] Red→green verification stated with the observed `cargo test` output (above)
- [x] `emit_resource_routes` doc comment drops `singleton(...)`/`apiSingleton(...)` from the punted list; `->names([...])`, the plural forms, and shallow/nested resources remain listed
- [x] `Route::singletons([...])` / `Route::apiSingletons([...])` left out of scope — no tests target them, no implementation effort spent

## Test plan

```bash
cargo test --manifest-path laravel-lsp/Cargo.toml
cargo clippy --manifest-path laravel-lsp/Cargo.toml --all-targets
cargo fmt --manifest-path laravel-lsp/Cargo.toml -- --check
```

Manual check in Zed: `Route::singleton('profile', ProfileController::class)` in `routes/web.php`, then `route('profile.show')` in a controller — no diagnostic, goto lands on the registration.
