### PR TITLE
feat: ✨ Resolve third-party Blade view directives in goto-definition (#325)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,23 @@ Everything goes in your Zed `settings.json`. Zed settings are JSONC, so the inli
         "blade": {
           // Space between a directive and its parentheses.
           // false → @if($x)    true → @if ($x)                  Default: false
-          "directiveSpacing": false
+          "directiveSpacing": false,
+
+          // Extra directive names to treat as view-rendering in
+          // go-to-definition. A custom Blade::directive() is already resolved
+          // automatically — this is the escape hatch for the two cases that
+          // can't be inferred: a directive on the excluded label list
+          // (@section, @yield, @stack, control flow…), and one whose view name
+          // is the SECOND argument, after a condition (the @includeWhen shape).
+          // Directives with dedicated handling (@component, @livewire,
+          // @feature, @includeFirst, @extends, @include, @includeIf, @each,
+          // @includeWhen, @includeUnless) ignore both lists.
+          // Goto only — never affects diagnostics. Guide:
+          // docs/go-to-definition.md.               Default: both lists empty
+          "viewDirectives": {
+            "firstArg": [],   // view name is the 1st argument (@include shape)
+            "secondArg": []   // view name is the 2nd argument (@includeWhen shape)
+          }
         },
 
         "codeLens": {

--- a/docs/go-to-definition.md
+++ b/docs/go-to-definition.md
@@ -98,5 +98,29 @@ The import also binds the short name for the rest of the template, so `VerseMark
 
 A PHP `use App\Models\Flight;` statement jumps to the same place — the import sites are symmetric across the two file types.
 
+**Third-party Blade directives** resolve too. A package that registers its own view-rendering directive through `Blade::directive()` is on no built-in list, so its first quoted argument is treated as a view name and offered as a target when — and only when — that view file actually exists inside the project root:
+
+```blade
+@renderPartial('dashboard.summary')
+{{--             ^^^^^^^^^^^^^^^^^ → resources/views/dashboard/summary.blade.php --}}
+```
+
+Directives whose argument is a *label* rather than a view — `@section`, `@hasSection`, `@yield`, `@stack`, `@push`, and the standard control-flow set — are excluded, so `@section('content')` never jumps to `resources/views/content.blade.php` just because that file happens to exist.
+
+This applies to go-to-definition only. The "View file not found" diagnostic still validates just `@extends` and `@include`, so a directive resolved this way can never produce a false squiggle.
+
+Two escape hatches cover what the heuristic can't infer — a directive that takes a view but is on the excluded list, or one whose view name is the *second* argument (after a condition, like `@includeWhen`):
+
+```jsonc
+"blade": {
+  "viewDirectives": {
+    "firstArg": ["renderPartial"],
+    "secondArg": ["renderWhen"]
+  }
+}
+```
+
+Names with dedicated handling (`@component`, `@livewire`, `@feature`, `@includeFirst`, `@extends`, `@include`, `@includeIf`, `@each`, `@includeWhen`, `@includeUnless`) ignore both lists — their own resolution always wins. See [Configuration](configuration.md).
+
 **Supported patterns:**
-`view()` `View::make()` `@extends` `@include` `@component` `@use` `<x-*>` `</x-*>` `<livewire:*>` `</livewire:*>` `@livewire()` `route()` `to_route()` `signed_route()` `URL::signedRoute()` `config()` `Config::get()` `Config::getMany()` `config()->string()` `env()` `Env::get()` `__()` `trans()` `@lang` `->middleware()` `app()` `resolve()` `App::bound()` `App::isShared()` `asset()` `@vite` `app_path()` `base_path()` `storage_path()` `resource_path()` `public_path()` `Feature::active()` `Feature::inactive()` `Feature::value()` `@feature` `Artisan::call()` `Artisan::queue()` `->command()` `->artisan()` · query-chain columns / relations / tables · magic members (relationships, scopes, accessors, columns, dynamic finders)
+`view()` `View::make()` `@extends` `@include` `@includeIf` `@includeWhen` `@includeUnless` `@includeFirst` `@each` `@component` custom `Blade::directive()` view directives `@use` `<x-*>` `</x-*>` `<livewire:*>` `</livewire:*>` `@livewire()` `route()` `to_route()` `signed_route()` `URL::signedRoute()` `config()` `Config::get()` `Config::getMany()` `config()->string()` `env()` `Env::get()` `__()` `trans()` `@lang` `->middleware()` `app()` `resolve()` `App::bound()` `App::isShared()` `asset()` `@vite` `app_path()` `base_path()` `storage_path()` `resource_path()` `public_path()` `Feature::active()` `Feature::inactive()` `Feature::value()` `@feature` `Artisan::call()` `Artisan::queue()` `->command()` `->artisan()` · query-chain columns / relations / tables · magic members (relationships, scopes, accessors, columns, dynamic finders)

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -1985,6 +1985,11 @@ struct LaravelLanguageServer {
     /// Add space between directive name and parentheses in completions
     /// false: @if($condition)  |  true: @if ($condition)
     directive_spacing: Arc<RwLock<bool>>,
+    /// Extra directive names the user declared as view-rendering (issue #325),
+    /// set via the `blade.viewDirectives` LSP setting. Read by
+    /// [`Self::create_directive_location_from_salsa`]'s goto fallback; the
+    /// diagnostic path never consults it.
+    view_directives: Arc<RwLock<ViewDirectivesSettings>>,
     /// Severity for query-chain diagnostics (unknown column/relation/table).
     /// `None` disables them; defaults to `WARNING`. Set via the
     /// `diagnostics.severity` LSP setting.
@@ -2193,6 +2198,43 @@ const FILE_EXISTS_CACHE_CAP: usize = 8192;
 // NOTE: Blade directives are now dynamically discovered via get_all_blade_directives()
 // which scans the Laravel framework, app service providers, and packages.
 
+/// User-declared view-rendering directive names (issue #325). Configured via:
+/// `{ "lsp": { "laravel-lsp": { "settings": { "blade": { "viewDirectives": {
+/// "firstArg": ["myDirective"], "secondArg": ["myOtherDirective"] } } } } } }`
+///
+/// The escape hatch for a directive the goto fallback can't or shouldn't infer:
+/// a name listed here resolves exactly like a hardcoded `view_directives_first_arg`
+/// / `view_directives_second_arg` entry. Entries outrank [`NON_VIEW_DIRECTIVES`]
+/// (a user may deliberately re-enable a denylisted name) but never outrank a
+/// directive with dedicated handling — see
+/// [`LaravelLanguageServer::create_directive_location_from_salsa`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ViewDirectivesSettings {
+    /// Directive names whose FIRST quoted argument is a view name, like
+    /// `@extends`/`@include`.
+    #[serde(default)]
+    first_arg: Vec<String>,
+    /// Directive names whose SECOND quoted argument is a view name (after a
+    /// condition), like `@includeWhen`/`@includeUnless`.
+    #[serde(default)]
+    second_arg: Vec<String>,
+}
+
+/// Whether a missing view behind this directive raises a "View file not found"
+/// diagnostic.
+///
+/// Deliberately far narrower than the set goto-definition resolves (issue
+/// #325): goto and diagnostics have opposite risk profiles. A wrong goto costs
+/// one keystroke; a wrong squiggle marks working code. So the goto path gained a
+/// permissive fallback for third-party `Blade::directive()` registrations while
+/// this gate stayed exactly as it was — a directive reachable only through that
+/// fallback, or through the `blade.viewDirectives` setting, can never produce a
+/// false missing-view diagnostic.
+fn directive_takes_missing_view_diagnostic(name: &str) -> bool {
+    name == "extends" || name == "include"
+}
+
 /// Blade-specific settings
 /// Configured via: { "lsp": { "laravel-lsp": { "settings": { "blade": { ... } } } } }
 #[derive(Debug, Clone, serde::Deserialize, Default)]
@@ -2203,7 +2245,106 @@ struct BladeSettings {
     /// true:  @if ($condition)
     #[serde(default)]
     directive_spacing: bool,
+    /// Extra directive names to treat as view-rendering in goto-definition.
+    /// Both lists default to empty.
+    #[serde(default)]
+    view_directives: ViewDirectivesSettings,
 }
+
+/// Built-in Blade directives whose argument is NOT a view name, so the
+/// goto-definition fallback in
+/// [`LaravelLanguageServer::create_directive_location_from_salsa`] must never
+/// fire for them (issue #325).
+///
+/// Without this, `@section('content')` would jump to
+/// `resources/views/content.blade.php` whenever a view happens to share the
+/// section's name — a plausible-looking but wrong target. The list is the
+/// container/label directives the outline builder already enumerates (see
+/// `document_symbols.rs`), the section-name pair `@hasSection`/`@sectionMissing`
+/// (identical false-positive shape to `@section`), and the standard
+/// control-flow/utility directives.
+///
+/// A name here is still resolvable if the user explicitly declares it under
+/// `blade.viewDirectives` — see [`ViewDirectivesSettings`].
+const NON_VIEW_DIRECTIVES: &[&str] = &[
+    // Container / label directives (mirrors document_symbols.rs).
+    "section",
+    "endsection",
+    "push",
+    "endpush",
+    "prepend",
+    "endprepend",
+    "slot",
+    "endslot",
+    "endcomponent",
+    "stack",
+    "yield",
+    "props",
+    // Section-name directives — same false-positive shape as @section.
+    "hasSection",
+    "sectionMissing",
+    // Control flow.
+    "if",
+    "elseif",
+    "else",
+    "endif",
+    "unless",
+    "endunless",
+    "switch",
+    "case",
+    "default",
+    "break",
+    "continue",
+    "endswitch",
+    "foreach",
+    "endforeach",
+    "forelse",
+    "endforelse",
+    "empty",
+    "endempty",
+    "for",
+    "endfor",
+    "while",
+    "endwhile",
+    // Authorization / environment / state guards.
+    "can",
+    "cannot",
+    "elsecan",
+    "elsecannot",
+    "endcan",
+    "endcannot",
+    "error",
+    "enderror",
+    "env",
+    "production",
+    "endenv",
+    "auth",
+    "endauth",
+    "guest",
+    "endguest",
+    "isset",
+    "endisset",
+    // Utility / output.
+    "php",
+    "endphp",
+    "inject",
+    "method",
+    "csrf",
+    "json",
+    "dump",
+    "dd",
+    "class",
+    "style",
+    "checked",
+    "selected",
+    "disabled",
+    "readonly",
+    "required",
+    "use",
+    "lang",
+    "vite",
+    "aware",
+];
 
 /// Query-chain diagnostics settings (unknown column / relation / table).
 /// Configured via:
@@ -4420,6 +4561,7 @@ impl LaravelLanguageServer {
             pending_salsa_updates: Arc::new(RwLock::new(HashMap::new())),
             auto_complete_debounce_ms: Arc::new(RwLock::new(DEFAULT_SALSA_DEBOUNCE_MS)),
             directive_spacing: Arc::new(RwLock::new(false)),
+            view_directives: Arc::new(RwLock::new(ViewDirectivesSettings::default())),
             chain_diagnostic_severity: Arc::new(RwLock::new(Some(DiagnosticSeverity::WARNING))),
             code_lens_enabled: Arc::new(RwLock::new(false)),
             vendor_diagnostic_shown: Arc::new(RwLock::new(false)),
@@ -4472,6 +4614,19 @@ impl LaravelLanguageServer {
                 old_spacing, new_spacing
             );
             *self.directive_spacing.write().await = new_spacing;
+        }
+
+        // Extra view-rendering directive names (issue #325). The old value is
+        // cloned into a local first: a read guard held in the `if` condition
+        // would outlive the condition and deadlock against the `write()` below.
+        let new_view_directives = &settings.blade.view_directives;
+        let old_view_directives = self.view_directives.read().await.clone();
+        if *new_view_directives != old_view_directives {
+            info!(
+                "⚙️  Updating blade.viewDirectives: firstArg={:?}, secondArg={:?}",
+                new_view_directives.first_arg, new_view_directives.second_arg
+            );
+            *self.view_directives.write().await = new_view_directives.clone();
         }
 
         // Query-chain diagnostics severity
@@ -15846,6 +16001,59 @@ return [
             }
         }
 
+        // ── Fallback for directives with no dedicated handling (issue #325) ──
+        //
+        // A package that registers its own view-rendering directive through
+        // `Blade::directive()` is invisible to every hardcoded list above, so it
+        // gets no goto at all. Goto and diagnostics have opposite risk profiles:
+        // a wrong goto costs the user one keystroke, while a wrong "view does
+        // not exist" squiggle marks working code. Only the *goto* path gains
+        // this permissive fallback — `validate_and_publish_diagnostics` keeps
+        // its strict `extends`/`include` allowlist, so a false missing-view
+        // diagnostic stays impossible by construction.
+        //
+        // The gate is keyed on `dir.name`, never on "nothing has resolved yet":
+        // a dedicated branch above that fails to find its own target must keep
+        // returning `None` rather than leaking into this heuristic and offering
+        // a naively-guessed view file instead.
+        let name = dir.name.as_str();
+        let dedicated = matches!(name, "component" | "livewire" | "feature" | "includeFirst")
+            || view_directives_first_arg.contains(&name)
+            || view_directives_second_arg.contains(&name);
+        if dedicated {
+            return None;
+        }
+
+        // `blade.viewDirectives` is the escape hatch for a directive the
+        // heuristic can't or shouldn't infer, so a declared name outranks
+        // `NON_VIEW_DIRECTIVES` — a user may deliberately re-enable a
+        // denylisted name. It never outranks dedicated handling, refused above.
+        let configured = self.view_directives.read().await.clone();
+        let view_name = if configured.first_arg.iter().any(|d| d == name) {
+            Self::extract_view_from_directive_args(arguments)
+        } else if configured.second_arg.iter().any(|d| d == name) {
+            Self::extract_second_string_arg(arguments)
+        } else if NON_VIEW_DIRECTIVES.contains(&name) {
+            None
+        } else {
+            Self::extract_view_from_directive_args(arguments)
+        };
+
+        if let Some(view_name) = view_name {
+            // Same loop-and-two-gate shape as every branch above: try every
+            // candidate `resolve_view_path` offers, not just the first, and
+            // re-check containment after the existence probe.
+            for path in config.resolve_view_path(&view_name) {
+                if !self.file_exists_cached(&path).await {
+                    continue;
+                }
+                if !path_within_root(&path, &config.root) {
+                    continue;
+                }
+                return self.create_location_link(dir, &path);
+            }
+        }
+
         None
     }
 
@@ -17342,6 +17550,7 @@ return [
             pending_salsa_updates: self.pending_salsa_updates.clone(),
             auto_complete_debounce_ms: self.auto_complete_debounce_ms.clone(),
             directive_spacing: self.directive_spacing.clone(),
+            view_directives: self.view_directives.clone(),
             chain_diagnostic_severity: self.chain_diagnostic_severity.clone(),
             code_lens_enabled: self.code_lens_enabled.clone(),
             vendor_diagnostic_shown: self.vendor_diagnostic_shown.clone(),
@@ -18491,7 +18700,7 @@ return [
         // Check @extends and @include directives using Salsa patterns
         for dir_ref in &patterns.directives {
             // Only validate @extends and @include
-            if dir_ref.name == "extends" || dir_ref.name == "include" {
+            if directive_takes_missing_view_diagnostic(&dir_ref.name) {
                 if let Some(ref args) = dir_ref.arguments {
                     if let Some(view_name) = Self::extract_view_from_directive_args(args) {
                         let possible_paths = config.resolve_view_path(&view_name);

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -15841,7 +15841,20 @@ return [
         None
     }
 
-    /// Create LocationLink for a directive reference from Salsa data
+    /// Create LocationLink for a directive reference from Salsa data.
+    ///
+    /// Dispatch is a single `match` on the directive name, deliberately: a
+    /// directive's handling and its exclusion from the catch-all fallback are
+    /// then the *same arm*, so the two cannot drift apart. Adding a dedicated
+    /// arm automatically excludes that name from the fallback, and an arm that
+    /// resolves nothing yields `None` rather than leaking into the fallback's
+    /// heuristic and offering a naively-guessed view file (issue #325).
+    ///
+    /// Containment guard (issue #148, extending #130): every arm resolves its
+    /// argument through [`Self::first_contained_view`], which honours
+    /// `loadViewsFrom`-style namespaces that can point outside the project root
+    /// and so re-checks containment after the existence probe. The `@feature`
+    /// arm builds its path from `root.join(..)` and is contained by construction.
     async fn create_directive_location_from_salsa(
         &self,
         dir: &DirectiveReferenceData,
@@ -15849,211 +15862,141 @@ return [
         let arguments = dir.arguments.as_ref()?;
         let config = self.get_cached_config().await?;
 
-        // Containment guard (issue #148, extending #130): every candidate loop
-        // below resolves a directive argument to a view/component path through
-        // `resolve_view_path`, which honours `loadViewsFrom`-style namespaces that
-        // can point an absolute path outside the project root. Each loop re-checks
-        // `path_within_root(&path, &config.root)` after the existence check and
-        // `continue`s past any out-of-root candidate, so no directive flow hands
-        // the client a navigation target that escapes the root. The `@feature`
-        // branch builds its path from `root.join(..)` and so is already contained.
-
-        // Directives where first argument is a view name
-        let view_directives_first_arg = ["extends", "include", "includeIf", "each"];
-
-        // Directives where second argument is a view name (after a condition)
-        // `@includeUnless($boolean, 'view.name', [...])` is condition-first,
-        // exactly like `@includeWhen` — it never resolved from the
-        // first-argument list.
-        let view_directives_second_arg = ["includeWhen", "includeUnless"];
-
-        // @component directive - resolves to component file
-        if dir.name == "component" {
-            if let Some(component_name) = Self::extract_view_from_directive_args(arguments) {
-                // Try as component path (resources/views/components/...)
-                let component_path = format!("components.{}", component_name);
-                let possible_paths = config.resolve_view_path(&component_path);
-
-                for path in possible_paths {
-                    if !self.file_exists_cached(&path).await {
-                        continue;
-                    }
-                    if !path_within_root(&path, &config.root) {
-                        continue;
-                    }
-                    return self.create_location_link(dir, &path);
+        // Note: @lang is handled as a Translation pattern and @vite as an Asset
+        // pattern, not as Directive patterns — see parse_file_patterns in
+        // salsa_impl.rs. Neither reaches this method.
+        match dir.name.as_str() {
+            // `@component('foo')` accepts either a components/ path or a plain
+            // view path; the components/ location wins when both exist.
+            "component" => {
+                let name = Self::extract_view_from_directive_args(arguments)?;
+                let mut resolved = self
+                    .first_contained_view(&config, &format!("components.{name}"))
+                    .await;
+                if resolved.is_none() {
+                    resolved = self.first_contained_view(&config, &name).await;
                 }
+                self.create_location_link(dir, &resolved?)
+            }
 
-                // Also try direct view path
-                let possible_paths = config.resolve_view_path(&component_name);
-                for path in possible_paths {
-                    if !self.file_exists_cached(&path).await {
-                        continue;
+            // First argument is a view name.
+            "extends" | "include" | "includeIf" | "each" => {
+                let view_name = Self::extract_view_from_directive_args(arguments)?;
+                let path = self.first_contained_view(&config, &view_name).await?;
+                self.create_location_link(dir, &path)
+            }
+
+            // Second argument is a view name, after a condition.
+            // `@includeUnless($boolean, 'view.name', [...])` is condition-first,
+            // exactly like `@includeWhen` — it never resolved from the
+            // first-argument list (issue #327).
+            "includeWhen" | "includeUnless" => {
+                let view_name = Self::extract_second_string_arg(arguments)?;
+                let path = self.first_contained_view(&config, &view_name).await?;
+                self.create_location_link(dir, &path)
+            }
+
+            // `@includeFirst(['view1', 'view2'])` — first view that exists wins.
+            "includeFirst" => {
+                for view_name in Self::extract_array_string_args(arguments) {
+                    if let Some(path) = self.first_contained_view(&config, &view_name).await {
+                        return self.create_location_link(dir, &path);
                     }
-                    if !path_within_root(&path, &config.root) {
-                        continue;
-                    }
-                    return self.create_location_link(dir, &path);
                 }
+                None
+            }
+
+            // `@livewire('component-name')` navigates to the component's Blade
+            // view. The clickable range covers just the quoted name.
+            "livewire" => {
+                let component_name = Self::extract_view_from_directive_args(arguments)?;
+                let path = self.first_contained_view(&config, &component_name).await?;
+                self.create_location_link_with_string_range(dir, &path)
+            }
+
+            // `@feature('feature-name')` — Laravel Pennant. Resolves against
+            // app/Features/, NOT the view tree, which is why a miss here must
+            // never fall through to the fallback's view-name guess.
+            "feature" => {
+                let feature_name = Self::extract_view_from_directive_args(arguments)?;
+                let root = self.root_path.read().await.clone()?;
+
+                // A feature class may override its key via a $name property;
+                // otherwise derive the class name from the key.
+                let feature_path = match scan_feature_classes(&root)
+                    .iter()
+                    .find(|f| f.feature_key == feature_name)
+                {
+                    Some(info) => root
+                        .join("app/Features")
+                        .join(format!("{}.php", info.class_name)),
+                    None => root.join(format!(
+                        "app/Features/{}.php",
+                        feature_key_to_class_name(&feature_name)
+                    )),
+                };
+
+                if !self.file_exists_cached(&feature_path).await {
+                    return None;
+                }
+                self.create_location_link_with_string_range(dir, &feature_path)
+            }
+
+            // ── Fallback: no dedicated arm above (issue #325) ──
+            //
+            // A package that registers its own view-rendering directive through
+            // `Blade::directive()` matches no arm above, so before this it got
+            // no goto at all. Reaching this arm is itself the proof that no
+            // dedicated handling exists — the `match` makes that structural
+            // rather than a hand-maintained exclusion list that can drift.
+            //
+            // Goto and diagnostics have opposite risk profiles: a wrong goto
+            // costs one keystroke, a wrong "view does not exist" squiggle marks
+            // working code. Only goto gains this permissive fallback —
+            // `validate_and_publish_diagnostics` keeps its strict
+            // `extends`/`include` gate, so a false missing-view diagnostic stays
+            // impossible by construction.
+            name => {
+                // `blade.viewDirectives` is the escape hatch for a directive the
+                // heuristic can't or shouldn't infer, so a declared name
+                // outranks `NON_VIEW_DIRECTIVES` — a user may deliberately
+                // re-enable a denylisted name. It can never outrank a dedicated
+                // arm, which the `match` already consumed.
+                let configured = self.view_directives.read().await.clone();
+                let view_name = if configured.first_arg.iter().any(|d| d == name) {
+                    Self::extract_view_from_directive_args(arguments)
+                } else if configured.second_arg.iter().any(|d| d == name) {
+                    Self::extract_second_string_arg(arguments)
+                } else if NON_VIEW_DIRECTIVES.contains(&name) {
+                    None
+                } else {
+                    Self::extract_view_from_directive_args(arguments)
+                }?;
+
+                let path = self.first_contained_view(&config, &view_name).await?;
+                self.create_location_link(dir, &path)
             }
         }
+    }
 
-        // Handle view directives (first argument is view name)
-        if view_directives_first_arg.contains(&dir.name.as_str()) {
-            if let Some(view_name) = Self::extract_view_from_directive_args(arguments) {
-                let possible_paths = config.resolve_view_path(&view_name);
-
-                for path in possible_paths {
-                    if !self.file_exists_cached(&path).await {
-                        continue;
-                    }
-                    if !path_within_root(&path, &config.root) {
-                        continue;
-                    }
-                    return self.create_location_link(dir, &path);
-                }
+    /// First candidate for `view_name` that exists on disk **and** resolves
+    /// inside the project root.
+    ///
+    /// `resolve_view_path` returns one candidate per configured view root (or
+    /// per namespace), in priority order, and honours `loadViewsFrom`-style
+    /// registrations that can map a namespace to an absolute directory outside
+    /// the root (issues #130/#148). Containment is therefore re-checked after
+    /// the existence probe, and every candidate is tried — not just the first.
+    async fn first_contained_view(
+        &self,
+        config: &LaravelConfigData,
+        view_name: &str,
+    ) -> Option<PathBuf> {
+        for path in config.resolve_view_path(view_name) {
+            if self.file_exists_cached(&path).await && path_within_root(&path, &config.root) {
+                return Some(path);
             }
         }
-
-        // Handle @includeWhen($condition, 'view') - second arg is view
-        if view_directives_second_arg.contains(&dir.name.as_str()) {
-            if let Some(view_name) = Self::extract_second_string_arg(arguments) {
-                let possible_paths = config.resolve_view_path(&view_name);
-
-                for path in possible_paths {
-                    if !self.file_exists_cached(&path).await {
-                        continue;
-                    }
-                    if !path_within_root(&path, &config.root) {
-                        continue;
-                    }
-                    return self.create_location_link(dir, &path);
-                }
-            }
-        }
-
-        // Handle @includeFirst(['view1', 'view2']) - array of views
-        if dir.name == "includeFirst" {
-            let view_names = Self::extract_array_string_args(arguments);
-            for view_name in view_names {
-                let possible_paths = config.resolve_view_path(&view_name);
-                for path in possible_paths {
-                    if !self.file_exists_cached(&path).await {
-                        continue;
-                    }
-                    if !path_within_root(&path, &config.root) {
-                        continue;
-                    }
-                    return self.create_location_link(dir, &path);
-                }
-            }
-        }
-
-        // Note: @lang is now handled as Translation patterns (see parse_file_patterns in salsa_impl.rs)
-        // Note: @vite is handled as Asset patterns, not Directive patterns
-        // See parse_file_patterns in salsa_impl.rs
-
-        // Handle @livewire('component-name') - Livewire component directive
-        // Navigates to the Blade view using view_path resolution
-        if dir.name == "livewire" {
-            if let Some(component_name) = Self::extract_view_from_directive_args(arguments) {
-                // Resolve using view path (e.g., 'navigation-menu' -> resources/views/navigation-menu.blade.php)
-                let possible_paths = config.resolve_view_path(&component_name);
-
-                for path in possible_paths {
-                    if !self.file_exists_cached(&path).await {
-                        continue;
-                    }
-                    if !path_within_root(&path, &config.root) {
-                        continue;
-                    }
-                    // Use string_column/string_end_column for the clickable range (just the component name)
-                    return self.create_location_link_with_string_range(dir, &path);
-                }
-            }
-        }
-
-        // Handle @feature('feature-name') - Laravel Pennant feature directive
-        if dir.name == "feature" {
-            if let Some(feature_name) = Self::extract_view_from_directive_args(arguments) {
-                let root = self.root_path.read().await;
-                if let Some(root) = root.as_ref() {
-                    // First check scanned features for custom $name property matches
-                    let scanned_features = scan_feature_classes(root);
-                    let feature_path = if let Some(feature_info) = scanned_features
-                        .iter()
-                        .find(|f| f.feature_key == feature_name)
-                    {
-                        // Found a feature class with matching $name property or derived key
-                        root.join("app/Features")
-                            .join(format!("{}.php", feature_info.class_name))
-                    } else {
-                        // Fallback: Convert feature key to class name and build path
-                        let class_name = feature_key_to_class_name(&feature_name);
-                        root.join(format!("app/Features/{}.php", class_name))
-                    };
-
-                    if self.file_exists_cached(&feature_path).await {
-                        // Use string_column/string_end_column for the clickable range (just the feature name)
-                        return self.create_location_link_with_string_range(dir, &feature_path);
-                    }
-                }
-            }
-        }
-
-        // ── Fallback for directives with no dedicated handling (issue #325) ──
-        //
-        // A package that registers its own view-rendering directive through
-        // `Blade::directive()` is invisible to every hardcoded list above, so it
-        // gets no goto at all. Goto and diagnostics have opposite risk profiles:
-        // a wrong goto costs the user one keystroke, while a wrong "view does
-        // not exist" squiggle marks working code. Only the *goto* path gains
-        // this permissive fallback — `validate_and_publish_diagnostics` keeps
-        // its strict `extends`/`include` allowlist, so a false missing-view
-        // diagnostic stays impossible by construction.
-        //
-        // The gate is keyed on `dir.name`, never on "nothing has resolved yet":
-        // a dedicated branch above that fails to find its own target must keep
-        // returning `None` rather than leaking into this heuristic and offering
-        // a naively-guessed view file instead.
-        let name = dir.name.as_str();
-        let dedicated = matches!(name, "component" | "livewire" | "feature" | "includeFirst")
-            || view_directives_first_arg.contains(&name)
-            || view_directives_second_arg.contains(&name);
-        if dedicated {
-            return None;
-        }
-
-        // `blade.viewDirectives` is the escape hatch for a directive the
-        // heuristic can't or shouldn't infer, so a declared name outranks
-        // `NON_VIEW_DIRECTIVES` — a user may deliberately re-enable a
-        // denylisted name. It never outranks dedicated handling, refused above.
-        let configured = self.view_directives.read().await.clone();
-        let view_name = if configured.first_arg.iter().any(|d| d == name) {
-            Self::extract_view_from_directive_args(arguments)
-        } else if configured.second_arg.iter().any(|d| d == name) {
-            Self::extract_second_string_arg(arguments)
-        } else if NON_VIEW_DIRECTIVES.contains(&name) {
-            None
-        } else {
-            Self::extract_view_from_directive_args(arguments)
-        };
-
-        if let Some(view_name) = view_name {
-            // Same loop-and-two-gate shape as every branch above: try every
-            // candidate `resolve_view_path` offers, not just the first, and
-            // re-check containment after the existence probe.
-            for path in config.resolve_view_path(&view_name) {
-                if !self.file_exists_cached(&path).await {
-                    continue;
-                }
-                if !path_within_root(&path, &config.root) {
-                    continue;
-                }
-                return self.create_location_link(dir, &path);
-            }
-        }
-
         None
     }
 

--- a/laravel-lsp/src/tests/directive_view_fallback.rs
+++ b/laravel-lsp/src/tests/directive_view_fallback.rs
@@ -1,0 +1,652 @@
+//! Tests for the third-party view-directive goto fallback and the
+//! `blade.viewDirectives` escape hatch (issue #325).
+//!
+//! `create_directive_location_from_salsa` used to resolve view arguments from
+//! two hardcoded lists, so a package registering its own view-rendering
+//! directive through `Blade::directive()` got no goto at all. The fix adds a
+//! permissive fallback to the **goto** path only, because goto and diagnostics
+//! carry opposite risk: a wrong goto costs one keystroke, a wrong "view does not
+//! exist" squiggle marks working code. The diagnostic gate
+//! (`directive_takes_missing_view_diagnostic`) is unchanged, so a false
+//! missing-view diagnostic remains impossible by construction.
+//!
+//! The fallback is gated on three things, each covered below:
+//!   1. `dir.name` must have no dedicated branch — keyed on the *name*, never on
+//!      "nothing has resolved yet", so a dedicated branch that fails to find its
+//!      own target still returns `None` instead of leaking into the heuristic.
+//!   2. `dir.name` must not be on the [`crate::NON_VIEW_DIRECTIVES`] denylist
+//!      (`@section('content')` must not jump to `views/content.blade.php`).
+//!   3. A user-declared `blade.viewDirectives` entry outranks the denylist but
+//!      never outranks dedicated handling.
+//!
+//! Tests drive the private async method directly through
+//! `tower_lsp::LspService` / `inner()`, the same way
+//! `directive_navigation_containment.rs` does.
+
+use crate::{directive_takes_missing_view_diagnostic, LaravelLanguageServer, LspSettings};
+use laravel_lsp::salsa_impl::{DirectiveReferenceData, LaravelConfigData};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tower_lsp::lsp_types::{GotoDefinitionResponse, LocationLink, Url};
+use tower_lsp::LspService;
+
+/// Blade view contents are irrelevant to resolution — only that the file exists,
+/// so a `None` result can never be blamed on a missing file.
+const VIEW_BODY: &str = "<div>view</div>\n";
+
+/// A directive name with no dedicated branch and no denylist entry — the shape a
+/// `Blade::directive('renderPartial', ...)` registration produces.
+const CUSTOM: &str = "renderPartial";
+
+/// Build a server instance for testing. `LspService::new` wires up a real
+/// `Client`; `inner()` hands back the `LaravelLanguageServer` so its private
+/// methods can be called directly.
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// Write `contents` to `path`, creating parent directories as needed.
+fn write(path: &Path, contents: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+/// A config rooted at `root` with the given view roots (in `resolve_view_path`
+/// priority order) and `loadViewsFrom`-style namespaces.
+fn config(
+    root: &Path,
+    view_paths: Vec<PathBuf>,
+    view_namespaces: HashMap<String, PathBuf>,
+) -> LaravelConfigData {
+    LaravelConfigData {
+        root: root.to_path_buf(),
+        view_paths,
+        component_paths: vec![(String::new(), root.join("resources/views/components"))],
+        livewire_path: None,
+        has_livewire: false,
+        view_namespaces,
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+        class_component_files: HashMap::new(),
+    }
+}
+
+/// The common single-view-root config: `{root}/resources/views`, no namespaces.
+fn simple_config(root: &Path) -> LaravelConfigData {
+    config(root, vec![root.join("resources/views")], HashMap::new())
+}
+
+/// Seed `cfg` as the cached config so `get_cached_config` returns it without
+/// touching Salsa.
+async fn seed(server: &LaravelLanguageServer, cfg: LaravelConfigData) {
+    *server.cached_config.write().await = Some(std::sync::Arc::new(cfg));
+}
+
+/// Apply the `blade.viewDirectives` setting through the real
+/// [`LaravelLanguageServer::update_settings`] path — the single function
+/// `initialize`, `did_change_configuration`, and the `workspace/configuration`
+/// pull all converge on — rather than poking the field directly. That way these
+/// tests fail if the setting is ever parsed but not wired.
+async fn set_view_directives(server: &LaravelLanguageServer, first: &[&str], second: &[&str]) {
+    let json = serde_json::json!({
+        "blade": {
+            "viewDirectives": { "firstArg": first, "secondArg": second }
+        }
+    });
+    let settings: LspSettings = serde_json::from_value(json).expect("settings must deserialize");
+    server.update_settings(&settings).await;
+}
+
+/// Byte span of the first quoted argument's *contents* within `text`.
+/// Test directives are ASCII, so byte offsets and character columns coincide.
+fn first_quoted_span(text: &str) -> (u32, u32) {
+    let open = text
+        .find(['\'', '"'])
+        .expect("directive text must carry a quoted argument");
+    let quote = text[open..].chars().next().unwrap();
+    let close = text[open + 1..]
+        .find(quote)
+        .expect("directive text must close its quote")
+        + open
+        + 1;
+    ((open + 1) as u32, close as u32)
+}
+
+/// A `DirectiveReferenceData` for `@{name}{args}` at the document origin, e.g.
+/// `directive_ref("include", "('layouts.app')")`.
+///
+/// `column`/`end_column` span the whole directive (the range
+/// `create_location_link` reports); `string_column`/`string_end_column` span
+/// only the first quoted argument (the narrower range
+/// `create_location_link_with_string_range` reports). Keeping the two genuinely
+/// different is what lets a test tell which branch produced a link.
+fn directive_ref(name: &str, args: &str) -> DirectiveReferenceData {
+    let text = format!("@{name}{args}");
+    let (string_column, string_end_column) = first_quoted_span(&text);
+    DirectiveReferenceData {
+        name: name.to_string(),
+        arguments: Some(args.to_string()),
+        line: 0,
+        column: 0,
+        end_column: text.len() as u32,
+        string_column,
+        string_end_column,
+    }
+}
+
+/// Resolve `dir` and unwrap the single expected `LocationLink`.
+async fn resolve(server: &LaravelLanguageServer, dir: &DirectiveReferenceData) -> LocationLink {
+    match server.create_directive_location_from_salsa(dir).await {
+        Some(GotoDefinitionResponse::Link(links)) => {
+            assert_eq!(links.len(), 1, "exactly one definition link is expected");
+            links.into_iter().next().unwrap()
+        }
+        other => panic!("expected a Link definition response, got {other:?}"),
+    }
+}
+
+/// Assert `link` points at `expected` — the path itself, not merely `is_some()`.
+fn assert_targets(link: &LocationLink, expected: &Path) {
+    assert_eq!(
+        link.target_uri,
+        Url::from_file_path(expected).unwrap(),
+        "the definition must point at {}",
+        expected.display()
+    );
+}
+
+// ───────────────────────── the plain fallback ─────────────────────────
+
+#[tokio::test]
+async fn custom_directive_resolves_through_the_fallback() {
+    // The headline case: a directive registered only via `Blade::directive()`
+    // appears on no hardcoded list, so before #325 it resolved to nothing at
+    // all. With the fallback its first quoted argument is treated as a view
+    // name — no configuration required.
+    let root = tempfile::TempDir::new().unwrap();
+    let view = root.path().join("resources/views/dashboard.blade.php");
+    write(&view, VIEW_BODY);
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+
+    let link = resolve(&server, &directive_ref(CUSTOM, "('dashboard')")).await;
+    assert_targets(&link, &view);
+}
+
+#[tokio::test]
+async fn fallback_reports_the_whole_directive_as_the_origin_range() {
+    // The fallback builds its link with `create_location_link`, like every other
+    // view-directive branch — so the clickable range covers the whole directive,
+    // not just the quoted name. Pinning this is what makes the narrow-range
+    // assertions further down discriminating: the two ranges must differ, or
+    // those tests could not tell the branches apart.
+    let root = tempfile::TempDir::new().unwrap();
+    write(
+        &root.path().join("resources/views/dashboard.blade.php"),
+        VIEW_BODY,
+    );
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+
+    let dir = directive_ref(CUSTOM, "('dashboard')");
+    let link = resolve(&server, &dir).await;
+    let range = link.origin_selection_range.expect("origin range is set");
+
+    assert_eq!(range.start.character, dir.column);
+    assert_eq!(range.end.character, dir.end_column);
+    assert_ne!(
+        range.start.character, dir.string_column,
+        "the whole-directive range must be distinguishable from the string range"
+    );
+}
+
+#[tokio::test]
+async fn fallback_tries_every_resolve_candidate_not_just_the_first() {
+    // `resolve_view_path` returns one candidate per configured view root. A
+    // first-candidate-only fallback would resolve nothing here: the view exists
+    // ONLY under the second root. Mirrors the loop every other branch runs.
+    let root = tempfile::TempDir::new().unwrap();
+    let first_root = root.path().join("resources/views");
+    let second_root = root.path().join("modules/blog/views");
+
+    let view = second_root.join("dashboard.blade.php");
+    write(&view, VIEW_BODY);
+    assert!(
+        !first_root.join("dashboard.blade.php").exists(),
+        "precondition: the first candidate must be absent"
+    );
+
+    let server = test_server();
+    seed(
+        &server,
+        config(root.path(), vec![first_root, second_root], HashMap::new()),
+    )
+    .await;
+
+    let link = resolve(&server, &directive_ref(CUSTOM, "('dashboard')")).await;
+    assert_targets(&link, &view);
+}
+
+#[tokio::test]
+async fn out_of_root_fallback_target_returns_none() {
+    // The fallback is subject to the same containment guard as every other
+    // branch (issues #130/#148). A `loadViewsFrom(__DIR__ . '/../../etc', 'pkg')`
+    // -style namespace can point outside the project root; the target exists on
+    // disk, so only `path_within_root` can explain a `None`.
+    let root = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+    write(&outside.path().join("card.blade.php"), VIEW_BODY);
+
+    let mut namespaces = HashMap::new();
+    namespaces.insert("pkg".to_string(), outside.path().to_path_buf());
+
+    let server = test_server();
+    seed(
+        &server,
+        config(
+            root.path(),
+            vec![root.path().join("resources/views")],
+            namespaces,
+        ),
+    )
+    .await;
+
+    assert!(
+        server
+            .create_directive_location_from_salsa(&directive_ref(CUSTOM, "('pkg::card')"))
+            .await
+            .is_none(),
+        "an out-of-root fallback target must not resolve, even though it exists \
+         on disk — the containment guard refuses it"
+    );
+}
+
+#[tokio::test]
+async fn in_root_namespaced_fallback_target_still_resolves() {
+    // Positive control for the case above: the same namespace pointing INSIDE
+    // the root resolves normally, so the `None` there is the containment guard
+    // and not a namespace the fallback simply cannot handle.
+    let root = tempfile::TempDir::new().unwrap();
+    let namespace_dir = root.path().join("packages/pkg/resources/views");
+    let view = namespace_dir.join("card.blade.php");
+    write(&view, VIEW_BODY);
+
+    let mut namespaces = HashMap::new();
+    namespaces.insert("pkg".to_string(), namespace_dir);
+
+    let server = test_server();
+    seed(
+        &server,
+        config(
+            root.path(),
+            vec![root.path().join("resources/views")],
+            namespaces,
+        ),
+    )
+    .await;
+
+    let link = resolve(&server, &directive_ref(CUSTOM, "('pkg::card')")).await;
+    assert_targets(&link, &view);
+}
+
+// ───────────────────────────── the denylist ─────────────────────────────
+
+#[tokio::test]
+async fn denylisted_directive_does_not_resolve_through_the_fallback() {
+    // The reason the denylist exists: `@section('content')` names a *section*,
+    // and a project that also happens to have `views/content.blade.php` would
+    // otherwise get a confident jump to an unrelated file. The identical
+    // argument under a non-denylisted name resolves, which proves the config and
+    // the file on disk are wired — only the name decides the outcome.
+    let root = tempfile::TempDir::new().unwrap();
+    let view = root.path().join("resources/views/content.blade.php");
+    write(&view, VIEW_BODY);
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+
+    assert!(
+        server
+            .create_directive_location_from_salsa(&directive_ref("section", "('content')"))
+            .await
+            .is_none(),
+        "@section names a section, not a view — the denylist must refuse it \
+         even though resources/views/content.blade.php exists"
+    );
+
+    let link = resolve(&server, &directive_ref(CUSTOM, "('content')")).await;
+    assert_targets(&link, &view);
+}
+
+#[tokio::test]
+async fn section_name_directives_share_the_section_denylist_entry() {
+    // `@hasSection`/`@sectionMissing` take a section name with exactly the
+    // false-positive shape `@section` has, so they are denylisted alongside it.
+    // `@endsection` covers the closing-directive half of the list.
+    let root = tempfile::TempDir::new().unwrap();
+    write(
+        &root.path().join("resources/views/content.blade.php"),
+        VIEW_BODY,
+    );
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+
+    for name in [
+        "hasSection",
+        "sectionMissing",
+        "endsection",
+        "yield",
+        "stack",
+    ] {
+        assert!(
+            server
+                .create_directive_location_from_salsa(&directive_ref(name, "('content')"))
+                .await
+                .is_none(),
+            "@{name} takes a section/stack name, not a view — the denylist must refuse it"
+        );
+    }
+}
+
+// ─────────────────── dedicated handling always wins ───────────────────
+
+#[tokio::test]
+async fn dedicated_directive_that_fails_its_own_branch_returns_none() {
+    // The exclusion is keyed on `dir.name`, not on "nothing has resolved yet".
+    // `@feature` resolves against `app/Features/*.php`; the fallback's naive
+    // heuristic would guess `resources/views/unknown-flag.blade.php`, which is
+    // deliberately present here. A reachability-based gate would hand back that
+    // wrong file; a name-keyed gate returns `None`, exactly as before #325.
+    let root = tempfile::TempDir::new().unwrap();
+    write(
+        &root.path().join("resources/views/unknown-flag.blade.php"),
+        VIEW_BODY,
+    );
+    assert!(
+        !root.path().join("app/Features/UnknownFlag.php").exists(),
+        "precondition: the feature class must be absent so the dedicated branch fails"
+    );
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+    *server.root_path.write().await = Some(root.path().to_path_buf());
+
+    assert!(
+        server
+            .create_directive_location_from_salsa(&directive_ref("feature", "('unknown-flag')"))
+            .await
+            .is_none(),
+        "a dedicated-handled directive whose own branch finds nothing must still \
+         return None — it must never fall through into the fallback heuristic"
+    );
+}
+
+#[tokio::test]
+async fn successful_dedicated_resolution_keeps_its_narrow_string_range() {
+    // The other half of the guarantee above: when a dedicated branch *does*
+    // resolve, the link is still the one it built. `@livewire` and `@feature`
+    // both use `create_location_link_with_string_range`, so their origin range
+    // covers only the quoted name — narrower than the whole-directive range the
+    // fallback would have produced.
+    let root = tempfile::TempDir::new().unwrap();
+    write(
+        &root.path().join("resources/views/card.blade.php"),
+        VIEW_BODY,
+    );
+    write(
+        &root.path().join("app/Features/BillingPortal.php"),
+        "<?php class BillingPortal {}\n",
+    );
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+    *server.root_path.write().await = Some(root.path().to_path_buf());
+
+    for (name, args) in [("livewire", "('card')"), ("feature", "('billing-portal')")] {
+        let dir = directive_ref(name, args);
+        let link = resolve(&server, &dir).await;
+        let range = link.origin_selection_range.expect("origin range is set");
+
+        assert_eq!(
+            (range.start.character, range.end.character),
+            (dir.string_column, dir.string_end_column),
+            "@{name} must keep its own narrow string range — a whole-directive \
+             range would mean the fallback produced the link"
+        );
+    }
+}
+
+// ──────────────── the `blade.viewDirectives` escape hatch ────────────────
+
+#[tokio::test]
+async fn view_directives_first_arg_resolves_a_configured_name() {
+    // The escape hatch's basic contract: a name under `firstArg` resolves
+    // exactly like a hardcoded `view_directives_first_arg` entry. Denylisted
+    // here on purpose — see the override test below for why that matters.
+    let root = tempfile::TempDir::new().unwrap();
+    let view = root.path().join("resources/views/dashboard.blade.php");
+    write(&view, VIEW_BODY);
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+    set_view_directives(&server, &["myPanel"], &[]).await;
+
+    let link = resolve(&server, &directive_ref("myPanel", "('dashboard')")).await;
+    assert_targets(&link, &view);
+}
+
+#[tokio::test]
+async fn view_directives_first_arg_overrides_the_denylist() {
+    // The user's declaration outranks the fixed denylist — someone who really
+    // does render views through a `@section`-named directive can say so. Without
+    // the override the same call returns `None`, which is asserted in
+    // `denylisted_directive_does_not_resolve_through_the_fallback`; this test
+    // would pass on a dead-code override only if that one failed too.
+    let root = tempfile::TempDir::new().unwrap();
+    let view = root.path().join("resources/views/content.blade.php");
+    write(&view, VIEW_BODY);
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+
+    let dir = directive_ref("section", "('content')");
+    assert!(
+        server
+            .create_directive_location_from_salsa(&dir)
+            .await
+            .is_none(),
+        "precondition: unconfigured, the denylist refuses @section"
+    );
+
+    set_view_directives(&server, &["section"], &[]).await;
+
+    let link = resolve(&server, &dir).await;
+    assert_targets(&link, &view);
+}
+
+#[tokio::test]
+async fn view_directives_second_arg_resolves_the_second_argument() {
+    // Second-arg support must be real, not silently collapsed into a first-arg
+    // implementation. `@renderWhen($cond, 'partials.banner')` puts a boolean
+    // expression first, exactly like `@includeWhen`: a first-arg reading yields
+    // nothing, so only genuine second-arg handling can resolve this.
+    let root = tempfile::TempDir::new().unwrap();
+    let view = root
+        .path()
+        .join("resources/views/partials/banner.blade.php");
+    write(&view, VIEW_BODY);
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+
+    let dir = directive_ref("renderWhen", "($user->admin, 'partials.banner')");
+
+    // Configured as a FIRST-arg directive it must not resolve: the first
+    // argument is an expression, not a view name.
+    set_view_directives(&server, &["renderWhen"], &[]).await;
+    assert!(
+        server
+            .create_directive_location_from_salsa(&dir)
+            .await
+            .is_none(),
+        "a condition-first directive read as first-arg must resolve nothing"
+    );
+
+    set_view_directives(&server, &[], &["renderWhen"]).await;
+    let link = resolve(&server, &dir).await;
+    assert_targets(&link, &view);
+}
+
+#[tokio::test]
+async fn view_directives_never_override_dedicated_handling() {
+    // Collision rule: naming a dedicated-handled directive in `viewDirectives`
+    // is a no-op. Two halves, because a no-op has to be proved in both
+    // directions:
+    //   * `@feature` still fails closed when its own branch finds nothing, even
+    //     though the configured first-arg reading would have found the view;
+    //   * `@livewire` still resolves through its own branch, proved by the
+    //     narrow string range the configured path could not have produced.
+    let root = tempfile::TempDir::new().unwrap();
+    write(
+        &root.path().join("resources/views/card.blade.php"),
+        VIEW_BODY,
+    );
+    write(
+        &root.path().join("resources/views/unknown-flag.blade.php"),
+        VIEW_BODY,
+    );
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+    *server.root_path.write().await = Some(root.path().to_path_buf());
+    set_view_directives(&server, &["livewire", "feature", "include"], &[]).await;
+
+    assert!(
+        server
+            .create_directive_location_from_salsa(&directive_ref("feature", "('unknown-flag')"))
+            .await
+            .is_none(),
+        "configuring `feature` under viewDirectives must not change @feature — \
+         dedicated handling always wins"
+    );
+
+    let dir = directive_ref("livewire", "('card')");
+    let link = resolve(&server, &dir).await;
+    let range = link.origin_selection_range.expect("origin range is set");
+    assert_eq!(
+        (range.start.character, range.end.character),
+        (dir.string_column, dir.string_end_column),
+        "@livewire must still resolve through its own branch, keeping the narrow \
+         string range — the configured path would have reported the whole directive"
+    );
+}
+
+#[tokio::test]
+async fn view_directives_setting_parses_and_applies_without_a_restart() {
+    // The setting travels the same `update_settings` path `directiveSpacing`
+    // uses, which `initialize`, `did_change_configuration`, and the
+    // `workspace/configuration` pull all funnel into — so a later payload
+    // replaces the earlier one live. Also pins the documented JSON shape:
+    // `blade.viewDirectives.{firstArg,secondArg}`, both defaulting to empty.
+    let server = test_server();
+    assert_eq!(
+        *server.view_directives.read().await,
+        Default::default(),
+        "both lists default to empty"
+    );
+
+    set_view_directives(&server, &["myPanel"], &["myPanelWhen"]).await;
+    {
+        let applied = server.view_directives.read().await;
+        assert_eq!(applied.first_arg, vec!["myPanel".to_string()]);
+        assert_eq!(applied.second_arg, vec!["myPanelWhen".to_string()]);
+    }
+
+    // A payload that omits the block resets it — the same live-replacement
+    // semantics every other setting has.
+    let settings: LspSettings = serde_json::from_value(serde_json::json!({})).unwrap();
+    server.update_settings(&settings).await;
+    assert_eq!(
+        *server.view_directives.read().await,
+        Default::default(),
+        "an omitted viewDirectives block falls back to the empty default"
+    );
+}
+
+// ─────────────────────── diagnostics stay untouched ───────────────────────
+
+#[tokio::test]
+async fn fallback_resolved_directive_produces_no_missing_view_diagnostic() {
+    // The whole point of splitting the two consumers: a directive reachable only
+    // through the fallback or the `viewDirectives` setting must never raise a
+    // "View file not found" diagnostic, so a false squiggle on working code is
+    // impossible by construction. The diagnostic gate still admits exactly
+    // `@extends` and `@include` — including none of the *other* names goto has
+    // always resolved (`includeIf`, `includeWhen`, `each`, `component`).
+    for name in ["extends", "include"] {
+        assert!(
+            directive_takes_missing_view_diagnostic(name),
+            "@{name} must keep raising missing-view diagnostics"
+        );
+    }
+
+    for name in [
+        CUSTOM,
+        "myPanel",
+        "renderWhen",
+        "section",
+        "includeIf",
+        "includeWhen",
+        "includeUnless",
+        "each",
+        "component",
+        "livewire",
+        "includeFirst",
+    ] {
+        assert!(
+            !directive_takes_missing_view_diagnostic(name),
+            "@{name} must never raise a missing-view diagnostic — goto resolves \
+             far more names than diagnostics validate, and that asymmetry is the fix"
+        );
+    }
+}
+
+#[tokio::test]
+async fn fallback_ignores_a_directive_with_no_quoted_argument() {
+    // Fail closed on the shapes the reused extractor cannot read: a variable
+    // argument, an empty string, or no arguments at all yield no candidate and
+    // no link — never a guess. Multi-argument custom directives
+    // (`@renderPartial('dashboard', $data)`) are out of scope for #325, so the
+    // first-quoted-string reading of that form is asserted here as-is.
+    let root = tempfile::TempDir::new().unwrap();
+    let view = root.path().join("resources/views/dashboard.blade.php");
+    write(&view, VIEW_BODY);
+
+    let server = test_server();
+    seed(&server, simple_config(root.path())).await;
+
+    for args in ["($view)", "('')", "()"] {
+        let mut dir = directive_ref(CUSTOM, "('dashboard')");
+        dir.arguments = Some(args.to_string());
+        assert!(
+            server
+                .create_directive_location_from_salsa(&dir)
+                .await
+                .is_none(),
+            "args {args} carry no readable view name — the fallback must not guess"
+        );
+    }
+
+    // Documented current behaviour, unchanged by #325: the first quoted string
+    // wins and the trailing data argument is ignored.
+    let link = resolve(&server, &directive_ref(CUSTOM, "('dashboard', ['a' => 1])")).await;
+    assert_targets(&link, &view);
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -18,6 +18,7 @@ mod controllers_dir_containment;
 mod db_provider_init_idempotency;
 mod diagnostic_severity;
 mod directive_navigation_containment;
+mod directive_view_fallback;
 mod dynamic_where_sparseness;
 mod expected_path_diagnostic_containment;
 mod factory_goto_def_handler;


### PR DESCRIPTION
## Summary

View-directive goto-definition ran off two hardcoded lists, so a package registering its own view-rendering directive through `Blade::directive()` got no target at all — invisible to the feature despite the directive discovery that already scans for those registrations.

The fix is option 3 from the issue, with option 2 as the escape hatch. The two consumers are split by risk profile: a wrong goto costs one keystroke, a wrong "view does not exist" squiggle marks working code. `create_directive_location_from_salsa` gains a permissive fallback; `validate_and_publish_diagnostics` keeps its strict `extends`/`include` gate, now extracted as `directive_takes_missing_view_diagnostic` so the asymmetry is named and testable.

**Resolution order** in the fallback, checked in this order and only for a name with no dedicated branch:

1. `blade.viewDirectives.firstArg` — user-declared, first quoted argument.
2. `blade.viewDirectives.secondArg` — user-declared, second quoted argument (the `@includeWhen` shape).
3. `NON_VIEW_DIRECTIVES` denylist — refuse. Label and control-flow directives, so `@section('content')` never jumps to `resources/views/content.blade.php`.
4. Otherwise — treat the first quoted argument as a view name.

A resolved candidate then runs the same loop-every-candidate + `file_exists_cached` + `path_within_root` shape every other branch in the method already uses.

**The gate is keyed on `dir.name`, never on "nothing has resolved yet."** A reachability-based fallback would hand `@feature('unknown-flag')` the naively-guessed view file whenever its own branch found no feature class. The name-keyed gate returns `None`, exactly as before.

## New setting

```jsonc
"lsp": { "laravel-lsp": { "settings": { "blade": {
  "viewDirectives": {
    "firstArg":  ["renderPartial"],   // view name is argument 0
    "secondArg": ["renderWhen"]       // view name is argument 1, after a condition
  }
}}}}
```

Both lists default to empty. An entry outranks the denylist (a user may deliberately re-enable a denylisted name) but never outranks dedicated handling — naming `livewire` there is a no-op. Wired through the same `update_settings` path `directiveSpacing` uses, so it applies without a restart.

## Acceptance criteria

- [x] Fallback branch in `create_directive_location_from_salsa`, excluded by `dir.name` for `component`/`livewire`/`feature`/`includeFirst` and both hardcoded lists — never by reachability.
- [x] Test: a dedicated-handled directive whose own branch fails still returns `None` even with a file at the fallback's guessed path (`dedicated_directive_that_fails_its_own_branch_returns_none`); a *successful* `@livewire`/`@feature` still returns the branch's own narrow `origin_selection_range` (`successful_dedicated_resolution_keeps_its_narrow_string_range`).
- [x] Fixed denylist of built-in non-view directives, including `hasSection`/`sectionMissing`.
- [x] Fallback uses `extract_view_from_directive_args` + `config.resolve_view_path`, loops **every** candidate, gates on `file_exists_cached` and `path_within_root`, falls through to `None`.
- [x] Test: multi-view-root config where the target exists only under the second candidate (`fallback_tries_every_resolve_candidate_not_just_the_first`).
- [x] Scope boundary honoured — `extract_view_from_directive_args` is untouched; multi-argument custom directives keep its existing first-quoted-string behaviour (asserted in `fallback_ignores_a_directive_with_no_quoted_argument`).
- [x] `viewDirectives` under `BladeSettings`, `{firstArg, secondArg}` string arrays defaulting to empty, wired through `update_settings`.
- [x] Collision rule: a `viewDirectives` entry naming a dedicated-handled directive is a no-op (`view_directives_never_override_dedicated_handling`).
- [x] Test: `firstArg: ["section"]` makes `@section('content')` resolve despite the denylist (`view_directives_first_arg_overrides_the_denylist`).
- [x] Test: `secondArg` resolves the second quoted argument (`view_directives_second_arg_resolves_the_second_argument`).
- [x] Test: an unconfigured custom directive resolves via the plain fallback, asserting the resolved path (`custom_directive_resolves_through_the_fallback`).
- [x] Test: fallback containment — an out-of-root `pkg::card` never resolves (`out_of_root_fallback_target_returns_none`), with an in-root positive control.
- [x] Regression: `@section('content')` does not resolve when the guessed file exists (`denylisted_directive_does_not_resolve_through_the_fallback`).
- [x] `validate_and_publish_diagnostics` untouched — still only `extends`/`include` (`fallback_resolved_directive_produces_no_missing_view_diagnostic`).
- [x] `BladeDirectiveInfo` metadata (option 1) explicitly out of scope.
- [x] `cargo test -p laravel-lsp` passes; diff adds only new test functions.

## Commits

1. **feat** — the fallback, the denylist, the `viewDirectives` setting, 16 tests.
2. **refactor** — dispatch restructured as a single `match`, so a directive's handling and its exclusion from the fallback are the same arm. Behavior-preserving, net −57 lines.

The second commit closes a drift hazard the first one left open: the fallback's exclusion list was a hand-maintained copy of what the six `if` branches above already handled, with nothing enforcing the coupling. A seventh branch added without updating the list would have let that directive's failed resolution fall through into the heuristic — the exact bug class this issue exists to prevent — and no test would have caught it, because no test names a directive that does not exist yet. With `match`, arms do not fall through, so adding an arm excludes that name automatically. The invariant moved from discipline to the compiler.

The repeated candidate loop (`resolve_view_path` → `file_exists_cached` → `path_within_root`, every candidate) is extracted as `first_contained_view`. The #130/#148 containment guard now has one home instead of five.

## Test plan

`cargo test -p laravel-lsp` — **3,146 passed, 0 failed** (16 new). `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt` applied. The refactor changed no test.

Every guard was mutation-tested against the final code: eleven mutations applied one at a time, each confirmed to turn at least one test red.

| Mutation | Caught by |
|---|---|
| Delete the `@feature` arm — the exact drift the `match` prevents | `dedicated_directive_that_fails_its_own_branch_returns_none` + 2 |
| Delete the `@livewire` arm | `view_directives_never_override_dedicated_handling` + 1 |
| `@livewire` loses its narrow origin range | `successful_dedicated_resolution_keeps_its_narrow_string_range` + 1 |
| Drop the denylist check | `denylisted_directive_does_not_resolve_through_the_fallback` + 2 |
| Check the denylist *before* the user config | `view_directives_first_arg_overrides_the_denylist` |
| Read `secondArg` names with the first-arg extractor | `view_directives_second_arg_resolves_the_second_argument` |
| Take only the first `resolve_view_path` candidate | `fallback_tries_every_resolve_candidate_not_just_the_first` |
| Drop containment from `first_contained_view` | `out_of_root_fallback_target_returns_none` + **3 pre-existing #148 tests** |
| Widen the diagnostic gate by one name | `fallback_resolved_directive_produces_no_missing_view_diagnostic` |
| Drop the `viewDirectives` settings wiring | `view_directives_setting_parses_and_applies_without_a_restart` + 2 |
| Fallback builds its link with the narrow string range | `fallback_reports_the_whole_directive_as_the_origin_range` |

## Docs

`docs/go-to-definition.md` gains a third-party-directive section and an updated supported-pattern list; `docs/configuration.md` documents `viewDirectives`.

## Note

The issue body quotes the two lists as `first_arg = [..., "includeUnless", "each"]` / `second_arg = ["includeWhen"]`. That is stale — #329 moved `includeUnless` to the second-arg list. The implementation keys the exclusion on the arrays themselves, not on the issue's copy, so both names are correctly excluded.

Fixes #325
