### PR TITLE
feat: ✨ Correct .env classification docs and highlight inline comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,99 +376,43 @@ When working on this project:
 - Laravel VSCode extension (for feature reference): https://github.com/amiralizadeh9480/laravel-extra-intellisense
 
 ---
+## Session State (2026-08-26)
 
-## Session State (2026-02-08)
+### `.env` handling — settled
 
-### Last Session Summary
+Zed classifies **every** env file as Shell Script: bare `.env` via the bash
+grammar's `path_suffixes`, and `.env.*` variants via `"Shell Script": [".env.*"]`
+in Zed's own `assets/settings/default.json`. The extension therefore attaches to
+`.env` through the single `"Shell Script"` entry in `extension.toml`, and the LSP
+dispatches env features on **filename** (`main.rs` `is_env` / `is_env_file`), not
+on Zed's language classification.
 
-**Focus**: Investigating whether to remove the bundled Blade language definition and rely on the separate Blade Zed extension, per Zed reviewer feedback. Explored Option C (LSP semantic tokens) in depth and found it's not viable yet.
+Consequences, all verified against primary sources:
 
-### Context: Zed Reviewer Feedback
+- **No language definition is shipped for `.env`, and none should be.** An
+  extension language could tie-and-win bare `.env` (bash offers `".env"`), but
+  the `.env.*` variants sit at the `UserConfigured` tier that only a user's own
+  `file_types` can override. Shipping one would fix `.env` and leave
+  `.env.local` shell-linted — a split worse than the uniform status quo.
+- **`zarifpour/zed-env` is not recommended, but the `"env"` attach entry stays.**
+  Its `path_suffixes` are a bare `"env"` (loses the length tie to `".env"`), so
+  it never claims the files it appears to; and its bare `"conf"` / `"example"` /
+  `"local"` / `"test"` entries reclassify unrelated files project-wide (e.g.
+  `laravel/sail`'s `supervisord.conf`). The docs argue against remapping — but
+  arguing against a path is not the same as breaking it. `extension.toml` keeps
+  `"env"` in its `languages` list so a user who wants a purpose-built dotenv
+  grammar does not thereby lose this extension's `.env` features. Docs express
+  a recommendation; the manifest expresses a capability. Don't conflate them.
+- **SC2034 noise is silenced automatically** in Laravel worktrees via the
+  extension's additional-workspace-configuration hook (`src/lib.rs`). A user's
+  own `bashIde.shellcheckArguments` containing `SC2034` short-circuits the
+  injection and passes through untouched.
 
-The Zed extension reviewer asked why this extension bundles its own Blade language definition when the existing Blade extension (`bajrangCoder/zed-laravel-blade`) already provides one. The reviewer suggested users could disable the Blade extension's language servers and use `laravel-lsp` instead.
+### Blade language definition — still open
 
-### Branch: `experiment/remove-blade-language`
-
-**What was done:**
-- Deleted `languages/blade/` (config.toml, highlights.scm, brackets.scm, indents.scm, injections.scm)
-- Deleted `languages/php_only/` (config.toml, highlights.scm)
-- Removed `[grammars.blade]` and `[grammars.php_only]` from `extension.toml`
-- Removed empty `languages/` directory
-- Updated README: replaced "Blade Language Support" section, updated project structure, added note about separate Blade extension
-- Changed LSP semantic token type from `KEYWORD` to `FUNCTION` in `main.rs` (so directive highlighting matches our `@function` tree-sitter capture)
-- Build passes, all 190 tests pass
-
-**What was NOT changed:**
-- `extension.toml` still lists `languages = ["PHP", "Blade", "XML", "Shell Script"]` for the LSP (correct — this just activates the LSP for those file types, doesn't own the language)
-- All LSP code (build.rs, parser.rs, queries.rs, etc.) still uses tree-sitter-blade internally for parsing
-
-### Key Findings
-
-1. **Zed does NOT support augmenting a language from another extension** — you either own the full language definition or you don't. No partial overrides. Community has requested this but it's not implemented.
-
-2. **Providing `languages/blade/` with .scm files but no `config.toml` errors** — Zed requires `config.toml` when it finds the directory.
-
-3. **Providing `config.toml` without grammar declarations works** — Zed resolves the `blade` grammar from the other Blade extension. BUT this takes full ownership of the language definition, replacing (not augmenting) the other extension's .scm files.
-
-4. **A file can only belong to ONE language in Zed** — creating a separate language name (e.g., "laravel-blade") doesn't work because the Blade extension's language servers are registered for "Blade", not the custom name.
-
-5. **The Blade extension (`bajrangCoder/zed-laravel-blade`) provides:**
-   - Language definition: config.toml, highlights.scm, brackets.scm, indents.scm, injections.scm, outline.scm, overrides.scm
-   - Grammars: tree-sitter-blade, tree-sitter-php (php_only)
-   - Language servers: emmet, intelephense, phptools, phpactor (all PHP LSPs wired to Blade files)
-   - No custom Blade LSP of its own
-   - Cloned to `/Users/mike/Developer/zed-laravel-blade` and installed as dev extension for testing
-
-6. **Semantic tokens (Option C) NOT viable yet:**
-   - Zed PR #46356 "editor: Implement semantic highlighting" merged to `main` on Feb 4, 2026
-   - But it has NOT been released in any build — not in stable (0.222.4) nor preview (0.223.2)
-   - The `semantic_tokens` setting, `lsp: restart language servers` command, and `dev: open highlights tree view` command do not exist in current Zed builds
-   - The documentation at https://zed.dev/docs/semantic-tokens is published ahead of the actual release
-   - Once released, users would need `"semantic_tokens": "combined"` in their Blade language settings
-   - The LSP already sends `FUNCTION` tokens for directives (changed from `KEYWORD` this session)
-
-### Detailed Feature Comparison (Our Extension vs Blade Extension)
-
-**Losses from removing our language files:**
-
-| Category | Impact | Details |
-|---|---|---|
-| **Directive highlighting** | **Significant** | Our `@function` (blue) vs their `@tag` (cyan) — directives become visually indistinguishable from HTML tags |
-| **Blade bracket pairs** | **Moderate** | `{{ }}`, `{!! !!}`, `{{-- --}}` bracket matching/pairing lost — they don't define these in config.toml |
-| **`{` auto-close** | **Minor** | We set `close = false` (LSP handles snippets), they set `close = true` |
-| **Hyphenated word selection** | **Minor** | We define `word_characters = ["-"]` on root + `element` + `string` overrides; they only define it on `string` |
-
-**No loss:**
-- Indentation (`indents.scm`) — identical files
-- Injections (`injections.scm`) — identical files
-- Bracket queries (`brackets.scm`) — identical files
-- `php_only` language — identical highlights and config (whitespace-only diff)
-
-**Features gained from Blade extension:**
-- `outline.scm` — comments in symbol outline panel
-- `overrides.scm` — TailwindCSS completions in attribute values
-- `wrap_characters` — HTML tag wrapping support
-
-### Network Issue (Resolved)
-
-- **Proxyman Guard** network extension was still active on macOS despite the app being uninstalled, causing connection timeouts to `api.zed.dev` and `zed-extensions.nyc3.digitaloceanspaces.com`
-- Disabled via System Settings > General > Login Items & Extensions > Network Extensions
-- `api.zed.dev` works after disabling Proxyman; DigitalOcean Spaces still has ISP-level routing issues (Lumen NYC edge router drops packets to DO's NYC3 region)
-- Workaround: `/etc/hosts` entry for `api.zed.dev` pointing to working Cloudflare IP `172.66.165.132` (can be removed when ISP routing resolves)
-- Blade extension installed as dev extension from `/Users/mike/Developer/zed-laravel-blade` to bypass download
-
-### Remaining Options
-
-1. **Option A: Contribute upstream** — PR our highlighting improvements (`@function` for directives, bracket pair definitions, `word_characters` config) to `bajrangCoder/zed-laravel-blade`. Cleanest long-term solution.
-2. **Option B: Keep owning the language definition without grammars** — Provide `languages/blade/` with our `.scm` files + `config.toml` but no `[grammars.*]` in `extension.toml`. Grammar resolves from Blade extension. Addresses reviewer's duplicate grammar concern but still duplicates language definition.
-3. **Option C: Wait for semantic tokens** — Once Zed ships the feature (PR #46356), the LSP's `FUNCTION` tokens will overlay directive highlighting. Doesn't solve bracket pairs or config differences. Can be combined with A or B later.
-
-### Current Status
-
-- Branch: `experiment/remove-blade-language`
-- Build: **Passing**
-- Tests: **190 tests passing**
-- Uncommitted changes: language files deleted, README updated, extension.toml grammar refs removed, LSP semantic token type changed to FUNCTION
-- Blade extension cloned to `/Users/mike/Developer/zed-laravel-blade` and installed as dev extension
-- Zed settings reverted (removed `semantic_tokens: "combined"` that was added for testing)
-- Decision pending on which option (A, B, or C) to pursue
+The `experiment/remove-blade-language` investigation (options A/B/C: contribute
+upstream to `bajrangCoder/zed-laravel-blade`, own the language definition without
+bundling grammars, or wait for semantic tokens) has **not** been decided. Note
+that Zed has since shipped semantic highlighting, so the `semantic_tokens`
+setting referenced by option C now exists and is documented in
+`docs/configuration.md` for Blade.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,6 +155,15 @@ Everything goes in your Zed `settings.json`. Zed settings are JSONC, so the inli
       // (e.g. a @money($x) Blade::directive). Requires Zed semantic-token
       // support; "combined" overlays them on the Blade extension's colors.
       "semantic_tokens": "combined"
+    },
+    "Shell Script": {
+      // Zed classifies .env (and .env.*) as Shell Script, so the bash grammar
+      // highlights it — and bash treats a mid-word "#" as literal text, while
+      // dotenv treats it as the start of an inline comment. Turning semantic
+      // tokens on lets us paint those comments correctly. Zed defaults this to
+      // "off", so the fix is invisible without this line. Guide:
+      // docs/environment.md.                                  Default: "off"
+      "semantic_tokens": "combined"
     }
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,30 @@ Everything goes in your Zed `settings.json`. Zed settings are JSONC, so the inli
           ]
         }
       }
+    },
+
+    // Tailwind completions inside Blade. The Tailwind server only offers
+    // completions in languages it knows, and only inside attributes it's told
+    // to treat as class lists — neither covers Blade out of the box. This block
+    // fixes both. It only takes effect once the server actually attaches, so
+    // also add "tailwindcss-language-server" to the Blade `language_servers`
+    // list further down (it is NOT in the list shown there — that list is the
+    // minimum this extension needs). Nothing here is required by this
+    // extension; skip the whole block if you don't use Tailwind.
+    "tailwindcss-language-server": {
+      "settings": {
+        // Parse Blade (and PHP) as HTML so the server offers completions there.
+        "includeLanguages": { "Blade": "html", "PHP": "html" },
+        // Attributes treated as class lists. Beyond plain `class`: Blade's
+        // @class([...]) directive, Alpine's :class / x-bind:class, and
+        // Livewire's wire:class.
+        "classAttributes": ["class", "@class", ":class", "wire:class", "x-bind:class"],
+        "experimental": {
+          // Completions inside any *:class="…" attribute the list above misses
+          // (e.g. x-transition:class, or a custom wire:*:class).
+          "classRegex": ["\\w?:class=\"([^\"]*)"]
+        }
+      }
     }
   },
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -100,9 +100,16 @@ Map `.env` files to a non-shell language in `settings.json`. A `.env` is `KEY=va
 }
 ```
 
-Install the Ini extension (`zed: extensions`, search "INI") if you don't already have it. To avoid any extra install, map to the built-in **Plain Text** instead — the warnings disappear, but `.env` renders without highlighting. There's also a dedicated [env extension](https://github.com/zarifpour/zed-env) with a purpose-built dotenv grammar (keys, values, booleans, URLs, `${interpolations}`) — map to `"env"` after installing it.
+Install the Ini extension (`zed: extensions`, search "INI") if you don't already have it. To avoid any extra install, map to the built-in **Plain Text** instead — the warnings disappear, but `.env` renders without highlighting.
 
-> Heads-up: this extension's `.env` features (reference-count lens, hover, go-to) attach to the **Shell Script** and **env** languages. Remapping to Ini or Plain Text detaches them.
+> ⚠️ **This detaches our `.env` features.** The reference-count lens, hover, and go-to attach to the **Shell Script** language — Zed's default classification for `.env` and every `.env.*` variant. Remap to Ini or Plain Text and you trade shellcheck noise for losing them. Since v0.7.2 silences that noise automatically, approach 4 is now rarely the right trade.
+
+### A note on dedicated dotenv extensions
+
+[`zarifpour/zed-env`](https://github.com/zarifpour/zed-env) ships a purpose-built dotenv grammar and looks like the obvious answer. It isn't — for two reasons worth knowing before you install it:
+
+- **It does not claim your `.env` files.** Its `path_suffixes` list a bare `"env"`, which loses the length tie to Shell Script's `".env"`; the `.env.*` variants are claimed by Zed's own default settings at a tier the extension can't reach. Installing it changes nothing about `.env` unless you *also* write a `file_types` line — and that line works with or without the extension. This is the extension's own [issue #5](https://github.com/zarifpour/zed-env/issues/5), still open.
+- **It reclassifies files you didn't ask it to.** Those same `path_suffixes` include bare `"conf"`, `"example"`, `"local"`, and `"test"`, which match *any* otherwise-unclaimed file ending in them. In a stock Laravel app that captures `laravel/sail`'s `supervisord.conf` files, and it will keep reaching across every project you open.
 
 ## Per-project
 
@@ -111,4 +118,4 @@ Any of the `settings.json` blocks above also work in `.zed/settings.json` at the
 ## What the extension can — and can't — do for you
 
 - **Can (and does):** configure the bash language server. Zed lets one extension contribute *additional workspace configuration* to another server, merged into that server's own config — that's how the automatic fix above is delivered, and why it works even on Zed versions that drop your own `bash-language-server` settings.
-- **Can't:** change how Zed classifies files. The extension manifest has no `file_types` field, and Zed's default settings claim `.env*` for Shell Script at a tier only *your* `file_types` setting can override. That's why approach 4 is one line in your config, not something the extension ships.
+- **Can't:** change how Zed classifies files. The extension manifest has no `file_types` field, so the only lever an extension has is a language of its own with matching `path_suffixes` — and that lever reaches exactly half the problem. Bare `.env` is claimed by the bash grammar's `path_suffixes`, which an extension language could tie and win; the `.env.*` variants are claimed by Zed's *default settings*, a tier no extension can reach and only *your* `file_types` can override. Shipping a language would therefore fix `.env` and leave `.env.local` shell-linted — a split we'd rather not hand you. That's why approach 4 is one line in your config, and why this extension attaches to Shell Script instead of trying to replace it.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -111,6 +111,34 @@ Install the Ini extension (`zed: extensions`, search "INI") if you don't already
 - **It does not claim your `.env` files.** Its `path_suffixes` list a bare `"env"`, which loses the length tie to Shell Script's `".env"`; the `.env.*` variants are claimed by Zed's own default settings at a tier the extension can't reach. Installing it changes nothing about `.env` unless you *also* write a `file_types` line — and that line works with or without the extension. This is the extension's own [issue #5](https://github.com/zarifpour/zed-env/issues/5), still open.
 - **It reclassifies files you didn't ask it to.** Those same `path_suffixes` include bare `"conf"`, `"example"`, `"local"`, and `"test"`, which match *any* otherwise-unclaimed file ending in them. In a stock Laravel app that captures `laravel/sail`'s `supervisord.conf` files, and it will keep reaching across every project you open.
 
+## 💬 Inline comments
+
+Inline comments are standard dotenv syntax — `vlucas/phpdotenv` (what Laravel runs), `motdotla/dotenv`, `bkeepers/dotenv`, and `python-dotenv` all support them, and all agree that inside an **unquoted** value a `#` starts a comment with no preceding space required:
+
+```dotenv
+APP_NAME=Laravel        # this is a comment
+SECRET="has#a#hash"     # quoted, so the hashes are part of the value
+DB_PASSWORD=p@ss#word   # the value here is p@ss — NOT p@ss#word
+```
+
+**To keep a literal `#` in a value, quote it.** That is the documented remedy in every implementation, not a workaround.
+
+Because Zed highlights `.env` with the bash grammar, and bash treats a mid-word `#` as ordinary text, the third line above renders as though `#word` were part of the value. The value colouring is misleading; Laravel still reads `p@ss`. Comments written the idiomatic way — with a space before the `#` — highlight correctly.
+
+The extension corrects this via LSP semantic tokens, which Zed leaves **off** by default. To turn it on:
+
+```json
+{
+  "languages": {
+    "Shell Script": {
+      "semantic_tokens": "combined"
+    }
+  }
+}
+```
+
+`"combined"` overlays our tokens on the bash grammar's colours rather than replacing them. Without it the highlighting is cosmetic-only and everything above still parses the same way at runtime.
+
 ## Per-project
 
 Any of the `settings.json` blocks above also work in `.zed/settings.json` at the project root, scoping the change to one project instead of all of Zed. (The `.shellcheckrc` approach is already project-scoped by nature.)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,7 +14,7 @@ The extension is built against `zed_extension_api 0.7.0`, which requires **Zed 0
 
 ## 2. Does Zed recognize the file as PHP / Blade?
 
-The language server only attaches to files Zed has classified as **PHP**, **Blade**, **XML**, or `.env` (**Shell Script** by Zed's default, or **env** if you've remapped `.env` files to the [env extension](https://github.com/zarifpour/zed-env) via `file_types`). Open a `.php` file and check the **bottom-right status bar**:
+The language server only attaches to files Zed has classified as **PHP**, **Blade**, **XML**, or **Shell Script** — the last being Zed's default classification for `.env` and every `.env.*` variant. If you've remapped `.env` to another language via `file_types`, the server no longer attaches there; see [Environment files](environment.md). Open a `.php` file and check the **bottom-right status bar**:
 
 - Says **"PHP"** → good, the language is registered.
 - Says **"Plain Text"** → install the official [**PHP**](https://github.com/zed-extensions/php) extension (and [**Laravel Blade**](https://github.com/bajrangCoder/zed-laravel-blade) for `.blade.php`). Without a language registered, no language server — ours included — can attach.

--- a/extension.toml
+++ b/extension.toml
@@ -14,6 +14,16 @@ version = "0.7.2"
 # Short form: this is Zed's compact status-bar / language-server-list slot.
 name = "Laravel CE"
 # XML: for phpunit.xml env var autocomplete
-# Shell Script: Zed treats .env files as Shell Script (see bash/config.toml path_suffixes)
-# env: .env files remapped to the "env" extension's language via a user file_types setting
+# Shell Script: Zed classifies every env file as Shell Script — bare `.env` via
+# bash/config.toml `path_suffixes`, and `.env.*` variants via the
+# `"Shell Script": [".env.*"]` entry in Zed's own default settings. One entry
+# therefore attaches the server to `.env` and every variant alike, with no
+# user configuration.
+# env: the language name registered by dotenv extensions such as
+# zarifpour/zed-env. Inert on a default install — it only matters once a user
+# has installed such an extension AND remapped `.env` via `file_types`.
+# docs/environment.md argues against doing that, but arguing against a path is
+# not the same as breaking it: a user who wants a purpose-built dotenv grammar
+# should not thereby lose this extension's `.env` features. The LSP dispatches
+# env features on filename, not language, so attaching is all that is required.
 languages = ["PHP", "Blade", "XML", "Shell Script", "env"]

--- a/laravel-lsp/src/env_comment_tokens.rs
+++ b/laravel-lsp/src/env_comment_tokens.rs
@@ -1,0 +1,155 @@
+//! Inline-comment semantic tokens for `.env` files.
+//!
+//! Zed classifies every env file as **Shell Script** and highlights it with the
+//! bash grammar (see `docs/environment.md`). That is the right trade overall,
+//! but bash and dotenv disagree about one thing: where an inline comment starts.
+//!
+//! Inline comments are standard dotenv syntax — `vlucas/phpdotenv` (Laravel),
+//! `motdotla/dotenv`, `bkeepers/dotenv`, and `python-dotenv` all support them,
+//! and all agree that in an **unquoted** value a `#` begins a comment with no
+//! preceding whitespace required. Bash follows shell rules, where `#` mid-word
+//! is literal, so it paints those comments as part of the value:
+//!
+//! | Line | bash | dotenv (and this module) |
+//! |---|---|---|
+//! | `A=unquoted #spaced`   | value + comment ✅ | value + comment |
+//! | `B="quoted" #after`    | value + comment ✅ | value + comment |
+//! | `C="quoted#inside"`    | all value ✅       | all value |
+//! | `D=unquoted#nospace`   | **all value** ❌   | value + comment |
+//! | `E=#immediate`         | **all value** ❌   | empty value + comment |
+//! | `F=value# trailing`    | **all value** ❌   | value + comment |
+//!
+//! With `"semantic_tokens": "combined"` the `COMMENT` tokens emitted here
+//! overlay bash's colours, correcting the three broken rows. The three rows
+//! bash already gets right are emitted too — painting a comment as a comment is
+//! idempotent, and re-deriving them from one state machine is less code and
+//! fewer edges than special-casing which ones to skip.
+//!
+//! The state machine mirrors `EntryParser::processToken()` in phpdotenv, which
+//! is what Laravel actually runs. Deviating from it would mean colouring a
+//! value differently from how the framework reads it.
+//!
+//! Positions are 0-based and columns are **byte** offsets from the line start,
+//! matching the rest of the LSP's token handling. Iteration is over
+//! `char_indices`, so a multi-byte value never yields an offset that splits a
+//! character.
+
+use tower_lsp::lsp_types::SemanticToken;
+
+/// Where the parser is within a value, mirroring phpdotenv's states.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum State {
+    /// Immediately after `=`, before any value character.
+    Initial,
+    /// Inside a bare (unquoted) value.
+    Unquoted,
+    /// Inside `'…'`. phpdotenv applies no escapes here — only `'` closes it.
+    SingleQuoted,
+    /// Inside `"…"`.
+    DoubleQuoted,
+    /// The character after a `\` inside `"…"`, consumed literally.
+    Escape,
+    /// After a closing quote, where only whitespace or a comment may follow.
+    Whitespace,
+}
+
+/// Byte offset of the `#` that begins an inline comment in `line`, if any.
+///
+/// Returns `None` when the line has no value-level comment: a blank line, a
+/// whole-line comment (bash already colours those correctly, and they carry no
+/// `=` to split on), a line with no `=` at all, or a value whose `#` characters
+/// are all inside quotes.
+///
+/// The offset is relative to the start of `line`.
+pub fn inline_comment_start(line: &str) -> Option<usize> {
+    // A whole-line comment is not a *value* comment. Checked before the `=`
+    // scan below, because a comment may itself contain an `=`
+    // (`# set FOO=bar to enable`) and must not be read as an assignment.
+    let trimmed_start = line.len() - line.trim_start().len();
+    if line.trim_start().starts_with('#') || line.trim().is_empty() {
+        return None;
+    }
+
+    // The value begins after the first `=`. phpdotenv splits on the first one,
+    // so `KEY=a=b` has the value `a=b`. Anything before it (whitespace, an
+    // `export ` prefix, the name) cannot contain a comment.
+    let eq = line[trimmed_start..].find('=')? + trimmed_start;
+    let value_start = eq + 1;
+
+    let mut state = State::Initial;
+    for (offset, ch) in line[value_start..].char_indices() {
+        let abs = value_start + offset;
+        state = match state {
+            State::Initial => match ch {
+                '\'' => State::SingleQuoted,
+                '"' => State::DoubleQuoted,
+                '#' => return Some(abs),
+                _ => State::Unquoted,
+            },
+            State::Unquoted => match ch {
+                '#' => return Some(abs),
+                c if c.is_whitespace() => State::Whitespace,
+                _ => State::Unquoted,
+            },
+            State::SingleQuoted => {
+                if ch == '\'' {
+                    State::Whitespace
+                } else {
+                    State::SingleQuoted
+                }
+            }
+            State::DoubleQuoted => match ch {
+                '"' => State::Whitespace,
+                '\\' => State::Escape,
+                _ => State::DoubleQuoted,
+            },
+            // Whatever follows a backslash is consumed as part of the value,
+            // including a `"` that would otherwise close the string.
+            State::Escape => State::DoubleQuoted,
+            State::Whitespace => match ch {
+                '#' => return Some(abs),
+                c if c.is_whitespace() => State::Whitespace,
+                // Trailing junk after a closing quote is a phpdotenv parse
+                // error. It is not our job to report it, and we cannot know
+                // where a comment would have started, so stop scanning.
+                _ => return None,
+            },
+        };
+    }
+
+    None
+}
+
+/// LSP semantic tokens marking every inline comment in an env-file buffer.
+///
+/// One `COMMENT` token per line that has a value-level comment, spanning the
+/// `#` through end of line.
+pub fn extract_env_comment_tokens(content: &str) -> Vec<SemanticToken> {
+    let mut tokens = Vec::new();
+    let mut prev_line: u32 = 0;
+
+    for (index, line) in content.lines().enumerate() {
+        let Some(start) = inline_comment_start(line) else {
+            continue;
+        };
+        let line_no = index as u32;
+        let col = start as u32;
+
+        tokens.push(SemanticToken {
+            delta_line: line_no - prev_line,
+            // Every token here is the last on its line, so a same-line
+            // predecessor is impossible and `delta_start` is always absolute.
+            delta_start: col,
+            length: (line.len() - start) as u32,
+            token_type: 1, // COMMENT (index 1 in the server legend)
+            token_modifiers_bitset: 0,
+        });
+
+        prev_line = line_no;
+    }
+
+    tokens
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/env_comment_tokens/tests.rs
+++ b/laravel-lsp/src/env_comment_tokens/tests.rs
@@ -1,0 +1,241 @@
+//! Tests for inline-comment detection in `.env` files.
+//!
+//! The expectations are not invented: each asserts the boundary
+//! `vlucas/phpdotenv`'s `EntryParser::processToken()` produces, which is what
+//! Laravel actually reads at runtime.
+
+use super::{extract_env_comment_tokens, inline_comment_start};
+
+/// Offset of `#` in a line, for readable expectations.
+fn hash_at(line: &str) -> usize {
+    line.find('#').expect("test line must contain a #")
+}
+
+// ── The three shapes bash gets wrong ────────────────────────────────────────
+
+#[test]
+fn unquoted_hash_without_space_starts_a_comment() {
+    let line = "A=unquoted#nospace";
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+#[test]
+fn hash_immediately_after_equals_starts_a_comment() {
+    let line = "E=#immediate";
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+#[test]
+fn hash_then_space_after_unquoted_value_starts_a_comment() {
+    let line = "F=value# trailing";
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+// ── The shapes bash already gets right; we must agree, not differ ───────────
+
+#[test]
+fn unquoted_value_then_spaced_hash_starts_a_comment() {
+    let line = "A=unquoted #spaced";
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+#[test]
+fn comment_after_closing_double_quote_is_found() {
+    let line = "B=\"quoted\" #after";
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+#[test]
+fn comment_after_closing_single_quote_is_found() {
+    let line = "B='quoted' #after";
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+// ── Quoted values: a `#` inside quotes is value data, never a comment ───────
+
+#[test]
+fn hash_inside_double_quotes_is_not_a_comment() {
+    assert_eq!(inline_comment_start("C=\"quoted#inside\""), None);
+}
+
+#[test]
+fn hash_inside_single_quotes_is_not_a_comment() {
+    assert_eq!(inline_comment_start("C='quoted#inside'"), None);
+}
+
+#[test]
+fn hash_inside_double_quotes_with_later_comment_finds_only_the_comment() {
+    let line = "C=\"has#hash\" #real";
+    // The second `#` — the one outside the quotes.
+    let expected = line.rfind('#').unwrap();
+    assert_eq!(inline_comment_start(line), Some(expected));
+}
+
+#[test]
+fn escaped_quote_does_not_close_the_string_early() {
+    // The `#` sits immediately after the escaped quote. If `\"` were treated as
+    // closing the string, the very next character would be read in the
+    // post-quote state and the `#` reported as a comment. It is not: `\"` is
+    // value data, so the `#` is still inside the quotes.
+    assert_eq!(inline_comment_start(r##"C="a\"#b""##), None);
+}
+
+#[test]
+fn comment_after_a_string_containing_an_escaped_quote_is_still_found() {
+    // The mirror of the above: once the *real* closing quote arrives, a
+    // following `#` is a comment. Mishandling `\"` ends the string early and
+    // loses this comment entirely.
+    let line = r##"C="a\"b" #tag"##;
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+#[test]
+fn backslash_in_single_quotes_is_literal_and_does_not_escape() {
+    // phpdotenv applies no escapes inside single quotes: only `'` closes them,
+    // so the `'` here closes and the `#` that follows is a comment.
+    let line = r"C='ends\' #after";
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+// ── Non-assignment lines ────────────────────────────────────────────────────
+
+#[test]
+fn whole_line_comment_is_not_a_value_comment() {
+    assert_eq!(inline_comment_start("# just a comment"), None);
+}
+
+#[test]
+fn indented_whole_line_comment_is_not_a_value_comment() {
+    assert_eq!(inline_comment_start("   # indented comment"), None);
+}
+
+#[test]
+fn whole_line_comment_containing_equals_is_not_parsed_as_an_assignment() {
+    // Guards the ordering inside `inline_comment_start`: the whole-line-comment
+    // check must run before the `=` scan, or this line is read as an assignment
+    // whose value contains no `#` after the `=`.
+    assert_eq!(inline_comment_start("# set FOO=bar#baz to enable"), None);
+}
+
+#[test]
+fn blank_line_has_no_comment() {
+    assert_eq!(inline_comment_start(""), None);
+    assert_eq!(inline_comment_start("    "), None);
+}
+
+#[test]
+fn line_without_equals_has_no_value_comment() {
+    assert_eq!(inline_comment_start("NOT_AN_ASSIGNMENT"), None);
+}
+
+// ── Value shapes that must not be mistaken for comments ─────────────────────
+
+#[test]
+fn value_with_no_hash_has_no_comment() {
+    assert_eq!(inline_comment_start("APP_NAME=Laravel"), None);
+}
+
+#[test]
+fn empty_value_has_no_comment() {
+    assert_eq!(inline_comment_start("DB_PASSWORD="), None);
+}
+
+#[test]
+fn export_prefix_does_not_shift_the_comment_offset() {
+    let line = "export MAIL_MAILER=smtp#tag";
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+#[test]
+fn first_equals_splits_the_value_so_a_later_equals_is_value_data() {
+    // Base64 app keys end in `=` padding; the comment must still be found.
+    let line = "APP_KEY=base64:AAAA==#tag";
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+#[test]
+fn interpolated_value_then_comment_is_found() {
+    let line = "ASSET_URL=${APP_URL}/assets #cdn";
+    assert_eq!(inline_comment_start(line), Some(hash_at(line)));
+}
+
+#[test]
+fn junk_after_a_closing_quote_stops_the_scan() {
+    // phpdotenv rejects this line outright ("unexpected whitespace"); we return
+    // None rather than guess where a comment would have begun.
+    assert_eq!(inline_comment_start("C=\"quoted\" junk #after"), None);
+}
+
+// ── Byte-offset safety ──────────────────────────────────────────────────────
+
+#[test]
+fn multibyte_value_yields_a_char_boundary_offset() {
+    let line = "GREETING=héllo→wörld#tag";
+    let start = inline_comment_start(line).expect("comment found");
+    assert!(
+        line.is_char_boundary(start),
+        "offset {start} splits a character"
+    );
+    assert_eq!(&line[start..], "#tag");
+}
+
+#[test]
+fn multibyte_inside_quotes_does_not_shift_a_later_comment() {
+    let line = "GREETING=\"héllo→wörld\" #tag";
+    let start = inline_comment_start(line).expect("comment found");
+    assert!(line.is_char_boundary(start));
+    assert_eq!(&line[start..], "#tag");
+}
+
+// ── Token emission ──────────────────────────────────────────────────────────
+
+#[test]
+fn tokens_use_comment_type_and_span_to_end_of_line() {
+    let tokens = extract_env_comment_tokens("A=value#tag\n");
+    assert_eq!(tokens.len(), 1);
+    let t = &tokens[0];
+    assert_eq!(t.token_type, 1, "must be COMMENT (legend index 1)");
+    assert_eq!(t.delta_line, 0);
+    assert_eq!(t.delta_start, 7, "byte offset of the #");
+    assert_eq!(t.length, 4, "#tag");
+}
+
+#[test]
+fn delta_lines_are_relative_to_the_previous_emitted_token() {
+    // Comments sit on lines 1 and 4; lines 0, 2 and 3 carry none. Neither
+    // commented line is line 0 — that matters: with the first comment on line
+    // 0, `line_no - prev_line` and a plain `line_no` produce identical output
+    // and the test could not tell a relative encoding from an absolute one.
+    let content = concat!(
+        "# header\n",            // line 0 — whole-line comment, not emitted
+        "A=one#first\n",         // line 1 — emitted, delta 1 from line 0
+        "B=plain\n",             // line 2
+        "C=\"quoted#inside\"\n", // line 3 — hash is inside quotes
+        "D=two#second\n",        // line 4 — emitted, delta 3 from line 1
+    );
+    let tokens = extract_env_comment_tokens(content);
+    assert_eq!(tokens.len(), 2, "only the two real comments");
+    assert_eq!(tokens[0].delta_line, 1, "line 1, relative to the 0 origin");
+    assert_eq!(
+        tokens[1].delta_line, 3,
+        "line 4 minus the previous token's line 1 — not the absolute 4"
+    );
+}
+
+#[test]
+fn buffer_with_no_inline_comments_emits_nothing() {
+    let content = "# header\nAPP_NAME=Laravel\nAPP_DEBUG=true\nQ=\"has#hash\"\n";
+    assert!(extract_env_comment_tokens(content).is_empty());
+}
+
+#[test]
+fn token_length_counts_bytes_not_characters() {
+    // A multi-byte comment body: 5 chars, more than 5 bytes. LSP columns here
+    // are byte offsets, so the length must be the byte count.
+    let line = "A=v#→→→";
+    let tokens = extract_env_comment_tokens(line);
+    assert_eq!(tokens.len(), 1);
+    let start = inline_comment_start(line).unwrap();
+    assert_eq!(tokens[0].length as usize, line.len() - start);
+    assert_eq!(tokens[0].length, 10, "'#' + three 3-byte arrows");
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -68,6 +68,7 @@ pub mod database;
 pub mod directive_args;
 pub mod display_truncate;
 pub mod document_symbols;
+pub mod env_comment_tokens;
 pub mod env_key_locator;
 pub mod facade_resolver;
 pub mod factory_resolver;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -22187,6 +22187,7 @@ impl LanguageServer for LaravelLanguageServer {
                             legend: SemanticTokensLegend {
                                 token_types: vec![
                                     SemanticTokenType::FUNCTION, // index 0 - @directive
+                                    SemanticTokenType::COMMENT,  // index 1 - .env inline comment
                                 ],
                                 token_modifiers: vec![],
                             },
@@ -26724,8 +26725,17 @@ impl LanguageServer for LaravelLanguageServer {
         let uri = &params.text_document.uri;
         let path = uri.path();
 
-        // Only process Blade files
-        if !path.ends_with(".blade.php") {
+        // Two buffer kinds carry semantic tokens: Blade files (custom inline
+        // directives the grammar can't colour) and env files (inline comments,
+        // where the bash grammar Zed highlights `.env` with disagrees with
+        // dotenv about where a comment starts — see `env_comment_tokens`).
+        let file_name = std::path::Path::new(path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+        let is_blade = path.ends_with(".blade.php");
+        let is_env = file_name == ".env" || file_name.starts_with(".env.");
+        if !is_blade && !is_env {
             return Ok(None);
         }
 
@@ -26743,13 +26753,16 @@ impl LanguageServer for LaravelLanguageServer {
             }
         };
 
-        // Extract directive tokens, keeping only names we recognise as real
-        // directives (standard + registered custom) and skipping commented-out ones.
-        let known = self.get_directive_name_set().await;
-        let tokens =
-            laravel_lsp::blade_directive_tokens::extract_blade_directive_tokens(&content, &known);
+        let tokens = if is_env {
+            laravel_lsp::env_comment_tokens::extract_env_comment_tokens(&content)
+        } else {
+            // Extract directive tokens, keeping only names we recognise as real
+            // directives (standard + registered custom) and skipping commented-out ones.
+            let known = self.get_directive_name_set().await;
+            laravel_lsp::blade_directive_tokens::extract_blade_directive_tokens(&content, &known)
+        };
 
-        info!("   Found {} directive tokens", tokens.len());
+        info!("   Found {} semantic tokens", tokens.len());
 
         Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
             result_id: None,


### PR DESCRIPTION
Fixes #51

## What this does

**Corrects the `.env` documentation.** Zed classifies every env file as Shell Script — bare `.env` via the bash grammar's `path_suffixes`, `.env.*` via the `"Shell Script": [".env.*"]` entry in Zed's own `assets/settings/default.json`. One `"Shell Script"` entry in `extension.toml` therefore attaches the server to all of them with zero user config, and the LSP dispatches env features on filename, not language.

**Demotes `zarifpour/zed-env` from recommendation to warning.** Measured, not assumed: its `path_suffixes` are a bare `"env"`, which loses the length tie to Shell Script's `".env"`, so it never claims the files it appears to ([zed-env#5](https://github.com/zarifpour/zed-env/issues/5)); and its bare `"conf"`, `"example"`, `"local"`, `"test"` suffixes reclassify unrelated files project-wide, including `laravel/sail`'s `supervisord.conf`.

**Ships inline-comment highlighting for `.env`.** See below.

**Documents the Tailwind language-server block for Blade**, which was undocumented despite being the tweak most Laravel + Tailwind projects want.

## The `.env` inline-comment fix

Inline comments are standard dotenv syntax. All four major implementations support them and agree that in an **unquoted** value a `#` starts a comment with no preceding whitespace required:

| Implementation | Rule |
|---|---|
| `vlucas/phpdotenv` (Laravel) | `UNQUOTED_STATE` + `#` → `COMMENT_STATE` |
| `motdotla/dotenv` | *"Comments may be added to your file on their own line or inline"* |
| `bkeepers/dotenv` | documents `KEY=value # comment` and `KEY="has-a-#-hash"` |
| `python-dotenv` | *"Values can be followed by a comment"* |

Bash follows shell rules, where a mid-word `#` is literal. So `DB_PASSWORD=p@ss#word` renders as though the value were `p@ss#word` when Laravel actually reads `p@ss`.

`env_comment_tokens` emits `COMMENT` semantic tokens for value-level comments, mirroring phpdotenv's `EntryParser::processToken()` state machine so the colouring cannot disagree with how the framework reads the file.

Requires `"semantic_tokens": "combined"` on the Shell Script language — Zed defaults it to `"off"`. Documented in `docs/environment.md` and the settings reference.

> **Correction to [this comment on #51](https://github.com/mike-bronner/zed-laravel/issues/51#issuecomment-5431906145).** That comment proposed the semantic-token overlay as fixing a *defect*, and floated a diagnostic warning on "silently truncated" values. Both framings were wrong: inline comments are specified behaviour in every implementation, and the documented remedy for a literal `#` is to quote the value. A diagnostic would have flagged correct, standard syntax. What shipped is the highlighting overlay only. The comment is left as-is for the record.

## Verification

- **3,175 tests passing**, 0 failed (+29 new)
- `cargo clippy --all-targets` clean, `cargo fmt` applied
- **9/9 mutations of the new module go red.** Two tests were theatre when first written and were rewritten: an escape-handling fixture where the mutant bailed before reaching the assertion point, and a delta-line fixture anchored at line 0, where relative and absolute encodings coincide.
- Grammar comparison was run, not estimated: both grammars compiled at the versions each project pins (`tree-sitter-bash` 0.25.1, `tree-sitter-dotenv` @ `a854096`), each project's own `highlights.scm` applied, captures dumped per token.

## Acceptance criteria (#51)

- [x] **AC1** — bash-grammar gaps documented concretely (interpolation, quoting, `export`, comments)
- [x] **AC2** — bash vs `tree-sitter-dotenv` compared with measured output
- [x] **AC3** — variant-split UX: no split exists; all env files behave identically
- [x] **AC4** — scope fit: we own no language definition
- [x] **AC5** — `zed-env` compatibility: language name matches, entry retained
- [x] **AC6** — four-approach comparison table, plus a fifth row for what shipped
- [x] **AC7** — explicit recommendation with rationale

## Notes

`extension.toml` keeps its `"env"` attach entry. An earlier commit removed it; that was reverted. The docs argue against remapping `.env` to a dotenv extension — they do not break it. A user who wants a purpose-built dotenv grammar should not thereby lose this extension's `.env` features. **Docs express a recommendation; the manifest expresses a capability.**

`CLAUDE.md`'s session-state block was stale (a February Blade-language investigation, including a since-released finding that Zed had not shipped semantic highlighting). Replaced with the settled `.env` handling; the Blade language question is preserved as still open, because it is.

Refs: #51
