### PR TITLE
feat: ✨ Component-member navigation & completion in Blade (wire: values, $this->…, $ variables)

### DIFF
--- a/docs/autocomplete.md
+++ b/docs/autocomplete.md
@@ -155,6 +155,29 @@ Variables are resolved from:
 
 A variable typed from a query-builder terminal (`$users = User::all();`, `User::where(...)->get()`, …) honors the model's custom collection — when `User` declares `protected $collectionClass = UserCollection::class;` (or a `newCollection()` override), `$users` resolves as `UserCollection<User>` instead of the default `Collection<User>`, matching the relationship-completion behavior above.
 
+## ⚡ `wire:` Attribute Values
+
+Inside a `wire:*="…"` value, completion offers the backing component's members — with either quote style, and before the closing quote is typed:
+
+```blade
+<button wire:click="
+{{--                ^ enterEditMode()   ← public, non-static methods --}}
+{{--                  checkPrefillStatus() --}}
+
+<input wire:model.live="
+{{--                    ^ contractData (ContractData)   ← public, non-static properties --}}
+{{--                      prefillStatus (string) --}}
+
+<input wire:model="contractData.
+{{--                            ^ title (string)   ← the segment resolves through ContractData --}}
+```
+
+- **Action bindings** (`wire:click`, `wire:submit`, any DOM-event directive) offer public, non-static **methods** — excluding the lifecycle surface (`mount`, `boot`, `booted`, `hydrate`, `dehydrate`, `rendering`, `rendered`, `exception`) and the per-property `updatedFoo`/`updatingFoo` hook families. Dotted values are rejected for actions.
+- **Data bindings** (`wire:model` with any modifiers, `wire:show`, `wire:text`) offer public, non-static **properties**. Dotted paths complete segment by segment: each leading segment resolves to its declared class, and that class's properties are offered — at any depth while the types stay resolvable.
+- Values that are already a JS expression (`$wire.count++`, `open = true`) get no member completion, so nothing conflicts with Alpine.
+
+`$` completion in the template body offers the same public, non-static property surface, merged (and de-duplicated) with the view-data variables below — properties declared only on framework base classes are not offered. Trait- and parent-provided members are a known limitation: only members declared in the component's own class (or SFC/Volt front matter) appear.
+
 ## 🔄 Loop Variables (Scope-Aware)
 
 Variables from loop directives are available **only inside** the loop block:

--- a/docs/go-to-definition.md
+++ b/docs/go-to-definition.md
@@ -122,5 +122,26 @@ Two escape hatches cover what the heuristic can't infer — a directive that tak
 
 Names with dedicated handling (`@component`, `@livewire`, `@feature`, `@includeFirst`, `@extends`, `@include`, `@includeIf`, `@each`, `@includeWhen`, `@includeUnless`) ignore both lists — their own resolution always wins. See [Configuration](configuration.md).
 
+**Component members in Blade** — inside a template backed by a component class (a Livewire component in any format, a class-based Volt component, or a Filament `$view`-property page), `$this->member`, bare `$variable` references, and `wire:` attribute values all jump to the member's declaration in the backing class. For a Livewire v4 single-file component or a class-based Volt component the class lives in the template's own front matter, so the jump lands inside the `.blade.php` itself:
+
+```blade
+<button wire:click="enterEditMode">Edit</button>
+{{--                ^^^^^^^^^^^^^ → app/Livewire/ContractPage.php  (public function enterEditMode()) --}}
+
+<input wire:model.live="contractData.title">
+{{--                    ^^^^^^^^^^^^ → app/Livewire/ContractPage.php  (public ContractData $contractData) --}}
+
+<input wire:keydown.enter="performSearch">
+{{--                       ^^^^^^^^^^^^^ any DOM-event directive works, not just click/submit/poll --}}
+
+{{ $this->getCalculatedEndDateForDisplay() }}
+{{--      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ → the method declaration in the backing class --}}
+
+{{ $prefillStatus }}
+{{-- ^^^^^^^^^^^^ → public string $prefillStatus in the backing class --}}
+```
+
+A `wire:` value that isn't a plain member reference (`$wire.count++`, `count++`, `open = true`) is left alone entirely, so nothing conflicts with Alpine. A bare `$variable` bound locally in the template first — an enclosing `@foreach`/`@for` loop variable, a `@php` assignment, a component `@props` entry, or Blade's own `$loop` — is NOT treated as a class member: local scope wins and no navigation is offered. Members inherited from traits or parent classes are a known limitation — only members declared in the component's own class file (or front matter) resolve.
+
 **Supported patterns:**
-`view()` `View::make()` `@extends` `@include` `@includeIf` `@includeWhen` `@includeUnless` `@includeFirst` `@each` `@component` custom `Blade::directive()` view directives `@use` `<x-*>` `</x-*>` `<livewire:*>` `</livewire:*>` `@livewire()` `route()` `to_route()` `signed_route()` `URL::signedRoute()` `config()` `Config::get()` `Config::getMany()` `config()->string()` `env()` `Env::get()` `__()` `trans()` `@lang` `->middleware()` `app()` `resolve()` `App::bound()` `App::isShared()` `asset()` `@vite` `app_path()` `base_path()` `storage_path()` `resource_path()` `public_path()` `Feature::active()` `Feature::inactive()` `Feature::value()` `@feature` `Artisan::call()` `Artisan::queue()` `->command()` `->artisan()` · query-chain columns / relations / tables · magic members (relationships, scopes, accessors, columns, dynamic finders)
+`view()` `View::make()` `@extends` `@include` `@includeIf` `@includeWhen` `@includeUnless` `@includeFirst` `@each` `@component` custom `Blade::directive()` view directives `@use` `<x-*>` `</x-*>` `<livewire:*>` `</livewire:*>` `@livewire()` `route()` `to_route()` `signed_route()` `URL::signedRoute()` `config()` `Config::get()` `Config::getMany()` `config()->string()` `env()` `Env::get()` `__()` `trans()` `@lang` `->middleware()` `app()` `resolve()` `App::bound()` `App::isShared()` `asset()` `@vite` `app_path()` `base_path()` `storage_path()` `resource_path()` `public_path()` `Feature::active()` `Feature::inactive()` `Feature::value()` `@feature` `Artisan::call()` `Artisan::queue()` `->command()` `->artisan()` · query-chain columns / relations / tables · magic members (relationships, scopes, accessors, columns, dynamic finders) · `wire:*` attribute values · `$this->member` / bare `$variable` in component-backed Blade

--- a/docs/hover.md
+++ b/docs/hover.md
@@ -22,6 +22,19 @@ $tz = config('app.timezone');
 {{-- ^^^^^ hover →  App\Models\User::$email, its PHPDoc summary, and the declaration --}}
 ```
 
+**Component members in Blade** — `$this->member` in a template backed by a component class (Livewire in any format, class-based Volt, a Filament `$view`-property page) gets a card with the member's kind, the backing class, the full declaration header, and a click-to-open link. This card is emitted unconditionally in Blade: Intelephense cannot resolve `$this` inside a template's PHP context, so there is no PHP-tooling card to defer to.
+
+```blade
+{{ $this->getCalculatedEndDateForDisplay() }}
+{{--      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ hover →  App\Livewire\ContractPage::getCalculatedEndDateForDisplay()
+                                                   public function getCalculatedEndDateForDisplay(): ?string
+                                                   + click-to-open link to the declaration --}}
+
+{{ $this->uploadedFile }}
+{{--      ^^^^^^^^^^^^ hover →  App\Livewire\ContractPage::$uploadedFile
+                                public ?TemporaryUploadedFile $uploadedFile --}}
+```
+
 **Eloquent magic members** get semantic cards explaining what the magic actually is — the classification, the declaring class, and the method source that backs it:
 
 ```php

--- a/laravel-lsp/src/component_member_locator.rs
+++ b/laravel-lsp/src/component_member_locator.rs
@@ -86,6 +86,68 @@ pub fn locate_member(source: &str, member: &str) -> Option<MemberLocation> {
     None
 }
 
+/// The declaration header of `member` in `source`, for a hover card: a
+/// method's signature up to (not including) its body — modifiers, name,
+/// parameters, return type — or a property's declaration up to (not
+/// including) its initializer. Whitespace runs are collapsed so a multiline
+/// signature renders as one line. `None` when the member isn't declared.
+pub fn member_declaration_summary(source: &str, member: &str) -> Option<String> {
+    let tree = parse_php(source).ok()?;
+    let bytes = source.as_bytes();
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        match n.kind() {
+            "method_declaration" => {
+                if let Some(name) = n.child_by_field_name("name") {
+                    if name.utf8_text(bytes).ok() == Some(member) {
+                        let end = n
+                            .child_by_field_name("body")
+                            .map(|b| b.start_byte())
+                            .unwrap_or_else(|| n.end_byte());
+                        return Some(collapse_ws(&source[n.start_byte()..end]));
+                    }
+                }
+            }
+            "property_declaration" => {
+                let mut c = n.walk();
+                for element in n.children(&mut c) {
+                    if element.kind() != "property_element" {
+                        continue;
+                    }
+                    if let Some(name) = element.child_by_field_name("name") {
+                        if matches_dollar_name(name, bytes, member) {
+                            // Header = the declaration up to the property
+                            // NAME (modifiers + type), then the `$name`
+                            // itself — the initializer stays out.
+                            let head = collapse_ws(&source[n.start_byte()..name.start_byte()]);
+                            return Some(format!("{} ${}", head.trim_end(), member));
+                        }
+                    }
+                }
+            }
+            "property_promotion_parameter" => {
+                if let Some(name) = n.child_by_field_name("name") {
+                    if matches_dollar_name(name, bytes, member) {
+                        let head = collapse_ws(&source[n.start_byte()..name.start_byte()]);
+                        return Some(format!("{} ${}", head.trim_end(), member));
+                    }
+                }
+            }
+            _ => {}
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    None
+}
+
+/// Collapse every whitespace run (including newlines) to a single space.
+fn collapse_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 /// Every PUBLIC property of the class in `source`, as `(name, declared type
 /// text)` — `"mixed"` when untyped. Includes promoted public constructor
 /// properties. Unlike the render-index surface (which keeps only
@@ -106,11 +168,18 @@ pub fn public_property_types(source: &str) -> Vec<(String, String)> {
                     let mut c = n.walk();
                     // A property_declaration without an explicit modifier is
                     // public by PHP default; a promoted parameter without one
-                    // isn't a property at all (plain constructor arg).
+                    // isn't a property at all (plain constructor arg). A
+                    // `static` property isn't part of the component's
+                    // template surface — Livewire only serializes instance
+                    // state — so it's excluded like a non-public one.
                     let mut public = n.kind() == "property_declaration";
                     for ch in n.children(&mut c) {
-                        if ch.kind() == "visibility_modifier" {
-                            public = ch.utf8_text(bytes).ok() == Some("public");
+                        match ch.kind() {
+                            "visibility_modifier" => {
+                                public = ch.utf8_text(bytes).ok() == Some("public");
+                            }
+                            "static_modifier" => public = false,
+                            _ => {}
                         }
                     }
                     public
@@ -198,9 +267,21 @@ pub fn public_action_method_names(source: &str) -> Vec<String> {
                     .child_by_field_name("name")
                     .and_then(|nm| nm.utf8_text(bytes).ok())
                 {
+                    // A prefix only counts when the hook's target follows in
+                    // camelCase (`updatedFooBar`) or the name IS the bare
+                    // hook — a method that merely starts with the same
+                    // letters (`updates`, `hydrateX` vs `hydraulics`) is a
+                    // legitimate action.
+                    let is_lifecycle_hook = |name: &str| {
+                        LIFECYCLE_PREFIXES.iter().any(|p| {
+                            name.strip_prefix(p).is_some_and(|rest| {
+                                rest.is_empty() || rest.starts_with(char::is_uppercase)
+                            })
+                        })
+                    };
                     let excluded = name.starts_with("__")
                         || LIFECYCLE.contains(&name)
-                        || LIFECYCLE_PREFIXES.iter().any(|p| name.starts_with(p));
+                        || is_lifecycle_hook(name);
                     if !excluded {
                         out.push(name.to_string());
                     }

--- a/laravel-lsp/src/component_member_locator.rs
+++ b/laravel-lsp/src/component_member_locator.rs
@@ -1,0 +1,241 @@
+//! Locate a class member's declaration by name.
+//!
+//! Blade goto/hover fallbacks that resolve `$this->member` or a `wire:*`
+//! attribute value against the class backing the template (a Filament
+//! `$view`-property page, a Livewire component) need to know where `member`
+//! is actually declared in that class's source. This module is the dumb,
+//! reusable primitive for that: no type resolution, no member classification
+//! (that's `member_resolver`'s job) — just "does a member with this NAME
+//! exist in this source, and where".
+//!
+//! Three declaration shapes are recognised: a `method_declaration`, a
+//! `property_element` inside a `property_declaration`, and a promoted
+//! constructor property (`public function __construct(public Foo $bar) {}`).
+//! Positions land on the NAME token — for properties/promoted params, the
+//! leading `$` is skipped so the caret sits on the bare name.
+
+use tree_sitter::Node;
+
+use crate::parser::parse_php;
+
+/// The declaration shape [`locate_member`] found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemberKind {
+    Method,
+    Property,
+}
+
+/// A located member declaration: 0-based line, and the start/end column of
+/// the NAME token (the `$` sigil excluded for properties).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemberLocation {
+    pub line: u32,
+    pub start_column: u32,
+    pub end_column: u32,
+    pub kind: MemberKind,
+}
+
+/// Find `member`'s declaration in `source`. Checks every `method_declaration`,
+/// property (`property_declaration` → `property_element`), and promoted
+/// constructor property in the file, in document order; returns the first
+/// match. A method and a property never share a name within one class, so in
+/// practice there's nothing to disambiguate between the two kinds.
+///
+/// Returns `None` when `source` doesn't parse, or no member named `member`
+/// is declared.
+pub fn locate_member(source: &str, member: &str) -> Option<MemberLocation> {
+    let tree = parse_php(source).ok()?;
+    let bytes = source.as_bytes();
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        match n.kind() {
+            "method_declaration" => {
+                if let Some(name) = n.child_by_field_name("name") {
+                    if name.utf8_text(bytes).ok() == Some(member) {
+                        return Some(node_location(name, 0, MemberKind::Method));
+                    }
+                }
+            }
+            "property_declaration" => {
+                let mut c = n.walk();
+                for element in n.children(&mut c) {
+                    if element.kind() != "property_element" {
+                        continue;
+                    }
+                    if let Some(name) = element.child_by_field_name("name") {
+                        if matches_dollar_name(name, bytes, member) {
+                            return Some(node_location(name, 1, MemberKind::Property));
+                        }
+                    }
+                }
+            }
+            "property_promotion_parameter" => {
+                if let Some(name) = n.child_by_field_name("name") {
+                    if matches_dollar_name(name, bytes, member) {
+                        return Some(node_location(name, 1, MemberKind::Property));
+                    }
+                }
+            }
+            _ => {}
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    None
+}
+
+/// Every PUBLIC property of the class in `source`, as `(name, declared type
+/// text)` — `"mixed"` when untyped. Includes promoted public constructor
+/// properties. Unlike the render-index surface (which keeps only
+/// class-typed properties, since scalars have no members to resolve), this
+/// keeps scalar and untyped publics too: a Livewire/Filament template reads
+/// them as bare `$vars`, so `$`-completion must offer all of them.
+pub fn public_property_types(source: &str) -> Vec<(String, String)> {
+    let Ok(tree) = parse_php(source) else {
+        return Vec::new();
+    };
+    let bytes = source.as_bytes();
+    let mut out = Vec::new();
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        match n.kind() {
+            "property_declaration" | "property_promotion_parameter" => {
+                let is_public = {
+                    let mut c = n.walk();
+                    // A property_declaration without an explicit modifier is
+                    // public by PHP default; a promoted parameter without one
+                    // isn't a property at all (plain constructor arg).
+                    let mut public = n.kind() == "property_declaration";
+                    for ch in n.children(&mut c) {
+                        if ch.kind() == "visibility_modifier" {
+                            public = ch.utf8_text(bytes).ok() == Some("public");
+                        }
+                    }
+                    public
+                };
+                if is_public {
+                    let type_text = n
+                        .child_by_field_name("type")
+                        .and_then(|t| t.utf8_text(bytes).ok())
+                        .map(|t| t.trim_start_matches('?').to_string())
+                        .unwrap_or_else(|| "mixed".to_string());
+                    if n.kind() == "property_promotion_parameter" {
+                        if let Some(name) = n.child_by_field_name("name") {
+                            if let Ok(t) = name.utf8_text(bytes) {
+                                out.push((t.trim_start_matches('$').to_string(), type_text));
+                            }
+                        }
+                    } else {
+                        let mut c = n.walk();
+                        for element in n.children(&mut c) {
+                            if element.kind() != "property_element" {
+                                continue;
+                            }
+                            if let Some(name) = element.child_by_field_name("name") {
+                                if let Ok(t) = name.utf8_text(bytes) {
+                                    out.push((
+                                        t.trim_start_matches('$').to_string(),
+                                        type_text.clone(),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    out
+}
+
+/// Every PUBLIC, non-static method of the class in `source` that can be a
+/// Livewire action target, sorted by name. Magic methods (`__*`) and the
+/// Livewire/Filament lifecycle surface (`mount`, `render`, `boot`, `booted`,
+/// `rendering`, `rendered`, `exception`, and the `updated*` / `updating*` /
+/// `hydrate*` / `dehydrate*` hook families) are excluded — they exist on
+/// every component and are never what a `wire:click` wants to call.
+pub fn public_action_method_names(source: &str) -> Vec<String> {
+    const LIFECYCLE: &[&str] = &[
+        "mount",
+        "render",
+        "boot",
+        "booted",
+        "rendering",
+        "rendered",
+        "exception",
+    ];
+    const LIFECYCLE_PREFIXES: &[&str] = &["updated", "updating", "hydrate", "dehydrate"];
+
+    let Ok(tree) = parse_php(source) else {
+        return Vec::new();
+    };
+    let bytes = source.as_bytes();
+    let mut out = Vec::new();
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "method_declaration" {
+            let mut public = true; // PHP methods default to public
+            let mut is_static = false;
+            let mut c = n.walk();
+            for ch in n.children(&mut c) {
+                match ch.kind() {
+                    "visibility_modifier" => {
+                        public = ch.utf8_text(bytes).ok() == Some("public");
+                    }
+                    "static_modifier" => is_static = true,
+                    _ => {}
+                }
+            }
+            if public && !is_static {
+                if let Some(name) = n
+                    .child_by_field_name("name")
+                    .and_then(|nm| nm.utf8_text(bytes).ok())
+                {
+                    let excluded = name.starts_with("__")
+                        || LIFECYCLE.contains(&name)
+                        || LIFECYCLE_PREFIXES.iter().any(|p| name.starts_with(p));
+                    if !excluded {
+                        out.push(name.to_string());
+                    }
+                }
+            }
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Whether `name` node's text, with a leading `$` stripped, equals `member`.
+fn matches_dollar_name(name: Node, bytes: &[u8], member: &str) -> bool {
+    name.utf8_text(bytes)
+        .map(|t| t.trim_start_matches('$') == member)
+        .unwrap_or(false)
+}
+
+/// Build a [`MemberLocation`] from a name node, skipping `dollar_skip`
+/// columns off the start (1 for a `$name` property/param, 0 for a bare
+/// method name).
+fn node_location(node: Node, dollar_skip: u32, kind: MemberKind) -> MemberLocation {
+    let start = node.start_position();
+    let end = node.end_position();
+    MemberLocation {
+        line: start.row as u32,
+        start_column: start.column as u32 + dollar_skip,
+        end_column: end.column as u32,
+        kind,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/component_member_locator/tests.rs
+++ b/laravel-lsp/src/component_member_locator/tests.rs
@@ -129,3 +129,123 @@ class Page {
         "mixed"
     );
 }
+
+#[test]
+fn public_property_types_excludes_static_properties() {
+    // A `static` property isn't part of the component's template surface —
+    // Livewire only serializes instance state.
+    let source = r#"<?php
+class Page {
+    public static string $registry = 'none';
+    protected static $view = 'pages.x';
+    public string $title = '';
+}
+"#;
+    let names: Vec<String> = public_property_types(source)
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    assert_eq!(names, vec!["title".to_string()]);
+}
+
+#[test]
+fn action_names_lifecycle_prefix_requires_camel_case_boundary() {
+    // `updatedFoo` is Livewire's per-property hook; `updates` and
+    // `hydraulics` merely share the prefix letters and ARE actions.
+    let source = r#"<?php
+class Page {
+    public function updatedTitle(): void {}
+    public function updating(): void {}
+    public function updates(): void {}
+    public function hydraulics(): void {}
+}
+"#;
+    assert_eq!(
+        public_action_method_names(source),
+        vec!["hydraulics".to_string(), "updates".to_string()]
+    );
+}
+
+#[test]
+fn member_declaration_summary_renders_a_method_signature() {
+    let source = r#"<?php
+class Page {
+    public function save(
+        string $status,
+        ?int $retries = null,
+    ): bool { return true; }
+}
+"#;
+    assert_eq!(
+        member_declaration_summary(source, "save").as_deref(),
+        Some("public function save( string $status, ?int $retries = null, ): bool")
+    );
+}
+
+#[test]
+fn member_declaration_summary_renders_a_property_header_without_initializer() {
+    let source = r#"<?php
+class Page {
+    protected static string $view = 'pages.report';
+    public ?\App\Models\User $user = null;
+}
+"#;
+    assert_eq!(
+        member_declaration_summary(source, "user").as_deref(),
+        Some("public ?\\App\\Models\\User $user")
+    );
+    assert_eq!(
+        member_declaration_summary(source, "view").as_deref(),
+        Some("protected static string $view")
+    );
+    assert!(member_declaration_summary(source, "missing").is_none());
+}
+
+#[test]
+fn locates_member_inside_an_inline_sfc_blade_source() {
+    // Livewire v4 single-file component: the class lives in the template's
+    // own front matter, so the .blade.php content IS the source to parse —
+    // positions land inside the blade file.
+    let source = r#"<?php
+
+use Livewire\Component;
+
+new class extends Component {
+    public int $count = 0;
+
+    public function increment(): void
+    {
+        $this->count++;
+    }
+};
+?>
+
+<div>
+    <span>{{ $count }}</span>
+    <button wire:click="increment">+</button>
+</div>
+"#;
+    let count = locate_member(source, "count").expect("property in front matter");
+    assert_eq!(count.kind, MemberKind::Property);
+    assert_eq!(count.line, 5, "0-based line of `public int $count = 0;`");
+    let increment = locate_member(source, "increment").expect("method in front matter");
+    assert_eq!(increment.kind, MemberKind::Method);
+    assert_eq!(increment.line, 7);
+}
+
+#[test]
+fn locates_member_inside_a_volt_class_blade_source() {
+    let source = r#"<?php
+
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public string $search = '';
+}; ?>
+
+<div><input wire:model="search"></div>
+"#;
+    let loc = locate_member(source, "search").expect("Volt front-matter property");
+    assert_eq!(loc.kind, MemberKind::Property);
+    assert_eq!(loc.line, 5);
+}

--- a/laravel-lsp/src/component_member_locator/tests.rs
+++ b/laravel-lsp/src/component_member_locator/tests.rs
@@ -1,0 +1,131 @@
+use super::*;
+
+#[test]
+fn locates_a_method_declaration() {
+    let source = r#"<?php
+class ContractViewPage extends Page
+{
+    public function checkPrefillStatus(): void
+    {
+    }
+}
+"#;
+    let loc = locate_member(source, "checkPrefillStatus").expect("method found");
+    assert_eq!(loc.kind, MemberKind::Method);
+    // Line 3 (0-based) is `    public function checkPrefillStatus(): void`.
+    assert_eq!(loc.line, 3);
+    let name = &source.lines().nth(3).unwrap()[loc.start_column as usize..loc.end_column as usize];
+    assert_eq!(name, "checkPrefillStatus");
+}
+
+#[test]
+fn locates_a_property_declaration_and_skips_the_dollar() {
+    let source = r#"<?php
+class ContractViewPage extends Page
+{
+    public ?string $prefillStatus = null;
+}
+"#;
+    let loc = locate_member(source, "prefillStatus").expect("property found");
+    assert_eq!(loc.kind, MemberKind::Property);
+    assert_eq!(loc.line, 3);
+    let line = source.lines().nth(3).unwrap();
+    let name = &line[loc.start_column as usize..loc.end_column as usize];
+    assert_eq!(name, "prefillStatus");
+    // The `$` sigil sits immediately before the located range.
+    assert_eq!(
+        &line[loc.start_column as usize - 1..loc.start_column as usize],
+        "$"
+    );
+}
+
+#[test]
+fn locates_a_promoted_constructor_property() {
+    let source = r#"<?php
+class ContractService
+{
+    public function __construct(public readonly ContractRepository $repository)
+    {
+    }
+}
+"#;
+    let loc = locate_member(source, "repository").expect("promoted property found");
+    assert_eq!(loc.kind, MemberKind::Property);
+    let line = source.lines().nth(3).unwrap();
+    let name = &line[loc.start_column as usize..loc.end_column as usize];
+    assert_eq!(name, "repository");
+}
+
+#[test]
+fn returns_none_when_no_member_matches() {
+    let source = r#"<?php
+class ContractViewPage extends Page
+{
+    public ?string $prefillStatus = null;
+
+    public function checkPrefillStatus(): void
+    {
+    }
+}
+"#;
+    assert!(locate_member(source, "doesNotExist").is_none());
+}
+
+#[test]
+fn returns_none_for_unparseable_source() {
+    // Not actually invalid PHP as far as tree-sitter's concerned, but there's
+    // no member declaration matching — same shape as `returns_none_when_no_member_matches`,
+    // just confirms an empty/degenerate file doesn't panic.
+    assert!(locate_member("", "anything").is_none());
+}
+
+#[test]
+fn public_action_method_names_skips_lifecycle_and_non_public() {
+    let source = r#"<?php
+class ContractViewPage {
+    public function mount(?string $id = null): void {}
+    public function render() {}
+    public function updatedContractData(): void {}
+    public function checkPrefillStatus(): void {}
+    public function enterEditMode(): void {}
+    public static function staticHelper(): void {}
+    protected function internal(): void {}
+    public function __get($name) {}
+}
+"#;
+    assert_eq!(
+        public_action_method_names(source),
+        vec![
+            "checkPrefillStatus".to_string(),
+            "enterEditMode".to_string()
+        ]
+    );
+}
+
+#[test]
+fn public_property_types_includes_scalars_and_untyped() {
+    let source = r#"<?php
+class Page {
+    public string $prefillStatus = 'none';
+    public ?string $contractId = null;
+    public $legacy;
+    protected string $hidden = '';
+    public function __construct(public int $count) {}
+}
+"#;
+    let props = public_property_types(source);
+    let names: Vec<&str> = props.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(names.contains(&"prefillStatus"));
+    assert!(names.contains(&"contractId"));
+    assert!(names.contains(&"legacy"));
+    assert!(names.contains(&"count"));
+    assert!(!names.contains(&"hidden"));
+    assert_eq!(
+        props.iter().find(|(n, _)| n == "contractId").unwrap().1,
+        "string"
+    );
+    assert_eq!(
+        props.iter().find(|(n, _)| n == "legacy").unwrap().1,
+        "mixed"
+    );
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -60,6 +60,7 @@ pub mod completion_display;
 pub mod completion_format;
 pub mod component_completion;
 pub mod component_declaration_locator;
+pub mod component_member_locator;
 pub mod composer_autoload;
 pub mod config;
 pub mod config_key_locator;

--- a/laravel-lsp/src/livewire_resolver.rs
+++ b/laravel-lsp/src/livewire_resolver.rs
@@ -307,7 +307,16 @@ pub fn wire_attribute_completion_context(
         }
         let typed = line[value_start..cursor].trim();
         let kind = wire_value_kind(attr_name.strip_prefix("wire:")?.split('.').next()?)?;
-        return if typed.is_empty() || is_php_identifier(typed) {
+        let acceptable = match kind {
+            // Actions are a single identifier.
+            WireValueKind::Method => typed.is_empty() || is_php_identifier(typed),
+            // Bindings may be a dotted path into a nested object
+            // (`wire:model="contractData.title"`): every completed segment
+            // must be an identifier, the segment under the cursor may be
+            // empty (right after a dot) or partial.
+            WireValueKind::Property => is_property_path_prefix(typed),
+        };
+        return if acceptable {
             Some((kind, typed.to_string()))
         } else {
             None
@@ -315,6 +324,19 @@ pub fn wire_attribute_completion_context(
     }
 
     None
+}
+
+/// A (possibly unfinished) dotted property path: `a`, `a.b`, `a.` or an
+/// empty string. Every segment before the last must be an identifier; the
+/// last may be empty (cursor right after a dot) or a partial identifier.
+fn is_property_path_prefix(s: &str) -> bool {
+    if s.is_empty() {
+        return true;
+    }
+    let segments: Vec<&str> = s.split('.').collect();
+    let (last, completed) = segments.split_last().unwrap();
+    completed.iter().all(|seg| is_php_identifier(seg))
+        && (last.is_empty() || is_php_identifier(last))
 }
 
 /// A bare PHP identifier: `[A-Za-z_][A-Za-z0-9_]*`, nothing else. Used to

--- a/laravel-lsp/src/livewire_resolver.rs
+++ b/laravel-lsp/src/livewire_resolver.rs
@@ -163,6 +163,13 @@ pub enum WireTarget {
 /// [`extract_blade_variable_at_cursor`]'s convention.
 pub fn wire_attribute_target_at(line: &str, cursor_col: u32) -> Option<WireTarget> {
     let cursor = cursor_col as usize;
+    // Same cursor guard as every other cursor site (alpine.rs,
+    // method_name_completion.rs): the LSP position is not a trustworthy
+    // byte index — past-the-end and mid-UTF-8-codepoint offsets both
+    // arrive in practice, and slicing on them panics.
+    if cursor > line.len() || !line.is_char_boundary(cursor) {
+        return None;
+    }
     let bytes = line.as_bytes();
     let mut search_from = 0usize;
 
@@ -200,7 +207,7 @@ pub fn wire_attribute_target_at(line: &str, cursor_col: u32) -> Option<WireTarge
             continue;
         };
         let value_end = value_start + rel_end;
-        search_from = value_end + 1;
+        search_from = (value_end + 1).min(line.len());
 
         if cursor < value_start || cursor > value_end {
             continue;
@@ -262,6 +269,11 @@ pub fn wire_attribute_completion_context(
     cursor_col: u32,
 ) -> Option<(WireValueKind, String)> {
     let cursor = cursor_col as usize;
+    // See wire_attribute_target_at — identical cursor guard, identical
+    // reason.
+    if cursor > line.len() || !line.is_char_boundary(cursor) {
+        return None;
+    }
     let bytes = line.as_bytes();
     let mut search_from = 0usize;
 
@@ -300,7 +312,9 @@ pub fn wire_attribute_completion_context(
             .find(quote as char)
             .map(|rel_end| value_start + rel_end)
             .unwrap_or(line.len());
-        search_from = value_end + 1;
+        // An unclosed value ends AT line.len(); the resume point must not
+        // step past it — `line[search_from..]` on len()+1 panics.
+        search_from = (value_end + 1).min(line.len());
 
         if cursor < value_start || cursor > value_end {
             continue;

--- a/laravel-lsp/src/livewire_resolver.rs
+++ b/laravel-lsp/src/livewire_resolver.rs
@@ -139,6 +139,196 @@ pub fn extract_blade_variable_at_cursor(
     None
 }
 
+/// The Livewire binding target of a `wire:` attribute, extracted from its
+/// quoted value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WireTarget {
+    /// A method-call binding (`wire:click`, `wire:submit.prevent`,
+    /// `wire:poll.2000ms`, ...) — the bare identifier before any `(`.
+    Method(String),
+    /// `wire:model[.modifiers]` binds a PROPERTY, not a method call — the
+    /// target is the first dot-segment of the value (`contractData.title`
+    /// → `contractData`).
+    Property(String),
+}
+
+/// If the cursor sits inside a `wire:*="value"` attribute's quoted value on
+/// `line`, extract its goto/hover target.
+///
+/// Returns `None` when the cursor isn't inside such a value, or the value
+/// isn't a resolvable PHP identifier (`wire:click="$wire.foo++"` has no
+/// member target — a Blade/JS expression, not a bound method).
+///
+/// `cursor_col` is treated as a byte offset into `line`, matching
+/// [`extract_blade_variable_at_cursor`]'s convention.
+pub fn wire_attribute_target_at(line: &str, cursor_col: u32) -> Option<WireTarget> {
+    let cursor = cursor_col as usize;
+    let bytes = line.as_bytes();
+    let mut search_from = 0usize;
+
+    while let Some(rel) = line[search_from..].find("wire:") {
+        let attr_start = search_from + rel;
+        let mut i = attr_start + "wire:".len();
+        // Attribute name, modifiers included (`wire:poll.2000ms`, `wire:model.live`).
+        while i < bytes.len()
+            && (bytes[i].is_ascii_alphanumeric()
+                || bytes[i] == b'.'
+                || bytes[i] == b'-'
+                || bytes[i] == b'_')
+        {
+            i += 1;
+        }
+        let attr_name = &line[attr_start..i];
+        search_from = i;
+
+        let mut j = i;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if bytes.get(j) != Some(&b'=') {
+            continue;
+        }
+        j += 1;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        let Some(&quote) = bytes.get(j).filter(|b| **b == b'"' || **b == b'\'') else {
+            continue;
+        };
+        let value_start = j + 1;
+        let Some(rel_end) = line[value_start..].find(quote as char) else {
+            continue;
+        };
+        let value_end = value_start + rel_end;
+        search_from = value_end + 1;
+
+        if cursor < value_start || cursor > value_end {
+            continue;
+        }
+        let value = &line[value_start..value_end];
+        let base = attr_name.strip_prefix("wire:")?.split('.').next()?;
+        return match wire_value_kind(base) {
+            Some(WireValueKind::Property) => {
+                let prop = value.split('.').next().unwrap_or("").trim();
+                is_php_identifier(prop).then(|| WireTarget::Property(prop.to_string()))
+            }
+            Some(WireValueKind::Method) => {
+                let ident = value.split('(').next().unwrap_or("").trim();
+                is_php_identifier(ident).then(|| WireTarget::Method(ident.to_string()))
+            }
+            None => None,
+        };
+    }
+
+    None
+}
+
+/// What kind of component member a `wire:{base}` attribute's value names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WireValueKind {
+    /// The value is an action — a public method (`wire:click`, `wire:poll`,
+    /// `wire:submit`, any DOM-event binding).
+    Method,
+    /// The value binds a public property (`wire:model`, `wire:show`,
+    /// `wire:text`).
+    Property,
+}
+
+/// Classify a `wire:` attribute's base name (modifiers stripped) by what its
+/// value names. `None` for attributes whose value is not a component member
+/// at all (`wire:key`, `wire:target`, `wire:ignore`, ...). Everything not
+/// explicitly listed is treated as a DOM-event action binding, since Livewire
+/// accepts `wire:{any-dom-event}`.
+fn wire_value_kind(base: &str) -> Option<WireValueKind> {
+    match base {
+        "model" | "show" | "text" => Some(WireValueKind::Property),
+        "key" | "id" | "ignore" | "loading" | "dirty" | "offline" | "target" | "stream"
+        | "replace" | "transition" | "navigate" | "cloak" | "current" | "confirm" => None,
+        _ => Some(WireValueKind::Method),
+    }
+}
+
+/// If the cursor sits inside a `wire:*="…"` quoted value on `line`, return
+/// the completion context: what member kind the attribute binds and the
+/// (possibly empty) identifier prefix typed before the cursor.
+///
+/// Unlike [`wire_attribute_target_at`] this accepts empty and partial
+/// values — that's the completion moment. `None` when the typed text is
+/// already something other than a plain identifier (a JS expression, a
+/// nested `wire:model` path past its first segment), so richer expressions
+/// fall through to other completion providers.
+pub fn wire_attribute_completion_context(
+    line: &str,
+    cursor_col: u32,
+) -> Option<(WireValueKind, String)> {
+    let cursor = cursor_col as usize;
+    let bytes = line.as_bytes();
+    let mut search_from = 0usize;
+
+    while let Some(rel) = line[search_from..].find("wire:") {
+        let attr_start = search_from + rel;
+        let mut i = attr_start + "wire:".len();
+        while i < bytes.len()
+            && (bytes[i].is_ascii_alphanumeric()
+                || bytes[i] == b'.'
+                || bytes[i] == b'-'
+                || bytes[i] == b'_')
+        {
+            i += 1;
+        }
+        let attr_name = &line[attr_start..i];
+        search_from = i;
+
+        let mut j = i;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if bytes.get(j) != Some(&b'=') {
+            continue;
+        }
+        j += 1;
+        while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        let Some(&quote) = bytes.get(j).filter(|b| **b == b'"' || **b == b'\'') else {
+            continue;
+        };
+        let value_start = j + 1;
+        // The closing quote may not be typed yet — treat end-of-line as the
+        // value end in that case.
+        let value_end = line[value_start..]
+            .find(quote as char)
+            .map(|rel_end| value_start + rel_end)
+            .unwrap_or(line.len());
+        search_from = value_end + 1;
+
+        if cursor < value_start || cursor > value_end {
+            continue;
+        }
+        let typed = line[value_start..cursor].trim();
+        let kind = wire_value_kind(attr_name.strip_prefix("wire:")?.split('.').next()?)?;
+        return if typed.is_empty() || is_php_identifier(typed) {
+            Some((kind, typed.to_string()))
+        } else {
+            None
+        };
+    }
+
+    None
+}
+
+/// A bare PHP identifier: `[A-Za-z_][A-Za-z0-9_]*`, nothing else. Used to
+/// reject `wire:` values that are JS/Blade expressions rather than a plain
+/// method or property name (`$wire.foo++`, `save() && close()`).
+fn is_php_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 // ============================================================================
 // Component resolution (Phase 3)
 // ============================================================================

--- a/laravel-lsp/src/livewire_resolver.rs
+++ b/laravel-lsp/src/livewire_resolver.rs
@@ -740,6 +740,206 @@ fn front_matter_window(content: &str) -> &str {
     &content[..adjusted]
 }
 
+/// True when `var` (name without the `$`) is bound LOCALLY in the template
+/// at 0-based `line`, so a bare-`$var` reference there must not navigate to a
+/// backing-class property — the local binding shadows it.
+///
+/// Local binding sources, per Blade's own scoping:
+/// - an ENCLOSING `@foreach` / `@forelse` loop variable (`as $item`,
+///   `as $key => $item`) — out of scope again after the matching
+///   `@endforeach` / `@endforelse`;
+/// - Blade's `$loop`, inside any `@foreach` / `@forelse`;
+/// - an ENCLOSING `@for` init variable (`@for ($i = 0; …)`);
+/// - a `@php` assignment (block or inline `@php($x = …)`) — PHP locals
+///   persist in the compiled template's scope, so the binding holds from
+///   that line to the end of the file;
+/// - a `@props([...])` / `@aware([...])` component-prop declaration —
+///   file-wide.
+///
+/// Line-granular by design: a binding and a use on the same line count as
+/// in scope (`@foreach ($users as $user)` — cursor on `$user`).
+pub fn is_template_local_binding(content: &str, line: u32, var: &str) -> bool {
+    let mut loop_stack: Vec<Vec<String>> = Vec::new();
+    let mut for_stack: Vec<Vec<String>> = Vec::new();
+    let mut persistent: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut in_php_block = false;
+
+    for (idx, text) in content.lines().enumerate() {
+        if idx > line as usize {
+            break;
+        }
+        let mut scan = text;
+
+        // `@php($x = …)` inline form first — it must not toggle block state.
+        if let Some(rest) = find_directive(scan, "@php") {
+            if rest.trim_start().starts_with('(') {
+                collect_assignments(rest, &mut persistent);
+            } else {
+                in_php_block = true;
+                scan = rest;
+            }
+        }
+        if in_php_block {
+            collect_assignments(scan, &mut persistent);
+        }
+        if scan.contains("@endphp") {
+            in_php_block = false;
+        }
+
+        if let Some(rest) =
+            find_directive(text, "@props").or_else(|| find_directive(text, "@aware"))
+        {
+            collect_quoted_names(rest, &mut persistent);
+        }
+
+        if let Some(rest) =
+            find_directive(text, "@foreach").or_else(|| find_directive(text, "@forelse"))
+        {
+            loop_stack.push(loop_binding_names(rest));
+        }
+        if let Some(rest) = find_directive(text, "@for") {
+            // `@for` only — `@foreach`/`@forelse` were consumed above and
+            // find_directive requires a non-identifier char after the name.
+            let mut names = Vec::new();
+            collect_assignment_names(rest, &mut names);
+            for_stack.push(names);
+        }
+
+        if idx == line as usize {
+            break;
+        }
+        if text.contains("@endforeach") || text.contains("@endforelse") {
+            loop_stack.pop();
+        }
+        if text.contains("@endfor")
+            && !text.contains("@endforeach")
+            && !text.contains("@endforelse")
+        {
+            for_stack.pop();
+        }
+    }
+
+    if var == "loop" && !loop_stack.is_empty() {
+        return true;
+    }
+    persistent.contains(var)
+        || loop_stack
+            .iter()
+            .any(|names| names.iter().any(|n| n == var))
+        || for_stack.iter().any(|names| names.iter().any(|n| n == var))
+}
+
+/// The text following `@{name}` on `line`, when the directive occurs with a
+/// non-identifier character (or end of line) right after it — so `@for`
+/// never matches inside `@foreach`.
+fn find_directive<'a>(line: &'a str, name: &str) -> Option<&'a str> {
+    let mut from = 0;
+    while let Some(rel) = line[from..].find(name) {
+        let at = from + rel;
+        let after = at + name.len();
+        let boundary = line[after..]
+            .chars()
+            .next()
+            .is_none_or(|c| !c.is_alphanumeric() && c != '_');
+        if boundary {
+            return Some(&line[after..]);
+        }
+        from = after;
+    }
+    None
+}
+
+/// The variables an `@foreach` / `@forelse` head binds: everything after
+/// `as` — `$item`, or `$key => $item`.
+fn loop_binding_names(rest: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    if let Some(pos) = rest.find(" as ") {
+        collect_dollar_names(&rest[pos + 4..], &mut names);
+    }
+    names
+}
+
+/// Every `$name` token in `s`.
+fn collect_dollar_names(s: &str, out: &mut Vec<String>) {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' {
+            let start = i + 1;
+            let mut end = start;
+            while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+                end += 1;
+            }
+            if end > start {
+                out.push(s[start..end].to_string());
+            }
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+}
+
+/// Every `$name` that is being ASSIGNED (`$name =`, not `==`/`=>`/`<=` etc.)
+/// in `s`, appended to `out`.
+fn collect_assignment_names(s: &str, out: &mut Vec<String>) {
+    let mut names = Vec::new();
+    collect_dollar_names(s, &mut names);
+    for name in names {
+        // Find `$name` followed (after whitespace) by a single `=`.
+        let needle = format!("${name}");
+        let mut from = 0;
+        while let Some(rel) = s[from..].find(&needle) {
+            let after = from + rel + needle.len();
+            let rest = s[after..].trim_start();
+            let assigns = rest.starts_with('=')
+                && !rest.starts_with("==")
+                && !rest.starts_with("=>")
+                && !rest.starts_with("===");
+            if assigns {
+                out.push(name.clone());
+                break;
+            }
+            from = after;
+        }
+    }
+}
+
+/// [`collect_assignment_names`] into a set.
+fn collect_assignments(s: &str, out: &mut std::collections::HashSet<String>) {
+    let mut names = Vec::new();
+    collect_assignment_names(s, &mut names);
+    out.extend(names);
+}
+
+/// Every `'name'` / `"name"` string key or entry in a `@props([...])` /
+/// `@aware([...])` argument on this line.
+fn collect_quoted_names(s: &str, out: &mut std::collections::HashSet<String>) {
+    let mut chars = s.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if c == '\'' || c == '"' {
+            if let Some(rel) = s[i + 1..].find(c) {
+                let name = &s[i + 1..i + 1 + rel];
+                if !name.is_empty()
+                    && name
+                        .chars()
+                        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+                {
+                    out.insert(name.to_string());
+                }
+                // skip past the closing quote
+                while let Some(&(j, _)) = chars.peek() {
+                    if j <= i + 1 + rel {
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
 const VOLT_FUNCTIONAL_CALLS: &[&str] = &[
     "state(",
     "action(",

--- a/laravel-lsp/src/livewire_resolver/tests.rs
+++ b/laravel-lsp/src/livewire_resolver/tests.rs
@@ -454,3 +454,139 @@ fn reverse_none_for_non_livewire_file() {
 
     assert!(livewire_name_for_path(&path, &cfg, LivewireVersion::V4).is_none());
 }
+
+// ---- wire_attribute_target_at --------------------------------------------
+
+#[test]
+fn wire_click_method_call() {
+    let line = r#"<button wire:click="enterEditMode">Edit</button>"#;
+    let cursor = line.find("enterEditMode").unwrap() as u32 + 3;
+    assert_eq!(
+        wire_attribute_target_at(line, cursor),
+        Some(WireTarget::Method("enterEditMode".to_string()))
+    );
+}
+
+#[test]
+fn wire_poll_with_modifier_and_method_call_with_args() {
+    let line = r#"<div wire:poll.2000ms="checkPrefillStatus"></div>"#;
+    let cursor = line.find("checkPrefillStatus").unwrap() as u32;
+    assert_eq!(
+        wire_attribute_target_at(line, cursor),
+        Some(WireTarget::Method("checkPrefillStatus".to_string()))
+    );
+}
+
+#[test]
+fn wire_submit_prevent_method_call_with_arguments() {
+    let line = r#"<form wire:submit.prevent="save('draft')">"#;
+    let cursor = line.find("save(").unwrap() as u32 + 1;
+    assert_eq!(
+        wire_attribute_target_at(line, cursor),
+        Some(WireTarget::Method("save".to_string()))
+    );
+}
+
+#[test]
+fn wire_model_targets_the_first_dot_segment_as_a_property() {
+    let line = r#"<input wire:model="contractData.title">"#;
+    let cursor = line.find("contractData").unwrap() as u32 + 2;
+    assert_eq!(
+        wire_attribute_target_at(line, cursor),
+        Some(WireTarget::Property("contractData".to_string()))
+    );
+}
+
+#[test]
+fn wire_model_live_modifier_still_targets_the_property() {
+    let line = r#"<input wire:model.live.debounce.500ms="filters.search">"#;
+    let cursor = line.find("filters").unwrap() as u32 + 1;
+    assert_eq!(
+        wire_attribute_target_at(line, cursor),
+        Some(WireTarget::Property("filters".to_string()))
+    );
+}
+
+#[test]
+fn wire_click_js_expression_has_no_target() {
+    let line = r#"<button wire:click="$wire.count++">+</button>"#;
+    let cursor = line.find("count").unwrap() as u32;
+    assert!(wire_attribute_target_at(line, cursor).is_none());
+}
+
+#[test]
+fn cursor_outside_the_quoted_value_has_no_target() {
+    let line = r#"<button wire:click="enterEditMode">Edit</button>"#;
+    let cursor = line.find("wire:click").unwrap() as u32;
+    assert!(wire_attribute_target_at(line, cursor).is_none());
+}
+
+#[test]
+fn no_wire_attribute_on_line_has_no_target() {
+    let line = r#"<button class="btn">Edit</button>"#;
+    assert!(wire_attribute_target_at(line, 10).is_none());
+}
+
+#[test]
+fn wire_completion_context_empty_value_is_method_kind() {
+    let line = r#"<button wire:click="">"#;
+    let col = line.find('"').unwrap() as u32 + 1;
+    assert_eq!(
+        wire_attribute_completion_context(line, col),
+        Some((WireValueKind::Method, String::new()))
+    );
+}
+
+#[test]
+fn wire_completion_context_partial_value_carries_prefix() {
+    let line = r#"<div wire:poll.2000ms="check">"#;
+    let col = (line.find("check").unwrap() + "check".len()) as u32;
+    assert_eq!(
+        wire_attribute_completion_context(line, col),
+        Some((WireValueKind::Method, "check".to_string()))
+    );
+}
+
+#[test]
+fn wire_completion_context_model_is_property_kind() {
+    let line = r#"<input wire:model="contract">"#;
+    let col = (line.find("contract").unwrap() + 3) as u32;
+    assert_eq!(
+        wire_attribute_completion_context(line, col),
+        Some((WireValueKind::Property, "con".to_string()))
+    );
+}
+
+#[test]
+fn wire_completion_context_unclosed_quote_still_matches() {
+    let line = r#"<button wire:click="sa"#;
+    let col = line.len() as u32;
+    assert_eq!(
+        wire_attribute_completion_context(line, col),
+        Some((WireValueKind::Method, "sa".to_string()))
+    );
+}
+
+#[test]
+fn wire_completion_context_rejects_expression_values() {
+    let line = r#"<button wire:click="$wire.count++">"#;
+    let col = (line.find("count").unwrap() + 2) as u32;
+    assert_eq!(wire_attribute_completion_context(line, col), None);
+}
+
+#[test]
+fn wire_completion_context_non_member_attribute_is_none() {
+    let line = r#"<div wire:key="row-1">"#;
+    let col = (line.find("row").unwrap() + 1) as u32;
+    assert_eq!(wire_attribute_completion_context(line, col), None);
+}
+
+#[test]
+fn wire_target_show_and_text_bind_properties() {
+    let line = r#"<span wire:text="prefillStatus">"#;
+    let col = (line.find("prefill").unwrap() + 2) as u32;
+    assert_eq!(
+        wire_attribute_target_at(line, col),
+        Some(WireTarget::Property("prefillStatus".to_string()))
+    );
+}

--- a/laravel-lsp/src/livewire_resolver/tests.rs
+++ b/laravel-lsp/src/livewire_resolver/tests.rs
@@ -793,3 +793,34 @@ fn class_property_reference_is_not_shadowed() {
 </div>";
     assert!(!is_template_local_binding(content, 1, "prefillStatus"));
 }
+
+#[test]
+fn unclosed_quote_with_cursor_elsewhere_on_the_line_does_not_panic() {
+    // Regression: with an unclosed value, the scan's resume point stepped
+    // one byte past the end of the line — any cursor NOT inside that value
+    // (which returns early) then sliced out of bounds and killed the serve
+    // loop. Cursor in `class=""`, half-typed wire:click to its right.
+    let line = r#"<div class="" wire:click="save"#;
+    assert!(wire_attribute_completion_context(line, 5).is_none());
+    assert!(wire_attribute_target_at(line, 5).is_none());
+}
+
+#[test]
+fn non_ascii_value_with_mid_codepoint_cursor_does_not_panic() {
+    // Regression: `position.character` is a UTF-16 code-unit offset, not a
+    // byte index — a caret after `prü` arrives as column 22, which lands
+    // INSIDE the two-byte `ü` when used as a byte offset and panicked on
+    // the slice. The guard (same as every other cursor site) bails out
+    // instead of unwinding the server.
+    let line = r#"<input wire:model="prüfung">"#;
+    assert!(wire_attribute_completion_context(line, 22).is_none());
+    assert!(wire_attribute_target_at(line, 22).is_none());
+}
+
+#[test]
+fn cursor_past_end_of_line_does_not_panic() {
+    let line = r#"<input wire:model="title">"#;
+    let past = line.len() as u32 + 5;
+    assert!(wire_attribute_completion_context(line, past).is_none());
+    assert!(wire_attribute_target_at(line, past).is_none());
+}

--- a/laravel-lsp/src/livewire_resolver/tests.rs
+++ b/laravel-lsp/src/livewire_resolver/tests.rs
@@ -590,3 +590,37 @@ fn wire_target_show_and_text_bind_properties() {
         Some(WireTarget::Property("prefillStatus".to_string()))
     );
 }
+
+#[test]
+fn wire_completion_context_accepts_dotted_binding_paths() {
+    let line = r#"<input wire:model="formData.">"#;
+    let col = (line.find("formData.").unwrap() + "formData.".len()) as u32;
+    assert_eq!(
+        wire_attribute_completion_context(line, col),
+        Some((WireValueKind::Property, "formData.".to_string()))
+    );
+
+    let line = r#"<input wire:model="formData.ti">"#;
+    let col = (line.find("ti\"").unwrap() + 2) as u32;
+    assert_eq!(
+        wire_attribute_completion_context(line, col),
+        Some((WireValueKind::Property, "formData.ti".to_string()))
+    );
+}
+
+#[test]
+fn wire_completion_context_still_rejects_dotted_action_values() {
+    let line = r#"<button wire:click="save.now">"#;
+    let col = (line.find("save").unwrap() + 6) as u32;
+    assert_eq!(wire_attribute_completion_context(line, col), None);
+}
+
+#[test]
+fn property_path_prefix_rejects_malformed_paths() {
+    assert!(is_property_path_prefix("a.b.c"));
+    assert!(is_property_path_prefix("a."));
+    assert!(is_property_path_prefix(""));
+    assert!(!is_property_path_prefix(".a"));
+    assert!(!is_property_path_prefix("a..b"));
+    assert!(!is_property_path_prefix("a.b c"));
+}

--- a/laravel-lsp/src/livewire_resolver/tests.rs
+++ b/laravel-lsp/src/livewire_resolver/tests.rs
@@ -624,3 +624,172 @@ fn property_path_prefix_rejects_malformed_paths() {
     assert!(!is_property_path_prefix("a..b"));
     assert!(!is_property_path_prefix("a.b c"));
 }
+
+#[test]
+fn wire_keydown_enter_is_an_action_binding() {
+    // Any DOM-event directive is an action binding, not just click/submit/
+    // poll — and the method name need not echo the event name.
+    let line = r#"<input wire:keydown.enter="performSearch">"#;
+    let cursor = line.find("performSearch").unwrap() as u32 + 2;
+    assert_eq!(
+        wire_attribute_target_at(line, cursor),
+        Some(WireTarget::Method("performSearch".to_string()))
+    );
+}
+
+#[test]
+fn wire_submit_with_mismatched_method_name_navigates() {
+    let line = r#"<form wire:submit="handleSubmit">"#;
+    let cursor = line.find("handleSubmit").unwrap() as u32;
+    assert_eq!(
+        wire_attribute_target_at(line, cursor),
+        Some(WireTarget::Method("handleSubmit".to_string()))
+    );
+}
+
+#[test]
+fn wire_change_and_blur_are_action_bindings() {
+    for line in [
+        r#"<select wire:change="applyFilter">"#,
+        r#"<input wire:blur="validateField">"#,
+    ] {
+        let value_start = line.find('"').unwrap() as u32 + 1;
+        assert!(
+            matches!(
+                wire_attribute_target_at(line, value_start),
+                Some(WireTarget::Method(_))
+            ),
+            "line: {line}"
+        );
+    }
+}
+
+#[test]
+fn wire_confirm_value_is_a_message_not_a_member() {
+    // Deviation from the issue's example list, deliberately: `wire:confirm`'s
+    // value is the confirmation MESSAGE shown to the user, not a method name.
+    let line = r#"<button wire:confirm="Delete" wire:click="delete">x</button>"#;
+    let cursor = line.find("Delete").unwrap() as u32;
+    assert!(wire_attribute_target_at(line, cursor).is_none());
+}
+
+#[test]
+fn non_wire_prefixed_js_expressions_have_no_target() {
+    // The `$wire.`-prefixed case is covered above; these two prove the
+    // exclusion is the value GRAMMAR, not a `$wire` special case.
+    for line in [
+        r#"<button wire:click="count++">+</button>"#,
+        r#"<button wire:click="open = true">go</button>"#,
+    ] {
+        let value_start = line.find('"').unwrap() as u32 + 1;
+        assert!(
+            wire_attribute_target_at(line, value_start).is_none(),
+            "line: {line}"
+        );
+    }
+}
+
+#[test]
+fn wire_target_works_with_single_quoted_values() {
+    let line = "<button wire:click='enterEditMode'>Edit</button>";
+    let cursor = line.find("enterEditMode").unwrap() as u32 + 1;
+    assert_eq!(
+        wire_attribute_target_at(line, cursor),
+        Some(WireTarget::Method("enterEditMode".to_string()))
+    );
+}
+
+#[test]
+fn wire_completion_context_single_quotes_and_unclosed_mid_line() {
+    // Single-quote style.
+    let line = "<input wire:model='contract";
+    let cursor = line.len() as u32;
+    assert_eq!(
+        wire_attribute_completion_context(line, cursor),
+        Some((WireValueKind::Property, "contract".to_string()))
+    );
+    // Unclosed double quote while the document continues past this line —
+    // the value ends at end-of-line for completion purposes.
+    let line = r#"    <button wire:click="ent"#;
+    let cursor = line.len() as u32;
+    assert_eq!(
+        wire_attribute_completion_context(line, cursor),
+        Some((WireValueKind::Method, "ent".to_string()))
+    );
+}
+
+// ---- template-local bindings shadow class properties ----------------------
+
+#[test]
+fn foreach_loop_variable_is_local_inside_the_loop_only() {
+    let content = "\
+<div>
+@foreach ($users as $user)
+    <span>{{ $user->name }}</span>
+@endforeach
+<span>{{ $user }}</span>
+</div>";
+    assert!(is_template_local_binding(content, 2, "user"));
+    assert!(
+        is_template_local_binding(content, 1, "user"),
+        "binding and use on the @foreach line itself count as in scope"
+    );
+    assert!(
+        !is_template_local_binding(content, 4, "user"),
+        "after @endforeach the loop variable is out of scope"
+    );
+}
+
+#[test]
+fn foreach_key_value_binds_both_names_and_loop() {
+    let content = "\
+@foreach ($rows as $index => $row)
+    {{ $loop->iteration }} {{ $index }} {{ $row }}
+@endforeach";
+    assert!(is_template_local_binding(content, 1, "row"));
+    assert!(is_template_local_binding(content, 1, "index"));
+    assert!(is_template_local_binding(content, 1, "loop"));
+    assert!(!is_template_local_binding(content, 1, "rows"));
+}
+
+#[test]
+fn php_block_assignment_persists_after_endphp() {
+    let content = "\
+@php
+    $total = 0;
+@endphp
+<span>{{ $total }}</span>";
+    assert!(
+        is_template_local_binding(content, 3, "total"),
+        "PHP locals persist in the compiled template scope"
+    );
+    assert!(!is_template_local_binding(content, 3, "other"));
+}
+
+#[test]
+fn inline_php_and_for_and_props_bind_locals() {
+    let content = "\
+@props(['variant', 'size' => 'md'])
+@php($discount = 5)
+@for ($i = 0; $i < 3; $i++)
+    {{ $i }} {{ $variant }} {{ $discount }}
+@endfor
+{{ $i }}";
+    assert!(is_template_local_binding(content, 3, "variant"));
+    assert!(is_template_local_binding(content, 3, "size"));
+    assert!(is_template_local_binding(content, 3, "discount"));
+    assert!(is_template_local_binding(content, 3, "i"));
+    assert!(
+        !is_template_local_binding(content, 5, "i"),
+        "@endfor closes the loop-variable scope"
+    );
+}
+
+#[test]
+fn class_property_reference_is_not_shadowed() {
+    let content = "\
+<div>
+    <span>{{ $prefillStatus }}</span>
+</div>";
+    assert!(!is_template_local_binding(content, 1, "prefillStatus"));
+}

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -11065,31 +11065,57 @@ impl LaravelLanguageServer {
 
         let root = self.root_path.read().await.clone()?;
 
-        let (target_path, declaration_position) = match property {
+        let target = match &property {
             // $var → component file + property declaration line for $var
             None => {
-                let component_path = self.find_livewire_component_php(&root, path)?;
-                let component_content = std::fs::read_to_string(&component_path).ok()?;
-                let pos = laravel_lsp::php_class::find_property_declaration_position(
-                    &component_content,
-                    &var_name,
-                )?;
-                (component_path, pos)
+                let via_component =
+                    self.find_livewire_component_php(&root, path)
+                        .and_then(|component_path| {
+                            let component_content =
+                                std::fs::read_to_string(&component_path).ok()?;
+                            let pos = laravel_lsp::php_class::find_property_declaration_position(
+                                &component_content,
+                                &var_name,
+                            )?;
+                            Some((component_path, pos))
+                        });
+                match via_component {
+                    Some(t) => Some(t),
+                    // Project-wide fallback: a Filament `$view`-property page
+                    // or Livewire component the checks above don't reach —
+                    // `$var` itself is the member name to locate.
+                    None => self
+                        .locate_in_backing_class_files(&file_path, &var_name)
+                        .await
+                        .map(|(p, loc)| (p, (loc.line, loc.start_column, loc.end_column))),
+                }
             }
             // $var->prop → class file (whatever type $var resolves to) + prop line
             Some(prop_name) => {
-                let var_type = self
-                    .resolve_blade_variable_type(uri, &format!("${}", var_name))
-                    .await?;
-                let class_path = laravel_lsp::class_locator::find_php_class_file(&var_type, &root)?;
-                let class_content = std::fs::read_to_string(&class_path).ok()?;
-                let pos = laravel_lsp::php_class::find_property_declaration_position(
-                    &class_content,
-                    &prop_name,
-                )?;
-                (class_path, pos)
+                let via_resolved_type = async {
+                    let var_type = self
+                        .resolve_blade_variable_type(uri, &format!("${}", var_name))
+                        .await?;
+                    let class_path =
+                        laravel_lsp::class_locator::find_php_class_file(&var_type, &root)?;
+                    let class_content = std::fs::read_to_string(&class_path).ok()?;
+                    let pos = laravel_lsp::php_class::find_property_declaration_position(
+                        &class_content,
+                        prop_name,
+                    )?;
+                    Some((class_path, pos))
+                }
+                .await;
+                match via_resolved_type {
+                    Some(t) => Some(t),
+                    None => self
+                        .locate_in_backing_class_files(&file_path, prop_name)
+                        .await
+                        .map(|(p, loc)| (p, (loc.line, loc.start_column, loc.end_column))),
+                }
             }
         };
+        let (target_path, declaration_position) = target?;
 
         let (line, start_col, end_col) = declaration_position;
         let target_uri = Url::from_file_path(&target_path).ok()?;
@@ -11107,6 +11133,42 @@ impl LaravelLanguageServer {
                 },
             },
         }))
+    }
+
+    /// Goto-definition for a `wire:*="value"` attribute in a Blade template:
+    /// extract the binding target ([`livewire_resolver::wire_attribute_target_at`])
+    /// and locate it in whichever `.php` file backs this view.
+    ///
+    /// Returns `None` when the cursor isn't inside a `wire:` value, the value
+    /// isn't a resolvable identifier (`wire:click="$wire.foo++"`), or no
+    /// backing class declares the target member.
+    async fn wire_attribute_goto_definition(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<GotoDefinitionResponse> {
+        use laravel_lsp::livewire_resolver::WireTarget;
+
+        let file_path = uri.to_file_path().ok()?;
+        let content = self
+            .documents
+            .read()
+            .await
+            .get(uri)
+            .map(|(c, _)| c.clone())?;
+        let line_text = content.lines().nth(position.line as usize)?;
+        let target = laravel_lsp::livewire_resolver::wire_attribute_target_at(
+            line_text,
+            position.character,
+        )?;
+        let member = match &target {
+            WireTarget::Method(m) => m,
+            WireTarget::Property(p) => p,
+        };
+        let (class_path, loc) = self
+            .locate_in_backing_class_files(&file_path, member)
+            .await?;
+        Self::goto_link(&class_path, loc.line, loc.start_column, loc.end_column)
     }
 
     /// Resolve the type of a property `prop` on a given class. Uses the class
@@ -11423,6 +11485,66 @@ impl LaravelLanguageServer {
                             php_type,
                             source: "slot".to_string(),
                         });
+                    }
+                }
+            }
+        }
+
+        // 7. Project-wide render index fallback (lowest priority — everything
+        // above already claimed its names via `seen`). Covers render-site
+        // shapes the per-source checks above don't — any class whose render
+        // site was captured into the index (controllers, and `$view`-property
+        // pages once #295 lands). Namespace-aware reverse mapping arrives
+        // with the #295 branch; until then plain view roots resolve here.
+        let view_paths_config = self
+            .cached_config
+            .try_read()
+            .ok()
+            .map(|g| match g.as_ref() {
+                Some(config) => config.view_paths.clone(),
+                None => vec![root.join("resources/views")],
+            });
+        if let Some(view_paths) = view_paths_config {
+            if let Some(vn) =
+                laravel_lsp::view_var_index::view_name_for_path(&file_path, &view_paths)
+            {
+                let source_files = if let Ok(idx) = self.view_vars.read() {
+                    for (name, types) in idx.vars_for_view(&vn) {
+                        if seen.insert(name.clone()) {
+                            variables.push(BladeVariableInfo {
+                                name,
+                                php_type: types
+                                    .into_iter()
+                                    .next()
+                                    .unwrap_or_else(|| "mixed".to_string()),
+                                source: "component".to_string(),
+                            });
+                        }
+                    }
+                    idx.render_source_files(&vn)
+                } else {
+                    Vec::new()
+                };
+
+                // The render index keeps only class-typed properties (scalars
+                // have no members to resolve), but a template reads scalar
+                // and untyped publics as bare `$vars` too — enumerate every
+                // public property of the contributing class files so
+                // `$`-completion offers the full surface.
+                for class_file in source_files {
+                    let Ok(class_source) = std::fs::read_to_string(&class_file) else {
+                        continue;
+                    };
+                    for (name, php_type) in
+                        laravel_lsp::component_member_locator::public_property_types(&class_source)
+                    {
+                        if seen.insert(name.clone()) {
+                            variables.push(BladeVariableInfo {
+                                name,
+                                php_type,
+                                source: "component".to_string(),
+                            });
+                        }
                     }
                 }
             }
@@ -12514,6 +12636,86 @@ impl LaravelLanguageServer {
         }
 
         self.view_path_to_livewire_class_path(root, blade_path)
+    }
+
+    /// Every `.php` file backing `blade_path`'s rendered content — the union
+    /// of two independent sources:
+    ///   1. The project-wide render index's contributors for the file's
+    ///      namespaced view name (a Filament-style `$view`-property page, or
+    ///      any controller `view(...)` call site).
+    ///   2. The conventionally-resolved Livewire component class, when
+    ///      `blade_path` is a Livewire view — so goto/hover `$this->member`
+    ///      and `wire:` fallbacks work for plain Livewire components too, not
+    ///      just Filament pages.
+    ///
+    /// Resolution for (2) goes through `livewire_name_for_path` +
+    /// `resolve_component` (the reverse-then-forward resolver), not
+    /// `find_livewire_component_php`'s file heuristics — a V4 SFC or Volt
+    /// component's class lives inline in the `.blade.php` itself, which has
+    /// no separate `.php` source for `component_member_locator` to parse, so
+    /// those legitimately contribute nothing here.
+    ///
+    /// Deduped; only paths that exist on disk and end in a plain `.php`
+    /// extension (not `.blade.php`) are kept.
+    async fn blade_backing_class_files(&self, blade_path: &Path) -> Vec<PathBuf> {
+        let mut out: Vec<PathBuf> = Vec::new();
+
+        let (view_paths, view_namespaces) = match self.cached_config.read().await.as_ref() {
+            Some(config) => (config.view_paths.clone(), config.view_namespaces.clone()),
+            None => (Vec::new(), HashMap::new()),
+        };
+        if let Some(view_name) = laravel_lsp::view_var_index::view_name_for_path_namespaced(
+            blade_path,
+            &view_paths,
+            &view_namespaces,
+        ) {
+            if let Ok(idx) = self.view_vars.read() {
+                out.extend(idx.render_source_files(&view_name));
+            }
+        }
+
+        if let Some((lw_config, lw_version)) = self.get_cached_livewire().await {
+            if let Some(name) = laravel_lsp::livewire_resolver::livewire_name_for_path(
+                blade_path, &lw_config, lw_version,
+            ) {
+                if let Some(component) =
+                    laravel_lsp::livewire_resolver::resolve_component(&name, &lw_config, lw_version)
+                {
+                    out.extend(component.paths);
+                }
+            }
+        }
+
+        let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+        out.retain(|p| {
+            let is_plain_php = p.extension().and_then(|e| e.to_str()) == Some("php")
+                && !p.to_string_lossy().ends_with(".blade.php");
+            is_plain_php && p.is_file() && seen.insert(p.clone())
+        });
+        out
+    }
+
+    /// Locate `member` (a property or method name) in whichever `.php`
+    /// file(s) back `blade_path` (see [`Self::blade_backing_class_files`]).
+    /// Returns the first hit's file plus its declaration position.
+    async fn locate_in_backing_class_files(
+        &self,
+        blade_path: &Path,
+        member: &str,
+    ) -> Option<(
+        PathBuf,
+        laravel_lsp::component_member_locator::MemberLocation,
+    )> {
+        for class_path in self.blade_backing_class_files(blade_path).await {
+            let Ok(source) = std::fs::read_to_string(&class_path) else {
+                continue;
+            };
+            if let Some(loc) = laravel_lsp::component_member_locator::locate_member(&source, member)
+            {
+                return Some((class_path, loc));
+            }
+        }
+        None
     }
 
     /// Given a Livewire-view iterable expression (e.g. "$this->audits") and the view's path,
@@ -19055,6 +19257,21 @@ return [
                 // Fall through so `{{ $user->posts()->count() }}` keeps the
                 // variable hover it had before call-form capture (#77).
                 if card.is_empty() && uri.path().ends_with(".blade.php") {
+                    // `$this->member` refers to the component backing this
+                    // view (Filament `$view`-property page, Livewire
+                    // component) — `hover_for_magic_member` doesn't resolve
+                    // it (there's no receiver class to classify against), so
+                    // try the backing-class lookup before the generic
+                    // Blade-variable fallback.
+                    if member_ref.receiver.trim() == "$this" {
+                        if let Ok(path) = uri.to_file_path() {
+                            if let Some(rendered) =
+                                self.this_member_hover_card(&path, &member_ref.member).await
+                            {
+                                return Some(rendered);
+                            }
+                        }
+                    }
                     if let Some((var_name, property)) = self
                         .blade_variable_at_position(uri, member_ref.line, member_ref.column)
                         .await
@@ -19419,6 +19636,33 @@ return [
             Err(_) => (data.decl_line.unwrap_or(0), 0, 0),
         };
         Self::goto_link(&decl_file, line, start, end)
+    }
+
+    /// Minimal hover card for `$this->member` in a Blade template whose
+    /// backing class is known (a Filament `$view`-property page, a Livewire
+    /// component): header `ClassName::member` (methods) or `ClassName::$member`
+    /// (properties), plus a source link to the declaration. `None` when no
+    /// backing class declares `member`.
+    async fn this_member_hover_card(&self, blade_path: &Path, member: &str) -> Option<String> {
+        use laravel_lsp::component_member_locator::MemberKind;
+        use laravel_lsp::hover;
+
+        let (class_path, loc) = self
+            .locate_in_backing_class_files(blade_path, member)
+            .await?;
+        let class_name = laravel_lsp::php_class::extract_class_fqn(&class_path)
+            .unwrap_or_else(|| "Component".to_string());
+        let header = match loc.kind {
+            MemberKind::Method => format!("{class_name}::{member}()"),
+            MemberKind::Property => format!("{class_name}::${member}"),
+        };
+        let link = self.source_link(&class_path, Some(loc.line + 1)).await;
+        let rendered = hover::render(&hover::HoverContent {
+            header: Some(&header),
+            source_link: Some(&link),
+            ..Default::default()
+        });
+        (!rendered.is_empty()).then_some(rendered)
     }
 
     /// The Blade variable (and optional property) under a position, read from
@@ -23198,6 +23442,17 @@ impl LanguageServer for LaravelLanguageServer {
                     return Ok(Some(slot_location));
                 }
 
+                // `wire:` attribute fallback: cmd-click on a `wire:click="save"` /
+                // `wire:model="contractData.title"` value jumps into the
+                // backing component's method / property. Tried before the
+                // Blade-variable fallback since a `wire:` value isn't a `$var`
+                // reference and would never match it anyway.
+                if uri.path().ends_with(".blade.php") {
+                    if let Some(loc) = self.wire_attribute_goto_definition(&uri, position).await {
+                        return Ok(Some(loc));
+                    }
+                }
+
                 // Blade-variable fallback: when the cursor sits on a `$var` or
                 // `$var->prop` reference in a `.blade.php` file, jump to the
                 // declaration site instead of returning nothing.
@@ -23363,6 +23618,27 @@ impl LanguageServer for LaravelLanguageServer {
                 // Blade-variable goto rather than swallowing a position that
                 // jumped before call-form capture existed.
                 if location.is_none() && file_path.to_string_lossy().ends_with(".blade.php") {
+                    // `$this->member` in a template refers to the component
+                    // backing this view (a Filament `$view`-property page, a
+                    // Livewire component) rather than any Blade-scoped `$var`
+                    // — jump straight into the backing class before falling
+                    // through to the generic Blade-variable fallback, which
+                    // only understands bare `$var` / `$var->prop`.
+                    if member.receiver.trim() == "$this" {
+                        if let Some((class_path, loc)) = self
+                            .locate_in_backing_class_files(&file_path, &member.member)
+                            .await
+                        {
+                            if let Some(resp) = Self::goto_link(
+                                &class_path,
+                                loc.line,
+                                loc.start_column,
+                                loc.end_column,
+                            ) {
+                                return Ok(Some(resp));
+                            }
+                        }
+                    }
                     return Ok(self.blade_variable_goto_definition(&uri, position).await);
                 }
                 location
@@ -24953,6 +25229,73 @@ impl LanguageServer for LaravelLanguageServer {
             // Check for variable name context in Blade files (typing $user, $u, etc.)
             // This must come BEFORE model property context to avoid conflicts
             if uri.path().ends_with(".blade.php") {
+                // `wire:*` attribute value completion: actions (public
+                // methods) for event bindings, public properties for
+                // `wire:model`/`wire:show`/`wire:text` — sourced from the
+                // template's backing component class (Filament `$view` page
+                // or conventional Livewire component).
+                if let Some((wire_kind, typed_prefix)) =
+                    laravel_lsp::livewire_resolver::wire_attribute_completion_context(
+                        line_text,
+                        position.character,
+                    )
+                {
+                    if let Ok(blade_path) = uri.to_file_path() {
+                        let mut items: Vec<CompletionItem> = Vec::new();
+                        let mut seen_members = std::collections::HashSet::new();
+                        for class_file in self.blade_backing_class_files(&blade_path).await {
+                            let Ok(class_source) = std::fs::read_to_string(&class_file) else {
+                                continue;
+                            };
+                            match wire_kind {
+                                laravel_lsp::livewire_resolver::WireValueKind::Property => {
+                                    for (name, php_type) in
+                                        laravel_lsp::component_member_locator::public_property_types(
+                                            &class_source,
+                                        )
+                                    {
+                                        if name.starts_with(&typed_prefix)
+                                            && seen_members.insert(name.clone())
+                                        {
+                                            items.push(CompletionItem {
+                                                label: name,
+                                                kind: Some(CompletionItemKind::FIELD),
+                                                detail: Some(php_type),
+                                                ..Default::default()
+                                            });
+                                        }
+                                    }
+                                }
+                                laravel_lsp::livewire_resolver::WireValueKind::Method => {
+                                    for name in
+                                        laravel_lsp::component_member_locator::public_action_method_names(
+                                            &class_source,
+                                        )
+                                    {
+                                        if name.starts_with(&typed_prefix)
+                                            && seen_members.insert(name.clone())
+                                        {
+                                            items.push(CompletionItem {
+                                                label: name,
+                                                kind: Some(CompletionItemKind::METHOD),
+                                                detail: Some("Livewire action".to_string()),
+                                                ..Default::default()
+                                            });
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if !items.is_empty() {
+                            items.sort_by(|a, b| a.label.cmp(&b.label));
+                            return Ok(Some(CompletionResponse::List(CompletionList {
+                                is_incomplete: false,
+                                items,
+                            })));
+                        }
+                    }
+                }
+
                 // Alpine.js magic completion (`@click="$dis|"`, `x-data="{… $st|"`).
                 // Must precede the Blade `$variable` context below so a magic
                 // inside an Alpine expression wins over plain variable suggestions

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -3302,6 +3302,7 @@ struct VariableAccess {
 
 /// Represents an available variable in a Blade file
 /// Used for $variable name autocompletion
+#[derive(Debug)]
 struct BladeVariableInfo {
     name: String,
     php_type: String,
@@ -11063,6 +11064,20 @@ impl LaravelLanguageServer {
         let (var_name, property) =
             extract_blade_variable_at_cursor(&line_text, position.character)?;
 
+        // Template-local bindings shadow class properties: a `$var` bound by
+        // an enclosing `@foreach`/`@for` loop, a `@php` assignment, a
+        // component `@props`, or Blade's own `$loop` is NOT a reference to a
+        // backing-class member, so no class-property navigation is offered.
+        if property.is_none()
+            && laravel_lsp::livewire_resolver::is_template_local_binding(
+                &content,
+                position.line,
+                &var_name,
+            )
+        {
+            return None;
+        }
+
         let root = self.root_path.read().await.clone()?;
 
         let target = match &property {
@@ -11545,6 +11560,31 @@ impl LaravelLanguageServer {
                                 source: "component".to_string(),
                             });
                         }
+                    }
+                }
+            }
+        }
+
+        // An inline `new class extends Component` (Livewire v4 SFC, Volt
+        // class API) has no standalone `.php` file for the render index or
+        // the loops above to reach — its public properties come straight
+        // from the template's own front matter. `seen` keeps the merge
+        // deduplicated against every earlier source.
+        let blade_content = match content {
+            Some(c) => Some(c.to_string()),
+            None => std::fs::read_to_string(&file_path).ok(),
+        };
+        if let Some(blade_content) = blade_content {
+            if laravel_lsp::php_class::detect_inline_livewire_class(&blade_content) {
+                for (name, php_type) in
+                    laravel_lsp::component_member_locator::public_property_types(&blade_content)
+                {
+                    if seen.insert(name.clone()) {
+                        variables.push(BladeVariableInfo {
+                            name,
+                            php_type,
+                            source: "component".to_string(),
+                        });
                     }
                 }
             }
@@ -12696,6 +12736,42 @@ impl LaravelLanguageServer {
     /// Locate `member` (a property or method name) in whichever `.php`
     /// file(s) back `blade_path` (see [`Self::blade_backing_class_files`]).
     /// Returns the first hit's file plus its declaration position.
+    /// Every `(path, source)` pair whose PHP class backs `blade_path` — the
+    /// plain-`.php` backing files ([`Self::blade_backing_class_files`]), plus
+    /// the blade file ITSELF when it declares an inline
+    /// `new class extends Component` (a Livewire v4 single-file component or
+    /// a class-based Volt component). Those two shapes have no standalone
+    /// `.php` source: the class lives in the template's own front matter, so
+    /// the template is the source to parse and member positions land in the
+    /// `.blade.php` itself. The live editor buffer wins over disk for it.
+    async fn blade_backing_class_sources(&self, blade_path: &Path) -> Vec<(PathBuf, String)> {
+        let mut out: Vec<(PathBuf, String)> = Vec::new();
+        for class_path in self.blade_backing_class_files(blade_path).await {
+            if let Ok(source) = std::fs::read_to_string(&class_path) {
+                out.push((class_path, source));
+            }
+        }
+        let live = match Url::from_file_path(blade_path) {
+            Ok(url) => self
+                .documents
+                .read()
+                .await
+                .get(&url)
+                .map(|(c, _)| c.clone()),
+            Err(()) => None,
+        };
+        let blade_content = match live {
+            Some(content) => Some(content),
+            None => std::fs::read_to_string(blade_path).ok(),
+        };
+        if let Some(content) = blade_content {
+            if laravel_lsp::php_class::detect_inline_livewire_class(&content) {
+                out.push((blade_path.to_path_buf(), content));
+            }
+        }
+        out
+    }
+
     async fn locate_in_backing_class_files(
         &self,
         blade_path: &Path,
@@ -12704,10 +12780,7 @@ impl LaravelLanguageServer {
         PathBuf,
         laravel_lsp::component_member_locator::MemberLocation,
     )> {
-        for class_path in self.blade_backing_class_files(blade_path).await {
-            let Ok(source) = std::fs::read_to_string(&class_path) else {
-                continue;
-            };
+        for (class_path, source) in self.blade_backing_class_sources(blade_path).await {
             if let Some(loc) = laravel_lsp::component_member_locator::locate_member(&source, member)
             {
                 return Some((class_path, loc));
@@ -19636,27 +19709,40 @@ return [
         Self::goto_link(&decl_file, line, start, end)
     }
 
-    /// Minimal hover card for `$this->member` in a Blade template whose
-    /// backing class is known (a Filament `$view`-property page, a Livewire
-    /// component): header `ClassName::member` (methods) or `ClassName::$member`
-    /// (properties), plus a source link to the declaration. `None` when no
-    /// backing class declares `member`.
+    /// Hover card for `$this->member` in a Blade template whose backing
+    /// class is known (a Filament `$view`-property page, a Livewire
+    /// component, an inline SFC/Volt class): header `ClassName::member()` /
+    /// `ClassName::$member`, the member's declaration header as a PHP code
+    /// block (a method's full signature — modifiers, parameters, return
+    /// type — or a property's modifiers + declared type), and a source link
+    /// to the declaration. Emitted unconditionally in Blade: Intelephense
+    /// cannot resolve `$this` in a template's PHP context, so there is no
+    /// PHP-tooling card to defer to. `None` when no backing class declares
+    /// `member`.
     async fn this_member_hover_card(&self, blade_path: &Path, member: &str) -> Option<String> {
         use laravel_lsp::component_member_locator::MemberKind;
         use laravel_lsp::hover;
 
-        let (class_path, loc) = self
-            .locate_in_backing_class_files(blade_path, member)
-            .await?;
-        let class_name = laravel_lsp::php_class::extract_class_fqn(&class_path)
+        let sources = self.blade_backing_class_sources(blade_path).await;
+        let (class_path, source, loc) = sources.iter().find_map(|(path, source)| {
+            laravel_lsp::component_member_locator::locate_member(source, member)
+                .map(|loc| (path, source, loc))
+        })?;
+        let class_name = laravel_lsp::php_class::extract_class_fqn(class_path)
             .unwrap_or_else(|| "Component".to_string());
         let header = match loc.kind {
             MemberKind::Method => format!("{class_name}::{member}()"),
             MemberKind::Property => format!("{class_name}::${member}"),
         };
-        let link = self.source_link(&class_path, Some(loc.line + 1)).await;
+        let signature =
+            laravel_lsp::component_member_locator::member_declaration_summary(source, member);
+        let link = self.source_link(class_path, Some(loc.line + 1)).await;
         let rendered = hover::render(&hover::HoverContent {
             header: Some(&header),
+            code: signature.as_deref().map(|sig| hover::CodeBlock {
+                language: hover::CodeLanguage::Php,
+                content: sig,
+            }),
             source_link: Some(&link),
             ..Default::default()
         });
@@ -25301,10 +25387,8 @@ impl LanguageServer for LaravelLanguageServer {
                     if let Ok(blade_path) = uri.to_file_path() {
                         let mut items: Vec<CompletionItem> = Vec::new();
                         let mut seen_members = std::collections::HashSet::new();
-                        for class_file in self.blade_backing_class_files(&blade_path).await {
-                            let Ok(class_source) = std::fs::read_to_string(&class_file) else {
-                                continue;
-                            };
+                        for (_, class_source) in self.blade_backing_class_sources(&blade_path).await
+                        {
                             match wire_kind {
                                 laravel_lsp::livewire_resolver::WireValueKind::Property => {
                                     for (name, php_type) in

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -12660,15 +12660,13 @@ impl LaravelLanguageServer {
     async fn blade_backing_class_files(&self, blade_path: &Path) -> Vec<PathBuf> {
         let mut out: Vec<PathBuf> = Vec::new();
 
-        let (view_paths, view_namespaces) = match self.cached_config.read().await.as_ref() {
-            Some(config) => (config.view_paths.clone(), config.view_namespaces.clone()),
-            None => (Vec::new(), HashMap::new()),
+        let view_paths = match self.cached_config.read().await.as_ref() {
+            Some(config) => config.view_paths.clone(),
+            None => Vec::new(),
         };
-        if let Some(view_name) = laravel_lsp::view_var_index::view_name_for_path_namespaced(
-            blade_path,
-            &view_paths,
-            &view_namespaces,
-        ) {
+        if let Some(view_name) =
+            laravel_lsp::view_var_index::view_name_for_path(blade_path, &view_paths)
+        {
             if let Ok(idx) = self.view_vars.read() {
                 out.extend(idx.render_source_files(&view_name));
             }
@@ -25240,6 +25238,66 @@ impl LanguageServer for LaravelLanguageServer {
                         position.character,
                     )
                 {
+                    // Dotted binding path (`wire:model="contractData.title"`):
+                    // resolve the leading segments to a class through the same
+                    // machinery `$var->` member completion uses, then offer
+                    // THAT class's properties for the segment under the
+                    // cursor. Depth beyond the first hop resolves as far as
+                    // the property types stay resolvable class names.
+                    if matches!(
+                        wire_kind,
+                        laravel_lsp::livewire_resolver::WireValueKind::Property
+                    ) && typed_prefix.contains('.')
+                    {
+                        let segments: Vec<&str> = typed_prefix.split('.').collect();
+                        let (leaf_prefix, path) = segments.split_last().unwrap();
+                        let mut fqcn = self
+                            .resolve_blade_variable_type(uri, &format!("${}", path[0]))
+                            .await;
+                        for seg in &path[1..] {
+                            let Some(current) = fqcn.take() else {
+                                break;
+                            };
+                            fqcn = self
+                                .get_class_properties(&current)
+                                .await
+                                .into_iter()
+                                .find(|p| p.name == *seg)
+                                .map(|p| {
+                                    p.php_type
+                                        .trim_start_matches('?')
+                                        .trim_start_matches('\\')
+                                        .to_string()
+                                });
+                        }
+                        if let Some(class_name) = fqcn {
+                            let leaf_lower = leaf_prefix.to_lowercase();
+                            let mut items: Vec<CompletionItem> = self
+                                .get_class_properties(&class_name)
+                                .await
+                                .into_iter()
+                                // A binding names a property — the
+                                // `relationship query` (`posts()`) shape
+                                // can't be bound.
+                                .filter(|p| !p.name.ends_with("()"))
+                                .filter(|p| p.name.to_lowercase().starts_with(&leaf_lower))
+                                .map(|p| CompletionItem {
+                                    label: p.name.clone(),
+                                    kind: Some(CompletionItemKind::FIELD),
+                                    detail: Some(p.php_type.clone()),
+                                    ..Default::default()
+                                })
+                                .collect();
+                            if !items.is_empty() {
+                                items.sort_by(|a, b| a.label.cmp(&b.label));
+                                return Ok(Some(CompletionResponse::List(CompletionList {
+                                    is_incomplete: false,
+                                    items,
+                                })));
+                            }
+                        }
+                    }
+
                     if let Ok(blade_path) = uri.to_file_path() {
                         let mut items: Vec<CompletionItem> = Vec::new();
                         let mut seen_members = std::collections::HashSet::new();

--- a/laravel-lsp/src/tests/component_member_navigation.rs
+++ b/laravel-lsp/src/tests/component_member_navigation.rs
@@ -1,0 +1,238 @@
+//! End-to-end member resolution for the inline-class component shapes.
+//!
+//! A Livewire v4 single-file component and a class-based Volt component keep
+//! their class in the template's own front matter — there is no standalone
+//! `.php` file for `component_member_locator` to read. `blade_backing_class_
+//! sources` therefore hands the `.blade.php` content itself to the locator,
+//! so `$this->member`, bare-`$var` and `wire:` navigation land at the exact
+//! member declaration INSIDE the blade file. These tests drive the private
+//! async methods on a server built through the `tower_lsp::LspService`
+//! harness against a tempdir (same pattern as the translation tests).
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::component_member_locator::MemberKind;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tower_lsp::LspService;
+
+async fn backend_with_root(root: &Path) -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    let backend = service.inner().clone();
+    *backend.root_path.write().await = Some(root.to_path_buf());
+    backend
+}
+
+const SFC_SOURCE: &str = r#"<?php
+
+use Livewire\Component;
+
+new class extends Component {
+    public int $count = 0;
+
+    public function increment(): void
+    {
+        $this->count++;
+    }
+};
+?>
+
+<div>
+    <span>{{ $count }}</span>
+    <button wire:click="increment">+</button>
+</div>
+"#;
+
+fn write_sfc(root: &Path) -> PathBuf {
+    let dir = root.join("resources/views/livewire");
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("counter.blade.php");
+    fs::write(&path, SFC_SOURCE).unwrap();
+    path
+}
+
+#[tokio::test]
+async fn sfc_member_resolves_into_the_blade_file_itself() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_sfc(dir.path());
+
+    let (path, loc) = backend
+        .locate_in_backing_class_files(&blade, "increment")
+        .await
+        .expect("the inline class declares increment()");
+    assert_eq!(path, blade, "an SFC's member lives in the blade file");
+    assert_eq!(loc.kind, MemberKind::Method);
+    assert_eq!(loc.line, 7, "0-based line of `public function increment`");
+
+    let (_, count) = backend
+        .locate_in_backing_class_files(&blade, "count")
+        .await
+        .expect("the inline class declares $count");
+    assert_eq!(count.kind, MemberKind::Property);
+    assert_eq!(count.line, 5);
+}
+
+#[tokio::test]
+async fn volt_class_member_resolves_into_the_blade_file() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let pages = dir.path().join("resources/views/pages");
+    fs::create_dir_all(&pages).unwrap();
+    let blade = pages.join("search.blade.php");
+    fs::write(
+        &blade,
+        r#"<?php
+
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public string $search = '';
+}; ?>
+
+<div><input wire:model="search"></div>
+"#,
+    )
+    .unwrap();
+
+    let (path, loc) = backend
+        .locate_in_backing_class_files(&blade, "search")
+        .await
+        .expect("the Volt front-matter class declares $search");
+    assert_eq!(path, blade);
+    assert_eq!(loc.kind, MemberKind::Property);
+    assert_eq!(loc.line, 5);
+}
+
+#[tokio::test]
+async fn hover_card_carries_kind_class_and_signature() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_sfc(dir.path());
+
+    let card = backend
+        .this_member_hover_card(&blade, "increment")
+        .await
+        .expect("member exists, so a card must be emitted");
+    assert!(
+        card.contains("::increment()"),
+        "header names the member as a method: {card}"
+    );
+    assert!(
+        card.contains("public function increment(): void"),
+        "card carries the full signature: {card}"
+    );
+
+    let card = backend
+        .this_member_hover_card(&blade, "count")
+        .await
+        .expect("property card");
+    assert!(card.contains("::$count"), "property header: {card}");
+    assert!(
+        card.contains("public int $count"),
+        "card carries the declared type: {card}"
+    );
+}
+
+#[tokio::test]
+async fn plain_template_without_inline_class_contributes_no_source() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let views = dir.path().join("resources/views");
+    fs::create_dir_all(&views).unwrap();
+    let blade = views.join("welcome.blade.php");
+    fs::write(&blade, "<div>{{ $title }}</div>").unwrap();
+
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "title")
+            .await
+            .is_none(),
+        "no backing class, no navigation target"
+    );
+}
+
+#[tokio::test]
+async fn dollar_surface_offers_inline_class_properties_once() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_sfc(dir.path());
+    let uri = tower_lsp::lsp_types::Url::from_file_path(&blade).unwrap();
+
+    let vars = backend.get_blade_available_variables(&uri, Some(SFC_SOURCE), Some(16));
+    let count_entries: Vec<_> = vars.iter().filter(|v| v.name == "count").collect();
+    assert_eq!(
+        count_entries.len(),
+        1,
+        "the inline class's $count is offered exactly once, got {vars:?}"
+    );
+    assert_eq!(count_entries[0].php_type, "int");
+}
+
+#[tokio::test]
+async fn local_loop_binding_shadows_class_property_navigation() {
+    // The backing class declares $count; the template also binds $count as a
+    // @foreach loop variable. Inside the loop the LOCAL binding wins — no
+    // class-property navigation.
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_sfc(dir.path());
+    let shadowing = "@foreach ($items as $count)\n    {{ $count }}\n@endforeach\n";
+    fs::write(&blade, format!("{SFC_SOURCE}\n{shadowing}")).unwrap();
+    let uri = tower_lsp::lsp_types::Url::from_file_path(&blade).unwrap();
+    let content = fs::read_to_string(&blade).unwrap();
+    backend
+        .documents
+        .write()
+        .await
+        .insert(uri.clone(), (content.clone(), 0));
+
+    let inside_loop_line = content
+        .lines()
+        .position(|l| l.trim() == "{{ $count }}")
+        .unwrap() as u32;
+    let col = content
+        .lines()
+        .nth(inside_loop_line as usize)
+        .unwrap()
+        .find("count")
+        .unwrap() as u32;
+
+    assert!(
+        backend
+            .blade_variable_goto_definition(
+                &uri,
+                tower_lsp::lsp_types::Position {
+                    line: inside_loop_line,
+                    character: col,
+                },
+            )
+            .await
+            .is_none(),
+        "an enclosing @foreach binding must shadow the class property"
+    );
+
+    // Outside any loop the same $count still navigates to the class property.
+    let outside_line = content
+        .lines()
+        .position(|l| l.contains("<span>{{ $count }}</span>"))
+        .unwrap() as u32;
+    let outside_col = content
+        .lines()
+        .nth(outside_line as usize)
+        .unwrap()
+        .find("count")
+        .unwrap() as u32;
+    assert!(
+        backend
+            .blade_variable_goto_definition(
+                &uri,
+                tower_lsp::lsp_types::Position {
+                    line: outside_line,
+                    character: outside_col,
+                },
+            )
+            .await
+            .is_some(),
+        "outside the loop the class property is the target"
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod code_action_create_containment;
 mod code_lens_opt_in;
 mod completion_value_pipeline;
 mod component_file_navigation_containment;
+mod component_member_navigation;
 mod component_navigation_containment;
 mod composer_autoload_containment;
 mod controllers_dir_containment;

--- a/laravel-lsp/src/view_var_index.rs
+++ b/laravel-lsp/src/view_var_index.rs
@@ -142,11 +142,18 @@ impl ViewVarIndex {
     /// fallback jump straight from the template into whichever class(es)
     /// declare its variables.
     pub fn render_source_files(&self, view_name: &str) -> Vec<PathBuf> {
-        self.by_file
+        let mut files: Vec<PathBuf> = self
+            .by_file
             .iter()
             .filter(|(_, renders)| renders.iter().any(|r| r.view_name == view_name))
             .map(|(path, _)| path.clone())
-            .collect()
+            .collect();
+        // Sorted for the same reason `vars_for_view` sorts: `by_file` is a
+        // HashMap, and `locate_in_backing_class_files` takes the FIRST hit
+        // over this list — unsorted, a member declared by two contributing
+        // classes would flap between targets run to run.
+        files.sort();
+        files
     }
 
     /// Every variable `view_name` has a render site for, as `(name, sorted

--- a/laravel-lsp/src/view_var_index.rs
+++ b/laravel-lsp/src/view_var_index.rs
@@ -135,6 +135,41 @@ impl ViewVarIndex {
             .unwrap_or_default()
     }
 
+    /// Every file that currently contributes a render site for `view_name` —
+    /// the reverse of `by_file`'s per-file contribution. A Filament-style
+    /// `$view`-property page and any controller `view(...)` call site that
+    /// renders the same view both show up here, letting a Blade-goto/hover
+    /// fallback jump straight from the template into whichever class(es)
+    /// declare its variables.
+    pub fn render_source_files(&self, view_name: &str) -> Vec<PathBuf> {
+        self.by_file
+            .iter()
+            .filter(|(_, renders)| renders.iter().any(|r| r.view_name == view_name))
+            .map(|(path, _)| path.clone())
+            .collect()
+    }
+
+    /// Every variable `view_name` has a render site for, as `(name, sorted
+    /// FQCN types)` — the same union-across-render-sites [`Self::var_types`]
+    /// exposes, but for every variable at once (feeds `$`-completion). Pairs
+    /// are sorted by variable name for deterministic completion ordering;
+    /// empty when the view was never rendered.
+    pub fn vars_for_view(&self, view_name: &str) -> Vec<(String, Vec<String>)> {
+        let Some(vars) = self.forward.get(view_name) else {
+            return Vec::new();
+        };
+        let mut out: Vec<(String, Vec<String>)> = vars
+            .iter()
+            .map(|(name, types)| {
+                let mut sorted: Vec<String> = types.iter().cloned().collect();
+                sorted.sort();
+                (name.clone(), sorted)
+            })
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
     /// Clear everything — called at the start of a warm rebuild.
     pub fn clear(&mut self) {
         self.forward.clear();

--- a/laravel-lsp/src/view_var_index/tests.rs
+++ b/laravel-lsp/src/view_var_index/tests.rs
@@ -1437,3 +1437,18 @@ new class extends Component {
     );
     assert!(captured.iter().all(|e| e.fqcn.starts_with("volt::")));
 }
+
+#[test]
+fn render_source_files_are_sorted_for_deterministic_first_match() {
+    let mut idx = ViewVarIndex::new();
+    for name in ["zeta", "alpha", "midway"] {
+        idx.insert_file(
+            PathBuf::from(format!("/proj/{name}/Controller.php")),
+            &[render("users.show", &[("user", "App\\Models\\User")])],
+        );
+    }
+    let files = idx.render_source_files("users.show");
+    let mut sorted = files.clone();
+    sorted.sort();
+    assert_eq!(files, sorted, "HashMap order must not leak to callers");
+}

--- a/laravel-lsp/src/view_var_index/tests.rs
+++ b/laravel-lsp/src/view_var_index/tests.rs
@@ -170,6 +170,66 @@ fn index_clear_empties() {
     assert_eq!(idx.view_count(), 0);
 }
 
+#[test]
+fn render_source_files_returns_every_contributing_file() {
+    let mut idx = ViewVarIndex::new();
+    let controller = PathBuf::from("/proj/UserController.php");
+    let page = PathBuf::from("/proj/Filament/UserPage.php");
+    idx.insert_file(
+        controller.clone(),
+        &[render("users.show", &[("user", "App\\Models\\User")])],
+    );
+    idx.insert_file(
+        page.clone(),
+        &[render("users.show", &[("account", "App\\Models\\Account")])],
+    );
+    idx.insert_file(
+        PathBuf::from("/proj/OtherController.php"),
+        &[render("other.view", &[("x", "App\\X")])],
+    );
+
+    let mut sources = idx.render_source_files("users.show");
+    sources.sort();
+    let mut expected = vec![controller, page];
+    expected.sort();
+    assert_eq!(sources, expected);
+    assert!(idx.render_source_files("missing.view").is_empty());
+}
+
+#[test]
+fn vars_for_view_returns_every_variable_sorted() {
+    let mut idx = ViewVarIndex::new();
+    idx.insert_file(
+        PathBuf::from("/proj/UserController.php"),
+        &[render(
+            "dash",
+            &[
+                ("user", "App\\Models\\User"),
+                ("posts", "App\\Models\\Post"),
+            ],
+        )],
+    );
+    idx.insert_file(
+        PathBuf::from("/proj/AdminController.php"),
+        &[render("dash", &[("user", "App\\Models\\Admin")])],
+    );
+
+    assert_eq!(
+        idx.vars_for_view("dash"),
+        vec![
+            ("posts".to_string(), vec!["App\\Models\\Post".to_string()]),
+            (
+                "user".to_string(),
+                vec![
+                    "App\\Models\\Admin".to_string(),
+                    "App\\Models\\User".to_string()
+                ]
+            ),
+        ]
+    );
+    assert!(idx.vars_for_view("missing.view").is_empty());
+}
+
 // ---- view_name_for_path --------------------------------------------------
 
 #[test]


### PR DESCRIPTION
Fixes #296

Blade templates backed by a component class had no member awareness: `wire:click="save"` wasn't clickable, `$this->method()` had no goto or hover, and `$` completion didn't offer the component's properties. This implements the design from #296, including the acceptance criteria added there. Standalone — it does not depend on #334 (#295); the two compose when both land.

## What it does

**`wire:` attribute navigation.** Any `wire:` directive whose value is a bindable action reference is goto-navigable to the named method — every DOM-event directive (`wire:keydown.enter`, `wire:change`, `wire:blur`, …), not a fixed list, and independent of whether the method name echoes the event (`wire:submit="handleSubmit"`). `wire:model` (with any dotted modifiers), `wire:show`, and `wire:text` navigate to the named property; a dotted path targets the top-level property. Values that are JS expressions (`$wire.count++`, `count++`, `open = true`) are left alone entirely, so nothing conflicts with Alpine.

**`wire:` attribute completion.** Action bindings offer the backing class's public, non-static methods — excluding `mount`, `boot`, `booted`, `hydrate`, `dehydrate`, `rendering`, `rendered`, `exception`, and the `updatedFoo`/`updatingFoo` hook families (the prefix match requires a camelCase boundary, so `updates()` and `hydraulics()` stay offered). Data bindings offer public, non-static properties, and dotted paths complete segment by segment: each leading segment resolves to its declared class through the same machinery `$var->` member completion uses, at any depth while the types stay resolvable. Works with either quote style, prefix-filtered, and before the closing quote is typed.

**`$this->member` goto + hover.** Goto lands on the exact line/column of the member's declaration. The hover card carries the member kind, the resolved backing class, the full declaration header (method signature with parameters and return type, or property modifiers + declared type) as a PHP block, and a source link — emitted unconditionally in Blade, since Intelephense cannot resolve `$this` in a template's PHP context.

**Bare `$variable` goto with local-scope shadowing.** A bare `$var` navigates to the matching public property in the backing class — except when the template binds it locally first: an enclosing `@foreach`/`@forelse`/`@for` variable, a `@php` assignment (block or inline; PHP locals persist for the rest of the template), a `@props`/`@aware` entry, or Blade's own `$loop`. Local scope wins and no class navigation is offered.

**All four backing-class shapes.** v3 class-based, v4 MFC, v4 SFC, and class-based Volt all resolve — resolution goes through the Livewire resolver (reverse-then-forward), not filename heuristics. For the two inline shapes (SFC, Volt) the class lives in the template's front matter, so the template's own content (live buffer over disk) is handed to the member locator and positions land inside the `.blade.php` itself.

**`$` completion.** Offers the backing class's public, non-static properties (inline front-matter classes included), merged and de-duplicated against the existing view-data `$` completion so no name appears twice. Framework-base-class properties are never offered — the surface comes from the component's own declaration, not its ancestry.

## Deliberate deviations from the AC, called out

- **`wire:confirm` is not action-bindable.** The AC's example list includes it, but its value is the confirmation *message* shown to the user, not a method name — a test pins the exclusion.
- **Action values with arguments still navigate.** `wire:click="save('draft')"` goes to `save` — that's Livewire's own action-call syntax, not an Alpine expression, so excluding it per the letter of the bindable-value grammar would break the most common parameterized-action shape. The grammar is applied to everything else.

## Known limitation (per the AC's carve-out)

Trait-provided and inherited members (`WithPagination`, `WithFileUploads`, abstract base components) do not resolve — only members declared in the component's own class file or front matter. Documented in all three docs pages.

## Tests

Fixtures per shape with exact line/column assertions, hover signature content, non-example directives, directive/method-name mismatch, two non-`$wire` JS-expression exclusions, static-property/method exclusion, lifecycle-boundary cases, dotted-modifier and 2-level nested `wire:model` completion, single-quote and unclosed-quote completion, per-source local-binding scope tests (including binding-and-use on the same line and out-of-scope after `@end*`), `$`-surface dedup, and an end-to-end shadowing test (loop-bound `$var` doesn't navigate; the same name outside the loop does). Full suite: 2589 lib + 557 integration tests green, clippy `-D warnings` clean.

`docs/go-to-definition.md`, `docs/hover.md`, and `docs/autocomplete.md` gained fenced examples in the existing `^^^^` pointer-annotation style.