### PR TITLE
Route every "is this an env file?" check through one strict predicate (3 spellings, 2 loose)

### DIFF
--- a/laravel-lsp/src/tests/env_completion_context_gate.rs
+++ b/laravel-lsp/src/tests/env_completion_context_gate.rs
@@ -1,0 +1,269 @@
+//! Which files the completion handler treats as env files (issue #345).
+//!
+//! `completion` picks the context helper for the cursor from the file's
+//! classification: an env file gets `${...}` interpolation, a PHPUnit XML file
+//! gets its `<env name="…">` attributes, and everything else — PHP and Blade
+//! included — gets `env('...')` call completion. That choice used to gate on
+//! `path.contains(".env")`, a substring test over the whole path, so every
+//! file under a directory such as `.envs/` classified as an env file. A `.php`
+//! file there was handed the interpolation helper, so its `env('…')` calls
+//! never reached the call-context helper that completes them.
+//!
+//! `env_key_locator::path_is_env_file` now owns the decision, and its own unit
+//! tests pin the predicate. They say nothing about whether this dispatch
+//! consults it: a predicate can be perfect while the handler that classifies
+//! with it reads something else entirely. `env_source_registration_gate`
+//! makes the same argument for the Salsa-registration call site; this module
+//! is its counterpart for the completion call site.
+//!
+//! So everything here drives the **real** `textDocument/completion` request
+//! and asserts on the items it returns. The two directions are both pinned,
+//! because a one-directional test cannot tell a narrowed gate from a closed
+//! one:
+//!
+//! - a rejected file must not get interpolation completion, and
+//! - a real `.env` variant must still get it.
+
+use crate::LaravelLanguageServer;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use tower_lsp::lsp_types::{
+    CompletionParams, CompletionResponse, DidChangeTextDocumentParams, Position,
+    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentPositionParams, Url,
+    VersionedTextDocumentIdentifier,
+};
+use tower_lsp::{LanguageServer, LspService};
+
+/// The variable the project's own `.env` declares. Deliberately unlike any
+/// real environment variable: the handler appends `std::env::vars()` matching
+/// the same prefix, so a name that could collide with the machine's
+/// environment would make "no items" mean "no match" rather than "no context".
+const SENTINEL: &str = "ZL345_SENTINEL";
+
+/// The prefix typed at the cursor. Must remain a prefix of [`SENTINEL`], so
+/// every fixture below builds its template from this constant rather than
+/// spelling the prefix out: a rejection test asserts that *nothing* is
+/// offered, and a prefix that had drifted out of sync with the sentinel would
+/// satisfy that assertion by matching nothing at all. The positive tests share
+/// the constant and so keep it honest — they fail if it stops matching.
+const PREFIX: &str = "ZL345_";
+
+/// A backend with `root_path` primed and the Salsa debounce removed, so a
+/// `did_change` can be awaited deterministically instead of slept on.
+/// Mirrors `env_source_registration_gate::backend_for`.
+async fn backend_for(root: &Path) -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    let backend = service.inner().clone();
+    *backend.root_path.write().await = Some(root.to_path_buf());
+    *backend.auto_complete_debounce_ms.write().await = 0;
+    backend
+}
+
+/// Register the project's `.env` as a real Salsa env source by driving the
+/// `did_change` handler, so the completion under test has something to offer.
+/// Without this every assertion below would read "no items" and pass for the
+/// wrong reason.
+async fn seed_env_source(backend: &LaravelLanguageServer, root: &Path) {
+    let text = format!("{SENTINEL}=from_dot_env\n");
+    let path = root.join(".env");
+    fs::write(&path, &text).unwrap();
+    let uri = Url::from_file_path(&path).unwrap();
+    backend
+        .did_change(DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier {
+                uri: uri.clone(),
+                version: 1,
+            },
+            content_changes: vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: text.clone(),
+            }],
+        })
+        .await;
+    if let Some(handle) = backend.pending_salsa_updates.write().await.remove(&uri) {
+        let _ = handle.await;
+    }
+}
+
+/// Build `(content, cursor position)` from a template carrying a single `◊`
+/// marker at the desired cursor, matching the convention in
+/// `query_chain_completion_handler`. The marker is stripped from the returned
+/// content; the position is its 0-based line + code-point column.
+fn cursor_at(template: &str) -> (String, Position) {
+    const MARK: char = '◊';
+    let byte_idx = template
+        .find(MARK)
+        .expect("template must contain the ◊ cursor marker");
+    let before = &template[..byte_idx];
+    let line = before.matches('\n').count() as u32;
+    let character = before.rsplit('\n').next().unwrap_or(before).chars().count() as u32;
+    (template.replace(MARK, ""), Position { line, character })
+}
+
+/// Write `rel` under `root`, open it in the server's document map, and drive
+/// the real `completion` request at the template's `◊` marker. Returns the
+/// offered labels — empty when the handler declines, which is what "not a
+/// completion context here" looks like from the client's side.
+async fn completion_labels(
+    backend: &LaravelLanguageServer,
+    root: &Path,
+    rel: &str,
+    template: &str,
+) -> Vec<String> {
+    let (content, position) = cursor_at(template);
+    let path: PathBuf = root.join(rel);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, &content).unwrap();
+    let uri = Url::from_file_path(&path).unwrap();
+    backend
+        .documents
+        .write()
+        .await
+        .insert(uri.clone(), (content, 1));
+
+    let response = backend
+        .completion(CompletionParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position,
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+            context: None,
+        })
+        .await
+        .expect("completion must not error");
+
+    match response {
+        None => Vec::new(),
+        Some(CompletionResponse::Array(items)) => items.into_iter().map(|i| i.label).collect(),
+        Some(CompletionResponse::List(list)) => list.items.into_iter().map(|i| i.label).collect(),
+    }
+}
+
+/// A `.php` file under a `.env`-named directory, with the cursor inside a
+/// `${...}` interpolation. Interpolation is env-file syntax, so the handler
+/// must not offer it here — under the old `path.contains(".env")` gate this
+/// file classified as an env file and the interpolation completed.
+#[tokio::test]
+async fn php_under_an_env_named_directory_is_not_offered_interpolation() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    seed_env_source(&backend, dir.path()).await;
+
+    let labels = completion_labels(
+        &backend,
+        dir.path(),
+        ".envs/deploy.php",
+        &format!("<?php\n$value = \"${{{PREFIX}◊}}\";\n"),
+    )
+    .await;
+
+    assert!(
+        labels.is_empty(),
+        "`.envs/deploy.php` is a PHP file whose *directory* merely mentions \
+         `.env`; `${{...}}` is env-file syntax and must not complete there. \
+         Got {labels:?}"
+    );
+}
+
+/// The same file reaching the PHP arm it belongs to. This is the positive half
+/// of the pair: a gate that classified nothing as an env file would satisfy
+/// the assertion above while breaking env completion everywhere, and a gate
+/// that classified this file as an env file would send `env('…')` to the
+/// interpolation helper, which finds no `${` and declines.
+#[tokio::test]
+async fn php_under_an_env_named_directory_gets_env_call_completion() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    seed_env_source(&backend, dir.path()).await;
+
+    let labels = completion_labels(
+        &backend,
+        dir.path(),
+        ".envs/deploy.php",
+        &format!("<?php\n$value = env('{PREFIX}◊');\n"),
+    )
+    .await;
+
+    assert!(
+        labels.iter().any(|l| l == SENTINEL),
+        "a PHP file must reach `env('…')` call completion regardless of a \
+         `.env` substring in its directory; got {labels:?}"
+    );
+}
+
+/// direnv's file. Starts with `.env`, is not a Laravel env file, and is
+/// common in Laravel repositories that pin per-project tooling.
+#[tokio::test]
+async fn envrc_is_not_offered_interpolation() {
+    assert_rejects(".envrc").await;
+}
+
+/// A dot-less suffix — the variant arm requires the separating dot.
+#[tokio::test]
+async fn environment_is_not_offered_interpolation() {
+    assert_rejects(".environment").await;
+}
+
+/// A non-dot separator. Named in the issue alongside `.envrc`.
+#[tokio::test]
+async fn env_backup_is_not_offered_interpolation() {
+    assert_rejects(".env-backup").await;
+}
+
+/// Drive interpolation completion in `name` and require the handler to
+/// decline. Each caller is its own test so that reverting the gate reddens
+/// every rejected name independently — an assertion loop would stop at the
+/// first and credit only one row.
+async fn assert_rejects(name: &str) {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    seed_env_source(&backend, dir.path()).await;
+
+    let labels =
+        completion_labels(&backend, dir.path(), name, &format!("FOO=${{{PREFIX}◊}}\n")).await;
+
+    assert!(
+        labels.is_empty(),
+        "`{name}` is not a Laravel env file, so the project's env variables \
+         must not complete inside its `${{...}}`. Got {labels:?}"
+    );
+}
+
+/// The control. Every accepted variant the predicate documents must still
+/// reach interpolation completion through this same dispatch — the gate
+/// narrows the class, it does not close it.
+///
+/// The misses are collected and asserted once rather than asserted per
+/// iteration: an `assert!` inside the loop stops at the first failing variant,
+/// so a gate that dropped the whole `.env.<suffix>` arm would be credited by
+/// `.env.local` alone and leave `.env.example` and `.env.testing` unproven.
+#[tokio::test]
+async fn real_env_variants_are_still_offered_interpolation() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    seed_env_source(&backend, dir.path()).await;
+
+    let mut missing = Vec::new();
+    for variant in [".env", ".env.local", ".env.example", ".env.testing"] {
+        let labels = completion_labels(
+            &backend,
+            dir.path(),
+            variant,
+            &format!("{SENTINEL}=from_dot_env\nOTHER=${{{PREFIX}◊}}\n"),
+        )
+        .await;
+        if !labels.iter().any(|l| l == SENTINEL) {
+            missing.push(variant);
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "every Laravel env variant must still complete `${{...}}` \
+         interpolation through this dispatch; these did not: {missing:?}"
+    );
+}

--- a/laravel-lsp/src/tests/env_completion_context_gate.rs
+++ b/laravel-lsp/src/tests/env_completion_context_gate.rs
@@ -2,12 +2,13 @@
 //!
 //! `completion` picks the context helper for the cursor from the file's
 //! classification: an env file gets `${...}` interpolation, a PHPUnit XML file
-//! gets its `<env name="…">` attributes, and everything else — PHP and Blade
-//! included — gets `env('...')` call completion. That choice used to gate on
-//! `path.contains(".env")`, a substring test over the whole path, so every
-//! file under a directory such as `.envs/` classified as an env file. A `.php`
-//! file there was handed the interpolation helper, so its `env('…')` calls
-//! never reached the call-context helper that completes them.
+//! gets its `<env name="…">` and `<server name="…">` attributes, and everything
+//! else — PHP and Blade included — gets `env('...')` call completion. That
+//! choice used to gate on `path.contains(".env")`, a substring test over the
+//! whole path, so every file under a directory such as `.envs/` classified as
+//! an env file. A `.php` file there was handed the interpolation helper, so
+//! its `env('…')` calls never reached the call-context helper that completes
+//! them.
 //!
 //! `env_key_locator::path_is_env_file` now owns the decision, and its own unit
 //! tests pin the predicate. They say nothing about whether this dispatch
@@ -36,9 +37,16 @@ use tower_lsp::lsp_types::{
 use tower_lsp::{LanguageServer, LspService};
 
 /// The variable the project's own `.env` declares. Deliberately unlike any
-/// real environment variable: the handler appends `std::env::vars()` matching
-/// the same prefix, so a name that could collide with the machine's
-/// environment would make "no items" mean "no match" rather than "no context".
+/// real environment variable.
+///
+/// The handler offers only what the project declares. It *used to* merge the
+/// server's own `std::env::vars()` into that list and no longer does — the
+/// leak was issue #342, `main.rs` states its removal outright where the items
+/// are built, and `env_completion_system_leak` pins it. So this sentinel
+/// guards against a regression rather than describing current behaviour: were
+/// the merge ever to return, a name colliding with the machine's environment
+/// would make a rejection test's empty result mean "no match" instead of
+/// "no context", and it would pass for the wrong reason.
 const SENTINEL: &str = "ZL345_SENTINEL";
 
 /// The prefix typed at the cursor. Must remain a prefix of [`SENTINEL`], so
@@ -47,7 +55,36 @@ const SENTINEL: &str = "ZL345_SENTINEL";
 /// offered, and a prefix that had drifted out of sync with the sentinel would
 /// satisfy that assertion by matching nothing at all. The positive tests share
 /// the constant and so keep it honest — they fail if it stops matching.
+///
+/// That downstream protection is real, but it lands in the wrong place: drift
+/// reddens the two positive controls, whose names point at env-variant
+/// classification and PHP call completion and say nothing about constant
+/// drift. The assertion below fails at the constants instead.
 const PREFIX: &str = "ZL345_";
+
+const _: () = assert!(
+    is_proper_prefix(PREFIX.as_bytes(), SENTINEL.as_bytes()),
+    "PREFIX must remain a proper prefix of SENTINEL: every fixture here types \
+     PREFIX at the cursor and expects SENTINEL back, so drift would leave the \
+     rejection tests asserting emptiness against a prefix that matches nothing"
+);
+
+/// Whether `prefix` is a proper prefix of `full`. A `const fn` because the
+/// invariant it serves is a property of the constants themselves, so it is
+/// checked when the crate compiles rather than when some test happens to run.
+const fn is_proper_prefix(prefix: &[u8], full: &[u8]) -> bool {
+    if prefix.len() >= full.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < prefix.len() {
+        if prefix[i] != full[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
 
 /// A backend with `root_path` primed and the Salsa debounce removed, so a
 /// `did_change` can be awaited deterministically instead of slept on.
@@ -62,8 +99,10 @@ async fn backend_for(root: &Path) -> LaravelLanguageServer {
 
 /// Register the project's `.env` as a real Salsa env source by driving the
 /// `did_change` handler, so the completion under test has something to offer.
-/// Without this every assertion below would read "no items" and pass for the
-/// wrong reason.
+/// Without it every *rejection* assertion below would read "no items" and pass
+/// for the wrong reason. The two positive controls are what stop that going
+/// unnoticed: they require the sentinel back, so an unseeded harness fails
+/// them loudly instead of quietly satisfying their negative siblings.
 async fn seed_env_source(backend: &LaravelLanguageServer, root: &Path) {
     let text = format!("{SENTINEL}=from_dot_env\n");
     let path = root.join(".env");

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -20,6 +20,7 @@ mod diagnostic_severity;
 mod directive_navigation_containment;
 mod directive_view_fallback;
 mod dynamic_where_sparseness;
+mod env_completion_context_gate;
 mod env_source_registration_gate;
 mod expected_path_diagnostic_containment;
 mod factory_goto_def_handler;


### PR DESCRIPTION
## Summary

Implements #345.

The issue reads as a consolidation task: three spellings of "is this an env file?", two of them loose. That consolidation is **already on `main`** — all four `main.rs` call sites route through `env_key_locator`'s strict predicate, and the predicate has thorough unit tests. Inspector Lestrade verified the same thing independently during triage and rewrote the AC around what actually remains.

What remained is a test gap, and it is the gap this repo has been bitten by before (#338): **a unit test of an extracted predicate proves nothing about whether the dispatch consults it.** `env_source_registration_gate` makes that argument for the Salsa-registration call site. The completion call site had no equivalent — in fact no test in the crate drove the real `textDocument/completion` request at all.

This PR adds that test module. **Behaviour is unchanged; this commit adds tests only.**

## Changes

- New `laravel-lsp/src/tests/env_completion_context_gate.rs` (6 tests), registered in `src/tests/mod.rs`.
- Drives the **real** `completion` handler on an `LspService` harness and asserts on the items it returns, mirroring `env_source_registration_gate`'s "drive the dispatch, read back through the public surface" convention.
- Pins **both** directions, because a one-directional suite cannot tell a narrowed gate from a closed one:
  - **rejected** — `.envrc`, `.environment`, `.env-backup`, and a `.php` file at `.envs/deploy.php` get no `${...}` interpolation;
  - **accepted** — `.env`, `.env.local`, `.env.example`, `.env.testing` still do;
  - plus the PHP positive: `.envs/deploy.php` reaches `env('…')` call completion.

## Acceptance Criteria

Copied from the `<!-- acceptance-criteria -->` comment on #345.

- [x] **The predicates in `env_key_locator.rs` are the only place env-file classification is decided; every call site delegates.** Verified on this branch: `main.rs:9066`, `21559`, `24906`, `26748` all call `is_env_file_name`/`path_is_env_file`. Already true on `main` — this PR does not change it, it pins it.
- [x] **Grep sweep produces hits only in the three allowed buckets.** Pattern validated against known positives first (`env_key_locator.rs:50`, the predicate body, and the `main.rs:24901` explanatory comment) so the count is not vacuous. Seven hits, all in-bucket — full classification below.
- [x] **Discriminating cases rejected and accepted at two levels.** Level 1 (predicate unit) was already covered in `env_key_locator/tests.rs`. Level 2 (dispatch) is new and is this PR, driving the real `textDocument/completion` request end-to-end.
- [x] **Full `cargo test` and `cargo clippy --all-targets -- -D warnings` clean**, with the new tests' names visible. Output pasted below.

### Grep sweep — all seven hits, bucketed

```
$ grep -rn '\.starts_with("\.env")\|\.starts_with("\.env\.")\|\.contains("\.env")\|== "\.env"\|\.ends_with("\.env")' laravel-lsp/
(a) predicate body / doc   env_key_locator.rs:39, :50
(b) call-site rationale    main.rs:24901
(c) test files             tests/env_source_registration_gate.rs:4
                           tests/env_completion_context_gate.rs:6, :143   ← new, doc comments naming the rejected form
                           env_key_locator/tests.rs:268
```

No live re-implementation. The sweep covered `src/`, `src/tests/`, `tests/`, and the module-adjacent `*/tests.rs` files — the test tree included, which is precisely the scope that was missed twice on #338.

I also ran a broader **behavioural** sweep (`grep -rn '"\.env'` across `src/` and `tests/`, ~110 hits) rather than trusting the AC's literal pattern alone. Every hit outside the buckets above is a fixture write, a path join, or the priority ladder — no second classification site. Two adjacent things I checked and am reporting as *not* gaps:

- `main.rs:5911-5919` names `.env`, `.env.local`, `.env.example` outright at startup registration. Not a classification site — it enumerates files rather than deciding env-ness, and the predicate's own doc comment already documents it as the one env path that never asks.
- `integration_tests.rs:1358` `env_priority` is a local shadow of the `main.rs:9075` priority ladder. Structurally the #338 shape, but it is about *priority*, not classification, so it is outside this issue's unit; it carries no "MUST match production" claim, and the real ladder is already pinned end-to-end by `env_priority_ladder_survives_the_gate`. Left alone deliberately.

## Test Plan

- [x] All existing tests pass — full suite, not a filtered subset.
- [x] New tests cover the change, and each is mutation-verified.
- [x] `cargo clippy --all-targets -- -D warnings` clean.

### Mutation evidence

Every test has a mutation that reddens it — none is coverage theatre. Verified live, and re-verified after the fixtures were edited.

| Mutation | Result |
|---|---|
| `main.rs:24906` → `path.contains(".env")` (the old loose gate) | **5 red**: 3 rejection tests + the `.php` interpolation test + the `.php` `env('…')` positive |
| `main.rs:24906` → `false` (gate closed) | **1 red**: the accepted-variants control |
| `env_key_locator.rs:50` → `name == ".env"` (variant arm dropped) | **1 red**: control, naming all three dropped variants — `[".env.local", ".env.example", ".env.testing"]` |

Two details worth stating, both learned from #338's review:

- The accepted-variants control **collects** its misses and asserts once, instead of asserting inside the loop. An in-loop `assert!` stops at the first failure, so the third mutation would have been credited by `.env.local` alone and left the other two variants unproven. As written it names all three.
- The three rejection cases are **separate tests**, not rows in one loop, so the loose-gate mutation reddens each independently and visibly by name.

One honesty note on the rejection tests: they assert that *nothing* is offered, which is exactly the shape that can pass for the wrong reason if the typed prefix stops matching the sentinel variable. Every fixture therefore builds its template from a single `PREFIX` constant — there is one spelling of the prefix in the file — and the two positive tests share that constant, so they fail loudly if it ever stops matching.

### `cargo test` — full suite

```
running 2548 tests ... ok. 2548 passed; 0 failed
running 561 tests
test tests::env_completion_context_gate::env_backup_is_not_offered_interpolation ... ok
test tests::env_completion_context_gate::envrc_is_not_offered_interpolation ... ok
test tests::env_completion_context_gate::environment_is_not_offered_interpolation ... ok
test tests::env_completion_context_gate::php_under_an_env_named_directory_gets_env_call_completion ... ok
test tests::env_completion_context_gate::php_under_an_env_named_directory_is_not_offered_interpolation ... ok
test tests::env_completion_context_gate::real_env_variants_are_still_offered_interpolation ... ok
... ok. 561 passed; 0 failed
running 80 tests ... ok. 80 passed; 0 failed
running 0 tests ... ok. 0 passed; 0 failed
```

### `cargo clippy --all-targets -- -D warnings`

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.27s
```

Fixes #345


---

## Review round 2 — both blockers fixed

Comments and one compile-time assertion. **No behaviour change**; the six tests, their fixtures, and every assertion are untouched.

### Blocker 1 — the `SENTINEL` rationale described a fixed leak as live

`env_completion_context_gate.rs:39` asserted, in the present tense, that the handler appends `std::env::vars()`. It does not, and has not since `8cb4679` (#343) closed #342. Verified rather than assumed: `std::env::vars` appears nowhere in `main.rs` or `salsa_impl.rs`, and `main.rs:26647-26655` states the opposite outright where the items are built.

The defensive choice was right; only the justification was stale. It is now past tense and framed as regression cover — the sentinel guards against the merge *returning*, and the file no longer contradicts the code it describes.

### Blocker 2 — the `PREFIX`/`SENTINEL` invariant now fails at its own definition

```rust
const _: () = assert!(
    is_proper_prefix(PREFIX.as_bytes(), SENTINEL.as_bytes()),
    "PREFIX must remain a proper prefix of SENTINEL: …"
);
```

It trips at the constants, at **compile time**, before any test runs — strictly earlier than the suggested runtime form. The `const fn` is three-outcome, and each outcome is proven live, not reasoned about:

| Mutation | Result |
|---|---|
| `PREFIX = "ZL999_"` (byte mismatch) | **compile error** `E0080` at `:65`, naming the invariant |
| `PREFIX = "ZL345_SENTINEL"` (length branch — no longer *proper*) | **compile error** `E0080`, same message |
| unmutated | compiles; full suite green |

### Two more of the same class, found by sweeping rather than patching

Fixing the reported instance is not evidence the class was swept, so I re-read every factual claim in the file against the tree. Two more were wrong, neither flagged in review:

- **The module doc named only `<env name="…">` for the PHPUnit arm.** `get_phpunit_env_context` (`main.rs:9312-9313`) dispatches on `<server name="…">` as well — the exact surface #342 bounced on. Both are now named.
- **`seed_env_source` claimed *every* assertion below would "pass for the wrong reason" without it.** Only the rejection assertions would. The two positive controls *fail* loudly on an unseeded harness, which is precisely what makes them controls; the doc now says so.

I also re-checked the claims that turned out fine, so the sweep is legible rather than assertion-by-silence: `path_is_env_file` owning the decision (`main.rs:24906`), `backend_for` mirroring `env_source_registration_gate` (byte-identical), the `◊` marker convention (`query_chain_completion_handler.rs:131-139`), `env_completion_system_leak` genuinely pinning the leak removal (`assert_no_process_var_leak`, with positive controls), and the accepted-variant list matching the predicate's documented set.

One wording correction to my own new prose during self-review: drift in `PREFIX` reddens **both** positive controls, not just `real_env_variants_are_still_offered_interpolation`. The comment now says two.

### Verification at `147d73c`

- `cargo test` (full suite, unfiltered): **3199 passed, 0 failed** — 2548 lib + 571 bin + 80 integration. All six `env_completion_context_gate` tests present and passing by name.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- The behavioural gate mutation re-verified on this commit, not carried over from round 1: `main.rs:24906` → `path.contains(".env")` reddens **5 tests** by name, exactly as the table above the fold claims.
