### PR TITLE
fix: 🐛 preview the app's configured locale in translation completion

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -14725,9 +14725,11 @@ impl LaravelLanguageServer {
     /// Served from the Salsa translation cache (issue #293). This used to
     /// re-enumerate the lang root *and* the locale directory, then re-read and
     /// re-parse every catalogue in that locale — recompiling the key regex each
-    /// time — on **every completion request**. The semantics are unchanged:
-    /// first existing lang root, first locale directory within it, first-wins
-    /// on duplicate keys. See
+    /// time — on **every completion request**. The semantics are unchanged
+    /// except for which locale answers: first existing lang root, one locale
+    /// directory within it — the app's configured locale since #340, the
+    /// alphabetically-first before that and still when the config names none
+    /// this project defines — and first-wins on duplicate keys. See
     /// [`laravel_lsp::salsa_impl::TranslationCache::completion_keys`] for why
     /// a single locale is the right answer here where the hover / goto /
     /// diagnostics trio unions every locale.

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -1661,6 +1661,73 @@ pub fn locales_in_dir(db: &dyn Db, dir: LangDir) -> Vec<String> {
     locales
 }
 
+/// The locale whose catalogues supply autocomplete's preview values.
+///
+/// Completion offers keys from exactly one locale (see
+/// [`TranslationCache::completion_keys`]), so *which* one decides every value
+/// previewed next to a key. That used to be the alphabetically-first
+/// directory, which is deterministic but arbitrary: a project with `lang/de/`,
+/// `lang/en/` and `'locale' => 'en'` previewed German for every key
+/// (issue #340).
+///
+/// The chain, first match wins:
+///
+/// 1. `app.locale` from `config/app.php`, normalized by
+///    [`config_string_literal`], when it names one of `candidates`;
+/// 2. `app.fallback_locale`, under the same normalization and the same
+///    membership check — Laravel ships it `env()`-wrapped, so it needs the
+///    normalization just as much as `app.locale` does;
+/// 3. the alphabetically-first candidate, preserving the pre-#340 behaviour
+///    for any project whose config cannot be read statically.
+///
+/// `candidates` is read, never mutated: step 3 sees the whole list
+/// [`locales_in_dir`] returned, not what the earlier steps failed to match, so
+/// the fallback answers with the same locale it always did.
+///
+/// `None` only when `candidates` is empty — a project with no locale
+/// directories has nothing to preview, whatever its config says.
+fn completion_locale(root: &Path, candidates: &[String]) -> Option<String> {
+    ["app.locale", "app.fallback_locale"]
+        .into_iter()
+        .find_map(|key| {
+            let locale = config_string_literal(&crate::config_lookup::resolve_value(root, key)?)?;
+            candidates.contains(&locale).then_some(locale)
+        })
+        .or_else(|| candidates.iter().min().cloned())
+}
+
+/// The string a PHP config value denotes, or `None` when it denotes none
+/// statically.
+///
+/// Mirrors the two forms
+/// [`crate::config::php_top_level_string_value`] accepts, because
+/// [`crate::config_lookup::resolve_value`] hands back raw source text either
+/// way: a quoted literal (`'en'` → `en`) and `env('NAME', 'default')`, whose
+/// default argument is taken since a static reader cannot see the running
+/// process's environment.
+///
+/// Everything else is unresolved — a constant, a concatenation, a function
+/// call, or an `env('NAME')` with no default. Those return `None` rather than
+/// the raw text, so a caller matching against real directory names can never
+/// match on an expression.
+fn config_string_literal(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if let Some(literal) = unquote_php_string(raw) {
+        return Some(literal.to_string());
+    }
+    let args = raw.strip_prefix("env(")?.rsplit_once(')')?.0;
+    unquote_php_string(args.split_once(',')?.1.trim()).map(str::to_string)
+}
+
+/// The body of a single- or double-quoted PHP string literal.
+///
+/// `None` when `raw` does not open and close with the same quote — an
+/// unquoted constant, or a truncated `'en`.
+fn unquote_php_string(raw: &str) -> Option<&str> {
+    let quote = raw.chars().next().filter(|c| *c == '\'' || *c == '"')?;
+    raw.strip_prefix(quote)?.strip_suffix(quote)
+}
+
 /// Every `namespace -> lang dir` registration one provider declares.
 ///
 /// Memoized per `(file, root)`. The vendor scan reads and substring-gates every
@@ -1953,14 +2020,18 @@ impl TranslationCache {
     /// Every translation key autocomplete should offer, sorted and deduped.
     ///
     /// Semantics deliberately preserved from the direct-`fs` version: the
-    /// **first** lang root that exists wins, and within it the **first** locale
-    /// subdirectory answers for the whole project — a key present in one locale
-    /// is offered regardless of which locale declares it, so enumerating the
-    /// union would read every catalogue in the project to produce the same
-    /// list. Only the reads changed: the directory listings and every
-    /// catalogue's key extraction are now memoized, where before each
-    /// completion request re-enumerated two directories and re-read *and
-    /// re-parsed* every catalogue in the locale (issue #293).
+    /// **first** lang root that exists wins, and within it **one** locale
+    /// answers for the whole project — a key present in one locale is offered
+    /// regardless of which locale declares it, so enumerating the union would
+    /// read every catalogue in the project to produce the same list. Only the
+    /// reads changed: the directory listings and every catalogue's key
+    /// extraction are now memoized, where before each completion request
+    /// re-enumerated two directories and re-read *and re-parsed* every
+    /// catalogue in the locale (issue #293).
+    ///
+    /// Which locale that is comes from [`completion_locale`]: the app's
+    /// configured locale where `config/app.php` names one this project
+    /// defines, else the alphabetically-first (issue #340).
     ///
     /// `exists()` on the lang roots is a stat, not a read, and picking the root
     /// this way keeps the pre-cache behaviour exactly: a first lang root that
@@ -1978,15 +2049,15 @@ impl TranslationCache {
             return Vec::new();
         };
         let listing = self.ensure_dir(db, &lang_root, root);
-        // Sorted before taking the first: `locales_in_dir` preserves the
-        // directory listing order, which is filesystem-dependent — APFS hands
-        // entries back sorted, ext4 does not. Taking `first()` off the raw
-        // listing therefore made *which locale answers autocomplete* vary by
-        // platform (caught by CI on ubuntu, green on macOS). Alphabetical is
-        // arbitrary but stable, and matches how `locales` orders.
-        let mut candidates = locales_in_dir(&*db, listing).clone();
-        candidates.sort();
-        let Some(locale) = candidates.first().cloned() else {
+        // `locales_in_dir` preserves the directory listing order, which is
+        // filesystem-dependent — APFS hands entries back sorted, ext4 does
+        // not. So the choice must never depend on position in that list:
+        // `completion_locale` selects by name, and its own last resort is the
+        // alphabetical minimum rather than whatever the filesystem listed
+        // first (the platform split CI caught on ubuntu while macOS stayed
+        // green).
+        let candidates = locales_in_dir(&*db, listing).clone();
+        let Some(locale) = completion_locale(root, &candidates) else {
             return Vec::new();
         };
 

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -5316,3 +5316,209 @@ async fn re_registration_leaves_the_published_table_live() {
         "re-registration must not swap the published table"
     );
 }
+
+// ─── Which locale answers translation autocomplete (issue #340) ─────────
+//
+// Completion previews values from exactly one locale, so `completion_locale`
+// decides what every key's preview says. It used to be the alphabetically
+// first directory, which previews German on a `de`/`en`/`fr` project that
+// renders `en`. These drive the chain directly; the end-to-end proof that
+// `completion_keys` actually consults it lives in
+// `tests/translation_salsa_cache.rs`.
+
+/// A project root whose `config/app.php` returns exactly `entries`.
+fn root_with_app_config(entries: &str) -> (TempDir, PathBuf) {
+    project_with_files(&[(
+        "config/app.php",
+        &format!("<?php\n\nreturn [\n{entries}\n];\n"),
+    )])
+}
+
+fn locales(names: &[&str]) -> Vec<String> {
+    names.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn configured_locale_beats_the_alphabetically_first() {
+    let (_tmp, root) = root_with_app_config("    'locale' => 'en',");
+
+    assert_eq!(
+        completion_locale(&root, &locales(&["de", "en", "fr"])).as_deref(),
+        Some("en"),
+        "the app renders `en`; previewing `de` because it sorts first is issue #340"
+    );
+}
+
+#[test]
+fn a_missing_app_locale_falls_through_to_fallback_locale() {
+    let (_tmp, root) = root_with_app_config("    'fallback_locale' => 'fr',");
+
+    assert_eq!(
+        completion_locale(&root, &locales(&["de", "en", "fr"])).as_deref(),
+        Some("fr"),
+        "no `locale` key at all must consult `fallback_locale`, not give up on the config"
+    );
+}
+
+#[test]
+fn a_configured_locale_with_no_directory_falls_through_to_fallback_locale() {
+    let (_tmp, root) =
+        root_with_app_config("    'locale' => 'es',\n    'fallback_locale' => 'fr',");
+
+    assert_eq!(
+        completion_locale(&root, &locales(&["de", "en", "fr"])).as_deref(),
+        Some("fr"),
+        "a locale the project does not translate has nothing to preview — but that \
+         is a reason to try `fallback_locale`, not to jump straight to alphabetical"
+    );
+}
+
+#[test]
+fn a_non_literal_app_locale_is_unresolved() {
+    let (_tmp, root) =
+        root_with_app_config("    'locale' => APP_DEFAULT_LOCALE,\n    'fallback_locale' => 'fr',");
+
+    assert_eq!(
+        completion_locale(&root, &locales(&["de", "en", "fr"])).as_deref(),
+        Some("fr"),
+        "a constant reference is not statically readable; it must never be matched \
+         as raw text, and must not panic"
+    );
+}
+
+#[test]
+fn a_concatenated_app_locale_is_unresolved() {
+    let (_tmp, root) = root_with_app_config("    'locale' => 'e' . 'n',");
+
+    assert_eq!(
+        completion_locale(&root, &locales(&["fr", "de", "en"])).as_deref(),
+        Some("de"),
+        "a concatenation is not a literal — fall all the way through to alphabetical \
+         rather than evaluating PHP"
+    );
+}
+
+#[test]
+fn neither_key_resolving_falls_back_to_alphabetically_first() {
+    let (_tmp, root) = root_with_app_config("    'name' => 'Laravel',");
+
+    // Deliberately not in sorted order: a fallback that took the list's first
+    // entry rather than its minimum would answer `fr` here, which is precisely
+    // the filesystem-order bug the sort was introduced to kill.
+    assert_eq!(
+        completion_locale(&root, &locales(&["fr", "de", "en"])).as_deref(),
+        Some("de"),
+        "the pre-#340 guarantee: deterministic on every filesystem"
+    );
+}
+
+#[test]
+fn a_project_with_no_config_directory_falls_back_to_alphabetically_first() {
+    let (dir, root) = project_with_files(&[]);
+    let _ = dir;
+
+    assert_eq!(
+        completion_locale(&root, &locales(&["en", "de"])).as_deref(),
+        Some("de"),
+        "an unreadable config must degrade to the old behaviour, not to no completions"
+    );
+}
+
+#[test]
+fn the_alphabetical_fallback_sees_every_candidate_the_chain_tried() {
+    let (_tmp, root) =
+        root_with_app_config("    'locale' => 'de',\n    'fallback_locale' => 'en',");
+
+    // Both configured locales exist as directories, so the chain matches at
+    // step 1 — but if a failing step ever removed what it tried from the list,
+    // this project's fallback would answer `fr` instead of `de`.
+    assert_eq!(
+        completion_locale(&root, &locales(&["de", "en", "fr"])).as_deref(),
+        Some("de"),
+    );
+    assert_eq!(
+        completion_locale(&root, &locales(&["gr", "fr"])).as_deref(),
+        Some("fr"),
+        "neither configured locale exists here, so the fallback must still see the \
+         whole candidate list"
+    );
+}
+
+#[test]
+fn an_env_wrapped_app_locale_uses_its_default_argument() {
+    let (_tmp, root) = root_with_app_config("    'locale' => env('APP_LOCALE', 'en'),");
+
+    assert_eq!(
+        completion_locale(&root, &locales(&["de", "en"])).as_deref(),
+        Some("en"),
+        "Laravel ships `app.locale` env-wrapped; matching the raw `env(...)` text \
+         against directory names would silently reproduce issue #340"
+    );
+}
+
+#[test]
+fn an_env_wrapped_fallback_locale_uses_its_default_argument() {
+    let (_tmp, root) = root_with_app_config(
+        "    'locale' => env('APP_LOCALE'),\n    'fallback_locale' => env('APP_FALLBACK_LOCALE', 'fr'),",
+    );
+
+    assert_eq!(
+        completion_locale(&root, &locales(&["de", "en", "fr"])).as_deref(),
+        Some("fr"),
+        "the env unwrap applies to both lookups — `fallback_locale` is env-wrapped \
+         in a stock Laravel skeleton too"
+    );
+}
+
+#[test]
+fn no_candidates_resolves_to_no_locale() {
+    let (_tmp, root) = root_with_app_config("    'locale' => 'en',");
+
+    assert_eq!(
+        completion_locale(&root, &[]),
+        None,
+        "a project with no locale directories has nothing to preview, whatever its \
+         config says"
+    );
+}
+
+#[test]
+fn config_string_literal_reads_both_quote_styles() {
+    assert_eq!(config_string_literal("'en'").as_deref(), Some("en"));
+    assert_eq!(config_string_literal("\"en\"").as_deref(), Some("en"));
+    assert_eq!(
+        config_string_literal("  'en'  ").as_deref(),
+        Some("en"),
+        "surrounding whitespace is not part of the literal"
+    );
+}
+
+#[test]
+fn config_string_literal_rejects_unresolvable_forms() {
+    for raw in [
+        "env('APP_LOCALE')",
+        "env('APP_LOCALE', APP_DEFAULT)",
+        "APP_LOCALE",
+        "'en",
+        "en'",
+        "'",
+        "",
+        "config('app.locale')",
+    ] {
+        assert_eq!(
+            config_string_literal(raw),
+            None,
+            "`{raw}` denotes no static string and must not be matched as raw text"
+        );
+    }
+}
+
+#[test]
+fn config_string_literal_reads_an_empty_literal() {
+    assert_eq!(
+        config_string_literal("''").as_deref(),
+        Some(""),
+        "an empty literal resolves to the empty string — it simply matches no \
+         directory name"
+    );
+}

--- a/laravel-lsp/src/tests/translation_salsa_cache.rs
+++ b/laravel-lsp/src/tests/translation_salsa_cache.rs
@@ -728,6 +728,11 @@ async fn autocomplete_answers_from_a_single_locale_directory() {
     // ext4 and `de` on APFS. Note that on a filesystem which already returns
     // entries sorted, this test passes with or without the fix; ext4 (CI) is
     // where it discriminates.
+    //
+    // Since #340 that is the *last resort* rather than the rule: this project
+    // ships no `config/app.php`, so nothing names a locale and the chain falls
+    // through to it. Which is the point — the fix must not cost projects whose
+    // config cannot be read statically their determinism.
     write(
         &root,
         "lang/zz/messages.php",
@@ -771,6 +776,124 @@ async fn autocomplete_is_empty_for_a_project_with_no_lang_directory() {
     assert!(
         backend.get_all_translation_keys().await.is_empty(),
         "no lang directory means nothing to offer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Autocomplete previews the app's configured locale (issue #340)
+//
+// One locale answers autocomplete, so which one decides every value previewed
+// next to a key. That used to be the alphabetically-first directory: a project
+// with `lang/de/`, `lang/en/` and `'locale' => 'en'` previewed German for
+// every key, silently, since the keys themselves looked right.
+//
+// The chain lives in `salsa_impl::completion_locale` and is unit-tested there.
+// These drive the real `Backend` end to end, because a unit test of the
+// resolver says nothing about whether `completion_keys` consults it.
+// ---------------------------------------------------------------------------
+
+/// A `config/app.php` returning exactly the given entry lines.
+fn app_config(entries: &str) -> String {
+    format!("<?php\n\nreturn [\n{entries}\n];\n")
+}
+
+#[tokio::test]
+async fn autocomplete_previews_the_configured_locale_not_the_first_alphabetically() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write(
+        &root,
+        "config/app.php",
+        &app_config("    'locale' => 'en',"),
+    );
+    write(
+        &root,
+        "lang/de/messages.php",
+        "<?php\nreturn [\n    'welcome' => 'Willkommen',\n];\n",
+    );
+    write(
+        &root,
+        "lang/en/messages.php",
+        "<?php\nreturn [\n    'welcome' => 'Welcome',\n];\n",
+    );
+    let backend = backend_for(&root).await;
+
+    let previews: Vec<(String, String)> = backend
+        .get_all_translation_keys()
+        .await
+        .into_iter()
+        .map(|c| (c.key, c.value))
+        .collect();
+
+    assert_eq!(
+        previews,
+        vec![("messages.welcome".to_string(), "Welcome".to_string())],
+        "`de` sorts first, but the app renders `en` — previewing the German string \
+         next to a key is issue #340"
+    );
+}
+
+#[tokio::test]
+async fn autocomplete_previews_the_fallback_locale_when_the_configured_one_is_untranslated() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write(
+        &root,
+        "config/app.php",
+        &app_config(
+            "    'locale' => env('APP_LOCALE', 'es'),\n    'fallback_locale' => env('APP_FALLBACK_LOCALE', 'en'),",
+        ),
+    );
+    write(
+        &root,
+        "lang/de/messages.php",
+        "<?php\nreturn [\n    'welcome' => 'Willkommen',\n];\n",
+    );
+    write(
+        &root,
+        "lang/en/messages.php",
+        "<?php\nreturn [\n    'welcome' => 'Welcome',\n];\n",
+    );
+    let backend = backend_for(&root).await;
+
+    let previews: Vec<(String, String)> = backend
+        .get_all_translation_keys()
+        .await
+        .into_iter()
+        .map(|c| (c.key, c.value))
+        .collect();
+
+    assert_eq!(
+        previews,
+        vec![("messages.welcome".to_string(), "Welcome".to_string())],
+        "`es` has no catalogue, so the env-wrapped `fallback_locale` answers — not \
+         `de`, which merely sorts first"
+    );
+}
+
+#[tokio::test]
+async fn autocomplete_is_empty_when_a_configured_locale_has_no_directories_to_read() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    write(
+        &root,
+        "config/app.php",
+        &app_config("    'locale' => 'en',"),
+    );
+    fs::create_dir_all(root.join("lang")).unwrap();
+    let backend = backend_for(&root).await;
+
+    // A contract guard, not a discriminating test, and deliberately so: with no
+    // candidates there is no directory to read, so `completion_keys` returns
+    // empty however `completion_locale` answers — verified by mutating the
+    // resolver to hand back `en` here and watching this stay green. What it
+    // does pin is that the configured-locale chain never turns "nothing to
+    // offer" into a panic or a read of a directory that was never there. The
+    // empty-candidate decision itself is pinned by
+    // `salsa_impl::tests::no_candidates_resolves_to_no_locale`.
+    assert!(
+        backend.get_all_translation_keys().await.is_empty(),
+        "a lang root with no locale in it offers nothing, whatever the config names"
     );
 }
 


### PR DESCRIPTION
## Summary

Implements #340.

Translation-key completion previewed values from the alphabetically-first locale directory. On a project with `lang/de/`, `lang/en/` and `'locale' => 'en'`, every completion detail showed the German string. The keys were right, so nothing looked wrong. `ar`, `cs` and `de` all sort ahead of `en`, so this hit a large share of multilingual projects.

The sort was itself a fix. `locales_in_dir` preserves directory-listing order, which is filesystem-dependent — APFS sorts, ext4 does not — so completion varied by platform until it was sorted. Sorting made the result deterministic. It also made it deterministically wrong.

The fix selects the locale **by name** instead of by position.

## Changes

- **`completion_locale(root, candidates)`** — new module-level function in `salsa_impl.rs`. Runs one chain, first match wins:
  1. `app.locale` from `config/app.php`, when it names one of `candidates`;
  2. `app.fallback_locale`, under the same normalization and the same membership check;
  3. the alphabetically-first candidate.
- **`config_string_literal(raw)`** — normalizes what `config_lookup::resolve_value` returns, which is raw source text. A quoted literal unquotes (`'en'` → `en`). `env('NAME', 'default')` yields its default argument, because a static reader cannot see the running process's environment. Everything else — a constant, a concatenation, `env('NAME')` with no default — is unresolved and falls through. It is never matched as raw text.
  Both lookups use it. Laravel ships `app.fallback_locale` as `env('APP_FALLBACK_LOCALE', 'en')`, so normalizing only `app.locale` would have reproduced this bug on a stock skeleton.
- **`completion_keys`** calls that function and holds no part of the chain itself.
- The fallback reads the candidate list, never mutates or filters it, so it answers with the same locale it always did.
- Doc comments on `completion_keys` and `get_all_translation_keys` updated — both stated "the first locale directory answers".

## Acceptance Criteria

- [x] `completion_keys` resolves the app's configured locale via a shared helper that calls `config_lookup::resolve_value(root, "app.locale")` before falling back to alphabetical order, and only uses that locale's directory when it is present among the candidates `locales_in_dir` returns.
- [x] The helper normalizes what `resolve_value` returns before matching: quoted literals are unquoted, `env('NAME', 'default')` is unwrapped to its default. Both normalizations apply to `app.locale` and `app.fallback_locale` alike — the helper applies them to whichever key it is resolving. A single-argument `env('NAME')` is unresolved and falls through; it is never matched as raw text and never panics.
- [x] When `app.locale` does not resolve to a candidate directory — key missing, value not a string literal, or a directory not among the candidates — the chain falls back to `app.fallback_locale` under the same normalization and existence check.
- [x] When neither resolves to a candidate directory, the alphabetically-first candidate answers, computed on the unmutated list `locales_in_dir` returned. The pre-existing `autocomplete_answers_from_a_single_locale_directory` test passes with its assertions unmodified.
- [x] The chain is a standalone, module-level function — not a closure, not a nested `fn` — with unit tests that call it directly. The namespaced-catalogue scan can call it once #336 lands. `completion_keys` inlines none of it.
- [x] New unit tests cover every listed case: configured locale not alphabetically first; `app.locale` missing; `app.locale` resolving to a directory that does not exist; a non-literal `app.locale`; neither key resolving; `env('APP_LOCALE', 'default')`; `env('APP_FALLBACK_LOCALE', 'fr')` with `app.locale` unresolved; zero locale directories.
- [x] Existing translation-completion tests pass unchanged. This changes which locale supplies preview values, and nothing about which keys are offered, deduped or sorted.
- [x] Hover and goto-definition are untouched. `translation_key_locator.rs` shows zero diff, and so does every hover/goto call path. See the note below on `main.rs`.

## Test Plan

- [x] Full suite green: 3210 tests, 0 failures (`cargo test --all-features`).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] **Mutation-verified — 8 mutations, each run live.** Every one reddened the tests named:
  1. Chain removed, alphabetical always → 3 unit tests red.
  2. `app.fallback_locale` leg dropped → 4 unit tests red.
  3. `env()` unwrap removed → both env tests red.
  4. Membership check removed → 3 unit tests red.
  5. Fallback takes the list's first entry instead of its minimum → 3 unit tests red.
  6. Unquote accepts a mismatched closing quote → the reject-forms test red.
  7. **`completion_keys` reverted to the pre-#340 sort-and-take-first** → both end-to-end tests red. This is the one that matters: a unit test of the resolver proves nothing about whether the dispatch consults it.
  8. Resolver returns a locale even with zero candidates → the empty-lang-root test stayed **green**.
- [x] Mutation 5 first passed against sorted fixtures, which cannot tell `min()` from `first()`. The fallback fixtures are now listed unsorted so they discriminate.
- [x] Mutation 8 is recorded in the test itself. With no candidates there is no directory to read, so `completion_keys` returns empty whatever the resolver says. That test is a contract-and-no-panic guard, not a discriminating one, and its comment says so. The empty-candidate decision is pinned by `no_candidates_resolves_to_no_locale`.

## Two notes for review

**1. `main.rs` carries a two-line doc correction, and the last AC said the diff should touch only `salsa_impl.rs` plus test files.**

`get_all_translation_keys` documented the old rule verbatim: "first existing lang root, first locale directory within it". Leaving that in place would have shipped a comment the code contradicts. The correction touches no code and no hover/goto path — `get_all_translation_keys` is the completion entry point. The AC bullet's stated purpose, that hover and goto-definition stay untouched, holds. Flagging the deviation rather than burying it.

**2. Deliberate scope boundary: this chain reads `config/app.php`, not `.env`.**

`SalsaActor::app_locale()` already resolves `APP_LOCALE` from `.env` and uses it to order hover's locale list. This chain does not consult it, because the AC names `config_lookup::resolve_value` and no other source.

The gap is real. A project whose `config/app.php` says `env('APP_LOCALE', 'en')` and whose `.env` says `APP_LOCALE=fr` will preview `en`, not `fr`. That is still a large improvement on previewing `de`, and it matches the AC exactly. Closing it means adding a fourth link to the chain and threading the actor's env reader into `TranslationCache` — a wider change than this issue specifies. Worth its own issue if you agree it should close; I did not open one, since the call is yours.

Fixes #340
