### PR TITLE
fix: 🐛 Static-modifier order, comment-blind shadowing, @props defaults

### DIFF
--- a/laravel-lsp/src/component_member_locator.rs
+++ b/laravel-lsp/src/component_member_locator.rs
@@ -172,17 +172,24 @@ pub fn public_property_types(source: &str) -> Vec<(String, String)> {
                     // `static` property isn't part of the component's
                     // template surface — Livewire only serializes instance
                     // state — so it's excluded like a non-public one.
+                    // Separate flags, exactly as `public_action_method_names`
+                    // below keeps them: PHP accepts either modifier order,
+                    // and a shared flag let `static public string $x` slip
+                    // through — the `static_modifier` child is visited
+                    // first, and the `visibility_modifier` then reset the
+                    // flag back to true.
                     let mut public = n.kind() == "property_declaration";
+                    let mut is_static = false;
                     for ch in n.children(&mut c) {
                         match ch.kind() {
                             "visibility_modifier" => {
                                 public = ch.utf8_text(bytes).ok() == Some("public");
                             }
-                            "static_modifier" => public = false,
+                            "static_modifier" => is_static = true,
                             _ => {}
                         }
                     }
-                    public
+                    public && !is_static
                 };
                 if is_public {
                     let type_text = n

--- a/laravel-lsp/src/component_member_locator/tests.rs
+++ b/laravel-lsp/src/component_member_locator/tests.rs
@@ -249,3 +249,21 @@ new class extends Component {
     assert_eq!(loc.kind, MemberKind::Property);
     assert_eq!(loc.line, 5);
 }
+
+#[test]
+fn static_property_excluded_in_either_modifier_order() {
+    // PHP accepts both orders; a shared flag let `static public` through
+    // because the visibility modifier was visited second and reset it.
+    let source = r#"<?php
+class Page {
+    public static string $canonical = '';
+    static public string $reversed = '';
+    public string $kept = '';
+}
+"#;
+    let names: Vec<String> = public_property_types(source)
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    assert_eq!(names, vec!["kept".to_string()], "got {names:?}");
+}

--- a/laravel-lsp/src/livewire_resolver.rs
+++ b/laravel-lsp/src/livewire_resolver.rs
@@ -773,6 +773,15 @@ fn front_matter_window(content: &str) -> &str {
 /// Line-granular by design: a binding and a use on the same line count as
 /// in scope (`@foreach ($users as $user)` — cursor on `$user`).
 pub fn is_template_local_binding(content: &str, line: u32, var: &str) -> bool {
+    // Blade (`{{-- --}}`) and HTML (`<!-- -->`) comments never execute, so a
+    // directive inside one binds nothing — a commented-out `@foreach` is the
+    // routine debugging move, and without this it would shadow its loop
+    // variable for the rest of the file (a single-line comment leaves no
+    // `@endforeach` to pop). Blanked rather than removed so line numbers
+    // stay stable. A directive in ordinary prose is deliberately still
+    // honored: Blade genuinely compiles those (that is what `@@` escaping
+    // is for).
+    let content = blank_template_comments(content);
     let mut loop_stack: Vec<Vec<String>> = Vec::new();
     let mut for_stack: Vec<Vec<String>> = Vec::new();
     let mut persistent: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -841,6 +850,38 @@ pub fn is_template_local_binding(content: &str, line: u32, var: &str) -> bool {
             .iter()
             .any(|names| names.iter().any(|n| n == var))
         || for_stack.iter().any(|names| names.iter().any(|n| n == var))
+}
+
+/// `content` with every Blade (`{{-- --}}`) and HTML (`<!-- -->`) comment
+/// blanked to spaces — newlines kept, so per-line scans keep their line
+/// numbers. An unterminated comment blanks to end of input, matching how
+/// the compiler would swallow the rest of the template.
+fn blank_template_comments(content: &str) -> String {
+    let bytes = content.as_bytes();
+    let mut out = content.as_bytes().to_vec();
+    let mut i = 0;
+    while i < bytes.len() {
+        let (open, close): (&[u8], &[u8]) = if bytes[i..].starts_with(b"{{--") {
+            (b"{{--", b"--}}")
+        } else if bytes[i..].starts_with(b"<!--") {
+            (b"<!--", b"-->")
+        } else {
+            i += 1;
+            continue;
+        };
+        let body_start = i + open.len();
+        let end = content[body_start..]
+            .find(std::str::from_utf8(close).unwrap())
+            .map(|rel| body_start + rel + close.len())
+            .unwrap_or(bytes.len());
+        for b in &mut out[i..end] {
+            if *b != b'\n' {
+                *b = b' ';
+            }
+        }
+        i = end;
+    }
+    String::from_utf8(out).expect("only ASCII bytes were replaced")
 }
 
 /// The text following `@{name}` on `line`, when the directive occurs with a
@@ -926,12 +967,30 @@ fn collect_assignments(s: &str, out: &mut std::collections::HashSet<String>) {
     out.extend(names);
 }
 
-/// Every `'name'` / `"name"` string key or entry in a `@props([...])` /
-/// `@aware([...])` argument on this line.
+/// Every `'name'` / `"name"` string KEY or bare entry in a `@props([...])` /
+/// `@aware([...])` argument on this line. A quoted string right after `=>`
+/// is a prop's default VALUE (`['size' => 'md']` declares `$size`, never
+/// `$md`) and binds nothing.
 fn collect_quoted_names(s: &str, out: &mut std::collections::HashSet<String>) {
     let mut chars = s.char_indices().peekable();
     while let Some((i, c)) = chars.next() {
         if c == '\'' || c == '"' {
+            if s[..i].trim_end().ends_with("=>") {
+                // Skip the whole default-value string.
+                if let Some(rel) = s[i + c.len_utf8()..].find(c) {
+                    let end = i + c.len_utf8() + rel;
+                    while let Some(&(j, _)) = chars.peek() {
+                        if j <= end {
+                            chars.next();
+                        } else {
+                            break;
+                        }
+                    }
+                    continue;
+                } else {
+                    break;
+                }
+            }
             if let Some(rel) = s[i + 1..].find(c) {
                 let name = &s[i + 1..i + 1 + rel];
                 if !name.is_empty()

--- a/laravel-lsp/src/livewire_resolver/tests.rs
+++ b/laravel-lsp/src/livewire_resolver/tests.rs
@@ -824,3 +824,60 @@ fn cursor_past_end_of_line_does_not_panic() {
     assert!(wire_attribute_completion_context(line, past).is_none());
     assert!(wire_attribute_target_at(line, past).is_none());
 }
+
+#[test]
+fn commented_out_foreach_binds_nothing() {
+    // Commenting out a loop while debugging is routine — a single-line
+    // Blade comment leaves no @endforeach, so without comment-blanking the
+    // variable stayed "shadowed" for the rest of the file and a real class
+    // property stopped navigating.
+    let content = "\
+{{-- @foreach ($rows as $row) --}}
+<span>{{ $row }}</span>";
+    assert!(!is_template_local_binding(content, 1, "row"));
+}
+
+#[test]
+fn multiline_blade_comment_blanks_its_whole_body() {
+    let content = "\
+{{--
+@foreach ($rows as $row)
+    {{ $row }}
+@endforeach
+--}}
+<span>{{ $row }}</span>";
+    assert!(!is_template_local_binding(content, 5, "row"));
+}
+
+#[test]
+fn html_comment_does_not_open_a_php_block() {
+    // `<!-- @php -->` used to open a block that never closes, so every
+    // later `$name = …` line registered as a local.
+    let content = "\
+<!-- @php -->
+<span>{{ $total }}</span>
+{{ $x = 'not php, just an echo of an assignment' }}";
+    assert!(!is_template_local_binding(content, 1, "total"));
+}
+
+#[test]
+fn uncommented_directives_still_bind_next_to_commented_ones() {
+    let content = "\
+{{-- @foreach ($old as $item) --}}
+@foreach ($rows as $item)
+    {{ $item }}
+@endforeach";
+    assert!(is_template_local_binding(content, 2, "item"));
+}
+
+#[test]
+fn props_default_values_are_not_bindings() {
+    // #339 item 8: `['size' => 'md']` declares $size — 'md' is its default
+    // VALUE and must not shadow a class property named $md.
+    let content = "\
+@props(['variant', 'size' => 'md'])
+<span>{{ $md }} {{ $size }} {{ $variant }}</span>";
+    assert!(is_template_local_binding(content, 1, "variant"));
+    assert!(is_template_local_binding(content, 1, "size"));
+    assert!(!is_template_local_binding(content, 1, "md"));
+}


### PR DESCRIPTION
Fixes #351 (both findings), plus #339 item 8 since it lives in the same function.

## 1. `static public $x` no longer offered as a component property

`public_property_types` kept one flag for two modifiers, so the reversed-but-legal order slipped through: the `static_modifier` child is visited first, and the `visibility_modifier` then reset the flag back to `true`. Separate `public`/`is_static` flags now — exactly the shape `public_action_method_names` in the same file already keeps, as the issue pointed out. The test pins **both** modifier orders; the old one only pinned the canonical order, which is how this survived.

## 2. `is_template_local_binding` scans a comment-blanked template

Blade (`{{-- --}}`) and HTML (`<!-- -->`) comments never execute, so the scanner now blanks them (newlines kept, so line numbers stay stable; an unterminated comment blanks to end of input, matching the compiler). That covers all three repro shapes:

- `{{-- @foreach ($rows as $row) --}}` — the routine debugging move — no longer shadows `$row` for the rest of the file;
- a multiline Blade comment around a whole loop binds nothing;
- `<!-- @php -->` no longer opens a phantom block that turned every later assignment-looking line into a local.

One deliberate boundary: a directive in ordinary **prose** (`<p>Use @props(['fake']) …</p>`) still binds — Blade genuinely compiles directives there (escaping them is what `@@` is for), so treating it as live is the semantically honest reading. Only the never-executing comment forms are blanked.

## 3. `@props` default values are not bindings (#339 item 8)

`['size' => 'md']` declares `$size` — `'md'` is its default **value**, and it used to be captured as a local binding too, shadowing any class property named `$md`. The key collector now skips a quoted string that follows `=>`.

## Tests

Both modifier orders, single-line and multiline commented-out loops, the HTML-comment phantom-`@php`-block case, a live directive next to a commented one (no over-blanking), and the `@props` key/value split. Full suite: 2655 lib + 580 integration green, clippy `-D warnings` clean.