### PR TITLE
fix: mask the whole credential when a password contains an unencoded `@`

### DIFF
--- a/laravel-lsp/Cargo.toml
+++ b/laravel-lsp/Cargo.toml
@@ -55,6 +55,14 @@ sqlx = { version = "0.9", features = ["runtime-tokio", "mysql", "postgres", "sql
 tiberius = { version = "0.12", default-features = false, features = ["tokio", "rustls"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 
+# RFC 3986 URL parsing for credential redaction. `mask_url_credentials` has to
+# know where a URL's authority ends before it can tell a password's `@` from a
+# path's, and a hand-rolled scan cannot: `mysql://host:3306/db@x` and
+# `postgres://user:p/ss@host/db` are the same shape to a scanner and different
+# URLs to a parser (issue #355). Already compiled transitively (sqlx parses its
+# connection strings with it), so this direct dep adds no new crate to the build.
+url = "2.5"
+
 # Tree-sitter parsers
 # Using latest version to match the Blade grammar from GitHub
 tree-sitter = "0.26"

--- a/laravel-lsp/src/completion_display.rs
+++ b/laravel-lsp/src/completion_display.rs
@@ -102,23 +102,40 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 /// display surface must not blank a value it merely failed to parse, and a log
 /// line must not panic the server.
 ///
-/// Only the first `@` after the credentials is treated as the host separator,
-/// so an `@` inside the password leaves its tail visible
-/// (`postgres://user:***@ssw0rd@host/db`). Deliberate: the characters that
-/// identify the credential are gone, and a stricter parse would trade a
-/// diagnostic that works on real URLs for one that fails on unusual ones.
+/// The credentials end at the **last** `@` inside the authority component —
+/// the run between `://` and the first `/`, `?` or `#` — which is the standard
+/// RFC 3986 authority parse. Taking the *first* `@` anywhere in the value left
+/// the tail of an unencoded-`@` password on screen
+/// (`postgres://user:***@ssw0rd@host/db`, issue #355) and read an `@` in the
+/// *path* as a credential separator, masking a host's port
+/// (`mysql://host:3306/db@x`).
+///
+/// One malformed shape still fails open: an unencoded `/`, `?` or `#` *inside*
+/// the password ends the authority early, so no `@` is found and the value
+/// comes back untouched. RFC 3986 requires all four characters percent-encoded
+/// in userinfo, and `postgres://user:p/ss@host/db` is indistinguishable from
+/// `mysql://host:3306/db@x` — honouring the later `@` for one masks the other's
+/// port and destroys the host, which is the more common URL and the more
+/// misleading diagnostic.
 ///
 /// Lives here rather than in `database`, where it started life as
 /// `mask_url_password`: it is now the second half of the redaction policy the
 /// four display surfaces and the server log share, and a second copy is how the
 /// two spellings drift apart.
 pub fn mask_url_credentials(value: &str) -> Cow<'_, str> {
-    // Find the `://` separator, then the `@` that ends the credentials.
+    // Find the `://` separator, then the authority component it opens.
     let Some(scheme_end) = value.find("://") else {
         return Cow::Borrowed(value);
     };
     let creds_start = scheme_end + 3;
-    let Some(at_offset) = value[creds_start..].find('@') else {
+    // The authority ends at the first `/`, `?` or `#`. Past that is path, query
+    // or fragment, where an `@` is an ordinary character and not a separator.
+    let authority_end = value[creds_start..]
+        .find(['/', '?', '#'])
+        .map_or(value.len(), |offset| creds_start + offset);
+    // The credentials end at the *last* `@` in the authority, so an unencoded
+    // `@` in the password does not end them early (issue #355).
+    let Some(at_offset) = value[creds_start..authority_end].rfind('@') else {
         return Cow::Borrowed(value);
     };
     let creds_end = creds_start + at_offset;

--- a/laravel-lsp/src/completion_display.rs
+++ b/laravel-lsp/src/completion_display.rs
@@ -28,14 +28,17 @@
 use crate::completion_format::{CodeBlock, CompletionDoc};
 use crate::display_truncate::truncate_for_display;
 use std::borrow::Cow;
+use url::Url;
 
 /// What every *client-rendered* surface prints in place of a sensitive `.env`
 /// value.
 ///
-/// One constant rather than a per-site literal: the four surfaces that used to
-/// echo dotenv values (env completion, `.env` hover, `config('…')` completion,
-/// and the warm-start disk cache) are meant to be indistinguishable to a
-/// reader, and a second spelling is how they drift apart (issue #344).
+/// One constant rather than a per-site literal: the three surfaces that used to
+/// echo dotenv values (env completion, `.env` hover and `config('…')`
+/// completion) are meant to be indistinguishable to a reader, and a second
+/// spelling is how they drift apart (issue #344). A fourth, the warm-start disk
+/// cache, was one of them until issue #356 deleted the cache outright — nothing
+/// ever read its map back.
 ///
 /// The server log is the one masked surface that does *not* use this string.
 /// It renders `(set)` — see `database::mask_env_value_for_log` — because a log
@@ -102,28 +105,46 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 /// display surface must not blank a value it merely failed to parse, and a log
 /// line must not panic the server.
 ///
-/// The credentials end at the **last** `@` inside the authority component —
-/// the run between `://` and the first `/`, `?` or `#` — which is the standard
-/// RFC 3986 authority parse. Taking the *first* `@` anywhere in the value left
-/// the tail of an unencoded-`@` password on screen
-/// (`postgres://user:***@ssw0rd@host/db`, issue #355) and read an `@` in the
-/// *path* as a credential separator, masking a host's port
-/// (`mysql://host:3306/db@x`).
+/// **Where the credentials end is decided by [`url`], not by scanning.** The two
+/// shapes a scanner confuses are `mysql://host:3306/db@x` — host, port and a
+/// path that happens to hold an `@` — and `postgres://user:p@ssword@host/db`,
+/// whose password holds one. They are the same shape to any hand-rolled rule,
+/// and taking the first `@` mangled the former into `mysql://host:***@x` while
+/// leaving the latter's tail on screen as `postgres://user:***@ssword@host/db`
+/// (issue #355). An RFC 3986 parse separates them outright, so:
 ///
-/// One malformed shape still fails open: an unencoded `/`, `?` or `#` *inside*
-/// the password ends the authority early, so no `@` is found and the value
-/// comes back untouched. RFC 3986 requires all four characters percent-encoded
-/// in userinfo, and `postgres://user:p/ss@host/db` is indistinguishable from
-/// `mysql://host:3306/db@x` — honouring the later `@` for one masks the other's
-/// port and destroys the host, which is the more common URL and the more
-/// misleading diagnostic.
+/// - the parse succeeds and reports a **password** — the userinfo is real, and
+///   it ends at the last `@` in the authority (the run from `://` to the first
+///   `/`, `?` or `#`). A raw `/`, `?` or `#` inside userinfo would have ended
+///   the authority in the parser too, so that window always holds the `@`;
+/// - the parse succeeds and reports **no password** — what looks like
+///   credentials is `host:port`, and every `@` after it is path, query or
+///   fragment. Untouched;
+/// - the parse **fails** — the value is not a URL any parser accepts, so the
+///   scan is all that is left. It prefers the last `@` in the authority and
+///   falls back to the first `@` anywhere, which is `main`'s original rule.
+///
+/// That third arm is not a rare corner. `database::build_postgres_candidates`
+/// builds the libpq socket URL `postgres://user:pass@/db?host=/var/run/…`,
+/// whose host is deliberately empty — [`url`] rejects it, and it is logged with
+/// a password spliced in raw by `database::userinfo`. Preferring the authority's
+/// last `@` there is what keeps an `@`-bearing password out of that log line.
+///
+/// **One shape still fails open**, narrower than the scan-only version it
+/// replaces: a password holding a raw `/`, `?` or `#` whose leading run happens
+/// to parse as a port, as in `mysql://user:12/34@host/db`. The parser reads
+/// `user` as the host and `12` as its port, exactly as it reads
+/// `mysql://host:3306/db@x`, because per RFC 3986 that *is* what the two strings
+/// say — a password must percent-encode all four characters, and `database::userinfo`
+/// not doing so is a connection-string defect rather than a display one. Every
+/// other `/`, `?` or `#` password (`postgres://user:p/ss@host/db` and friends)
+/// is rejected by the parse and masked by the fallback.
 ///
 /// Lives here rather than in `database`, where it started life as
 /// `mask_url_password`: it is now the second half of the redaction policy the
-/// four display surfaces and the server log share, and a second copy is how the
+/// three display surfaces and the server log share, and a second copy is how the
 /// two spellings drift apart.
 pub fn mask_url_credentials(value: &str) -> Cow<'_, str> {
-    // Find the `://` separator, then the authority component it opens.
     let Some(scheme_end) = value.find("://") else {
         return Cow::Borrowed(value);
     };
@@ -133,9 +154,15 @@ pub fn mask_url_credentials(value: &str) -> Cow<'_, str> {
     let authority_end = value[creds_start..]
         .find(['/', '?', '#'])
         .map_or(value.len(), |offset| creds_start + offset);
-    // The credentials end at the *last* `@` in the authority, so an unencoded
-    // `@` in the password does not end them early (issue #355).
-    let Some(at_offset) = value[creds_start..authority_end].rfind('@') else {
+    let authority_at = || value[creds_start..authority_end].rfind('@');
+
+    // Offsets are relative to `creds_start` on every arm.
+    let at_offset = match Url::parse(value) {
+        Ok(parsed) if parsed.password().is_some() => authority_at(),
+        Ok(_) => return Cow::Borrowed(value),
+        Err(_) => authority_at().or_else(|| value[creds_start..].find('@')),
+    };
+    let Some(at_offset) = at_offset else {
         return Cow::Borrowed(value);
     };
     let creds_end = creds_start + at_offset;

--- a/laravel-lsp/src/completion_display.rs
+++ b/laravel-lsp/src/completion_display.rs
@@ -117,9 +117,13 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 ///   it ends at the last `@` in the authority (the run from `://` to the first
 ///   `/`, `?` or `#`). A raw `/`, `?` or `#` inside userinfo would have ended
 ///   the authority in the parser too, so that window always holds the `@`;
-/// - the parse succeeds and reports **no password** — what looks like
-///   credentials is `host:port`, and every `@` after it is path, query or
-///   fragment. Untouched;
+/// - the parse succeeds and reports **no password** — either what looks like
+///   credentials is `host:port` and every `@` after it is path, query or
+///   fragment, or the userinfo carries a `:` with nothing after it
+///   (`mysql://user:@host/db`), which [`url`] reports identically to no
+///   password at all. Untouched on both counts — neither shape holds a secret,
+///   though the second is the one place this function is *less* eager than
+///   `main`'s scan, which rewrote it to `mysql://user:***@host/db`;
 /// - the parse **fails** — the value is not a URL any parser accepts, so the
 ///   scan is all that is left. It prefers the last `@` in the authority and
 ///   falls back to the first `@` anywhere, which is `main`'s original rule.
@@ -130,15 +134,25 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 /// a password spliced in raw by `database::userinfo`. Preferring the authority's
 /// last `@` there is what keeps an `@`-bearing password out of that log line.
 ///
-/// **One shape still fails open**, narrower than the scan-only version it
-/// replaces: a password holding a raw `/`, `?` or `#` whose leading run happens
-/// to parse as a port, as in `mysql://user:12/34@host/db`. The parser reads
-/// `user` as the host and `12` as its port, exactly as it reads
-/// `mysql://host:3306/db@x`, because per RFC 3986 that *is* what the two strings
-/// say — a password must percent-encode all four characters, and `database::userinfo`
-/// not doing so is a connection-string defect rather than a display one. Every
-/// other `/`, `?` or `#` password (`postgres://user:p/ss@host/db` and friends)
-/// is rejected by the parse and masked by the fallback.
+/// **One shape still fails open**: a password holding a raw `/`, `?` or `#`
+/// whose leading run happens to parse as a port, as in
+/// `mysql://user:12/34@host/db`. The parser reads `user` as the host and `12`
+/// as its port, exactly as it reads `mysql://host:3306/db@x`, because per RFC
+/// 3986 that *is* what the two strings say — a password must percent-encode all
+/// four characters, and `database::userinfo` not doing so is a
+/// connection-string defect rather than a display one. Every other `/`, `?` or
+/// `#` password (`postgres://user:p/ss@host/db` and friends) is rejected by the
+/// parse and masked by the fallback.
+///
+/// **Name the baseline, because the residue is narrower than one predecessor
+/// and not the other.** It is narrower than the authority-bounded scan this
+/// arm replaces, which failed open on *every* `/`, `?` or `#` password. It is
+/// **not** narrower than `main`'s greedy first-`@` scan, which masked
+/// `mysql://user:12/34@host/db` correctly. That scan bought the difference by
+/// rewriting `mysql://host:3306/db@x` into `mysql://host:***@x` — host, port
+/// and database thrown away — and by leaving an `@`-bearing password's tail
+/// on screen (issue #355). Both of those classes are closed here, so this is a
+/// net gain over `main` rather than a strict subset of it.
 ///
 /// Lives here rather than in `database`, where it started life as
 /// `mask_url_password`: it is now the second half of the redaction policy the

--- a/laravel-lsp/src/completion_display.rs
+++ b/laravel-lsp/src/completion_display.rs
@@ -117,22 +117,49 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 ///   it ends at the last `@` in the authority (the run from `://` to the first
 ///   `/`, `?` or `#`). A raw `/`, `?` or `#` inside userinfo would have ended
 ///   the authority in the parser too, so that window always holds the `@`;
-/// - the parse succeeds and reports **no password** — either what looks like
-///   credentials is `host:port` and every `@` after it is path, query or
-///   fragment, or the userinfo carries a `:` with nothing after it
-///   (`mysql://user:@host/db`), which [`url`] reports identically to no
-///   password at all. Untouched on both counts — neither shape holds a secret,
-///   though the second is the one place this function is *less* eager than
-///   `main`'s scan, which rewrote it to `mysql://user:***@host/db`;
-/// - the parse **fails** — the value is not a URL any parser accepts, so the
-///   scan is all that is left. It prefers the last `@` in the authority and
+/// - the parse reports **no password, and the value has an authority** — the
+///   only shape returned untouched. That is the *rule*, not a list of the
+///   shapes it admits: [`Url::password`] gates on [`Url::has_authority`], so an
+///   authority is exactly the condition under which the parser read a userinfo
+///   component. Only then is its silence evidence that no password was there.
+///   (`mysql://host:3306/db@x` is a host, a port and a path `@`;
+///   `https://example.com/webhook` has no userinfo at all; `mysql://user:@host/db`
+///   carries a `:` with nothing after it, which [`url`] reports identically to
+///   no password — the one place this function is *less* eager than `main`'s
+///   scan, which rewrote it to `mysql://user:***@host/db`. Those are examples
+///   of the rule and not a definition of it — earlier revisions of this comment
+///   listed members instead of stating the rule, and each rewrite added the one
+///   the last had missed while the arm below stayed hidden entirely.);
+/// - **everything else** — the parse fails, or it succeeds with no authority.
+///   Both are parses that never looked at a userinfo component, so the scan is
+///   all that is left. It prefers the last `@` in the authority window and
 ///   falls back to the first `@` anywhere, which is `main`'s original rule.
 ///
-/// That third arm is not a rare corner. `database::build_postgres_candidates`
-/// builds the libpq socket URL `postgres://user:pass@/db?host=/var/run/…`,
-/// whose host is deliberately empty — [`url`] rejects it, and it is logged with
-/// a password spliced in raw by `database::userinfo`. Preferring the authority's
-/// last `@` there is what keeps an `@`-bearing password out of that log line.
+/// That last arm is not a rare corner, and it has two members.
+///
+/// A **rejected** parse: `database::build_postgres_candidates` builds the libpq
+/// socket URL `postgres://user:pass@/db?host=/var/run/…`, whose host is
+/// deliberately empty — [`url`] rejects it, and it is logged with a password
+/// spliced in raw by `database::userinfo`. Preferring the authority's last `@`
+/// there is what keeps an `@`-bearing password out of that log line.
+///
+/// An **accepted** parse with no authority: `jdbc:mysql://user:secret@host/db`.
+/// `jdbc` is a valid scheme and the bytes after its colon are not `//`, so
+/// [`url`] takes its opaque-path branch and never parses userinfo — and
+/// [`Url::password`] then answers `None` however many credentials that path
+/// holds. `JDBC_URL`, `SPRING_DATASOURCE_URL` and `DB_URL` match no
+/// [`SENSITIVE_ENV_SEGMENTS`] keyword, so this function is the only gate
+/// standing between such a value and every display surface. The family is not
+/// the `jdbc:` prefix, either: any `://` that is only ever path
+/// (`foo:/bar://user:secret@host/db`) parses the same way, which is why the
+/// rule is "has an authority" and not a list of opaque schemes.
+///
+/// The price is **over-masking** on that same family when it carries no
+/// credential: `jdbc:mysql://host:3306/db@x` renders as
+/// `jdbc:mysql://host:***@x`, because the scan cannot tell that `@` from a
+/// credential separator. It is the trade the rejected-parse arm has always made
+/// — `mysql://host:70000/db@x` mangles identically — and a mangled display beats
+/// a printed password.
 ///
 /// **One shape still fails open**: a password holding a raw `/`, `?` or `#`
 /// whose leading run happens to parse as a port, as in
@@ -142,7 +169,10 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 /// four characters, and `database::userinfo` not doing so is a
 /// connection-string defect rather than a display one. Every other `/`, `?` or
 /// `#` password (`postgres://user:p/ss@host/db` and friends) is rejected by the
-/// parse and masked by the fallback.
+/// parse and masked by the fallback. The residue is bounded by the rule above,
+/// too: the same password behind an opaque scheme
+/// (`jdbc:mysql://user:12/34@host/db`) has no authority, so it takes the scan
+/// and masks.
 ///
 /// **Name the baseline, because the residue is narrower than one predecessor
 /// and not the other.** It is narrower than the authority-bounded scan this
@@ -173,8 +203,13 @@ pub fn mask_url_credentials(value: &str) -> Cow<'_, str> {
     // Offsets are relative to `creds_start` on every arm.
     let at_offset = match Url::parse(value) {
         Ok(parsed) if parsed.password().is_some() => authority_at(),
-        Ok(_) => return Cow::Borrowed(value),
-        Err(_) => authority_at().or_else(|| value[creds_start..].find('@')),
+        // The only arm whose silence is evidence. `Url::password` gates on
+        // `has_authority`, so an authority is exactly the condition under
+        // which the parser read a userinfo component at all.
+        Ok(parsed) if parsed.has_authority() => return Cow::Borrowed(value),
+        // Rejected, or accepted with no authority: either way the parser never
+        // looked where a credential lives, so the scan has to.
+        _ => authority_at().or_else(|| value[creds_start..].find('@')),
     };
     let Some(at_offset) = at_offset else {
         return Cow::Borrowed(value);

--- a/laravel-lsp/src/completion_display.rs
+++ b/laravel-lsp/src/completion_display.rs
@@ -33,12 +33,21 @@ use url::Url;
 /// What every *client-rendered* surface prints in place of a sensitive `.env`
 /// value.
 ///
-/// One constant rather than a per-site literal: the three surfaces that used to
-/// echo dotenv values (env completion, `.env` hover and `config('…')`
-/// completion) are meant to be indistinguishable to a reader, and a second
-/// spelling is how they drift apart (issue #344). A fourth, the warm-start disk
-/// cache, was one of them until issue #356 deleted the cache outright — nothing
-/// ever read its map back.
+/// One constant rather than a per-site literal: the client-rendered surfaces
+/// that echo dotenv values are meant to be indistinguishable to a reader, and a
+/// second spelling is how they drift apart (issue #344). They are named rather
+/// than counted, because a count is what goes stale when one is added or
+/// deleted:
+///
+/// - env completion (`completion`),
+/// - `config('…')` completion, via `env_display_value`,
+/// - hover over an `env('KEY')` call in PHP (`hover_for_env`),
+/// - hover over the declaration itself in a `.env` buffer
+///   (`hover_for_env_declaration`) — a separate handler for the reverse
+///   direction, not a second render site of the one above.
+///
+/// The warm-start disk cache was a fifth until issue #356 deleted the cache
+/// outright — nothing ever read its map back.
 ///
 /// The server log is the one masked surface that does *not* use this string.
 /// It renders `(set)` — see `database::mask_env_value_for_log` — because a log
@@ -118,18 +127,22 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 ///   `/`, `?` or `#`). A raw `/`, `?` or `#` inside userinfo would have ended
 ///   the authority in the parser too, so that window always holds the `@`;
 /// - the parse reports **no password, and the value has an authority** — the
-///   only shape returned untouched. That is the *rule*, not a list of the
-///   shapes it admits: [`Url::password`] gates on [`Url::has_authority`], so an
-///   authority is exactly the condition under which the parser read a userinfo
-///   component. Only then is its silence evidence that no password was there.
-///   (`mysql://host:3306/db@x` is a host, a port and a path `@`;
-///   `https://example.com/webhook` has no userinfo at all; `mysql://user:@host/db`
-///   carries a `:` with nothing after it, which [`url`] reports identically to
-///   no password — the one place this function is *less* eager than `main`'s
-///   scan, which rewrote it to `mysql://user:***@host/db`. Those are examples
-///   of the rule and not a definition of it — earlier revisions of this comment
-///   listed members instead of stating the rule, and each rewrite added the one
-///   the last had missed while the arm below stayed hidden entirely.);
+///   authority is acquitted, and nothing else is. [`Url::password`] gates on
+///   [`Url::has_authority`], so this is the one arm where the parser really did
+///   read a userinfo component — but it read *that* authority's, and its
+///   silence is evidence about that component alone. A credential can sit past
+///   the authority entirely, in a path, query or fragment that spells a second
+///   URL (`https://ok/cb?next=mysql://user:p@ss@host/db`, an `ES_HOSTS`-style
+///   endpoint list), and no property of the outer parse says otherwise. So the
+///   whole rule is re-run over the tail past the authority, and the value comes
+///   back borrowed only when that finds nothing either. (`mysql://host:3306/db@x`
+///   is a host, a port and a path `@`; `https://example.com/webhook` has no
+///   userinfo at all; `mysql://user:@host/db` carries a `:` with nothing after
+///   it, which [`url`] reports identically to no password — the one place this
+///   function is *less* eager than `main`'s scan, which rewrote it to
+///   `mysql://user:***@host/db`. Those are examples, not a definition: three
+///   revisions of this comment listed members instead of stating the rule, and
+///   each rewrite added the one the last had missed.);
 /// - **everything else** — the parse fails, or it succeeds with no authority.
 ///   Both are parses that never looked at a userinfo component, so the scan is
 ///   all that is left. It prefers the last `@` in the authority window and
@@ -161,6 +174,13 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 /// — `mysql://host:70000/db@x` mangles identically — and a mangled display beats
 /// a printed password.
 ///
+/// The tail rescan on the authority arm buys into the same trade, on the same
+/// terms. A credential-free nested URL whose inner half carries both a `:` and
+/// a later `@` is over-masked: `https://ok/mysql://host:3306/db@x` renders as
+/// `https://ok/mysql://host:***@x`. The outer URL is untouched either way, and
+/// a value with no second `://` in its tail never reaches the rescan at all —
+/// which is every ordinary `DATABASE_URL`, so the common path is unchanged.
+///
 /// **One shape still fails open**: a password holding a raw `/`, `?` or `#`
 /// whose leading run happens to parse as a port, as in
 /// `mysql://user:12/34@host/db`. The parser reads `user` as the host and `12`
@@ -186,8 +206,8 @@ pub fn is_sensitive_env_name(name: &str) -> bool {
 ///
 /// Lives here rather than in `database`, where it started life as
 /// `mask_url_password`: it is now the second half of the redaction policy the
-/// three display surfaces and the server log share, and a second copy is how the
-/// two spellings drift apart.
+/// client-rendered surfaces enumerated on [`REDACTED_ENV_VALUE`] and the server
+/// log share, and a second copy is how the two spellings drift apart.
 pub fn mask_url_credentials(value: &str) -> Cow<'_, str> {
     let Some(scheme_end) = value.find("://") else {
         return Cow::Borrowed(value);
@@ -203,10 +223,30 @@ pub fn mask_url_credentials(value: &str) -> Cow<'_, str> {
     // Offsets are relative to `creds_start` on every arm.
     let at_offset = match Url::parse(value) {
         Ok(parsed) if parsed.password().is_some() => authority_at(),
-        // The only arm whose silence is evidence. `Url::password` gates on
-        // `has_authority`, so an authority is exactly the condition under
-        // which the parser read a userinfo component at all.
-        Ok(parsed) if parsed.has_authority() => return Cow::Borrowed(value),
+        // An authority, and no password in it. `Url::password` gates on
+        // `has_authority`, so this is the one arm where the parser did read a
+        // userinfo component — but it read *this* authority's, and a value can
+        // carry a credential past it (`https://ok/cb?next=mysql://u:p@h/db`).
+        // So the silence acquits the authority and nothing else: re-run the
+        // whole rule over the tail, and keep the value borrowed only if that
+        // finds nothing either.
+        //
+        // Terminates at depth 2. The tail begins at the first `/`, `?` or `#`,
+        // so it begins *with* one of them, and no such string parses as an
+        // absolute URL — the recursive call can only reach the fallback arm
+        // below, which does not recurse. Pinned by
+        // `the_tail_rescan_cannot_recurse_past_one_level`.
+        Ok(parsed) if parsed.has_authority() => {
+            return match mask_url_credentials(&value[authority_end..]) {
+                Cow::Borrowed(_) => Cow::Borrowed(value),
+                Cow::Owned(masked_tail) => {
+                    let mut spliced = String::with_capacity(value.len() + 3);
+                    spliced.push_str(&value[..authority_end]);
+                    spliced.push_str(&masked_tail);
+                    Cow::Owned(spliced)
+                }
+            };
+        }
         // Rejected, or accepted with no authority: either way the parser never
         // looked where a credential lives, so the scan has to.
         _ => authority_at().or_else(|| value[creds_start..].find('@')),

--- a/laravel-lsp/src/completion_display/tests.rs
+++ b/laravel-lsp/src/completion_display/tests.rs
@@ -314,16 +314,57 @@ fn a_credential_inside_the_value_is_masked_whatever_the_name_says() {
         "mysql://sail:***@127.0.0.1:3306/db"
     );
     assert_eq!(
-        mask_url_credentials("postgres://user:p@ssw0rd@host/db"),
-        // Only the first `@` after the credentials is treated as the host
-        // separator — best-effort. An `@` inside the password leaves its tail
-        // visible, but the characters that identify the credential are gone.
-        "postgres://user:***@ssw0rd@host/db"
-    );
-    assert_eq!(
         mask_url_credentials("redis://default:redis-secret@redis:6379"),
         "redis://default:***@redis:6379"
     );
+}
+
+// ---- the authority parse (issue #355) ------------------------------------
+
+/// RFC 3986 wants an `@` in a password percent-encoded as `%40`, but nothing
+/// stops a developer typing one — and `database::userinfo` interpolates the
+/// `.env` password into a connection URL verbatim, so the server builds this
+/// shape itself before logging it through this function.
+///
+/// Reading the *first* `@` as the host separator left everything after it on
+/// screen; the password's tail is exactly the part long enough to be worth
+/// stealing. The credentials end at the last `@` in the authority instead.
+#[test]
+fn an_unencoded_at_in_the_password_does_not_end_the_credentials_early() {
+    for (value, expected) in [
+        (
+            "postgres://user:p@ssw0rd@host/db",
+            "postgres://user:***@host/db",
+        ),
+        // More than one, and a port after the host: the *last* `@` wins, not
+        // the second one either.
+        (
+            "mysql://sail:p@ss@w0rd@127.0.0.1:3306/db",
+            "mysql://sail:***@127.0.0.1:3306/db",
+        ),
+        // The no-username Redis form, which starts its credentials with the
+        // `:` the mask keys on.
+        ("redis://:p@ss@redis:6379", "redis://:***@redis:6379"),
+        // The libpq socket URL `build_postgres_candidates` generates: the
+        // authority ends immediately after the `@`, and the socket path lives
+        // in the query string.
+        (
+            "postgres://user:p@ss@/laravel?host=/var/run/postgresql",
+            "postgres://user:***@/laravel?host=/var/run/postgresql",
+        ),
+        // An `@` in the query must not be mistaken for the separator and drag
+        // the real credentials into the "host" half.
+        (
+            "mysql://sail:secret@127.0.0.1/db?user=a@b",
+            "mysql://sail:***@127.0.0.1/db?user=a@b",
+        ),
+    ] {
+        assert_eq!(
+            mask_url_credentials(value),
+            expected,
+            "{value:?} must mask the whole credential"
+        );
+    }
 }
 
 /// Fail-open, and borrowed while it is at it: a value the parser does not
@@ -340,6 +381,21 @@ fn a_value_carrying_no_credential_is_returned_untouched() {
         "https://example.com/webhook",    // no credentials at all
         "sqlite:///absolute/path.sqlite", // scheme, no `@`
         "",
+        // An `@` in the *path*, and a `:` that is a port rather than a
+        // credential separator. Reading the first `@` in the whole value made
+        // this `mysql://host:***@x` — the port masked as a password, host,
+        // port and database all gone (issue #355).
+        "mysql://host:3306/db@x",
+        // The same host and port with nothing after them to mislead the parse.
+        "mysql://host:3306/db",
+        // An `@` in the query string of a URL that carries no credentials.
+        "https://example.com/webhook?notify=ops@example.com",
+        // A documented limitation, pinned so it stays deliberate: an unencoded
+        // `/` in the password ends the authority before the `@`, so the value
+        // fails open. `postgres://user:p/ss@host/db` cannot be told apart from
+        // `mysql://host:3306/db@x` above, and honouring the later `@` there
+        // masks a port and throws the host away.
+        "postgres://user:p/ss@host/db",
     ] {
         assert!(
             matches!(mask_url_credentials(value), std::borrow::Cow::Borrowed(v) if v == value),

--- a/laravel-lsp/src/completion_display/tests.rs
+++ b/laravel-lsp/src/completion_display/tests.rs
@@ -328,7 +328,8 @@ fn a_credential_inside_the_value_is_masked_whatever_the_name_says() {
 ///
 /// Reading the *first* `@` as the host separator left everything after it on
 /// screen; the password's tail is exactly the part long enough to be worth
-/// stealing. The credentials end at the last `@` in the authority instead.
+/// stealing. Every value here parses as a URL and reports a password, so the
+/// credentials end at the last `@` in the parsed authority instead.
 #[test]
 fn an_unencoded_at_in_the_password_does_not_end_the_credentials_early() {
     for (value, expected) in [
@@ -358,6 +359,26 @@ fn an_unencoded_at_in_the_password_does_not_end_the_credentials_early() {
             "mysql://sail:secret@127.0.0.1/db?user=a@b",
             "mysql://sail:***@127.0.0.1/db?user=a@b",
         ),
+        // A credential `@` *and* a path `@` in one value. Bailing out on the
+        // trailing one would leave the whole credential on screen — worse than
+        // the defect being fixed — so the path `@` must survive untouched while
+        // the credential goes.
+        (
+            "postgres://user:p@ssword@host/path@literal",
+            "postgres://user:***@host/path@literal",
+        ),
+        // No path at all: the authority runs to the end of the string, which is
+        // a different arm of the bound than every fixture above.
+        ("postgres://user:p@ssword@host", "postgres://user:***@host"),
+        // A port colon *and* real credentials: the port's `:` must not be read
+        // as the credentials' `:`.
+        (
+            "mysql://user:pass@host:3306/db",
+            "mysql://user:***@host:3306/db",
+        ),
+        // The two ordinary shapes, which were already correct and stay so.
+        ("mysql://user:pass@host/db", "mysql://user:***@host/db"),
+        ("redis://:pass@host:6379", "redis://:***@host:6379"),
     ] {
         assert_eq!(
             mask_url_credentials(value),
@@ -367,11 +388,16 @@ fn an_unencoded_at_in_the_password_does_not_end_the_credentials_early() {
     }
 }
 
-/// Fail-open, and borrowed while it is at it: a value the parser does not
-/// recognise is returned untouched rather than blanked. `Cow::Borrowed` is
-/// asserted rather than just string equality because it is the observable proof
-/// that the untouched path never rebuilt the string — the property that lets
-/// every surface call this unconditionally.
+/// Fail-open, and borrowed while it is at it: a value carrying no credential to
+/// hide is returned untouched rather than blanked. Two populations land here —
+/// values with no `://` at all, which never reach the parser, and values the
+/// parser accepts while reporting no password. (A value the parser *rejects* is
+/// a third case entirely, and it gets masked; see
+/// `a_value_the_url_parser_rejects_is_still_masked_by_the_fallback_scan`.)
+///
+/// `Cow::Borrowed` is asserted rather than just string equality because it is
+/// the observable proof that the untouched path never rebuilt the string — the
+/// property that lets every surface call this unconditionally.
 #[test]
 fn a_value_carrying_no_credential_is_returned_untouched() {
     for value in [
@@ -390,16 +416,130 @@ fn a_value_carrying_no_credential_is_returned_untouched() {
         "mysql://host:3306/db",
         // An `@` in the query string of a URL that carries no credentials.
         "https://example.com/webhook?notify=ops@example.com",
-        // A documented limitation, pinned so it stays deliberate: an unencoded
-        // `/` in the password ends the authority before the `@`, so the value
-        // fails open. `postgres://user:p/ss@host/db` cannot be told apart from
-        // `mysql://host:3306/db@x` above, and honouring the later `@` there
-        // masks a port and throws the host away.
-        "postgres://user:p/ss@host/db",
+        // The same host and port with a *longer* path tail after the `@`.
+        "mysql://host:3306/db@extra",
+        // A path `@` with no port colon anywhere to hint at credentials — the
+        // only `@` in the value follows the first `/`.
+        "https://host/path@literal",
     ] {
         assert!(
             matches!(mask_url_credentials(value), std::borrow::Cow::Borrowed(v) if v == value),
             "{value:?} must come back borrowed and unchanged"
         );
     }
+}
+
+/// The fallback arm: values [`url::Url::parse`] rejects outright.
+///
+/// A password holding a raw `/`, `?` or `#` ends the authority before its `@`,
+/// so the parser refuses the whole string and the scan is all that is left.
+/// Masking still has to happen — `openssl rand -base64` draws from an alphabet
+/// containing `/`, so this is the *common* generated-password shape, not an
+/// exotic one.
+///
+/// The libpq socket URL is the case that decides the fallback's rule.
+/// `database::build_postgres_candidates` builds it with an empty host, which
+/// `url` rejects, and `database::userinfo` splices the `.env` password in raw —
+/// so a first-`@` scan would mask `p` and print `ss@` from `p@ss` into a log
+/// line. The authority's *last* `@` is what closes that.
+#[test]
+fn a_value_the_url_parser_rejects_is_still_masked_by_the_fallback_scan() {
+    for (value, expected) in [
+        // `/`, `?` and `#` in the password: an invalid port to the parser.
+        (
+            "postgres://user:p/ss@host/db",
+            "postgres://user:***@host/db",
+        ),
+        ("mysql://user:pa?ss@host/db", "mysql://user:***@host/db"),
+        ("mysql://user:pa#ss@host/db", "mysql://user:***@host/db"),
+        // A `/` password *and* a later `@` in the query: the fallback must not
+        // reach past the authority for its `@` and swallow the host.
+        (
+            "mysql://user:p/ss@host/db?u=a@b",
+            "mysql://user:***@host/db?u=a@b",
+        ),
+        // The libpq socket URL, with and without an `@` in the password.
+        (
+            "postgres://user:p@ss@/laravel?host=/var/run/postgresql",
+            "postgres://user:***@/laravel?host=/var/run/postgresql",
+        ),
+        (
+            "postgres://user:pass@/laravel?host=/var/run/postgresql",
+            "postgres://user:***@/laravel?host=/var/run/postgresql",
+        ),
+    ] {
+        assert!(
+            url::Url::parse(value).is_err(),
+            "{value:?} is only interesting because the parser rejects it — if it \
+             started parsing, this fixture stopped covering the fallback"
+        );
+        assert_eq!(
+            mask_url_credentials(value),
+            expected,
+            "{value:?} must be masked by the fallback scan"
+        );
+    }
+}
+
+/// The premise the fallback rests on: the shapes a greedy scan mangles never
+/// reach it.
+///
+/// `mysql://host:3306/db@x` is host, port and a path holding an `@`. The
+/// fallback would read the `@` as a credential separator and print
+/// `mysql://host:***@x`, throwing the host, port and database away. It is safe
+/// only because `url` parses this shape successfully and reports no password,
+/// which returns it untouched before the fallback is ever consulted.
+///
+/// Asserted here rather than inferred from the borrowed-and-unchanged fixture
+/// above, because that test would stay green if the value reached the fallback
+/// and the fallback happened to leave it alone for some other reason.
+#[test]
+fn the_shapes_the_fallback_would_mangle_never_reach_it() {
+    for value in [
+        "mysql://host:3306/db@x",
+        "mysql://host:3306/db@extra",
+        "https://host/path@literal",
+        "https://example.com/webhook?notify=ops@example.com",
+    ] {
+        let parsed = url::Url::parse(value).unwrap_or_else(|e| {
+            panic!("{value:?} must parse, or it falls through to the greedy scan: {e}")
+        });
+        assert!(
+            parsed.password().is_none(),
+            "{value:?} carries no credentials, so the parse must report no password"
+        );
+    }
+}
+
+/// The one shape that still fails open, pinned so it stays deliberate.
+///
+/// A password holding a raw `/`, `?` or `#` is normally rejected by the parser
+/// and masked by the fallback. It survives only when the run before that
+/// character also happens to be a valid port: `mysql://user:12/34@host/db`
+/// parses cleanly as host `user`, port `12`, path `/34@host/db` — byte for byte
+/// the reading `mysql://host:3306/db@x` gets, and the correct one per RFC 3986,
+/// which requires those characters percent-encoded in userinfo. No parse can
+/// separate the two, so the residue is irreducible here; percent-encoding in
+/// `database::userinfo` is what would remove it.
+#[test]
+fn a_password_whose_leading_run_parses_as_a_port_still_fails_open() {
+    for value in [
+        // All-digit run before the `/`.
+        "mysql://user:12/34@host/db",
+        // An empty port is valid too, so a password *starting* with `/` lands
+        // in the same place.
+        "mysql://user:/ss@host/db",
+    ] {
+        assert!(
+            matches!(mask_url_credentials(value), std::borrow::Cow::Borrowed(v) if v == value),
+            "{value:?} is the documented residue — if this now masks, the doc \
+             comment on mask_url_credentials is stale"
+        );
+    }
+    // The boundary: one digit more than a port can hold, and the parse fails,
+    // so the fallback masks it. This is what keeps the residue narrow.
+    assert_eq!(
+        mask_url_credentials("mysql://user:99999/ss@host/db"),
+        "mysql://user:***@host/db"
+    );
 }

--- a/laravel-lsp/src/completion_display/tests.rs
+++ b/laravel-lsp/src/completion_display/tests.rs
@@ -735,3 +735,160 @@ fn a_password_whose_leading_run_parses_as_a_port_still_fails_open() {
         "jdbc:mysql://user:***@host/db"
     );
 }
+
+/// The third member of the "parser did not find a password" family: a value
+/// whose outer URL parses, carries an authority, and hides a credential
+/// *past* that authority.
+///
+/// [`url::Url::password`] answers about the authority it parsed and nothing
+/// else. `https://ok/cb?next=mysql://user:secret@host/db` has an authority
+/// (`ok`), no password in it, and a live credential in its query — so routing
+/// on "has an authority" alone handed it back in the clear, which was a
+/// regression against the greedy scan this function replaced. `CALLBACK_URL`,
+/// `WEBHOOK_URL` and `NEXT_URL` match no [`SENSITIVE_ENV_SEGMENTS`] keyword,
+/// so nothing else stops such a value reaching a display surface.
+///
+/// The membership assertions are what make this a test about the *arm* rather
+/// than about the strings: each fixture must parse, must report an authority,
+/// and must report no password — the exact three conditions that used to end
+/// in `Cow::Borrowed`.
+#[test]
+fn a_credential_past_the_authority_is_found_by_the_tail_rescan() {
+    for (value, expected) in [
+        // A nested URL in the query — an OAuth `redirect_uri`, a webhook
+        // forwarding target.
+        (
+            "https://ok.example.com/cb?next=mysql://user:secret@host/db",
+            "https://ok.example.com/cb?next=mysql://user:***@host/db",
+        ),
+        // In the path, and in the fragment.
+        (
+            "https://ok/mysql://user:secret@host/db",
+            "https://ok/mysql://user:***@host/db",
+        ),
+        (
+            "https://ok/x#mysql://user:secret@host/db",
+            "https://ok/x#mysql://user:***@host/db",
+        ),
+        // The `@`-bearing password issue #355 is about, one layer in. The
+        // rescan reaches the fallback, which prefers the authority's last `@`,
+        // so the tail does not survive here either.
+        (
+            "https://ok/cb?next=postgres://user:p@ssword@host/db",
+            "https://ok/cb?next=postgres://user:***@host/db",
+        ),
+        // A `;`-delimited endpoint list, where only the second entry
+        // authenticates.
+        (
+            "https://a/b;mysql://user:secret@host/db",
+            "https://a/b;mysql://user:***@host/db",
+        ),
+        // The inner value is itself authority-less, so the rescan's own
+        // `jdbc:` arm has to fire inside the tail.
+        (
+            "https://ok/x?u=jdbc:mysql://user:secret@host/db",
+            "https://ok/x?u=jdbc:mysql://user:***@host/db",
+        ),
+    ] {
+        let parsed = url::Url::parse(value)
+            .unwrap_or_else(|e| panic!("{value:?} must parse, or it is in the rejected arm: {e}"));
+        assert!(
+            parsed.has_authority(),
+            "{value:?} is in this test only because the outer parse reports an authority"
+        );
+        assert!(
+            parsed.password().is_none(),
+            "{value:?} must report no password — the outer authority has none, and \
+             that silence is the whole defect"
+        );
+        assert_eq!(
+            mask_url_credentials(value),
+            expected,
+            "{value:?} hides its credential past the authority; the tail rescan \
+             has to find it"
+        );
+    }
+}
+
+/// The price of the rescan, pinned so it stays a known trade.
+///
+/// A credential-*free* nested URL whose inner half carries both a `:` and a
+/// later `@` is over-masked, because the scan inside the tail cannot tell a
+/// path's `@` from a credential separator. Identical in kind to the
+/// over-masking the rejected-parse and authority-less arms already do, and the
+/// alternative is the leak the test above closes.
+///
+/// The second half is the discriminating one: a tail with no second `://`
+/// never reaches the rescan, so every ordinary URL is byte-for-byte unchanged.
+#[test]
+fn a_credential_free_nested_url_is_over_masked_by_the_tail_rescan() {
+    for (value, expected) in [
+        (
+            "https://ok/mysql://host:3306/db@x",
+            "https://ok/mysql://host:***@x",
+        ),
+        (
+            "https://ok/x?u=jdbc:mysql://host:3306/db@x",
+            "https://ok/x?u=jdbc:mysql://host:***@x",
+        ),
+    ] {
+        assert_eq!(
+            mask_url_credentials(value),
+            expected,
+            "{value:?} carries no credential, but its nested URL has a `:` and a \
+             later `@` — over-masking, not a leak"
+        );
+    }
+
+    for value in [
+        // No second `://` in the tail: the rescan returns borrowed and the
+        // outer value is handed back untouched. This is every ordinary
+        // `DATABASE_URL`, so it is the path that must not move.
+        "mysql://host:3306/db@x",
+        "https://example.com/webhook?notify=ops@example.com",
+        "https://host/path@literal",
+        // A nested URL with no `:` in its credential position is left alone
+        // by the scan, so the rescan changes nothing here either.
+        "https://ok/x?u=https://other.example.com/p@th",
+    ] {
+        assert!(
+            matches!(mask_url_credentials(value), std::borrow::Cow::Borrowed(v) if v == value),
+            "{value:?} must still come back borrowed and unchanged"
+        );
+    }
+}
+
+/// The rescan recurses, so its bound is a safety property rather than a
+/// stylistic one: a `.env` value is arbitrary text off disk, and an unbounded
+/// recursion over one is a stack overflow in the language server.
+///
+/// The bound is two frames, and it is structural. The tail starts at the first
+/// `/`, `?` or `#` in the authority scan, so it *begins* with one of those
+/// characters — and no such string parses as an absolute URL, so the recursive
+/// call can only reach the fallback arm, which does not recurse. Asserted here
+/// against the parser rather than argued, because it is `url`'s behaviour and
+/// not this module's that makes it true.
+#[test]
+fn the_tail_rescan_cannot_recurse_past_one_level() {
+    for tail_start in ['/', '?', '#'] {
+        for tail in [
+            format!("{tail_start}db"),
+            format!("{tail_start}x?u=mysql://user:p@h/db"),
+            tail_start.to_string(),
+        ] {
+            assert!(
+                url::Url::parse(&tail).is_err(),
+                "{tail:?} must not parse as an absolute URL, or the rescan gains a \
+                 third frame and its depth stops being bounded"
+            );
+        }
+    }
+
+    // And the same bound observed end to end, on an input far past any depth a
+    // stack would survive if the recursion followed the nesting.
+    let deep = format!("https://a{}/user:secret@h/db", "/https://b".repeat(5_000));
+    assert!(
+        !mask_url_credentials(&deep).contains("secret"),
+        "a deeply nested value must still be masked, without recursing per level"
+    );
+}

--- a/laravel-lsp/src/completion_display/tests.rs
+++ b/laravel-lsp/src/completion_display/tests.rs
@@ -459,6 +459,10 @@ fn a_value_carrying_no_credential_is_returned_untouched() {
 /// `url` rejects, and `database::userinfo` splices the `.env` password in raw —
 /// so a first-`@` scan would mask `p` and print `ss@` from `p@ss` into a log
 /// line. The authority's *last* `@` is what closes that.
+///
+/// The parser's *other* silent arm — accepted, but with no authority — is
+/// covered by
+/// `a_credential_survives_a_successful_parse_that_never_read_the_userinfo`.
 #[test]
 fn a_value_the_url_parser_rejects_is_still_masked_by_the_fallback_scan() {
     for (value, expected) in [
@@ -554,6 +558,125 @@ fn a_successful_parse_is_the_only_thing_keeping_the_fallback_off_these_shapes() 
              the fallback, which masks the path's `@` — over-masking, not a leak"
         );
     }
+}
+
+/// The second member of the "parser never read the userinfo" arm: a value
+/// [`url::Url::parse`] *accepts* while reporting no authority.
+///
+/// `Url::password` gates on `has_authority`, so it answers `None` for every
+/// such value whatever its path holds — `jdbc:mysql://user:secret@host/db`
+/// included. Routing on "the parse succeeded" alone therefore handed that
+/// string straight back in the clear, which was a regression against the
+/// greedy scan this function replaced. `JDBC_URL` and `SPRING_DATASOURCE_URL`
+/// clear the name gate untouched, so nothing else stops it reaching a display
+/// surface.
+///
+/// The membership assertion above each fixture is what makes this test about
+/// the *arm* rather than about the strings: it fails if a fixture stops being
+/// an accepted-but-authority-less parse, at which point it is pinning some
+/// other code path and the sweep behind it has silently narrowed.
+#[test]
+fn a_credential_survives_a_successful_parse_that_never_read_the_userinfo() {
+    for (value, expected) in [
+        // The reported instance: a JDBC connection string.
+        (
+            "jdbc:mysql://user:secret@host:3306/db",
+            "jdbc:mysql://user:***@host:3306/db",
+        ),
+        // The same defect with the `@`-bearing password issue #355 is about.
+        (
+            "jdbc:mysql://user:p@ssword@host/db",
+            "jdbc:mysql://user:***@host/db",
+        ),
+        // A `/` password, which the *rejected* arm would also have masked.
+        (
+            "jdbc:postgresql://user:p/ss@host/db",
+            "jdbc:postgresql://user:***@host/db",
+        ),
+        // Multibyte on both sides of the `:`, to pin that every index still
+        // derives from an ASCII `find`/`rfind` and cannot split a codepoint.
+        (
+            "jdbc:mysql://usér:pässwörd@host/db",
+            "jdbc:mysql://usér:***@host/db",
+        ),
+        // Two scheme colons before the `://`.
+        (
+            "spring:datasource:mysql://user:secret@host/db",
+            "spring:datasource:mysql://user:***@host/db",
+        ),
+        // Not the `jdbc:` prefix — the *absence of an authority*. Here the
+        // `://` is only ever path, and `cannot_be_a_base()` is false, so a
+        // rule written against opaque schemes alone would still leak this one.
+        (
+            "foo:/bar://user:secret@host/db",
+            "foo:/bar://user:***@host/db",
+        ),
+    ] {
+        let parsed = url::Url::parse(value)
+            .unwrap_or_else(|e| panic!("{value:?} must parse, or it is in the rejected arm: {e}"));
+        assert!(
+            !parsed.has_authority(),
+            "{value:?} is in this test only because the parse reports no authority"
+        );
+        assert!(
+            parsed.password().is_none(),
+            "{value:?} must report no password — that silence is the whole defect"
+        );
+        assert_eq!(
+            mask_url_credentials(value),
+            expected,
+            "{value:?} carries a password the parser never looked for; the scan \
+             has to find it"
+        );
+    }
+}
+
+/// The price of the arm above, pinned so it stays a known trade.
+///
+/// A value with no authority reaches the scan, and the scan cannot tell a
+/// path's `@` from a credential separator — so a credential-*free* value in
+/// the same family is over-masked. That is not new behaviour invented here:
+/// the rejected-parse arm has always done it, and the second half of this test
+/// is the byte-for-byte proof, differing only in what stops the parse.
+///
+/// Over-masking rather than a leak, and the alternative is the leak the test
+/// above closes.
+#[test]
+fn a_credential_free_value_with_no_authority_is_over_masked_by_the_scan() {
+    for (value, expected) in [
+        ("jdbc:mysql://host:3306/db@x", "jdbc:mysql://host:***@x"),
+        (
+            "jdbc:mysql://host:3306?notify=ops@example.com",
+            "jdbc:mysql://host:***@example.com",
+        ),
+        // A bracketed IPv6 host is mangled mid-bracket, because the `:` the
+        // scan cuts at is inside the brackets.
+        ("jdbc:mysql://[::1]/db@x", "jdbc:mysql://[:***@x"),
+    ] {
+        assert_eq!(
+            mask_url_credentials(value),
+            expected,
+            "{value:?} has no authority, so the scan masks its path `@`"
+        );
+    }
+
+    // The same shapes, an authority away. These parse *with* an authority and
+    // so keep the untouched arm — the discriminating half of this fixture.
+    for value in ["mysql://host:3306/db@x", "mysql://[::1]/db@x"] {
+        assert!(
+            matches!(mask_url_credentials(value), std::borrow::Cow::Borrowed(v) if v == value),
+            "{value:?} has an authority, so it must still come back untouched"
+        );
+    }
+
+    // And the same over-masking from the rejected arm, which is where this
+    // behaviour has always lived: an unparseable port, not a missing authority.
+    assert_eq!(
+        mask_url_credentials("mysql://[::1]:70000/db@x"),
+        "mysql://[:***@x",
+        "the rejected arm mangles a bracketed host identically — this trade is \
+         inherited, not introduced"
+    );
 }
 
 /// The one shape that still fails open, pinned so it stays deliberate.

--- a/laravel-lsp/src/completion_display/tests.rs
+++ b/laravel-lsp/src/completion_display/tests.rs
@@ -346,13 +346,6 @@ fn an_unencoded_at_in_the_password_does_not_end_the_credentials_early() {
         // The no-username Redis form, which starts its credentials with the
         // `:` the mask keys on.
         ("redis://:p@ss@redis:6379", "redis://:***@redis:6379"),
-        // The libpq socket URL `build_postgres_candidates` generates: the
-        // authority ends immediately after the `@`, and the socket path lives
-        // in the query string.
-        (
-            "postgres://user:p@ss@/laravel?host=/var/run/postgresql",
-            "postgres://user:***@/laravel?host=/var/run/postgresql",
-        ),
         // An `@` in the query must not be mistaken for the separator and drag
         // the real credentials into the "host" half.
         (
@@ -379,7 +372,20 @@ fn an_unencoded_at_in_the_password_does_not_end_the_credentials_early() {
         // The two ordinary shapes, which were already correct and stay so.
         ("mysql://user:pass@host/db", "mysql://user:***@host/db"),
         ("redis://:pass@host:6379", "redis://:***@host:6379"),
+        // Multibyte user *and* password. Every offset this function splices at
+        // comes from an ASCII `find`/`rfind`, so a slice boundary can never
+        // land inside a codepoint — asserted rather than argued.
+        (
+            "postgres://usér:p@sswörd@host/db",
+            "postgres://usér:***@host/db",
+        ),
     ] {
+        assert!(
+            matches!(url::Url::parse(value), Ok(parsed) if parsed.password().is_some()),
+            "{value:?} belongs to this test only while the parser accepts it and \
+             reports a password — if that stops being true it has moved to the \
+             fallback arm, and this test is no longer covering what it says"
+        );
         assert_eq!(
             mask_url_credentials(value),
             expected,
@@ -389,10 +395,12 @@ fn an_unencoded_at_in_the_password_does_not_end_the_credentials_early() {
 }
 
 /// Fail-open, and borrowed while it is at it: a value carrying no credential to
-/// hide is returned untouched rather than blanked. Two populations land here —
-/// values with no `://` at all, which never reach the parser, and values the
-/// parser accepts while reporting no password. (A value the parser *rejects* is
-/// a third case entirely, and it gets masked; see
+/// hide is returned untouched rather than blanked. Two populations are pinned
+/// here — values with no `://` at all, which never reach the parser, and values
+/// the parser accepts while reporting no password. (A value the parser
+/// *rejects* is a third case: it goes to the fallback scan, which masks it when
+/// it finds an `@` with a `:` before it, and otherwise returns it borrowed like
+/// everything here. `mysql://host:70000/db` takes that second route. See
 /// `a_value_the_url_parser_rejects_is_still_masked_by_the_fallback_scan`.)
 ///
 /// `Cow::Borrowed` is asserted rather than just string equality because it is
@@ -421,6 +429,15 @@ fn a_value_carrying_no_credential_is_returned_untouched() {
         // A path `@` with no port colon anywhere to hint at credentials — the
         // only `@` in the value follows the first `/`.
         "https://host/path@literal",
+        // Userinfo carrying a `:` with nothing after it. `url` reports this
+        // exactly as it reports no password at all, so it takes the same arm.
+        // No secret is disclosed, but `main`'s scan did rewrite it to
+        // `mysql://user:***@host/db` — pinned because the doc comment on
+        // `mask_url_credentials` now names it.
+        "mysql://user:@host/db",
+        // A parser rejection that carries no `@` for the fallback to find, so
+        // it lands here rather than being masked.
+        "mysql://host:70000/db",
     ] {
         assert!(
             matches!(mask_url_credentials(value), std::borrow::Cow::Borrowed(v) if v == value),
@@ -481,8 +498,8 @@ fn a_value_the_url_parser_rejects_is_still_masked_by_the_fallback_scan() {
     }
 }
 
-/// The premise the fallback rests on: the shapes a greedy scan mangles never
-/// reach it.
+/// What keeps the shapes a greedy scan mangles away from the fallback: a
+/// successful parse, and nothing else.
 ///
 /// `mysql://host:3306/db@x` is host, port and a path holding an `@`. The
 /// fallback would read the `@` as a credential separator and print
@@ -493,8 +510,17 @@ fn a_value_the_url_parser_rejects_is_still_masked_by_the_fallback_scan() {
 /// Asserted here rather than inferred from the borrowed-and-unchanged fixture
 /// above, because that test would stay green if the value reached the fallback
 /// and the fallback happened to leave it alone for some other reason.
+///
+/// The protection is exactly that conditional, and the second half of this test
+/// pins the other side of it. Give the same credential-free shape a port the
+/// parser refuses — a typo, or a port past `u16::MAX` — and it *does* reach the
+/// fallback, whose unbounded `find('@')` walks into the path and prints a `***`
+/// password on a value that never had one. That is over-masking rather than a
+/// leak, and it is the price of the `or_else` that masks
+/// `postgres://user:p/ss@host/db`, so the behaviour stays. What must not stay is
+/// the impression that these shapes can never get there.
 #[test]
-fn the_shapes_the_fallback_would_mangle_never_reach_it() {
+fn a_successful_parse_is_the_only_thing_keeping_the_fallback_off_these_shapes() {
     for value in [
         "mysql://host:3306/db@x",
         "mysql://host:3306/db@extra",
@@ -507,6 +533,25 @@ fn the_shapes_the_fallback_would_mangle_never_reach_it() {
         assert!(
             parsed.password().is_none(),
             "{value:?} carries no credentials, so the parse must report no password"
+        );
+    }
+
+    // The same shapes with a port the parser refuses. The parse fails for a
+    // reason that has nothing to do with credentials, and the fallback masks
+    // the path's `@` anyway.
+    for (value, expected) in [
+        ("mysql://host:70000/db@extra", "mysql://host:***@extra"),
+        ("mysql://host:port/db@extra", "mysql://host:***@extra"),
+    ] {
+        assert!(
+            url::Url::parse(value).is_err(),
+            "{value:?} is in this half only because the parser rejects it"
+        );
+        assert_eq!(
+            mask_url_credentials(value),
+            expected,
+            "{value:?} carries no credential, but an unparseable port sends it to \
+             the fallback, which masks the path's `@` — over-masking, not a leak"
         );
     }
 }
@@ -529,6 +574,11 @@ fn a_password_whose_leading_run_parses_as_a_port_still_fails_open() {
         // An empty port is valid too, so a password *starting* with `/` lands
         // in the same place.
         "mysql://user:/ss@host/db",
+        // `?` and `#` end the authority for the parser exactly as `/` does, so
+        // the residue is all three characters the doc comment names, not only
+        // the one it gives an example of.
+        "mysql://user:12?34@host/db",
+        "mysql://user:12#34@host/db",
     ] {
         assert!(
             matches!(mask_url_credentials(value), std::borrow::Cow::Borrowed(v) if v == value),

--- a/laravel-lsp/src/completion_display/tests.rs
+++ b/laravel-lsp/src/completion_display/tests.rs
@@ -709,10 +709,29 @@ fn a_password_whose_leading_run_parses_as_a_port_still_fails_open() {
              comment on mask_url_credentials is stale"
         );
     }
-    // The boundary: one digit more than a port can hold, and the parse fails,
-    // so the fallback masks it. This is what keeps the residue narrow.
+    // The boundary, and it is the port's *value* rather than its length:
+    // `99999` is the same five digits as `65535` and fails only because it is
+    // past `u16::MAX`. Asserted rather than described — this comment used to
+    // read "one digit more than a port can hold", which is false about both
+    // numbers and which no assertion underneath it could contradict.
+    assert_eq!(
+        "99999".len(),
+        "65535".len(),
+        "the two ports must stay the same length, or this fixture stops \
+         demonstrating that the value is what decides"
+    );
+    assert!("65535".parse::<u16>().is_ok());
+    assert!("99999".parse::<u16>().is_err());
     assert_eq!(
         mask_url_credentials("mysql://user:99999/ss@host/db"),
         "mysql://user:***@host/db"
+    );
+
+    // The residue is bounded by the authority rule as well as by the port. The
+    // same password behind an opaque scheme has no authority, so it reaches the
+    // scan and masks.
+    assert_eq!(
+        mask_url_credentials("jdbc:mysql://user:12/34@host/db"),
+        "jdbc:mysql://user:***@host/db"
     );
 }

--- a/laravel-lsp/src/database/tests.rs
+++ b/laravel-lsp/src/database/tests.rs
@@ -1792,7 +1792,11 @@ const LOG_PLAIN_HOST: &str = "db.internal.example";
 /// segment of `SENSITIVE_ENV_SEGMENTS`, and Laravel's stock
 /// `config/database.php` ships `'url' => env('DATABASE_URL')`, so this value
 /// reaches the log on the default configuration of an ordinary project.
-const LOG_URL_SECRET: &str = "url-hunter2-issue-344";
+const LOG_URL_SECRET: &str = "url-hunter2@tail-355";
+/// The half of `LOG_URL_SECRET` the old first-`@` parse left in the log
+/// (issue #355). Asserted on its own: a whole-secret check passes vacuously on
+/// a partially masked line, which is the defect this fixture now pins.
+const LOG_URL_SECRET_TAIL: &str = "tail-355";
 
 fn log_fixture_db_url() -> String {
     format!("mysql://sail:{LOG_URL_SECRET}@{LOG_PLAIN_HOST}:3306/laravel")
@@ -1966,10 +1970,12 @@ fn parsing_the_database_config_never_logs_a_credential_inside_a_url_value() {
         Some(log_fixture_db_url().as_str()),
         "the parse still hands the driver the real URL — masking is a display concern only"
     );
-    assert!(
-        !logs.contains(LOG_URL_SECRET),
-        "the password inside DATABASE_URL reached the log in plaintext:\n{logs}"
-    );
+    for secret in [LOG_URL_SECRET, LOG_URL_SECRET_TAIL] {
+        assert!(
+            !logs.contains(secret),
+            "the password inside DATABASE_URL reached the log in plaintext:\n{logs}"
+        );
+    }
     // Two lines print this value, and both must mask it: the resolver's
     // `resolved from .env:` line and the config summary's `url:` line. Pinned
     // separately, because masking one and not its sibling is precisely the
@@ -2013,10 +2019,12 @@ fn resolve_env_masks_a_credential_inside_a_url_value_in_its_debug_log() {
         Some(log_fixture_db_url().as_str()),
         "caller still gets the real URL"
     );
-    assert!(
-        !logs.contains(LOG_URL_SECRET),
-        "the password inside DATABASE_URL reached the debug log in plaintext:\n{logs}"
-    );
+    for secret in [LOG_URL_SECRET, LOG_URL_SECRET_TAIL] {
+        assert!(
+            !logs.contains(secret),
+            "the password inside DATABASE_URL reached the debug log in plaintext:\n{logs}"
+        );
+    }
     assert!(
         logs.contains(&format!(
             r#"resolve_env(DATABASE_URL): Some("{}")"#,

--- a/laravel-lsp/src/database/tests.rs
+++ b/laravel-lsp/src/database/tests.rs
@@ -1798,6 +1798,15 @@ const LOG_URL_SECRET: &str = "url-hunter2@tail-355";
 /// a partially masked line, which is the defect this fixture now pins.
 const LOG_URL_SECRET_TAIL: &str = "tail-355";
 
+/// The credential *neither* gate could see. `JDBC_URL` matches no sensitive
+/// segment, and a `jdbc:` value parses to an opaque path with no authority, so
+/// `url` reports no password and the shape gate returned the whole line
+/// untouched — into an `info!` that renders in Zed's log panel by default.
+const LOG_JDBC_SECRET: &str = "jdbc-hunter2@tail-358";
+/// `LOG_JDBC_SECRET`'s surviving half, for the same reason as
+/// `LOG_URL_SECRET_TAIL`.
+const LOG_JDBC_SECRET_TAIL: &str = "tail-358";
+
 fn log_fixture_db_url() -> String {
     format!("mysql://sail:{LOG_URL_SECRET}@{LOG_PLAIN_HOST}:3306/laravel")
 }
@@ -1807,6 +1816,14 @@ fn log_fixture_db_url() -> String {
 /// altogether, which would be a lost diagnostic rather than a fix.
 fn log_fixture_db_url_masked() -> String {
     format!("mysql://sail:***@{LOG_PLAIN_HOST}:3306/laravel")
+}
+
+fn log_fixture_jdbc_url() -> String {
+    format!("jdbc:mysql://sail:{LOG_JDBC_SECRET}@{LOG_PLAIN_HOST}:3306/laravel")
+}
+
+fn log_fixture_jdbc_url_masked() -> String {
+    format!("jdbc:mysql://sail:***@{LOG_PLAIN_HOST}:3306/laravel")
 }
 
 /// `config/database.php` with the `url` setting Laravel ships by default.
@@ -2004,34 +2021,46 @@ fn parsing_the_database_config_never_logs_a_credential_inside_a_url_value() {
 /// whose output gets pasted into bug reports.
 #[test]
 fn resolve_env_masks_a_credential_inside_a_url_value_in_its_debug_log() {
-    let dir = TempDir::new().unwrap();
-    write(
-        dir.path(),
-        ".env",
-        &format!("DATABASE_URL={}\n", log_fixture_db_url()),
-    );
-    let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
+    // Both routes through the shape gate. `DATABASE_URL` parses with an
+    // authority and `url` reports its password; `JDBC_URL` parses to an opaque
+    // path with no authority, where `url` reports none however many the value
+    // holds. Masking the first says nothing about the second.
+    for (name, value, masked, secrets) in [
+        (
+            "DATABASE_URL",
+            log_fixture_db_url(),
+            log_fixture_db_url_masked(),
+            [LOG_URL_SECRET, LOG_URL_SECRET_TAIL],
+        ),
+        (
+            "JDBC_URL",
+            log_fixture_jdbc_url(),
+            log_fixture_jdbc_url_masked(),
+            [LOG_JDBC_SECRET, LOG_JDBC_SECRET_TAIL],
+        ),
+    ] {
+        let dir = TempDir::new().unwrap();
+        write(dir.path(), ".env", &format!("{name}={value}\n"));
+        let provider = DatabaseSchemaProvider::new(dir.path().to_path_buf());
 
-    let (url, logs) = capture_logs(|| provider.resolve_env("DATABASE_URL"));
+        let (resolved, logs) = capture_logs(|| provider.resolve_env(name));
 
-    assert_eq!(
-        url.as_deref(),
-        Some(log_fixture_db_url().as_str()),
-        "caller still gets the real URL"
-    );
-    for secret in [LOG_URL_SECRET, LOG_URL_SECRET_TAIL] {
+        assert_eq!(
+            resolved.as_deref(),
+            Some(value.as_str()),
+            "caller still gets the real URL"
+        );
+        for secret in secrets {
+            assert!(
+                !logs.contains(secret),
+                "the password inside {name} reached the debug log in plaintext:\n{logs}"
+            );
+        }
         assert!(
-            !logs.contains(secret),
-            "the password inside DATABASE_URL reached the debug log in plaintext:\n{logs}"
+            logs.contains(&format!(r#"resolve_env({name}): Some("{masked}")"#)),
+            "the debug line must carry the masked URL:\n{logs}"
         );
     }
-    assert!(
-        logs.contains(&format!(
-            r#"resolve_env(DATABASE_URL): Some("{}")"#,
-            log_fixture_db_url_masked()
-        )),
-        "the debug line must carry the masked URL:\n{logs}"
-    );
 }
 
 #[test]

--- a/laravel-lsp/src/tests/env_key_navigation.rs
+++ b/laravel-lsp/src/tests/env_key_navigation.rs
@@ -1004,7 +1004,8 @@ async fn sensitive_values_are_redacted_in_the_env_buffer_card() {
     let (server, dir) = server_with(
         &[(
             ".env",
-            "DB_PASSWORD=hunter2\nDATABASE_URL=mysql://root:hunter2@localhost/app\n",
+            "DB_PASSWORD=hunter2\nDATABASE_URL=mysql://root:hunter2@localhost/app\n\
+             CALLBACK_URL=https://app.example.com/cb?next=mysql://root:hunter3@localhost/app\n",
         )],
         &[],
     )
@@ -1033,5 +1034,21 @@ async fn sensitive_values_are_redacted_in_the_env_buffer_card() {
     assert!(
         by_shape.contains("mysql://"),
         "masking must keep the rest of the URL readable: {by_shape:?}"
+    );
+
+    // The shape gate's third arm, on this surface too: the outer URL parses
+    // and carries an authority reporting no password, while the credential
+    // sits past it in the query. `CALLBACK_URL` clears the name gate, so this
+    // card is one of the four places that value would have been printed.
+    let past_authority = hover_at(&server, &env, position(2, 2))
+        .await
+        .expect("CALLBACK_URL must still render a card");
+    assert!(
+        !past_authority.contains("hunter3"),
+        "a credential past the authority must not reach the card: {past_authority:?}"
+    );
+    assert!(
+        past_authority.contains("https://app.example.com/cb?next=mysql://root:***@localhost/app"),
+        "the outer URL and the inner host must both survive the mask: {past_authority:?}"
     );
 }

--- a/laravel-lsp/src/tests/env_value_redaction.rs
+++ b/laravel-lsp/src/tests/env_value_redaction.rs
@@ -60,7 +60,14 @@ const PLAIN_VALUE: &str = "Example";
 /// reads `'url' => env('DATABASE_URL')` and the value carries the password
 /// inside itself. Caught by shape, not by name.
 const URL_NAME: &str = "DATABASE_URL";
-const URL_SECRET: &str = "url-hunter2-issue-344";
+/// Carries an unencoded `@`, the shape issue #355 fixed: `database::userinfo`
+/// interpolates a `.env` password into a connection URL verbatim, so a
+/// developer who types one gets this value across all five surfaces.
+const URL_SECRET: &str = "url-hunter2@tail-355";
+/// The half of `URL_SECRET` that survived the old first-`@` parse. Asserted on
+/// its own because every whole-secret check passes vacuously on a *partially*
+/// masked value — `sail:***@tail-355@host` contains no `URL_SECRET`.
+const URL_SECRET_TAIL: &str = "tail-355";
 
 fn url_value() -> String {
     format!("mysql://sail:{URL_SECRET}@db.internal.example:3306/laravel")
@@ -165,7 +172,13 @@ fn assert_no_secret_leak(
     context: &str,
 ) -> Vec<CompletionItem> {
     let (items, json) = dissect(response);
-    for secret in [PASSWORD_VALUE, TOKEN_VALUE, COMMENTED_VALUE, URL_SECRET] {
+    for secret in [
+        PASSWORD_VALUE,
+        TOKEN_VALUE,
+        COMMENTED_VALUE,
+        URL_SECRET,
+        URL_SECRET_TAIL,
+    ] {
         assert!(
             !json.contains(secret),
             "{context}: {secret} leaked into the completion response: {json}"
@@ -334,10 +347,12 @@ async fn hover_masks_a_credential_carried_inside_the_value() {
     let (_dir, _root, server) = project(&dotenv()).await;
     let markdown = server.hover_for_env(URL_NAME).await;
 
-    assert!(
-        !markdown.contains(URL_SECRET),
-        "the password inside {URL_NAME} leaked into the hover markdown: {markdown}"
-    );
+    for secret in [URL_SECRET, URL_SECRET_TAIL] {
+        assert!(
+            !markdown.contains(secret),
+            "the password inside {URL_NAME} leaked into the hover markdown: {markdown}"
+        );
+    }
     assert!(
         markdown.contains(&format!("```\n{}\n```", url_masked())),
         "the masked URL must still render as a code block: {markdown}"

--- a/laravel-lsp/src/tests/env_value_redaction.rs
+++ b/laravel-lsp/src/tests/env_value_redaction.rs
@@ -27,9 +27,11 @@
 //! password sits inside the value. These tests drive the real entry points —
 //! `completion()`, `hover_for_env` and `get_all_config_keys` — with two
 //! different matched keyword categories (`DB_PASSWORD` and `API_TOKEN`) plus
-//! the URL shape crossing every one of them, so a surface that re-implemented
-//! either check locally and drifted is caught by observed behaviour rather than
-//! by reading the diff.
+//! both routes through the shape gate crossing every one of them — an
+//! authority-bearing URL (`DATABASE_URL`) and an authority-less one
+//! (`JDBC_URL`), which take different arms inside `mask_url_credentials`. So a
+//! surface that re-implemented either check locally and drifted is caught by
+//! observed behaviour rather than by reading the diff.
 //!
 //! Leak assertions run over the **whole serialized response**, not the fields
 //! this change touches: `insertText`, `label`, `sortText` and friends are just
@@ -88,8 +90,33 @@ const URL_SECRET: &str = "url-hunter2@tail-355";
 /// masked value — `sail:***@tail-355@host` contains no `URL_SECRET`.
 const URL_SECRET_TAIL: &str = "tail-355";
 
+/// The name gate's blind spot again, one layer deeper. `JDBC_URL` splits to
+/// `JDBC` / `URL` and matches no sensitive segment, exactly like
+/// `DATABASE_URL` — but a `jdbc:` value also defeats the *shape* gate's parse:
+/// `url` reads the opaque path, never parses userinfo, and reports no password
+/// however many the value holds. So both gates fell open at once and the
+/// password reached every surface in the clear.
+///
+/// Kept as its own variable rather than folded into `URL_NAME` because the two
+/// travel different routes through `mask_url_credentials` — an authority-
+/// bearing parse and an authority-less one — and one fixture cannot exercise
+/// both arms.
+const JDBC_NAME: &str = "JDBC_URL";
+const JDBC_SECRET: &str = "jdbc-hunter2@tail-358";
+/// `JDBC_SECRET`'s surviving half, for the same reason as `URL_SECRET_TAIL`.
+const JDBC_SECRET_TAIL: &str = "tail-358";
+
 fn url_value() -> String {
     format!("mysql://sail:{URL_SECRET}@db.internal.example:3306/laravel")
+}
+
+fn jdbc_value() -> String {
+    format!("jdbc:mysql://sail:{JDBC_SECRET}@db.internal.example:3306/laravel")
+}
+
+/// The masked form of [`jdbc_value`]. Host, port and database survive here too.
+fn jdbc_masked() -> String {
+    "jdbc:mysql://sail:***@db.internal.example:3306/laravel".to_string()
 }
 
 /// What every surface must render instead: masked, not dropped. The host, port
@@ -110,8 +137,9 @@ const PLANTED_MIDDLEWARE: &str = "planted-issue-356";
 /// The project `.env` every test registers with Salsa.
 fn dotenv() -> String {
     format!(
-        "{PLAIN_NAME}={PLAIN_VALUE}\n{PASSWORD_NAME}={PASSWORD_VALUE}\n{TOKEN_NAME}={TOKEN_VALUE}\n{URL_NAME}={}\n# {COMMENTED_NAME}={COMMENTED_VALUE}\n",
-        url_value()
+        "{PLAIN_NAME}={PLAIN_VALUE}\n{PASSWORD_NAME}={PASSWORD_VALUE}\n{TOKEN_NAME}={TOKEN_VALUE}\n{URL_NAME}={}\n{JDBC_NAME}={}\n# {COMMENTED_NAME}={COMMENTED_VALUE}\n",
+        url_value(),
+        jdbc_value()
     )
 }
 
@@ -221,6 +249,8 @@ fn assert_no_secret_leak(
         COMMENTED_VALUE,
         URL_SECRET,
         URL_SECRET_TAIL,
+        JDBC_SECRET,
+        JDBC_SECRET_TAIL,
     ] {
         assert!(
             !haystack.contains(secret),
@@ -249,6 +279,8 @@ fn the_leak_search_still_finds_a_needle_the_panel_spells_with_escapes() {
         COMMENTED_VALUE,
         URL_SECRET,
         URL_SECRET_TAIL,
+        JDBC_SECRET,
+        JDBC_SECRET_TAIL,
     ] {
         let escaped = laravel_lsp::markdown_safety::escape_inline(secret);
         assert!(
@@ -343,6 +375,21 @@ async fn env_completion_redacts_every_matched_category_and_leaves_the_rest_alone
         documentation_markdown(url, "env completion"),
         expected_panel(URL_NAME, &url_masked()),
         "{URL_NAME}: the panel must show the masked URL, not the credential"
+    );
+
+    // The same shape gate, on a value whose parse reports no authority. The
+    // name clears the gate exactly as `DATABASE_URL` does, so this is the only
+    // check standing between a JDBC password and the completion panel.
+    let jdbc = item(&items, JDBC_NAME, "env completion");
+    assert_eq!(
+        jdbc.detail.as_deref(),
+        Some(format!("{} (from .env)", jdbc_masked()).as_str()),
+        "{JDBC_NAME}: the detail line must show the URL with its password masked"
+    );
+    assert_eq!(
+        documentation_markdown(jdbc, "env completion"),
+        expected_panel(JDBC_NAME, &jdbc_masked()),
+        "{JDBC_NAME}: the panel must show the masked URL, not the credential"
     );
 
     // Positive control: the unmatched variable is byte-for-byte what it was.
@@ -503,23 +550,31 @@ async fn hover_redacts_every_matched_category() {
 #[tokio::test]
 async fn hover_masks_a_credential_carried_inside_the_value() {
     let (_dir, _root, server) = project(&dotenv()).await;
-    let markdown = server.hover_for_env(URL_NAME).await;
 
-    for secret in [URL_SECRET, URL_SECRET_TAIL] {
+    // Both routes through the shape gate: an authority-bearing parse, and an
+    // authority-less one whose password `url` never looks for.
+    for (name, masked, secrets) in [
+        (URL_NAME, url_masked(), [URL_SECRET, URL_SECRET_TAIL]),
+        (JDBC_NAME, jdbc_masked(), [JDBC_SECRET, JDBC_SECRET_TAIL]),
+    ] {
+        let markdown = server.hover_for_env(name).await;
+
+        for secret in secrets {
+            assert!(
+                !markdown.contains(secret),
+                "the password inside {name} leaked into the hover markdown: {markdown}"
+            );
+        }
         assert!(
-            !markdown.contains(secret),
-            "the password inside {URL_NAME} leaked into the hover markdown: {markdown}"
+            markdown.contains(&format!("```\n{masked}\n```")),
+            "the masked URL must still render as a code block: {markdown}"
+        );
+        assert!(
+            !markdown.contains(REDACTED_ENV_VALUE),
+            "the shape gate masks, it does not fall back to the name gate's \
+             whole-value redaction: {markdown}"
         );
     }
-    assert!(
-        markdown.contains(&format!("```\n{}\n```", url_masked())),
-        "the masked URL must still render as a code block: {markdown}"
-    );
-    assert!(
-        !markdown.contains(REDACTED_ENV_VALUE),
-        "the shape gate masks, it does not fall back to the name gate's \
-         whole-value redaction: {markdown}"
-    );
 }
 
 /// Positive control and regression guard: an unmatched variable still renders

--- a/laravel-lsp/src/tests/env_value_redaction.rs
+++ b/laravel-lsp/src/tests/env_value_redaction.rs
@@ -69,7 +69,10 @@ const PLAIN_VALUE: &str = "Example";
 const URL_NAME: &str = "DATABASE_URL";
 /// Carries an unencoded `@`, the shape issue #355 fixed: `database::userinfo`
 /// interpolates a `.env` password into a connection URL verbatim, so a
-/// developer who types one gets this value across all five surfaces.
+/// developer who types one gets this value on every masked surface — the three
+/// client-rendered ones covered here, plus the server log covered in
+/// `database::tests`. Four, not the five there were when #344 shipped: #356
+/// deleted the warm-start disk cache, as the module doc above records.
 const URL_SECRET: &str = "url-hunter2@tail-355";
 /// The half of `URL_SECRET` that survived the old first-`@` parse. Asserted on
 /// its own because every whole-secret check passes vacuously on a *partially*

--- a/laravel-lsp/src/tests/env_value_redaction.rs
+++ b/laravel-lsp/src/tests/env_value_redaction.rs
@@ -2,15 +2,20 @@
 //!
 //! #342 closed the *process*-environment leak. The project's own `.env` is a
 //! milder but real second source: a Laravel `.env` routinely holds `APP_KEY`,
-//! `DB_PASSWORD`, `MAIL_PASSWORD` and third-party tokens, and three
-//! client-rendered surfaces echoed them — env completion, `.env` hover, and
-//! `config('…')` completion.
+//! `DB_PASSWORD`, `MAIL_PASSWORD` and third-party tokens, and four
+//! client-rendered surfaces echoed them — env completion, `config('…')`
+//! completion, hover over an `env('KEY')` call in PHP (`hover_for_env`), and
+//! hover over the declaration itself in a `.env` buffer
+//! (`hover_for_env_declaration`). The two hovers are separate handlers for
+//! opposite directions, not one surface rendered twice; the second is driven
+//! through the real `hover` entry point in `env_key_navigation`, whose
+//! `sensitive_values_are_redacted_in_the_env_buffer_card` carries its
+//! redaction assertions. The first three are covered here.
 //!
-//! A fourth was found in review: the server log. It consults the same predicate
-//! and is covered next to the code that logs, in `database::tests` — these
-//! three are the client-rendered ones.
+//! One more was found in review: the server log. It consults the same
+//! predicate and is covered next to the code that logs, in `database::tests`.
 //!
-//! There was a fifth when #344 shipped: the warm-start disk cache, which wrote
+//! And there was one more again when #344 shipped: the warm-start disk cache, which wrote
 //! a redacted copy of every `.env` variable to `cache.json`. Issue #356 deleted
 //! that cache outright — nothing ever read the map back, so it was a file of
 //! `.env` names with no consumer — and its two tests went with it. What
@@ -19,7 +24,7 @@
 //! cleartext are still on disk, and the version check is still the only thing
 //! stopping a later build from serving them.
 //!
-//! All three now consult the same two gates: `is_sensitive_env_name`, which
+//! All of them now consult the same two gates: `is_sensitive_env_name`, which
 //! reads the variable's **name**, and `mask_url_credentials`, which reads the
 //! value's **shape**. The second exists because the first cannot see
 //! `DATABASE_URL=mysql://user:pass@host/db` — a name matching no sensitive
@@ -27,11 +32,12 @@
 //! password sits inside the value. These tests drive the real entry points —
 //! `completion()`, `hover_for_env` and `get_all_config_keys` — with two
 //! different matched keyword categories (`DB_PASSWORD` and `API_TOKEN`) plus
-//! both routes through the shape gate crossing every one of them — an
-//! authority-bearing URL (`DATABASE_URL`) and an authority-less one
-//! (`JDBC_URL`), which take different arms inside `mask_url_credentials`. So a
-//! surface that re-implemented either check locally and drifted is caught by
-//! observed behaviour rather than by reading the diff.
+//! all three routes through the shape gate crossing every one of them, each
+//! taking a different arm inside `mask_url_credentials`: a credential in the
+//! authority (`DATABASE_URL`), a value with no authority at all (`JDBC_URL`),
+//! and a credential hidden *past* the authority (`CALLBACK_URL`). So a surface
+//! that re-implemented either check locally and drifted is caught by observed
+//! behaviour rather than by reading the diff.
 //!
 //! Leak assertions run over the **whole serialized response**, not the fields
 //! this change touches: `insertText`, `label`, `sortText` and friends are just
@@ -80,10 +86,11 @@ const PLAIN_VALUE: &str = "Example";
 const URL_NAME: &str = "DATABASE_URL";
 /// Carries an unencoded `@`, the shape issue #355 fixed: `database::userinfo`
 /// interpolates a `.env` password into a connection URL verbatim, so a
-/// developer who types one gets this value on every masked surface — the three
-/// client-rendered ones covered here, plus the server log covered in
-/// `database::tests`. Four, not the five there were when #344 shipped: #356
-/// deleted the warm-start disk cache, as the module doc above records.
+/// developer who types one gets this value on every masked surface — the ones
+/// enumerated in the module doc above, plus the server log covered in
+/// `database::tests`. Named there rather than counted here: #356 deleted the
+/// warm-start disk cache and a count would have gone stale silently, which is
+/// exactly what it did.
 const URL_SECRET: &str = "url-hunter2@tail-355";
 /// The half of `URL_SECRET` that survived the old first-`@` parse. Asserted on
 /// its own because every whole-secret check passes vacuously on a *partially*
@@ -106,6 +113,21 @@ const JDBC_SECRET: &str = "jdbc-hunter2@tail-358";
 /// `JDBC_SECRET`'s surviving half, for the same reason as `URL_SECRET_TAIL`.
 const JDBC_SECRET_TAIL: &str = "tail-358";
 
+/// The third route, and the one both gates missed at once. `CALLBACK_URL`
+/// splits to `CALLBACK` / `URL` and matches no sensitive segment; the value
+/// then *parses cleanly and carries an authority*, so the shape gate's
+/// no-password arm returned it untouched — while the credential sat one layer
+/// down, in the query. `Url::password` answers about the authority it parsed
+/// and nothing else, which is why the arm rescans its own tail.
+///
+/// Its own variable rather than another `DATABASE_URL` spelling, for the same
+/// reason `JDBC_NAME` is: the three travel different arms, and one fixture
+/// cannot exercise more than one of them.
+const NESTED_NAME: &str = "CALLBACK_URL";
+const NESTED_SECRET: &str = "nested-hunter2@tail-358b";
+/// `NESTED_SECRET`'s surviving half, for the same reason as `URL_SECRET_TAIL`.
+const NESTED_SECRET_TAIL: &str = "tail-358b";
+
 fn url_value() -> String {
     format!("mysql://sail:{URL_SECRET}@db.internal.example:3306/laravel")
 }
@@ -117,6 +139,17 @@ fn jdbc_value() -> String {
 /// The masked form of [`jdbc_value`]. Host, port and database survive here too.
 fn jdbc_masked() -> String {
     "jdbc:mysql://sail:***@db.internal.example:3306/laravel".to_string()
+}
+
+fn nested_value() -> String {
+    format!("https://app.example.com/cb?next=mysql://sail:{NESTED_SECRET}@db.internal.example:3306/laravel")
+}
+
+/// The masked form of [`nested_value`]. The outer URL is untouched and the
+/// inner one keeps its host, port and database — the rescan masks the
+/// credential, it does not blank the tail.
+fn nested_masked() -> String {
+    "https://app.example.com/cb?next=mysql://sail:***@db.internal.example:3306/laravel".to_string()
 }
 
 /// What every surface must render instead: masked, not dropped. The host, port
@@ -137,9 +170,10 @@ const PLANTED_MIDDLEWARE: &str = "planted-issue-356";
 /// The project `.env` every test registers with Salsa.
 fn dotenv() -> String {
     format!(
-        "{PLAIN_NAME}={PLAIN_VALUE}\n{PASSWORD_NAME}={PASSWORD_VALUE}\n{TOKEN_NAME}={TOKEN_VALUE}\n{URL_NAME}={}\n{JDBC_NAME}={}\n# {COMMENTED_NAME}={COMMENTED_VALUE}\n",
+        "{PLAIN_NAME}={PLAIN_VALUE}\n{PASSWORD_NAME}={PASSWORD_VALUE}\n{TOKEN_NAME}={TOKEN_VALUE}\n{URL_NAME}={}\n{JDBC_NAME}={}\n{NESTED_NAME}={}\n# {COMMENTED_NAME}={COMMENTED_VALUE}\n",
         url_value(),
-        jdbc_value()
+        jdbc_value(),
+        nested_value()
     )
 }
 
@@ -251,6 +285,8 @@ fn assert_no_secret_leak(
         URL_SECRET_TAIL,
         JDBC_SECRET,
         JDBC_SECRET_TAIL,
+        NESTED_SECRET,
+        NESTED_SECRET_TAIL,
     ] {
         assert!(
             !haystack.contains(secret),
@@ -281,6 +317,8 @@ fn the_leak_search_still_finds_a_needle_the_panel_spells_with_escapes() {
         URL_SECRET_TAIL,
         JDBC_SECRET,
         JDBC_SECRET_TAIL,
+        NESTED_SECRET,
+        NESTED_SECRET_TAIL,
     ] {
         let escaped = laravel_lsp::markdown_safety::escape_inline(secret);
         assert!(
@@ -390,6 +428,21 @@ async fn env_completion_redacts_every_matched_category_and_leaves_the_rest_alone
         documentation_markdown(jdbc, "env completion"),
         expected_panel(JDBC_NAME, &jdbc_masked()),
         "{JDBC_NAME}: the panel must show the masked URL, not the credential"
+    );
+
+    // The same shape gate again, on a value whose parse reports an authority
+    // *and* no password while a credential sits past that authority. The
+    // no-password arm used to hand this back untouched.
+    let nested = item(&items, NESTED_NAME, "env completion");
+    assert_eq!(
+        nested.detail.as_deref(),
+        Some(format!("{} (from .env)", nested_masked()).as_str()),
+        "{NESTED_NAME}: the detail line must show the URL with its password masked"
+    );
+    assert_eq!(
+        documentation_markdown(nested, "env completion"),
+        expected_panel(NESTED_NAME, &nested_masked()),
+        "{NESTED_NAME}: the panel must show the masked URL, not the credential"
     );
 
     // Positive control: the unmatched variable is byte-for-byte what it was.
@@ -551,11 +604,17 @@ async fn hover_redacts_every_matched_category() {
 async fn hover_masks_a_credential_carried_inside_the_value() {
     let (_dir, _root, server) = project(&dotenv()).await;
 
-    // Both routes through the shape gate: an authority-bearing parse, and an
-    // authority-less one whose password `url` never looks for.
+    // All three routes through the shape gate: a credential in the authority,
+    // a value with no authority whose password `url` never looks for, and a
+    // credential hidden past an authority that reports none of its own.
     for (name, masked, secrets) in [
         (URL_NAME, url_masked(), [URL_SECRET, URL_SECRET_TAIL]),
         (JDBC_NAME, jdbc_masked(), [JDBC_SECRET, JDBC_SECRET_TAIL]),
+        (
+            NESTED_NAME,
+            nested_masked(),
+            [NESTED_SECRET, NESTED_SECRET_TAIL],
+        ),
     ] {
         let markdown = server.hover_for_env(name).await;
 


### PR DESCRIPTION
## Summary
Implements #355.

`mask_url_credentials` decided where a URL's credentials end by scanning for an `@`. Two strings defeat every scanning rule, because they are the same shape:

| | |
|---|---|
| `mysql://host:3306/db@x` | host, port, and a path holding an `@` |
| `postgres://user:p@ssword@host/db` | credentials whose password holds an `@` |

Take the **first** `@` and the first is mangled to `mysql://host:***@x` — host, port and database gone — while the second leaks its tail as `postgres://user:***@ssword@host/db`, which is the defect #355 reported. Bound the authority at the first `/`, `?` or `#` and take the **last** `@` inside it — this PR's previous head — and both are right, but a password containing a raw `/`, `?` or `#` closes the window before its `@` and comes back **unmasked**. `/` is 1 of the 64 base64 symbols; `@` is in none. That trade swapped a rare leak for a common one.

Holmes caught it, @mikebronner asked whether anything better existed, and Holmes's re-review answered: parse the URL instead of scanning it.

## The change
`url` — already compiled into this binary via sqlx, now a direct dependency, no `Cargo.lock` change — resolves the authority to spec, so the two shapes above stop being one shape:

- **parse succeeds, reports a password** — the userinfo is real. The credentials end at the last `@` in the parsed authority. (A raw `/`, `?` or `#` inside userinfo would have ended the authority in the parser too, so that window always holds the `@`.)
- **parse reports no password, and the value has an authority** — the only shape returned untouched. That is the rule, not a list of the shapes it admits: `Url::password` gates on `Url::has_authority`, so an authority is exactly the condition under which the parser *read* a userinfo component, and only then is its silence evidence. (`mysql://host:3306/db@x` is host, port and a path `@`; `https://example.com/webhook` has no userinfo; `mysql://user:@host/db` has a `:` with nothing after it, which `url` reports identically to no password.)
- **everything else** — the parse fails, *or* it succeeds with no authority. Neither ever looked at userinfo, so the scan is all that is left.

### The fallback is load-bearing, and greedy is the wrong rule for it
`database::build_postgres_candidates` builds the libpq socket URL `postgres://user:pass@/db?host=/var/run/postgresql` with a deliberately empty host. `url` rejects it (`empty host`), and `database::userinfo` splices the `.env` password in raw — so this reaches the fallback **with a live credential**, and it is logged at `database.rs:1471` on every socket-configured Postgres introspection.

A plain first-`@` fallback masks `p` and prints `ss@` from `p@ss` into that log line — reintroducing the exact defect this PR exists to close. The fallback therefore prefers the authority's **last** `@`, and only then falls back to the first `@` anywhere. Both halves are pinned:

| Input | Reaches fallback because | Masked to |
|---|---|---|
| `postgres://user:p@ss@/laravel?host=/var/run/postgresql` | empty host | `postgres://user:***@/laravel?host=…` |
| `postgres://user:p/ss@host/db` | invalid port | `postgres://user:***@host/db` |
| `mysql://user:pa?ss@host/db` | invalid port | `mysql://user:***@host/db` |
| `mysql://user:pa#ss@host/db` | invalid port | `mysql://user:***@host/db` |

`a_successful_parse_is_the_only_thing_keeping_the_fallback_off_these_shapes` pins the premise separately: `mysql://host:3306/db@x` and friends parse cleanly and report no password, so they are returned before the fallback is consulted. Asserted directly rather than inferred from the borrowed-and-unchanged fixture, which would stay green if the value reached the fallback and survived for some unrelated reason.

That protection is **conditional on the parse succeeding**, and the same test now pins the other side of it. A credential-free value whose port the parser refuses does reach the fallback, and the unbounded `find('@')` masks the path's `@`:

| Input | Parse | Out |
|---|---|---|
| `mysql://host:70000/db@extra` | `invalid port number` | `mysql://host:***@extra` |
| `mysql://host:port/db@extra` | `invalid port number` | `mysql://host:***@extra` |

Over-masking, not a leak — the safe direction, and the price of the `or_else` that masks `postgres://user:p/ss@host/db`. The behaviour stays; the claim that these shapes can never get there does not.

### One shape still fails open — narrower, and pinned
A `/`, `?` or `#` password whose leading run *also* parses as a valid port: `mysql://user:12/34@host/db`, or `mysql://user:/ss@host/db` (an empty port is valid too). The parser reads host `user`, port `12`, path `/34@host/db` — byte for byte the reading `mysql://host:3306/db@x` gets, and the correct one per RFC 3986, which requires all four characters percent-encoded in userinfo.

No parse separates them, so this is irreducible here. `a_password_whose_leading_run_parses_as_a_port_still_fails_open` pins both shapes **and** the boundary: `mysql://user:99999/ss@host/db` exceeds the port range, so the parse fails and the fallback masks it. That boundary assertion is what keeps the residue from silently widening.

Every other `/`, `?` or `#` password is rejected by the parse and masked by the fallback, so the residue is strictly smaller than the previous head's (which failed open on *all* of them) and does not exist on `main` — `main` masks these but mangles `mysql://host:3306/db@x`.

## Round 3 — the comments, not the code

Holmes approved the design and verified all fourteen AC by execution, then bounced four comments this branch added that asserted properties the code does not have. On a fail-open redaction gate the documentation of *which* shapes fail open **is** the safety argument, so these are blockers rather than nitpicks. `e7c7c43` fixes them. **No production behaviour changed — every non-comment edit in that commit is a test fixture.**

| # | The claim | What execution showed | Fix |
|---|---|---|---|
| 1 | The parses-with-password test's doc: *"every value here parses as a URL and reports a password"* | `postgres://user:p@ss@/laravel?host=…` is `ERR(empty host)` and drove the fallback arm, duplicating the fallback test's own coverage | Fixture moved out; the premise is now **asserted per fixture**, matching the `is_err()` guard its sibling already carries |
| 2 | `the_shapes_the_fallback_would_mangle_never_reach_it` | `mysql://host:70000/db@extra` fails on the port and does reach it | Renamed, narrowed, and both halves pinned (table above) |
| 3 | *"all five surfaces"* in `env_value_redaction.rs` | Four. #356 deleted the fifth, which this same file's module doc already narrates | Count replaced with the enumeration, so the next deletion cannot stale it silently |
| 4 | The `Ok(_)` arm described as *"what looks like credentials is `host:port`"* | It also swallows `mysql://user:@host/db`, which `url` reports identically to no password | Named in the comment, pinned by a fixture |

The residue paragraph now **names its baseline**, which the previous wording left ambiguous and which I had wrong: the residue is narrower than the authority-bounded scan this arm replaces, which failed open on *every* `/`, `?` or `#` password — **not** narrower than `main`'s greedy scan, which masked `mysql://user:12/34@host/db` correctly and paid for it by mangling `mysql://host:3306/db@x`. Net gain over `main`, not a strict subset of it.

### Sweeping the class found two more

Fixing four reported instances is not evidence the class was swept, so I audited every prose claim this branch added against execution rather than only the four named:

- The borrowed-value test's doc said a value the parser rejects *"gets masked"*. One carrying no `@` for the scan to find — `mysql://host:70000/db` — comes back borrowed like everything else in that test. Narrowed, and the shape is now a fixture.
- The residue test pinned only `/` of the three characters its own doc names. `mysql://user:12?34@host/db` and `mysql://user:12#34@host/db` behave identically and are now fixtures too.

One claim survived the sweep intact, and it is the load-bearing one: *a successful parse reporting a password always leaves an `@` inside the hand-rolled authority window.* Were it false the function would fail open silently, so I brute-forced it rather than arguing it — **55,566 generated inputs across 9 schemes × 9 users × 14 passwords × 7 hosts × 7 tails, zero violations.**

## Round 4 — a third member of that arm, holding a live password

Holmes verified round 3's four fixes, then found that the sweep had gone over the prose and not over the `Ok(_)` arm's own input space. It has a third member and it leaked:

```
mask_url_credentials("jdbc:mysql://user:secret@host:3306/db")
  round-3 head  ->  jdbc:mysql://user:secret@host:3306/db     ← borrowed, in the clear
  origin/main   ->  jdbc:mysql://user:***@host:3306/db        ← masked
```

`jdbc` is a valid scheme and the bytes after its colon are not `//`, so `url` takes its opaque-path branch and never parses userinfo. `Url::password` gates on `has_authority()`, so it answers `None` unconditionally — whatever that path holds. `find("://")` meanwhile finds the *inner* `mysql://`, so the hand-rolled window was perfectly well-formed and simply never consulted.

Reachability is total: `JDBC_URL`, `SPRING_DATASOURCE_URL` and `DB_URL` split to no `SENSITIVE_ENV_SEGMENTS` keyword, so the name gate never fires and this function is the only gate. A regression against `main`, not merely a gap.

### The fix is the rule, because the member list leaks

Holmes proposed routing `cannot_be_a_base()` to the fallback and invited a better shape. **Execution says that predicate is itself a member list.** `foo:/bar://user:secret@host/db` reports `cannot_be_a_base() == false` and `has_authority() == false` — a `://` that is only ever path. It leaks under the proposed guard and masks under `has_authority()`.

So the guard is `has_authority()`, which is the predicate `Url::password` itself gates on. Same rule, one source.

### Sweeping the arm, not the instance

Round 3 brute-forced one arm and shipped a leak in its sibling, so this sweep is aimed at the arm Holmes named — *"parse succeeded with no password ⇒ no credential anywhere in the value"* — over **60,480 credential-bearing inputs** (5 prefixes × 7 schemes × 4 users × 12 passwords × 6 hosts × 6 tails), each carrying a marker asserted absent from the output:

| Guard | Leaks | Outside the documented residue |
|---|---|---|
| round-3 head (`Ok(_)`) | 49,032 | **48,384** |
| `cannot_be_a_base()` (as proposed) | 12,744 | **12,096** |
| `has_authority()` (shipped) | 648 | **0** |

The 648 survivors are the digit-leading-run residue tracked under #362, and only with an empty prefix — behind an opaque scheme the same password now masks, so the residue is *narrower* than it was.

### The price, pinned rather than discovered later

A credential-free value in that same family reaches the scan, which cannot tell a path's `@` from a separator. A second sweep over 1,470 credential-free inputs isolates the cost at 420, all over-masking:

| Input | Round-3 head | Now |
|---|---|---|
| `jdbc:mysql://host:3306/db@x` | untouched | `jdbc:mysql://host:***@x` |
| `jdbc:mysql://[::1]/db@x` | untouched | `jdbc:mysql://[:***@x` |

Not a new trade: `mysql://[::1]:70000/db@x` already mangled to `jdbc`-identical output on the rejected-parse arm, and that fixture is in the test as the proof. A mangled display beats a printed password. `mysql://host:3306/db@x` still comes back borrowed — the discriminating half of the same test.

### The other two findings

| # | Finding | Fix |
|---|---|---|
| 2 🔴 | The `Ok(_)` doc bullet asserted *"neither shape holds a secret"* — the safety argument, and false | Rewritten as the arm's **membership rule** (`has_authority`), with the shapes demoted to examples. A rule cannot go stale by omission; the list had done so three rounds running |
| 3 🟠 | *"one digit more than a port can hold"* for `99999` — same five digits as `65535`; the parse fails on **value** | Corrected, then pinned: both lengths and both `parse::<u16>()` outcomes are now assertions, so the sentence cannot go false silently |

### Mutation-verified

Reverting the guard to round 3's `Ok(_)` reddens **7 tests across all four masked surfaces** — the unit arm test, the over-masking test, the residue test, the server-log test, and three cross-surface fixtures (env completion, `.env` interpolation, hover). Restored, full suite green: 2,711 + 663 + 80 + 2 passing, `cargo fmt --check` clean, `cargo clippy --all-targets` silent.

The cross-surface fixture is `JDBC_URL`, kept as its own variable rather than folded into `DATABASE_URL`: the two travel different arms, and one fixture cannot exercise both. Its secret is asserted absent whole *and* by tail, so a partial mask fails too.

## Changes
- `completion_display::mask_url_credentials` dispatches on `Url::parse` instead of scanning; the scan survives only as the parse-failure fallback, authority-last-`@` first.
- `url = "2.5"` added as a direct dependency of `laravel-lsp`. Already in `Cargo.lock` at 2.5.8 via sqlx — the lockfile is unchanged by this PR.
- The doc comment states the arm-membership rule (an authority, not a list of shapes), names both members of the fallback arm — a rejected parse and an authority-less one — and documents the one surviving fail-open shape rather than claiming there is none.
- Fixtures for the fallback arm, for the premise it rests on, for the residual shape and its boundary, and the two AC-mandated shapes that were missing (`postgres://user:p@ssword@host/path@literal`, `https://host/path@literal`) plus the end-of-string, port-with-credentials and `db@extra` cases.
- Merged `main` (#359 deleted the warm-start disk cache) and swept the surface counts left stale by it: three client-rendered consumers, four masked surfaces counting the server log. Previously five.

## Acceptance Criteria
- [x] The credential-ending `@` is no longer the first `@` anywhere. It is resolved by an RFC 3986 parse, with the AC's authority-bounded last-`@` rule as the fallback for values no parser accepts.
- [x] `postgres://user:p@ssw0rd@host/db` → `postgres://user:***@host/db` (AC bullet 11 fixes this literal as `p@ssw0rd`; left as-is).
- [x] `postgres://user:p@ssword@host/path@literal` → `postgres://user:***@host/path@literal` — credential masked, path `@` untouched, no bail-out.
- [x] `postgres://user:p@ssword@host` → `postgres://user:***@host` — the end-of-string branch.
- [x] `mysql://user:pass@host:3306/db` → `mysql://user:***@host:3306/db` — port colon not mistaken for the credentials'.
- [x] `mysql://host:3306/db` and `mysql://host:3306/db@extra` both return `Cow::Borrowed`, untouched.
- [x] `https://host/path@literal` returns `Cow::Borrowed(value)`, asserted with `matches!(…, Cow::Borrowed(v) if v == value)`.
- [x] Fail-open paths preserved: no `://`, no `@` to be found, no `:` in the credentials all return `Cow::Borrowed`. **Deviation, sanctioned by the escalation:** bullet 8's enumeration also listed "no `@` before the first `/`" as fail-open. That clause is what made the bullet self-contradictory and what Holmes escalated; those values are now masked by the fallback rather than leaked.
- [x] Non-regression: `mysql://user:pass@host/db` → `mysql://user:***@host/db`, `redis://:pass@host:6379` → `redis://:***@host:6379`.
- [x] The doc comment no longer claims an `@` inside the password survives masking; it states the rule the code implements, arm by arm — and after round 3, states each arm's *full* extent rather than its most common case.
- [x] `a_credential_inside_the_value_is_masked_whatever_the_name_says` and the `p@ssw0rd` fixture expect the fully-masked form.
- [x] `completion_display/tests.rs` carries the new fixtures.
- [x] `tests/env_value_redaction.rs` drives an unencoded-`@` `DATABASE_URL` across the consumers, asserting the plaintext is absent from the serialized response *and* the masked form present, with the surviving tail pinned separately.
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo test --all-features` both clean.

## Test Plan
- [x] `cargo test --all-features` — 3406 pass, 0 fail.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `url`'s behaviour on all 40+ shapes in this description was measured against 2.5.8, not assumed — including the finding that it rejects the libpq socket URL, which is what set the fallback's rule.
- [x] Mutation-verified, each reverted independently and re-measured after the `main` merge:

  | Mutation | Red |
  |---|---|
  | `rfind` → `find` in the authority scan | **9** across both targets |
  | fallback loses its authority preference (greedy only) | 2 |
  | no-password values fall through to the fallback | 2 |
  | the whole `Url::parse` dispatch removed (the previous head) | 2 |

  The last row is the one that matters: it is the leak Holmes bounced this PR for, and it now has a test.

- [x] Round 3's new assertions mutation-verified the same way, each reverted independently:

  | Mutation | What reddens |
  |---|---|
  | libpq fixture restored to the parses-with-password test | the new per-fixture premise assert, by name |
  | fallback loses its `or_else(find('@'))` | the new over-masking fixtures, plus 2 pre-existing |
  | `Ok`/no-password arm falls through instead of returning borrowed | the new `mysql://user:@host/db` fixture |
  | fail closed on a parse rejection (the escalation's option 3) | the new `mysql://host:70000/db` fixture |

  **Stated honestly:** the `?`/`#` residue fixtures and the multibyte one are pins on documented behaviour, not mutation discriminators. They live in a test whose stated job is to go red when the doc comment goes stale, which is the alarm they arm.

## Noted, not fixed
- `database::userinfo` (`database.rs:466-472`) interpolates the `.env` password into a connection URL with no percent-encoding, which is what makes the server manufacture the malformed shapes above. Holmes flagged it **wont-fix-here** in review; it is a connection-string defect, not a display one.
- Multibyte input had no fixture. Holmes verified by execution that it is safe and marked it *noted — not tracked*; `postgres://usér:p@sswörd@host/db` is now a fixture anyway, since I was in the file.
- The digit-leading-run fail-open class is irreducible inside this function and tracked by Holmes under latent-hazard. Not built here.
- `database.rs:481` still lists "warm-start-cache redaction" in the present tense. #356 deleted that cache, so the claim went stale on `main`, not in this PR. Left out to keep this diff to the redaction parse.

Fixes #355


