### PR TITLE
The warm-start env-var cache has no display consumer — wire it up or delete it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,12 +174,12 @@ The LSP uses a dedicated thread for Salsa incremental computation to avoid lifet
 | Config | `ConfigFile` | `LaravelConfigData` | Project configuration |
 | Project Files | `ProjectFiles` | `ViewReferenceLocationData` | Reference finding across project |
 | Service Providers | `ServiceProviderFile` | `MiddlewareRegistrationData`, `BindingRegistrationData` | Middleware/binding lookups |
-| Env Variables | `EnvFile` | `EnvVariableData` | Environment variable lookups |
+| Env Variables | `EnvFile` | `ParsedEnvVarData` | Environment variable lookups |
 | Translations | `LangFile`, `LangDir` | `ResolvedTranslationData` | Translation key resolution + locale discovery |
 
 ### Important Conventions
 
-- **Data transfer types**: Use `*Data` suffix (e.g., `EnvVariableData`) for types crossing async boundaries
+- **Data transfer types**: Use `*Data` suffix (e.g., `ParsedEnvVarData`) for types crossing async boundaries
 - **Salsa inputs**: Use `#[salsa::input]` for source data, store in `HashMap` for O(1) lookup
 - **Registration pattern**: Call `register_*_with_salsa()` after successful parsing
 - **Fallback pattern**: Use Salsa cache first, fall back to direct computation if unavailable

--- a/laravel-lsp/src/cache_manager.rs
+++ b/laravel-lsp/src/cache_manager.rs
@@ -33,16 +33,23 @@ use tracing::{debug, info, warn};
 ///     resolve as "not found" until a provider edit forced a rebuild — drop
 ///     v4 on read so the namespace maps are indexed and cached up front.
 /// v6: Env variables are cached with their secrets removed (issue #344).
-///     A name matching `completion_display::is_sensitive_env_name` is stored
-///     with an empty value instead of its plaintext, and any *other* value is
+///     A name matching `completion_display::is_sensitive_env_name` was stored
+///     with an empty value instead of its plaintext, and any *other* value was
 ///     stored through `completion_display::mask_url_credentials`, so a
 ///     `DATABASE_URL=mysql://user:pass@host/db` — a name no segment matches —
-///     reaches the file with its password masked. A v5 cache was written by a
+///     reached the file with its password masked. A v5 cache was written by a
 ///     binary that stored `DB_PASSWORD` and friends in cleartext, so it holds
 ///     secrets this version refuses to write — drop it on read rather than
 ///     keep serving them, and let the rescan rebuild a redacted one.
 ///     (The value-shape half arrived while v6 was still unmerged, so no
 ///     released binary ever wrote a v6 cache without it; no further bump.)
+///
+/// Issue #356 then removed the env-var cache entirely: nothing ever read the
+/// map back, so the file held `.env` names for no consumer. The version is
+/// deliberately *not* bumped — a v6 file written before that removal carries an
+/// `env_vars` key this build simply ignores, and every section still in the
+/// struct stays valid. Dropping those caches would force a needless rescan to
+/// delete a key that is already inert.
 const CACHE_VERSION: u32 = 6;
 
 /// The redaction bump must never be walked back (issue #344).
@@ -53,6 +60,11 @@ const CACHE_VERSION: u32 = 6;
 /// stop being read. Lowering the constant would silently make them live again,
 /// so make it a build failure rather than something a reviewer has to notice —
 /// the same guard `completion_display` puts on its two display budgets.
+///
+/// This outlives the writer it was introduced for. Issue #356 deleted the
+/// env-var cache, so no build after it writes `.env` data at all — but the v5
+/// files already on disk are unchanged, and this floor is still the only thing
+/// stopping a future binary from reading their plaintext back.
 const _: () = assert!(CACHE_VERSION >= 6);
 
 /// Get the XDG-compliant cache directory for a project
@@ -217,21 +229,6 @@ pub struct CachedLaravelConfig {
     pub class_component_files: HashMap<String, PathBuf>,
 }
 
-/// Cached environment variables
-///
-/// A name matching `completion_display::is_sensitive_env_name` is stored with
-/// an **empty** value: the name is still needed on a warm start, the plaintext
-/// never is (issue #344). Every other value goes through
-/// `completion_display::mask_url_credentials` first, because a name the
-/// predicate clears can still carry a credential inside its value
-/// (`DATABASE_URL`). The writer in `main.rs` enforces both; readers must not
-/// treat an empty value as "unset", because the surfaces redact by name
-/// anyway.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct CachedEnvVars {
-    pub variables: HashMap<String, String>,
-}
-
 /// The full cache structure stored on disk
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LspCache {
@@ -249,8 +246,6 @@ pub struct LspCache {
     pub node_modules_scan: NodeModulesScan,
     /// Laravel configuration (view paths, component paths, etc.)
     pub laravel_config: Option<CachedLaravelConfig>,
-    /// Environment variables from .env files
-    pub env_vars: Option<CachedEnvVars>,
 }
 
 impl LspCache {
@@ -263,7 +258,6 @@ impl LspCache {
             app_scan: ScanResult::default(),
             node_modules_scan: NodeModulesScan::default(),
             laravel_config: None,
-            env_vars: None,
         }
     }
 }
@@ -552,19 +546,6 @@ impl CacheManager {
         self.ensure_cache();
         if let Some(ref mut cache) = self.cache {
             cache.laravel_config = Some(config);
-        }
-    }
-
-    /// Get cached env variables
-    pub fn get_env_vars(&self) -> Option<&CachedEnvVars> {
-        self.cache.as_ref().and_then(|c| c.env_vars.as_ref())
-    }
-
-    /// Set env variables
-    pub fn set_env_vars(&mut self, vars: CachedEnvVars) {
-        self.ensure_cache();
-        if let Some(ref mut cache) = self.cache {
-            cache.env_vars = Some(vars);
         }
     }
 

--- a/laravel-lsp/src/cache_manager/tests.rs
+++ b/laravel-lsp/src/cache_manager/tests.rs
@@ -116,3 +116,73 @@ fn test_clear_disk_caches_removes_dir_and_is_idempotent() {
     // Idempotent: clearing an already-absent dir is success, not an error.
     clear_disk_caches(project_root).expect("clearing a missing dir is a no-op success");
 }
+
+/// Issue #356 removed the `env_vars` section without bumping `CACHE_VERSION`,
+/// on the reasoning that a stale key is inert. Nothing else pins that: the
+/// version-rejection guard never sees this file, because the version does not
+/// change.
+///
+/// So a cache written by the pre-#356, post-#348 binary — already at
+/// `CACHE_VERSION`, still carrying a populated `"env_vars"` object — must load
+/// as a normal cache. Not rejected as corruption, not partially dropped: the
+/// key is ignored and every surviving section comes back intact.
+///
+/// The fixture is produced by a real `save()` and then edited as JSON, so the
+/// `"env_vars"` shape is grafted onto a genuinely current file rather than a
+/// hand-written one that could pass on a parse error.
+#[test]
+fn a_cache_at_the_current_version_ignores_a_stale_env_vars_key() {
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    let mut manager = CacheManager::load(project_root);
+    manager.set_laravel_config(CachedLaravelConfig {
+        root: project_root.to_path_buf(),
+        view_paths: vec![project_root.join("resources/views")],
+        ..Default::default()
+    });
+    let mut vendor_scan = ScanResult::new();
+    vendor_scan.middleware.insert(
+        "auth".to_string(),
+        MiddlewareEntry {
+            class: "Illuminate\\Auth\\Middleware\\Authenticate".to_string(),
+            class_file: None,
+            source_file: Some("bootstrap/app.php".to_string()),
+            line: 10,
+        },
+    );
+    manager.set_vendor_scan(vendor_scan);
+    manager.save().unwrap();
+
+    // Graft the section the pre-#356 binary wrote back onto the saved file,
+    // leaving the version untouched — that is exactly what is already on disk
+    // for anyone upgrading across this change.
+    let path = manager.cache_path().expect("cache path").to_path_buf();
+    let mut json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(
+        json["version"].as_u64(),
+        Some(u64::from(CACHE_VERSION)),
+        "precondition: the planted file is at the current version, so the \
+         version guard never fires on it"
+    );
+    json["env_vars"] = serde_json::json!({
+        "variables": { "APP_NAME": "Example", "DB_PASSWORD": "" }
+    });
+    std::fs::write(&path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+
+    let loaded = CacheManager::load(project_root);
+    assert!(
+        loaded.has_cached_data(),
+        "a stale env_vars key must not be read as corruption — the cache still has data"
+    );
+    assert_eq!(
+        loaded.get_laravel_config().map(|c| c.root.clone()),
+        Some(project_root.to_path_buf()),
+        "the surviving sections must load intact past the ignored key"
+    );
+    assert!(
+        loaded.get_all_middleware().contains_key("auth"),
+        "the surviving sections must load intact past the ignored key"
+    );
+}

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -19,8 +19,7 @@ use walkdir::WalkDir;
 
 // Use the library crate for all modules
 use laravel_lsp::cache_manager::{
-    BindingEntry, CacheManager, CachedEnvVars, CachedLaravelConfig, MiddlewareEntry, RescanType,
-    ScanResult,
+    BindingEntry, CacheManager, CachedLaravelConfig, MiddlewareEntry, RescanType, ScanResult,
 };
 use laravel_lsp::command_index::{build_command_index, CommandIndex};
 use laravel_lsp::completion_format::CompletionDoc;
@@ -6505,14 +6504,13 @@ impl LaravelLanguageServer {
                 *self.initialized_root.write().await = Some(actual_root);
             }
 
-            // 2-4: Register middleware/bindings/env with Salsa in background
+            // 2-3: Register middleware/bindings with Salsa in background
             // These are needed for goto but not for basic diagnostics
             let middleware_count = cache.get_all_middleware().len();
             let binding_count = cache.get_all_bindings().len();
-            let env_count = cache.get_env_vars().map(|e| e.variables.len()).unwrap_or(0);
             info!(
-                "📦 Queuing {} middleware, {} bindings, {} env vars for background registration",
-                middleware_count, binding_count, env_count
+                "📦 Queuing {} middleware, {} bindings for background registration",
+                middleware_count, binding_count
             );
 
             // Spawn background registration (doesn't block initialize)
@@ -6544,7 +6542,6 @@ impl LaravelLanguageServer {
                     )
                 })
                 .collect();
-            let env_vars = cache.get_env_vars().map(|e| e.variables.clone());
             let cached_config_for_salsa = cache.get_laravel_config().map(|c| LaravelConfigData {
                 root: c.root.clone(),
                 view_paths: c.view_paths.clone(),
@@ -6564,9 +6561,6 @@ impl LaravelLanguageServer {
                 // Register with Salsa in background for incremental updates
                 if let Some(config) = cached_config_for_salsa {
                     let _ = salsa.register_cached_config(config).await;
-                }
-                if let Some(vars) = env_vars {
-                    let _ = salsa.register_cached_env_vars(vars).await;
                 }
                 let _ = salsa
                     .register_cached_middleware_batch(middleware_entries)
@@ -7954,7 +7948,7 @@ impl LaravelLanguageServer {
         self.revalidate_open_documents().await;
     }
 
-    /// Populate cache with all data from Salsa (config, env, middleware, bindings)
+    /// Populate cache with all data from Salsa (config, middleware, bindings)
     async fn populate_cache_from_salsa(&self) {
         // Fetch the authoritative Laravel config from Salsa once, up front. This
         // is called after the vendor/app rescans have registered the service
@@ -8000,38 +7994,7 @@ impl LaravelLanguageServer {
             cache.set_laravel_config(cached_config);
         }
 
-        // 2. Cache env variables
-        if let Ok(env_vars) = self.salsa.get_all_parsed_env_vars().await {
-            let mut variables = std::collections::HashMap::new();
-            for var in &env_vars {
-                // A secret-bearing name is cached by name with an empty value
-                // (issue #344): the plaintext never reaches the cache file,
-                // which is world-readable-ish, long-lived, and outside the
-                // project the developer thinks they are protecting. The key is
-                // kept rather than dropped so a warm start still knows the
-                // variable exists and can offer it — the surfaces redact by
-                // name, so it renders identically to a live parse.
-                //
-                // No `is_commented` filter, matching the loop's existing
-                // behaviour: a commented-out `# DB_PASSWORD=hunter2` is cached
-                // too, so it must be redacted here as well.
-                //
-                // An unmatched name is still not written raw: `DATABASE_URL`
-                // matches no segment and carries the password inside its value,
-                // so it goes to disk with the credential masked. The plaintext
-                // must not reach this file under either gate.
-                let value = if laravel_lsp::completion_display::is_sensitive_env_name(&var.name) {
-                    String::new()
-                } else {
-                    laravel_lsp::completion_display::mask_url_credentials(&var.value).into_owned()
-                };
-                variables.insert(var.name.clone(), value);
-            }
-            debug!("Caching {} env variables", variables.len());
-            cache.set_env_vars(CachedEnvVars { variables });
-        }
-
-        // 3. Cache middleware
+        // 2. Cache middleware
         if let Ok(all_mw) = self.salsa.get_all_parsed_middleware().await {
             let mut vendor_scan = ScanResult::default();
             for mw in &all_mw {
@@ -8052,7 +8015,7 @@ impl LaravelLanguageServer {
             cache.set_vendor_scan(vendor_scan);
         }
 
-        // 4. Cache bindings
+        // 3. Cache bindings
         if let Ok(all_bindings) = self.salsa.get_all_parsed_bindings().await {
             let mut app_scan = ScanResult::default();
             for binding in &all_bindings {

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -5700,25 +5700,6 @@ impl crate::member_resolver::ClassFileResolver for ContainerAwareResolver<'_> {
     }
 }
 
-/// Environment variable data for transfer across async boundaries
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct EnvVariableData {
-    /// The variable name (e.g., "APP_NAME")
-    pub name: String,
-    /// The value (e.g., "Laravel")
-    pub value: String,
-    /// Which file this was defined in
-    pub file_path: PathBuf,
-    /// Line number where defined (0-based)
-    pub line: usize,
-    /// Column where the variable name starts (0-based)
-    pub column: usize,
-    /// Column where the value starts (after the =)
-    pub value_column: usize,
-    /// Whether this variable is commented out
-    pub is_commented: bool,
-}
-
 /// Package view namespace data for transfer across async boundaries
 /// From: $this->loadViewsFrom(__DIR__.'/../resources/views', 'courier')
 #[derive(Debug, Clone, serde::Serialize)]
@@ -6579,20 +6560,6 @@ pub enum SalsaRequest {
         reply: oneshot::Sender<Vec<ComponentNamespaceData>>,
     },
 
-    // === Environment Variable Management ===
-    /// Register environment variables from the env cache
-    RegisterEnvVariables {
-        variables: std::collections::HashMap<String, EnvVariableData>,
-        reply: oneshot::Sender<()>,
-    },
-    /// Get an environment variable by name
-    GetEnvVariable {
-        name: String,
-        reply: oneshot::Sender<Option<EnvVariableData>>,
-    },
-    /// Get all environment variable names (for autocomplete)
-    GetEnvVariableNames { reply: oneshot::Sender<Vec<String>> },
-
     // === Salsa-based Environment Variable Management (New) ===
     /// Register a raw .env file for Salsa to parse
     RegisterEnvSource {
@@ -6750,12 +6717,6 @@ pub enum SalsaRequest {
     /// clippy::large_enum_variant).
     RegisterCachedConfig {
         config: Box<LaravelConfigData>,
-        reply: oneshot::Sender<()>,
-    },
-
-    /// Register env variables from disk cache (bypasses parsing)
-    RegisterCachedEnvVars {
-        variables: std::collections::HashMap<String, String>,
         reply: oneshot::Sender<()>,
     },
 
@@ -7773,56 +7734,6 @@ impl SalsaHandle {
             .map_err(|_| "Salsa actor dropped reply channel")
     }
 
-    // === Environment Variable Methods ===
-
-    /// Register environment variables from the env cache
-    pub async fn register_env_variables(
-        &self,
-        variables: std::collections::HashMap<String, EnvVariableData>,
-    ) -> Result<(), &'static str> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.sender
-            .send(SalsaRequest::RegisterEnvVariables {
-                variables,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| "Salsa actor disconnected")?;
-        reply_rx
-            .await
-            .map_err(|_| "Salsa actor dropped reply channel")
-    }
-
-    /// Get an environment variable by name
-    pub async fn get_env_variable(
-        &self,
-        name: String,
-    ) -> Result<Option<EnvVariableData>, &'static str> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.sender
-            .send(SalsaRequest::GetEnvVariable {
-                name,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| "Salsa actor disconnected")?;
-        reply_rx
-            .await
-            .map_err(|_| "Salsa actor dropped reply channel")
-    }
-
-    /// Get all environment variable names (for autocomplete)
-    pub async fn get_env_variable_names(&self) -> Result<Vec<String>, &'static str> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.sender
-            .send(SalsaRequest::GetEnvVariableNames { reply: reply_tx })
-            .await
-            .map_err(|_| "Salsa actor disconnected")?;
-        reply_rx
-            .await
-            .map_err(|_| "Salsa actor dropped reply channel")
-    }
-
     // === Salsa-based Environment Variable Methods (New - Phase 1) ===
 
     /// Register a raw .env file for Salsa to parse
@@ -8320,24 +8231,6 @@ impl SalsaHandle {
             .await
             .map_err(|_| "Salsa actor dropped reply channel")
     }
-
-    /// Register env variables from disk cache (bypasses parsing)
-    pub async fn register_cached_env_vars(
-        &self,
-        variables: std::collections::HashMap<String, String>,
-    ) -> Result<(), &'static str> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.sender
-            .send(SalsaRequest::RegisterCachedEnvVars {
-                variables,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| "Salsa actor disconnected")?;
-        reply_rx
-            .await
-            .map_err(|_| "Salsa actor dropped reply channel")
-    }
 }
 
 /// Absolute root directories captured at `register_project_files` time.
@@ -8592,10 +8485,6 @@ pub struct SalsaActor {
     /// Cached component namespace registrations from Blade::componentNamespace() calls
     sp_component_namespaces: HashMap<String, ComponentNamespaceData>,
 
-    // === Environment Variables ===
-    /// Cached environment variables
-    env_variables: HashMap<String, EnvVariableData>,
-
     // === Salsa-based Environment Variable Tracking (New) ===
     /// Env files registered with Salsa for incremental parsing
     salsa_env_files: HashMap<PathBuf, EnvFile>,
@@ -8698,8 +8587,6 @@ impl SalsaActor {
                 sp_view_namespaces: HashMap::new(),
                 sp_blade_components: HashMap::new(),
                 sp_component_namespaces: HashMap::new(),
-                // Environment variables
-                env_variables: HashMap::new(),
                 // Salsa-based env tracking
                 salsa_env_files: HashMap::with_capacity(4),
                 salsa_env_version: 0,
@@ -9202,20 +9089,6 @@ impl SalsaActor {
                     let _ = reply.send(result);
                 }
 
-                // === Environment Variable Handlers ===
-                SalsaRequest::RegisterEnvVariables { variables, reply } => {
-                    self.handle_register_env_variables(variables);
-                    let _ = reply.send(());
-                }
-                SalsaRequest::GetEnvVariable { name, reply } => {
-                    let result = self.handle_get_env_variable(&name);
-                    let _ = reply.send(result);
-                }
-                SalsaRequest::GetEnvVariableNames { reply } => {
-                    let result = self.handle_get_env_variable_names();
-                    let _ = reply.send(result);
-                }
-
                 // === Salsa-based Environment Variable Handlers (New) ===
                 SalsaRequest::RegisterEnvSource {
                     path,
@@ -9408,26 +9281,6 @@ impl SalsaActor {
                     self.config_root = Some(config.root.clone());
                     self.config_cache = Some((self.config_version, *config));
                     tracing::info!("📋 Registered cached Laravel config");
-                    let _ = reply.send(());
-                }
-                SalsaRequest::RegisterCachedEnvVars { variables, reply } => {
-                    // Set env vars directly from cache
-                    let count = variables.len();
-                    for (name, value) in variables {
-                        self.env_variables.insert(
-                            name.clone(),
-                            EnvVariableData {
-                                name,
-                                value,
-                                file_path: PathBuf::from(".env"), // Placeholder
-                                line: 0,
-                                column: 0,
-                                value_column: 0,
-                                is_commented: false,
-                            },
-                        );
-                    }
-                    tracing::debug!("Registered {} cached env variables", count);
                     let _ = reply.send(());
                 }
 
@@ -11809,23 +11662,6 @@ impl SalsaActor {
         }
 
         merged.into_values().collect()
-    }
-
-    // === Environment Variable Handlers ===
-
-    /// Handle env variables registration
-    fn handle_register_env_variables(&mut self, variables: HashMap<String, EnvVariableData>) {
-        self.env_variables = variables;
-    }
-
-    /// Handle get env variable by name
-    fn handle_get_env_variable(&self, name: &str) -> Option<EnvVariableData> {
-        self.env_variables.get(name).cloned()
-    }
-
-    /// Handle get all env variable names
-    fn handle_get_env_variable_names(&self) -> Vec<String> {
-        self.env_variables.keys().cloned().collect()
     }
 
     // === Salsa-based Environment Variable Handlers (New) ===

--- a/laravel-lsp/src/tests/env_value_redaction.rs
+++ b/laravel-lsp/src/tests/env_value_redaction.rs
@@ -2,31 +2,38 @@
 //!
 //! #342 closed the *process*-environment leak. The project's own `.env` is a
 //! milder but real second source: a Laravel `.env` routinely holds `APP_KEY`,
-//! `DB_PASSWORD`, `MAIL_PASSWORD` and third-party tokens, and four surfaces
-//! echoed them — env completion, `.env` hover, `config('…')` completion, and
-//! the warm-start disk cache.
+//! `DB_PASSWORD`, `MAIL_PASSWORD` and third-party tokens, and three
+//! client-rendered surfaces echoed them — env completion, `.env` hover, and
+//! `config('…')` completion.
 //!
-//! A fifth was found in review: the server log. It consults the same predicate
-//! and is covered next to the code that logs, in `database::tests` — these four
-//! are the client-rendered ones.
+//! A fourth was found in review: the server log. It consults the same predicate
+//! and is covered next to the code that logs, in `database::tests` — these
+//! three are the client-rendered ones.
 //!
-//! All four now consult the same two gates: `is_sensitive_env_name`, which
+//! There was a fifth when #344 shipped: the warm-start disk cache, which wrote
+//! a redacted copy of every `.env` variable to `cache.json`. Issue #356 deleted
+//! that cache outright — nothing ever read the map back, so it was a file of
+//! `.env` names with no consumer — and its two tests went with it. What
+//! survives here is `a_pre_bump_cache_is_dropped_wholesale_and_the_rescan_restores_it`,
+//! which guards the `CACHE_VERSION` floor: the v5 files that binary wrote in
+//! cleartext are still on disk, and the version check is still the only thing
+//! stopping a later build from serving them.
+//!
+//! All three now consult the same two gates: `is_sensitive_env_name`, which
 //! reads the variable's **name**, and `mask_url_credentials`, which reads the
 //! value's **shape**. The second exists because the first cannot see
 //! `DATABASE_URL=mysql://user:pass@host/db` — a name matching no sensitive
 //! segment, filled by stock Laravel's `'url' => env('DATABASE_URL')`, whose
 //! password sits inside the value. These tests drive the real entry points —
-//! `completion()`, `hover_for_env`, `get_all_config_keys`, and a genuine
-//! `CacheManager` save/load round trip — with two different matched keyword
-//! categories (`DB_PASSWORD` and `API_TOKEN`) plus the URL shape crossing every
-//! one of them, so a surface that re-implemented either check locally and
-//! drifted is caught by observed behaviour rather than by reading the diff.
+//! `completion()`, `hover_for_env` and `get_all_config_keys` — with two
+//! different matched keyword categories (`DB_PASSWORD` and `API_TOKEN`) plus
+//! the URL shape crossing every one of them, so a surface that re-implemented
+//! either check locally and drifted is caught by observed behaviour rather than
+//! by reading the diff.
 //!
 //! Leak assertions run over the **whole serialized response**, not the fields
 //! this change touches: `insertText`, `label`, `sortText` and friends are just
-//! as visible in a screen-share as `detail` is. The cache assertion reads the
-//! deserialized struct rather than the file's bytes, because a reversible
-//! encoding of the value would pass a bytes-only check and still leak.
+//! as visible in a screen-share as `detail` is.
 //!
 //! Every leak assertion carries a positive control — the ordinary `APP_NAME`
 //! renders exactly as it did before this change — so a fixture that never
@@ -76,6 +83,10 @@ fn url_masked() -> String {
 /// surfaces skip commented entries already; the cache-write loop never did.
 const COMMENTED_NAME: &str = "MAIL_PASSWORD";
 const COMMENTED_VALUE: &str = "mail-hunter2-issue-344";
+
+/// A middleware alias planted only in the pre-bump cache fixture. It exists in
+/// no rescan, so its survival past a version rejection would be unambiguous.
+const PLANTED_MIDDLEWARE: &str = "planted-issue-356";
 
 /// The project `.env` every test registers with Salsa.
 fn dotenv() -> String {
@@ -490,8 +501,29 @@ async fn the_config_completion_response_carries_no_dotenv_secret() {
 }
 
 // ========================================================================
-// Surface 4 — the on-disk warm-start cache
+// The `CACHE_VERSION` floor — the last live consequence of #344 on disk
 // ========================================================================
+
+/// A minimal `LaravelConfigData` for the rescan to cache. `root` is the only
+/// field the assertion reads back; the rest are the least that makes the struct
+/// constructible and non-empty. Mirrors the helper shape the other handler
+/// tests in this tree use.
+fn laravel_config(root: &Path) -> laravel_lsp::salsa_impl::LaravelConfigData {
+    laravel_lsp::salsa_impl::LaravelConfigData {
+        root: root.to_path_buf(),
+        view_paths: vec![root.join("resources/views")],
+        component_paths: vec![],
+        livewire_path: None,
+        has_livewire: false,
+        view_namespaces: std::collections::HashMap::new(),
+        component_namespaces: std::collections::HashMap::new(),
+        anonymous_component_paths: std::collections::HashMap::new(),
+        anonymous_component_namespaces: std::collections::HashMap::new(),
+        component_aliases: std::collections::HashMap::new(),
+        icon_aliases: std::collections::HashMap::new(),
+        class_component_files: std::collections::HashMap::new(),
+    }
+}
 
 /// Run the real cache-population path and persist it, then load it back with a
 /// fresh `CacheManager`. Returns the reloaded manager.
@@ -509,101 +541,51 @@ async fn round_trip_cache(server: &LaravelLanguageServer, root: &Path) -> CacheM
     CacheManager::load(root)
 }
 
-#[tokio::test]
-async fn the_disk_cache_keeps_sensitive_names_but_never_their_values() {
-    let (_dir, root, server) = project(&dotenv()).await;
-    let reloaded = round_trip_cache(&server, &root).await;
-    let variables = &reloaded
-        .get_env_vars()
-        .expect("env vars should round-trip")
-        .variables;
-
-    // Asserted on the deserialized struct, not on the file's bytes: a
-    // reversible encoding would pass a substring check and still leak.
-    for name in [PASSWORD_NAME, TOKEN_NAME, COMMENTED_NAME] {
-        assert_eq!(
-            variables.get(name).map(String::as_str),
-            Some(""),
-            "{name} must be cached by name with an empty value — present, never plaintext"
-        );
-    }
-    // Not name-matched, so not emptied — but the credential inside it must not
-    // reach the file either. This is the worst of the four surfaces to get
-    // wrong: the cache is long-lived, sits outside the project, and no one
-    // reads it before it leaks.
-    assert_eq!(
-        variables.get(URL_NAME).map(String::as_str),
-        Some(url_masked().as_str()),
-        "{URL_NAME} must be cached with its password masked, never in plaintext"
-    );
-    assert_eq!(
-        variables.get(PLAIN_NAME).map(String::as_str),
-        Some(PLAIN_VALUE),
-        "an unmatched variable must round-trip unchanged"
-    );
-}
-
-/// A cache entry survives the round trip byte-for-byte for an unmatched name,
-/// and registering the reloaded map back into a cold server is accepted — the
-/// path `load_cache_data` takes on a warm start.
+/// A cache file written by a pre-#344 binary holds `.env` plaintext. The
+/// `CACHE_VERSION` bump is what stops it being trusted and served, and #356
+/// deliberately did **not** bump past it — so this guard has to keep holding
+/// with the env-var section gone.
 ///
-/// It stops there deliberately. `register_cached_env_vars` writes the Salsa
-/// actor's `env_variables` map, and **nothing renders from that map**:
-/// `get_env_variable` / `get_env_variable_names` have no caller outside
-/// `salsa_impl`, and all four surfaces read `get_all_parsed_env_vars` /
-/// `get_parsed_env_var`, which walk the registered `.env` *sources* only. So
-/// redaction in the cache is about the plaintext sitting on disk, not about
-/// what a warm start displays; asserting a rendering difference here would be
-/// asserting about code that never runs. The rendering half of the parity
-/// claim is pinned instead by
-/// `an_empty_sensitive_value_redacts_rather_than_reading_empty`, whose fixture
-/// is exactly the shape a cache read produces: a matched name with an empty
-/// value.
-#[tokio::test]
-async fn the_reloaded_cache_registers_cleanly_on_a_cold_server() {
-    let (_dir, root, server) = project(&dotenv()).await;
-    let reloaded = round_trip_cache(&server, &root).await;
-    let cached = reloaded.get_env_vars().expect("env vars").variables.clone();
-    assert_eq!(
-        cached.get(PLAIN_NAME).map(String::as_str),
-        Some(PLAIN_VALUE),
-        "the unmatched value must survive the round trip unchanged"
-    );
-
-    let warm = test_server();
-    warm.salsa
-        .register_cached_env_vars(cached)
-        .await
-        .expect("a redacted cache must still register on warm start");
-}
-
-/// A cache file written by a pre-fix binary already holds plaintext secrets.
-/// The `CACHE_VERSION` bump is what stops it being trusted and served — and the
-/// rescan it forces must leave an ordinary variable exactly as it was.
+/// The fixture is planted against the cached Laravel config, the section that
+/// survived #356, rather than against the deleted `CachedEnvVars`. Two
+/// disciplines carry over from the original: the planted version is derived
+/// from the file's own serialized `version` field, so the next bump cannot
+/// quietly turn this into a test of nothing, and the fixture is produced by a
+/// real `CacheManager::load` / `.save()` round trip rather than a hand-built
+/// struct literal, so a passing run cannot be a parse error in disguise.
 ///
 /// Both halves live in one test on purpose: "the old file is dropped" and "the
-/// replacement is correct" are one behaviour, and splitting them let AC #7's
-/// regression guard be satisfied by combining two fixtures neither of which
-/// contained both variables.
+/// replacement is correct" are one behaviour.
 #[tokio::test]
-async fn a_pre_bump_cache_holding_plaintext_is_rejected_and_rescanned() {
+async fn a_pre_bump_cache_is_dropped_wholesale_and_the_rescan_restores_it() {
     let (_dir, root, server) = project(&dotenv()).await;
+    server
+        .salsa
+        .register_cached_config(laravel_config(&root))
+        .await
+        .expect("register config with salsa");
 
-    // Write a well-formed current-version cache carrying the plaintext, then
-    // rewind only its version field. Hand-writing the JSON instead would risk
-    // the test passing on a parse error rather than on the version check.
+    // Write a well-formed current-version cache through the real path, then
+    // rewind only its version field.
     let mut cache = CacheManager::load(&root);
-    cache.set_env_vars(laravel_lsp::cache_manager::CachedEnvVars {
-        variables: [
-            (PASSWORD_NAME.to_string(), PASSWORD_VALUE.to_string()),
-            // The regression guard rides in the same planted file: an ordinary
-            // variable is dropped along with the secret, and has to come back
-            // unchanged from the rescan.
-            (PLAIN_NAME.to_string(), PLAIN_VALUE.to_string()),
-        ]
-        .into_iter()
-        .collect(),
+    cache.set_laravel_config(laravel_lsp::cache_manager::CachedLaravelConfig {
+        root: root.clone(),
+        view_paths: vec![root.join("resources/views")],
+        ..Default::default()
     });
+    // A second, independent section: "dropped wholesale" means *both* go, not
+    // just the one the rescan happens to rebuild.
+    let mut vendor_scan = laravel_lsp::cache_manager::ScanResult::default();
+    vendor_scan.middleware.insert(
+        PLANTED_MIDDLEWARE.to_string(),
+        laravel_lsp::cache_manager::MiddlewareEntry {
+            class: "App\\Http\\Middleware\\Planted".to_string(),
+            class_file: None,
+            source_file: None,
+            line: 1,
+        },
+    );
+    cache.set_vendor_scan(vendor_scan);
     cache.save().expect("cache should persist");
     let path = cache.cache_path().expect("cache path").to_path_buf();
 
@@ -615,39 +597,32 @@ async fn a_pre_bump_cache_holding_plaintext_is_rejected_and_rescanned() {
     json["version"] = serde_json::json!(version - 1);
     let previous = serde_json::to_string_pretty(&json).expect("serialize cache");
     assert!(
-        previous.contains(PASSWORD_VALUE),
-        "the planted cache must actually hold the plaintext this test is about"
+        previous.contains(PLANTED_MIDDLEWARE),
+        "the planted cache must actually hold the data this test is about"
     );
     std::fs::write(&path, previous).expect("plant pre-bump cache");
 
-    // `get_env_vars()` is the assertion that discriminates: `has_cached_data()`
-    // reads only the vendor/app/config sections and would answer the same with
-    // the version check deleted.
+    // Dropped *wholesale*, not partially reused: every section the file
+    // carried has to be gone, not merely the one the rescan will rebuild.
+    let stale = CacheManager::load(&root);
     assert!(
-        CacheManager::load(&root).get_env_vars().is_none(),
-        "a pre-bump cache must be dropped, not served — it holds plaintext secrets"
+        stale.get_laravel_config().is_none(),
+        "a pre-bump cache must be dropped, not served"
+    );
+    assert!(
+        stale.get_all_middleware().is_empty(),
+        "a pre-bump cache must be dropped wholesale — no section survives the version check"
+    );
+    assert!(
+        !stale.has_cached_data(),
+        "a dropped cache must report no data at all"
     );
 
     // The rescan the rejection forces, through the real populate/save/load path.
     let rescanned = round_trip_cache(&server, &root).await;
-    let variables = &rescanned
-        .get_env_vars()
-        .expect("the rescan must repopulate the cache")
-        .variables;
     assert_eq!(
-        variables.get(PLAIN_NAME).map(String::as_str),
-        Some(PLAIN_VALUE),
-        "an ordinary variable must survive the forced rescan unchanged"
-    );
-    assert_eq!(
-        variables.get(PASSWORD_NAME).map(String::as_str),
-        Some(""),
-        "the rescan must rewrite the secret as an empty value, not restore it"
-    );
-    assert!(
-        !std::fs::read_to_string(&path)
-            .expect("read rescanned cache")
-            .contains(PASSWORD_VALUE),
-        "the rescanned file must not carry the plaintext the planted one did"
+        rescanned.get_laravel_config().map(|c| c.root.clone()),
+        Some(root.clone()),
+        "the forced rescan must repopulate the surviving cache section"
     );
 }


### PR DESCRIPTION
## Summary

Implements #356 by taking **option B — delete the plumbing**. Lestrade resolved the A/B/C fork in triage; I built the resolved option.

The warm-start path read the cached env map and handed it to the Salsa actor. Nothing read it back. `get_env_variable` and `get_env_variable_names` had no caller outside `salsa_impl.rs`, and all four client-visible surfaces walk the registered `.env` **sources** via `get_all_parsed_env_vars` / `get_parsed_env_var` instead. The write, the registration, and the `CACHE_VERSION` bump all ran for a product nobody collected — and the file they produced held `.env` variable names, long-lived, outside the project directory.

## Changes

**Deleted — `salsa_impl.rs` (pure deletion, 164 lines, 0 added)**
- `SalsaHandle::{register_cached_env_vars, register_env_variables, get_env_variable, get_env_variable_names}`
- `SalsaRequest::{RegisterCachedEnvVars, RegisterEnvVariables, GetEnvVariable, GetEnvVariableNames}` + their match arms
- `handle_register_env_variables` / `handle_get_env_variable` / `handle_get_env_variable_names`
- the actor's `env_variables` field and its init, and the `EnvVariableData` type

**Deleted — `cache_manager.rs`**
- `CachedEnvVars`, `LspCache::env_vars`, `get_env_vars` / `set_env_vars`

**Deleted — `main.rs`**
- the `env_count` / `env_vars` warm-start locals and the `register_cached_env_vars` call
- the whole `// 2. Cache env variables` block; remaining blocks renumbered

**Kept deliberately**
- `is_sensitive_env_name` / `mask_url_credentials` — shared with the three live display surfaces and the database logger. Untouched.
- `CACHE_VERSION = 6` and its top-level, unconditional `const _: () = assert!(CACHE_VERSION >= 6)`. The v5 caches holding `.env` plaintext are still on disk, so the rejection guard still has a job.
- **The version is deliberately not bumped.** A v6 file written before this change carries an `env_vars` key serde now ignores. Bumping would force a rescan to delete an inert key.

**Tests**
- Removed `the_reloaded_cache_registers_cleanly_on_a_cold_server` and `the_disk_cache_keeps_sensitive_names_but_never_their_values` — both exercised only the deleted APIs.
- Rewrote `a_pre_bump_cache_holding_plaintext_is_rejected_and_rescanned` against the cached Laravel config, and **renamed** it to `a_pre_bump_cache_is_dropped_wholesale_and_the_rescan_restores_it`. The old name would now be a false claim — the test asserts nothing about plaintext. Both original disciplines carry over (version derived from the file's own `version` field; fixture built by a real `CacheManager::load` / `.save()` round trip). It gains a second planted section so *wholesale* is checked, not assumed.
- Added `a_cache_at_the_current_version_ignores_a_stale_env_vars_key` in `cache_manager/tests.rs` for the upgrade path nothing else covered.
- Module doc now describes **three** client-rendered surfaces, not four.

**Doc sweep beyond `src/`** — `CLAUDE.md` named the deleted `EnvVariableData` twice (Salsa component table, and as the `*Data`-suffix example). Both now name the live `ParsedEnvVarData`. `populate_cache_from_salsa`'s docstring no longer claims to cache env.

## Acceptance Criteria

- [x] Handle methods, `SalsaRequest` variants, match arms and handlers removed; no renamed survivor — `salsa_impl.rs` is deletion-only, 0 lines added.
- [x] Actor `env_variables` field, its init, and `EnvVariableData` removed. `EnvVariableData` returns **zero** matches repo-wide.
- [x] `main.rs` locals, `register_cached_env_vars` call and log message reworded; `grep -n 'Cache env variables' laravel-lsp/src/main.rs` → no matches. `is_sensitive_env_name` / `mask_url_credentials` not removed.
- [x] `CachedEnvVars`, `env_vars` field, `get_env_vars` / `set_env_vars` removed. `grep -rn env_vars laravel-lsp/src/cache_manager.rs` → one match, in prose explaining the ignored key.
- [x] `CACHE_VERSION` + `const _: () = assert!(CACHE_VERSION >= 6)` remain top-level and unconditional (`cache_manager.rs:68`), outside any `cfg(test)` or function.
- [x] New regression test for the stale-`env_vars`-key upgrade path.
- [x] Both dead tests removed; module doc updated to three surfaces.
- [x] Pre-bump test rewritten against a surviving section, keeping both disciplines, asserting wholesale drop + correct rescan, with no env-redaction assertions.
- [x] The four live surfaces are unchanged. Every `main.rs` hunk sits in the warm-start init block or `populate_cache_from_salsa`; their implementations at `:15685`, `:21102`, `:27768` are untouched, and no test file for them is modified.
- [x] No new zero-caller handle method or actor field. Symbol sweep clean. `cargo test` passes.

## Test Plan

- [x] `cargo test` — **3402 pass, 0 fail** (2687 lib + 635 bin + 80 integration + doctests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] **Mutation-verified, all four red:**
  1. `#[serde(deny_unknown_fields)]` on `LspCache` → stale-key test fails
  2. version guard → `if false` → pre-bump test fails on "dropped, not served"
  3. `set_laravel_config` write removed → pre-bump test fails on the rescan assertion
  4. version guard off **and** the first assertion deleted → the wholesale assertions fire on their own, so they aren't dead weight behind an earlier `assert!`
- [x] Symbol sweep run over the **whole repo**, not just `src/` — that is what surfaced the `CLAUDE.md` drift.

Fixes #356