### PR TITLE
fix: modular-monolith precedence and containment follow-ups from #336

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,9 @@ The LSP uses a dedicated thread for Salsa incremental computation to avoid lifet
 - **Salsa inputs**: Use `#[salsa::input]` for source data, store in `HashMap` for O(1) lookup
 - **Registration pattern**: Call `register_*_with_salsa()` after successful parsing
 - **Fallback pattern**: Use Salsa cache first, fall back to direct computation if unavailable
-- **Priority merging**: Framework=0, Package=1, App=2 (higher wins)
+- **Priority merging** (service providers): Framework=0, Package=1, Module=2, App=3 (higher wins).
+  On an equal-priority tie the module listed later in `modules.paths` wins, then the later
+  provider in lexicographic path order
 
 ### Position Indexing Convention
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,8 +66,12 @@ Everything goes in your Zed `settings.json`. Zed settings are JSONC, so the inli
         //     module < app), so on a namespace conflict an app/Providers
         //     registration always wins — the app boots last — and between
         //     two modules the later (higher glob-match precedence) one
-        //     wins. Paths a provider registers are containment-checked:
-        //     a registration pointing outside the project is dropped.
+        //     wins. Paths a provider registers are containment-checked
+        //     against the MODULE that registers them, so a registration
+        //     reaching into another module or outside the project is
+        //     dropped — while a module symlinked in from a composer path
+        //     repository keeps working. An app/Providers registration is
+        //     checked against the project root.
         // All of it is parsed statically (tree-sitter) — no project PHP is
         // ever executed. Two operational notes: changing "paths" MID-SESSION
         // re-resolves everything except the file watchers — restart the

--- a/laravel-lsp/src/command_index.rs
+++ b/laravel-lsp/src/command_index.rs
@@ -18,8 +18,10 @@
 //!
 //! Two classes can declare the same command name (a package ships
 //! `queue:work`, an app overrides it). The index keeps the highest-priority
-//! declaration, matching the convention in `CLAUDE.md`
-//! (*Framework=0, Package=1, App=2 — higher wins*):
+//! declaration. Higher wins, as everywhere else in the codebase, but this
+//! index has its own three-tier scale derived from the file path — it is NOT
+//! the four-tier service-provider scale (`0=framework, 1=package, 2=module,
+//! 3=app`), which no command declaration carries:
 //!
 //! | Source | Priority | Detected by |
 //! |--------|----------|-------------|

--- a/laravel-lsp/src/component_declaration_locator.rs
+++ b/laravel-lsp/src/component_declaration_locator.rs
@@ -137,12 +137,10 @@ pub fn locate_component(name: &str, config: &LaravelConfigData) -> Option<Compon
         .into_iter()
         .find(|p| p.is_file());
 
-    let class_file_path = conventional_class_file_path(name, config);
-    let class_file = if class_file_path.is_file() {
-        Some(class_file_path)
-    } else {
-        None
-    };
+    // `None` when the name can't form a safe relative path — the candidate
+    // simply doesn't exist, same as a miss on disk.
+    let class_file = conventional_class_file_path(name, config)
+        .filter(|class_file_path| class_file_path.is_file());
 
     if blade_file.is_none() && class_file.is_none() {
         return None;
@@ -173,12 +171,21 @@ pub fn locate_component(name: &str, config: &LaravelConfigData) -> Option<Compon
 /// The conventional PHP class file path for a tag name, regardless of
 /// whether the file actually exists. Used both to look up an existing file
 /// and to compute the target path for a rename.
-pub fn conventional_class_file_path(name: &str, config: &LaravelConfigData) -> PathBuf {
-    config
-        .root
-        .join("app/View/Components")
-        .join(naming::dotted_to_class_path(name))
-        .with_extension("php")
+///
+/// `None` when the tag name can't form a safe relative path (see
+/// [`naming::dotted_to_class_path`]) — a name carrying its own separator or
+/// an absolute prefix would otherwise make `Path::join` discard the
+/// `app/View/Components` base and name a file anywhere on disk. Both callers
+/// fail closed on `None`: the lookup reports no candidate, and the rename
+/// declines to move the file rather than inventing a destination.
+pub fn conventional_class_file_path(name: &str, config: &LaravelConfigData) -> Option<PathBuf> {
+    Some(
+        config
+            .root
+            .join("app/View/Components")
+            .join(naming::dotted_to_class_path(name)?)
+            .with_extension("php"),
+    )
 }
 
 /// The conventional PHP namespace for a class file at the given path, given

--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -1177,6 +1177,26 @@ pub fn expand_module_dirs(root: &Path, patterns: &[String]) -> Vec<PathBuf> {
         let mut matched = 0usize;
         for dir in current {
             if dir != *root && seen.insert(dir.clone()) {
+                // A module directory whose real target sits outside the
+                // project is admitted on purpose — that is the composer
+                // path-repository layout this expansion exists to support.
+                // It is not, however, something to do SILENTLY: the
+                // directory becomes a containment gate, so everything under
+                // the symlink's target is in scope for indexing. Announce it
+                // so an accidental link (a stray `Modules/Shared ->
+                // ../../other-checkout`) is visible rather than inferred
+                // from surprising results.
+                if let (Ok(real_dir), Ok(real_root)) = (dir.canonicalize(), root.canonicalize()) {
+                    if !real_dir.starts_with(&real_root) {
+                        tracing::warn!(
+                            module = %dir.display(),
+                            resolves_to = %real_dir.display(),
+                            "modules.paths entry resolves OUTSIDE the project root — it is \
+                             admitted (composer path repositories legitimately link outward) \
+                             and becomes a containment gate for everything under it"
+                        );
+                    }
+                }
                 out.push(dir);
                 matched += 1;
             }
@@ -1211,13 +1231,19 @@ pub fn expand_module_dirs(root: &Path, patterns: &[String]) -> Vec<PathBuf> {
 /// Resolving either side would move the provider out from under its own
 /// module and lose the ownership this answers.
 ///
-/// One lookup, two callers, by design: the Livewire containment gate
-/// (`livewire_namespaces`) gates a registration against its *owning module*
-/// instead of the project root, and the Salsa registration merge
-/// (`salsa_impl::handle_get_laravel_config`) breaks an equal-priority tie by
-/// `modules.paths` rank. Both ask the same question — which module owns this
-/// provider file, and where does it sit in the configured order — so both
-/// read one answer rather than two path-prefix implementations that drift.
+/// Used by the Salsa registration merge
+/// (`salsa_impl::handle_get_laravel_config`) to break an equal-priority tie by
+/// `modules.paths` rank, where a prefix match is the only signal available:
+/// the merge sees a provider file, not the discovery that produced it.
+///
+/// The Livewire containment gate deliberately does NOT use this. A gate needs
+/// to know which module a provider *was discovered as belonging to*, and a
+/// prefix match only guesses at that: a `modules.paths` glob such as `app/*`
+/// expands to include `app/Providers`, so the guess labels an APP provider a
+/// module provider and gates its registrations against `app/Providers` —
+/// silently dropping the ordinary `__DIR__.'/../Livewire'`. That call site
+/// carries provenance down from `module_provider_files` instead. Prefer the
+/// same wherever the answer must be exact rather than indicative.
 pub fn owning_module<'a>(module_dirs: &'a [PathBuf], path: &Path) -> Option<(usize, &'a Path)> {
     let normalized = crate::route_discovery::normalize_path(path);
     module_dirs

--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -1195,6 +1195,39 @@ pub fn expand_module_dirs(root: &Path, patterns: &[String]) -> Vec<PathBuf> {
     out
 }
 
+/// The configured module directory that owns `path`, plus that module's rank
+/// in `modules.paths` glob-match order.
+///
+/// `module_dirs` is [`expand_module_dirs`]'s output, and its order **is** the
+/// configured precedence order — later pattern, higher precedence. The rank
+/// returned is therefore 1-based, so `0` is free to mean "no owning module"
+/// in the plain tuple comparison the registration merge uses. On nesting the
+/// LONGEST matching directory wins: a module inside another module is owned
+/// by the inner one, the module whose `composer.json` actually boots it.
+///
+/// Matching is lexical on `..`/`.`-collapsed paths — never `canonicalize` —
+/// because a module may legitimately be a symlinked composer path repository
+/// whose real target sits outside the project ([`expand_module_dirs`]).
+/// Resolving either side would move the provider out from under its own
+/// module and lose the ownership this answers.
+///
+/// One lookup, two callers, by design: the Livewire containment gate
+/// (`livewire_namespaces`) gates a registration against its *owning module*
+/// instead of the project root, and the Salsa registration merge
+/// (`salsa_impl::handle_get_laravel_config`) breaks an equal-priority tie by
+/// `modules.paths` rank. Both ask the same question — which module owns this
+/// provider file, and where does it sit in the configured order — so both
+/// read one answer rather than two path-prefix implementations that drift.
+pub fn owning_module<'a>(module_dirs: &'a [PathBuf], path: &Path) -> Option<(usize, &'a Path)> {
+    let normalized = crate::route_discovery::normalize_path(path);
+    module_dirs
+        .iter()
+        .enumerate()
+        .filter(|(_, dir)| normalized.starts_with(crate::route_discovery::normalize_path(dir)))
+        .max_by_key(|(_, dir)| crate::route_discovery::normalize_path(dir).components().count())
+        .map(|(index, dir)| (index + 1, dir.as_path()))
+}
+
 /// Service-provider files of the configured module directories, discovered
 /// through each module's own `composer.json`: the classes its
 /// `extra.laravel.providers` array names are the providers Laravel actually

--- a/laravel-lsp/src/config.rs
+++ b/laravel-lsp/src/config.rs
@@ -1224,7 +1224,11 @@ pub fn owning_module<'a>(module_dirs: &'a [PathBuf], path: &Path) -> Option<(usi
         .iter()
         .enumerate()
         .filter(|(_, dir)| normalized.starts_with(crate::route_discovery::normalize_path(dir)))
-        .max_by_key(|(_, dir)| crate::route_discovery::normalize_path(dir).components().count())
+        .max_by_key(|(_, dir)| {
+            crate::route_discovery::normalize_path(dir)
+                .components()
+                .count()
+        })
         .map(|(index, dir)| (index + 1, dir.as_path()))
 }
 

--- a/laravel-lsp/src/config/tests.rs
+++ b/laravel-lsp/src/config/tests.rs
@@ -1497,7 +1497,11 @@ fn psr4_entries_escaping_the_module_resolve_nothing() {
 
     for psr4_dir in [
         outside.to_string_lossy().to_string(), // absolute
-        "../../outside".to_string(),           // traversal
+        // Four levels: `{n}` -> `Legal` -> `app` -> `proj` -> the temp dir,
+        // so the candidate lands ON the decoy written above. `../../outside`
+        // normalized to `proj/app/outside`, which holds nothing — the
+        // assertion then passed with or without the containment gate.
+        "../../../../outside".to_string(), // traversal
     ] {
         let module = tmp
             .path()

--- a/laravel-lsp/src/config/tests.rs
+++ b/laravel-lsp/src/config/tests.rs
@@ -1587,3 +1587,112 @@ fn expand_module_dirs_follows_a_symlinked_module_directory() {
         "a symlinked module expands (configured paths are trusted)"
     );
 }
+
+// ============================================================================
+// owning_module — the shared module-ownership + `modules.paths` rank lookup
+// ============================================================================
+
+#[test]
+fn owning_module_ranks_by_configured_order_not_by_name() {
+    // The rank is the module's position in `modules.paths`, so it must be
+    // readable off a list whose order is neither alphabetical nor its
+    // reverse — the property both the containment gate and the merge
+    // tie-break depend on.
+    let root = Path::new("/proj");
+    let dirs = vec![
+        root.join("app/Legal/Alpha"),
+        root.join("app/Legal/Gamma"),
+        root.join("app/Legal/Beta"),
+    ];
+
+    for (name, rank) in [("Alpha", 1), ("Gamma", 2), ("Beta", 3)] {
+        let provider = root.join(format!("app/Legal/{name}/app/Providers/Registrar.php"));
+        assert_eq!(
+            owning_module(&dirs, &provider),
+            Some((rank, root.join(format!("app/Legal/{name}")).as_path())),
+            "{name} is owned by its own module at configured rank {rank}"
+        );
+    }
+}
+
+#[test]
+fn owning_module_is_none_outside_every_module() {
+    let root = Path::new("/proj");
+    let dirs = vec![root.join("app/Legal/Alpha")];
+
+    assert_eq!(
+        owning_module(&dirs, &root.join("app/Providers/AppServiceProvider.php")),
+        None,
+        "an app provider has no owning module — the caller falls back to the root"
+    );
+    assert_eq!(
+        owning_module(&[], &root.join("app/Legal/Alpha/app/Providers/X.php")),
+        None,
+        "no configured modules, no ownership"
+    );
+}
+
+#[test]
+fn owning_module_prefers_the_innermost_module_on_nesting() {
+    // A module nested inside another is booted by its own composer.json, so
+    // it owns its files — the longest match wins regardless of rank order.
+    let root = Path::new("/proj");
+    // The outer module is listed FIRST so that both modules match the inner
+    // file and only the longest-match rule can pick the inner one — a
+    // first-match implementation returns the outer module here.
+    let dirs = vec![
+        root.join("app/Legal/Suite"),
+        root.join("app/Legal/Suite/packages/Billing"),
+    ];
+
+    assert_eq!(
+        owning_module(
+            &dirs,
+            &root.join("app/Legal/Suite/packages/Billing/src/Provider.php")
+        ),
+        Some((2, root.join("app/Legal/Suite/packages/Billing").as_path())),
+        "the inner module owns its own file even though the outer one is listed first"
+    );
+    assert_eq!(
+        owning_module(&dirs, &root.join("app/Legal/Suite/src/Provider.php")),
+        Some((1, root.join("app/Legal/Suite").as_path())),
+        "a file only the outer module contains stays with the outer module"
+    );
+}
+
+#[test]
+fn owning_module_does_not_match_a_sibling_sharing_a_name_prefix() {
+    // `Path::starts_with` is component-wise, so this is a pin against a
+    // future string-prefix rewrite: `.../Contract` must not own
+    // `.../ContractSupport/…`.
+    let root = Path::new("/proj");
+    let dirs = vec![root.join("app/Legal/Contract")];
+
+    assert_eq!(
+        owning_module(
+            &dirs,
+            &root.join("app/Legal/ContractSupport/app/Providers/X.php")
+        ),
+        None,
+        "a name-prefix sibling is a different module"
+    );
+}
+
+#[test]
+fn owning_module_collapses_traversal_before_matching() {
+    // The gate reads ownership off provider paths that may still carry
+    // `..`/`.`; a raw component compare would call an escaping path in-module.
+    let root = Path::new("/proj");
+    let dirs = vec![root.join("app/Legal/Alpha")];
+
+    assert_eq!(
+        owning_module(&dirs, &root.join("app/Legal/Alpha/../Beta/src/X.php")),
+        None,
+        "a path that walks out of the module is not owned by it"
+    );
+    assert_eq!(
+        owning_module(&dirs, &root.join("app/Legal/./Alpha/src/X.php")),
+        Some((1, root.join("app/Legal/Alpha").as_path())),
+        "a `.` segment is noise, not an escape"
+    );
+}

--- a/laravel-lsp/src/livewire_declaration_locator.rs
+++ b/laravel-lsp/src/livewire_declaration_locator.rs
@@ -292,7 +292,7 @@ fn compute_v3_class_targets(
     let _old_class = current.first()?;
     let new_class = config
         .class_path
-        .join(naming::dotted_to_class_path(new_name))
+        .join(naming::dotted_to_class_path(new_name)?)
         .with_extension("php");
     let mut out = vec![new_class];
 

--- a/laravel-lsp/src/livewire_namespaces.rs
+++ b/laravel-lsp/src/livewire_namespaces.rs
@@ -22,6 +22,8 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use tracing::warn;
+
 use crate::parser::parse_php;
 use crate::vendor_translations::{
     argument_value, is_this_receiver, resolve_path_arg, string_literal_text,
@@ -206,14 +208,14 @@ fn classify_registrar_call(
 ///   Livewire registration — silently, with no diagnostic — while
 ///   [`crate::config::expand_module_dirs`] deliberately admits exactly that
 ///   layout. Gating against the owning module keeps it working:
-///   [`crate::path_containment::path_within_root_registration`] canonicalizes
+///   [`crate::path_containment::canonical_within_root_registration`] canonicalizes
 ///   both sides, so the module's real target contains its own registrations.
 /// - The gate gets STRICTER for a module provider, not looser: a
 ///   registration reaching into a sibling module or into bare `app/` is
 ///   inside the root but outside its own module, and is dropped.
 ///
 /// **Fail-closed**, via
-/// [`crate::path_containment::path_within_root_registration`]: an out-of-root
+/// [`crate::path_containment::canonical_within_root_registration`]: an out-of-root
 /// candidate is refused lexically without a disk probe, and a path whose real
 /// target cannot be PROVEN inside `gate_dir` yields no registration — a
 /// dangling under-root symlink, an unsearchable parent, or a path with
@@ -231,8 +233,23 @@ fn contained_class_path(
     paths: &PathContext,
 ) -> Option<PathBuf> {
     let resolved = resolve_path_arg(arg, bytes, paths.provider_dir, paths.root)?;
-    crate::path_containment::path_within_root_registration(&resolved, paths.gate_dir)
-        .then(|| resolved.canonicalize().unwrap_or(resolved))
+    // The guard returns the canonical path it verified — canonicalizing again
+    // here would re-resolve the symlink and could store a path it never saw.
+    let contained =
+        crate::path_containment::canonical_within_root_registration(&resolved, paths.gate_dir);
+    if contained.is_none() {
+        // A dropped registration is otherwise invisible: there is no Livewire
+        // "component not found" diagnostic, so the only symptom is goto,
+        // hover and completion quietly doing nothing. Name the path and the
+        // gate it failed — a module provider legitimately reaching a shared
+        // sibling directory looks identical to a mistake from the outside.
+        warn!(
+            path = %resolved.display(),
+            gate = %paths.gate_dir.display(),
+            "Livewire registration dropped: the class path is not contained by its gate directory"
+        );
+    }
+    contained
 }
 
 /// Order a call's arguments by the given parameter names: positional

--- a/laravel-lsp/src/livewire_namespaces.rs
+++ b/laravel-lsp/src/livewire_namespaces.rs
@@ -27,6 +27,16 @@ use crate::vendor_translations::{
     argument_value, is_this_receiver, resolve_path_arg, string_literal_text,
 };
 
+/// The three directories every registration in one provider file is resolved
+/// and gated against: `provider_dir` is `__DIR__`, `root` backs the
+/// `base_path()`/`lang_path()` helpers, and `gate_dir` is what containment is
+/// judged by (see [`contained_class_path`]).
+struct PathContext<'a> {
+    provider_dir: &'a Path,
+    root: &'a Path,
+    gate_dir: &'a Path,
+}
+
 /// One registered Livewire class-component namespace: the PHP class
 /// namespace the prefix maps to and the directory its classes live in.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -62,14 +72,16 @@ pub fn extract_livewire_namespaces(
     let file_namespace = php_file_namespace(tree.root_node(), bytes);
     // A module provider is contained by its OWN module, an app provider by
     // the project root — see `contained_class_path`.
-    let gate_dir = module_dir.unwrap_or(root);
+    let paths = PathContext {
+        provider_dir,
+        root,
+        gate_dir: module_dir.unwrap_or(root),
+    };
 
     walk(
         tree.root_node(),
         bytes,
-        provider_dir,
-        root,
-        gate_dir,
+        &paths,
         registrar_methods,
         file_namespace.as_deref(),
         &mut out,
@@ -80,31 +92,21 @@ pub fn extract_livewire_namespaces(
 fn walk(
     node: tree_sitter::Node,
     bytes: &[u8],
-    provider_dir: &Path,
-    root: &Path,
-    gate_dir: &Path,
+    paths: &PathContext,
     registrar_methods: &[String],
     file_namespace: Option<&str>,
     out: &mut HashMap<String, LivewireClassNamespace>,
 ) {
     match node.kind() {
         "scoped_call_expression" => {
-            if let Some((prefix, reg)) =
-                classify_add_namespace(node, bytes, provider_dir, root, gate_dir)
-            {
+            if let Some((prefix, reg)) = classify_add_namespace(node, bytes, paths) {
                 out.insert(prefix, reg);
             }
         }
         "member_call_expression" => {
-            if let Some((prefix, reg)) = classify_registrar_call(
-                node,
-                bytes,
-                provider_dir,
-                root,
-                gate_dir,
-                registrar_methods,
-                file_namespace,
-            ) {
+            if let Some((prefix, reg)) =
+                classify_registrar_call(node, bytes, paths, registrar_methods, file_namespace)
+            {
                 out.insert(prefix, reg);
             }
         }
@@ -112,16 +114,7 @@ fn walk(
     }
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
-        walk(
-            child,
-            bytes,
-            provider_dir,
-            root,
-            gate_dir,
-            registrar_methods,
-            file_namespace,
-            out,
-        );
+        walk(child, bytes, paths, registrar_methods, file_namespace, out);
     }
 }
 
@@ -131,9 +124,7 @@ fn walk(
 fn classify_add_namespace(
     node: tree_sitter::Node,
     bytes: &[u8],
-    provider_dir: &Path,
-    root: &Path,
-    gate_dir: &Path,
+    paths: &PathContext,
 ) -> Option<(String, LivewireClassNamespace)> {
     let scope = node.child_by_field_name("scope")?.utf8_text(bytes).ok()?;
     if scope != "Livewire" && !scope.ends_with("\\Livewire") {
@@ -150,8 +141,7 @@ fn classify_add_namespace(
     // quoted text instead of the (truncated) first string_content chunk.
     let class_namespace =
         unescape_php_namespace(&string_literal_raw(*args.get(1)?.as_ref()?, bytes)?);
-    let class_path =
-        contained_class_path(*args.get(2)?.as_ref()?, bytes, provider_dir, root, gate_dir)?;
+    let class_path = contained_class_path(*args.get(2)?.as_ref()?, bytes, paths)?;
 
     Some((
         prefix,
@@ -168,9 +158,7 @@ fn classify_add_namespace(
 fn classify_registrar_call(
     node: tree_sitter::Node,
     bytes: &[u8],
-    provider_dir: &Path,
-    root: &Path,
-    gate_dir: &Path,
+    paths: &PathContext,
     registrar_methods: &[String],
     file_namespace: Option<&str>,
 ) -> Option<(String, LivewireClassNamespace)> {
@@ -183,8 +171,7 @@ fn classify_registrar_call(
     }
 
     let args = collect_arguments(node, bytes, &["path", "prefix"])?;
-    let class_path =
-        contained_class_path(*args.first()?.as_ref()?, bytes, provider_dir, root, gate_dir)?;
+    let class_path = contained_class_path(*args.first()?.as_ref()?, bytes, paths)?;
     let prefix = string_literal_text(*args.get(1)?.as_ref()?, bytes)?;
     if prefix.is_empty() {
         return None;
@@ -210,7 +197,7 @@ fn classify_registrar_call(
 /// `__DIR__.'/../../../..'` never enters the config, so nothing downstream
 /// can walk or probe outside the project.
 ///
-/// `gate_dir` is the provider's OWNING MODULE directory
+/// [`PathContext::gate_dir`] is the provider's OWNING MODULE directory
 /// ([`crate::config::owning_module`]) and falls back to the project root for
 /// an app-level provider. Two things follow, and both are the point:
 ///
@@ -232,12 +219,10 @@ fn classify_registrar_call(
 fn contained_class_path(
     arg: tree_sitter::Node,
     bytes: &[u8],
-    provider_dir: &Path,
-    root: &Path,
-    gate_dir: &Path,
+    paths: &PathContext,
 ) -> Option<PathBuf> {
-    let resolved = resolve_path_arg(arg, bytes, provider_dir, root)?;
-    crate::path_containment::path_within_root_lexical(&resolved, gate_dir)
+    let resolved = resolve_path_arg(arg, bytes, paths.provider_dir, paths.root)?;
+    crate::path_containment::path_within_root_lexical(&resolved, paths.gate_dir)
         .then(|| resolved.canonicalize().unwrap_or(resolved))
 }
 

--- a/laravel-lsp/src/livewire_namespaces.rs
+++ b/laravel-lsp/src/livewire_namespaces.rs
@@ -43,6 +43,7 @@ pub fn extract_livewire_namespaces(
     source: &str,
     provider_path: &Path,
     root: &Path,
+    module_dir: Option<&Path>,
     registrar_methods: &[String],
 ) -> HashMap<String, LivewireClassNamespace> {
     let mut out = HashMap::new();
@@ -59,12 +60,16 @@ pub fn extract_livewire_namespaces(
     let bytes = source.as_bytes();
     let provider_dir = provider_path.parent().unwrap_or(provider_path);
     let file_namespace = php_file_namespace(tree.root_node(), bytes);
+    // A module provider is contained by its OWN module, an app provider by
+    // the project root — see `contained_class_path`.
+    let gate_dir = module_dir.unwrap_or(root);
 
     walk(
         tree.root_node(),
         bytes,
         provider_dir,
         root,
+        gate_dir,
         registrar_methods,
         file_namespace.as_deref(),
         &mut out,
@@ -77,13 +82,16 @@ fn walk(
     bytes: &[u8],
     provider_dir: &Path,
     root: &Path,
+    gate_dir: &Path,
     registrar_methods: &[String],
     file_namespace: Option<&str>,
     out: &mut HashMap<String, LivewireClassNamespace>,
 ) {
     match node.kind() {
         "scoped_call_expression" => {
-            if let Some((prefix, reg)) = classify_add_namespace(node, bytes, provider_dir, root) {
+            if let Some((prefix, reg)) =
+                classify_add_namespace(node, bytes, provider_dir, root, gate_dir)
+            {
                 out.insert(prefix, reg);
             }
         }
@@ -93,6 +101,7 @@ fn walk(
                 bytes,
                 provider_dir,
                 root,
+                gate_dir,
                 registrar_methods,
                 file_namespace,
             ) {
@@ -108,6 +117,7 @@ fn walk(
             bytes,
             provider_dir,
             root,
+            gate_dir,
             registrar_methods,
             file_namespace,
             out,
@@ -123,6 +133,7 @@ fn classify_add_namespace(
     bytes: &[u8],
     provider_dir: &Path,
     root: &Path,
+    gate_dir: &Path,
 ) -> Option<(String, LivewireClassNamespace)> {
     let scope = node.child_by_field_name("scope")?.utf8_text(bytes).ok()?;
     if scope != "Livewire" && !scope.ends_with("\\Livewire") {
@@ -139,7 +150,8 @@ fn classify_add_namespace(
     // quoted text instead of the (truncated) first string_content chunk.
     let class_namespace =
         unescape_php_namespace(&string_literal_raw(*args.get(1)?.as_ref()?, bytes)?);
-    let class_path = contained_class_path(*args.get(2)?.as_ref()?, bytes, provider_dir, root)?;
+    let class_path =
+        contained_class_path(*args.get(2)?.as_ref()?, bytes, provider_dir, root, gate_dir)?;
 
     Some((
         prefix,
@@ -158,6 +170,7 @@ fn classify_registrar_call(
     bytes: &[u8],
     provider_dir: &Path,
     root: &Path,
+    gate_dir: &Path,
     registrar_methods: &[String],
     file_namespace: Option<&str>,
 ) -> Option<(String, LivewireClassNamespace)> {
@@ -170,7 +183,8 @@ fn classify_registrar_call(
     }
 
     let args = collect_arguments(node, bytes, &["path", "prefix"])?;
-    let class_path = contained_class_path(*args.first()?.as_ref()?, bytes, provider_dir, root)?;
+    let class_path =
+        contained_class_path(*args.first()?.as_ref()?, bytes, provider_dir, root, gate_dir)?;
     let prefix = string_literal_text(*args.get(1)?.as_ref()?, bytes)?;
     if prefix.is_empty() {
         return None;
@@ -187,25 +201,44 @@ fn classify_registrar_call(
     ))
 }
 
-/// Resolve, canonicalize, and CONTAIN a registration's class path.
+/// Resolve and CONTAIN a registration's class path, then canonicalize it.
 ///
 /// The path argument is provider-source-derived — discovered data — and the
 /// resolved value is consumed without further gating by the component
 /// completion walk and by `try_namespaced_class`. Gating here, at the single
 /// point where a registration is minted, covers both: a
 /// `__DIR__.'/../../../..'` never enters the config, so nothing downstream
-/// can walk or probe outside the project. Fail-closed via
-/// [`crate::path_containment::path_within_root`]: a path that cannot be
-/// proven inside `root` yields no registration.
+/// can walk or probe outside the project.
+///
+/// `gate_dir` is the provider's OWNING MODULE directory
+/// ([`crate::config::owning_module`]) and falls back to the project root for
+/// an app-level provider. Two things follow, and both are the point:
+///
+/// - A module symlinked in from a composer path repository canonicalizes
+///   OUTSIDE the project root, so gating the canonical path against the root
+///   dropped its every Livewire registration — silently, with no diagnostic —
+///   while [`crate::config::expand_module_dirs`] deliberately admits exactly
+///   that layout. Gating LEXICALLY against the owning module, before
+///   canonicalizing, is what `resolve_provider_class_file` already does for
+///   the PSR-4 provider branch, and it keeps the symlinked module working.
+/// - The gate gets STRICTER for a module provider, not looser: a
+///   registration reaching into a sibling module or into bare `app/` is
+///   inside the root but outside its own module, and is dropped.
+///
+/// Fail-closed via [`crate::path_containment::path_within_root_lexical`]: a
+/// path that cannot be proven inside `gate_dir` yields no registration.
+/// Canonicalization happens only after the gate passes, so the value handed
+/// downstream still resolves symlinks as it always did.
 fn contained_class_path(
     arg: tree_sitter::Node,
     bytes: &[u8],
     provider_dir: &Path,
     root: &Path,
+    gate_dir: &Path,
 ) -> Option<PathBuf> {
     let resolved = resolve_path_arg(arg, bytes, provider_dir, root)?;
-    let canonical = resolved.canonicalize().unwrap_or(resolved);
-    crate::path_containment::path_within_root(&canonical, root).then_some(canonical)
+    crate::path_containment::path_within_root_lexical(&resolved, gate_dir)
+        .then(|| resolved.canonicalize().unwrap_or(resolved))
 }
 
 /// Order a call's arguments by the given parameter names: positional

--- a/laravel-lsp/src/livewire_namespaces.rs
+++ b/laravel-lsp/src/livewire_namespaces.rs
@@ -202,27 +202,36 @@ fn classify_registrar_call(
 /// an app-level provider. Two things follow, and both are the point:
 ///
 /// - A module symlinked in from a composer path repository canonicalizes
-///   OUTSIDE the project root, so gating the canonical path against the root
-///   dropped its every Livewire registration — silently, with no diagnostic —
-///   while [`crate::config::expand_module_dirs`] deliberately admits exactly
-///   that layout. Gating LEXICALLY against the owning module, before
-///   canonicalizing, is what `resolve_provider_class_file` already does for
-///   the PSR-4 provider branch, and it keeps the symlinked module working.
+///   OUTSIDE the project root, so gating against the ROOT dropped its every
+///   Livewire registration — silently, with no diagnostic — while
+///   [`crate::config::expand_module_dirs`] deliberately admits exactly that
+///   layout. Gating against the owning module keeps it working:
+///   [`crate::path_containment::path_within_root_registration`] canonicalizes
+///   both sides, so the module's real target contains its own registrations.
 /// - The gate gets STRICTER for a module provider, not looser: a
 ///   registration reaching into a sibling module or into bare `app/` is
 ///   inside the root but outside its own module, and is dropped.
 ///
-/// Fail-closed via [`crate::path_containment::path_within_root_lexical`]: a
-/// path that cannot be proven inside `gate_dir` yields no registration.
-/// Canonicalization happens only after the gate passes, so the value handed
-/// downstream still resolves symlinks as it always did.
+/// **Fail-closed**, via
+/// [`crate::path_containment::path_within_root_registration`]: an out-of-root
+/// candidate is refused lexically without a disk probe, and a path whose real
+/// target cannot be PROVEN inside `gate_dir` yields no registration — a
+/// dangling under-root symlink, an unsearchable parent, or a path with
+/// nothing on disk.
+///
+/// The weaker `path_within_root_lexical` is deliberately NOT used here even
+/// though it shares the same lexical pre-gate. It admits every in-root path
+/// it cannot canonicalize, which is right for a speculative *candidate* and
+/// wrong here: this value is a directory that later gets walked and read, so
+/// admitting a dangling symlink would let a target created afterwards resolve
+/// outside the module (issues #134/#155).
 fn contained_class_path(
     arg: tree_sitter::Node,
     bytes: &[u8],
     paths: &PathContext,
 ) -> Option<PathBuf> {
     let resolved = resolve_path_arg(arg, bytes, paths.provider_dir, paths.root)?;
-    crate::path_containment::path_within_root_lexical(&resolved, paths.gate_dir)
+    crate::path_containment::path_within_root_registration(&resolved, paths.gate_dir)
         .then(|| resolved.canonicalize().unwrap_or(resolved))
 }
 

--- a/laravel-lsp/src/livewire_namespaces/tests.rs
+++ b/laravel-lsp/src/livewire_namespaces/tests.rs
@@ -291,3 +291,84 @@ class AppServiceProvider
         "negative control: an unconfigured wrapper name registers nothing"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn a_dangling_symlink_class_path_yields_no_registration() {
+    // #354 item 1 regression: gating with `path_within_root_lexical` admitted
+    // any in-root path it could not canonicalize, so a DANGLING under-root
+    // symlink minted a registration whose real target is unprovable. The class
+    // path is walked and read downstream (the component-completion walk,
+    // `try_namespaced_class`), so a target created later could resolve outside
+    // the module — issues #134/#155. It must fail closed.
+    let (_tmp, root, provider_path) = module_layout();
+    let module_dir = root.join("app/Common/UI");
+    let dangling = module_dir.join("app/Dangling");
+    std::os::unix::fs::symlink(module_dir.join("NEVER_CREATED"), &dangling).unwrap();
+
+    assert!(
+        dangling.canonicalize().is_err(),
+        "precondition: the link dangles, so it cannot be canonicalized"
+    );
+
+    let source = r#"<?php
+
+namespace App\Common\UI\Providers;
+
+class AppServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadLivewireComponentsFrom(__DIR__.'/../Dangling', 'common-ui');
+    }
+}
+"#;
+    let map = extract_livewire_namespaces(
+        source,
+        &provider_path,
+        &root,
+        Some(&module_dir),
+        &registrars(),
+    );
+
+    assert!(
+        !map.contains_key("common-ui"),
+        "a dangling under-root symlink is unverifiable and must yield no registration"
+    );
+}
+
+#[test]
+fn a_genuinely_absent_class_path_yields_no_registration() {
+    // The guard is fail-closed, not merely dangling-aware: a class path with
+    // nothing on disk proves nothing about where it will later resolve, so it
+    // is refused too. This is where `path_within_root_registration` parts
+    // company with `path_within_root_emit_safe`, which admits an absent path
+    // because a *create target* legitimately does not exist yet.
+    let (_tmp, root, provider_path) = module_layout();
+    let module_dir = root.join("app/Common/UI");
+
+    let source = r#"<?php
+
+namespace App\Common\UI\Providers;
+
+class AppServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadLivewireComponentsFrom(__DIR__.'/../NotCreatedYet', 'common-ui');
+    }
+}
+"#;
+    let map = extract_livewire_namespaces(
+        source,
+        &provider_path,
+        &root,
+        Some(&module_dir),
+        &registrars(),
+    );
+
+    assert!(
+        !map.contains_key("common-ui"),
+        "an absent class path yields no registration — the gate fails closed"
+    );
+}

--- a/laravel-lsp/src/livewire_namespaces/tests.rs
+++ b/laravel-lsp/src/livewire_namespaces/tests.rs
@@ -32,7 +32,7 @@ class AppServiceProvider extends AbstractModuleServiceProvider
     }
 }
 "#;
-    let map = extract_livewire_namespaces(source, &provider_path, &root, &registrars());
+    let map = extract_livewire_namespaces(source, &provider_path, &root, None, &registrars());
     let reg = map.get("common-ui").expect("common-ui registered");
     assert_eq!(reg.class_namespace, "App\\Common\\UI\\Livewire");
     assert_eq!(
@@ -64,7 +64,7 @@ class AppServiceProvider
     }
 }
 "#;
-    let map = extract_livewire_namespaces(source, &provider_path, &root, &registrars());
+    let map = extract_livewire_namespaces(source, &provider_path, &root, None, &registrars());
     let reg = map.get("common-ui").expect("common-ui registered");
     assert_eq!(reg.class_namespace, "App\\Common\\UI\\Livewire");
     assert_eq!(
@@ -87,7 +87,7 @@ class AppServiceProvider {
     }
 }
 "#;
-    let map = extract_livewire_namespaces(source, &provider_path, &root, &registrars());
+    let map = extract_livewire_namespaces(source, &provider_path, &root, None, &registrars());
     assert_eq!(
         map.get("common-ui").unwrap().class_namespace,
         "App\\Common\\UI\\Livewire"
@@ -112,7 +112,7 @@ abstract class AbstractModuleServiceProvider {
     }
 }
 "#;
-    let map = extract_livewire_namespaces(source, &provider_path, &root, &registrars());
+    let map = extract_livewire_namespaces(source, &provider_path, &root, None, &registrars());
     assert!(map.is_empty());
 }
 
@@ -127,7 +127,7 @@ class AppServiceProvider {
     }
 }
 "#;
-    let map = extract_livewire_namespaces(source, &provider_path, &root, &registrars());
+    let map = extract_livewire_namespaces(source, &provider_path, &root, None, &registrars());
     assert!(map.is_empty());
 }
 
@@ -168,7 +168,7 @@ class AppServiceProvider
     }
 }
 "#;
-    let map = extract_livewire_namespaces(source, &provider_path, &root, &registrars());
+    let map = extract_livewire_namespaces(source, &provider_path, &root, None, &registrars());
     let reg = map.get("common-ui").expect("common-ui registered");
     assert_eq!(reg.class_namespace, "App\\Common\\UI\\Livewire");
 }
@@ -197,7 +197,7 @@ class AppServiceProvider
     }
 }
 "#;
-    let map = extract_livewire_namespaces(source, &provider_path, &root, &registrars());
+    let map = extract_livewire_namespaces(source, &provider_path, &root, None, &registrars());
     assert!(
         map.contains_key("common-ui"),
         "one unknown flag must not drop the registration: {map:?}"
@@ -225,7 +225,7 @@ class AppServiceProvider
     }
 }
 "#;
-    let map = extract_livewire_namespaces(source, &provider_path, &root, &registrars());
+    let map = extract_livewire_namespaces(source, &provider_path, &root, None, &registrars());
     let reg = map.get("common-ui").expect("registered");
     assert_eq!(
         reg.class_namespace, "App\\Common\\UI\\Alt",
@@ -253,7 +253,7 @@ class AppServiceProvider
     }
 }
 "#;
-    let map = extract_livewire_namespaces(source, &provider_path, &root, &registrars());
+    let map = extract_livewire_namespaces(source, &provider_path, &root, None, &registrars());
     assert!(
         map.is_empty(),
         "the literals stay in their own slots, so nothing resolves: {map:?}"
@@ -278,7 +278,7 @@ class AppServiceProvider
 }
 "#;
     let configured = vec!["registerModuleLivewire".to_string()];
-    let map = extract_livewire_namespaces(source, &provider_path, &root, &configured);
+    let map = extract_livewire_namespaces(source, &provider_path, &root, None, &configured);
     assert!(
         map.contains_key("common-ui"),
         "the configured wrapper name is recognized: {map:?}"
@@ -286,7 +286,7 @@ class AppServiceProvider
 
     let defaults = registrars();
     assert!(
-        !extract_livewire_namespaces(source, &provider_path, &root, &defaults)
+        !extract_livewire_namespaces(source, &provider_path, &root, None, &defaults)
             .contains_key("common-ui"),
         "negative control: an unconfigured wrapper name registers nothing"
     );

--- a/laravel-lsp/src/livewire_resolver.rs
+++ b/laravel-lsp/src/livewire_resolver.rs
@@ -429,6 +429,19 @@ pub fn resolve_component(
     if leaf.is_empty() {
         return None;
     }
+    // Every segment becomes a path component: the parents through
+    // `parents_to_path` (which uses `PathBuf::push`, and an ABSOLUTE segment
+    // replaces the whole path), the leaf as a file stem. A name is discovered
+    // data — it comes from a `<livewire:…>` tag or an `@livewire('…')`
+    // literal — so one carrying its own path syntax must not become a path.
+    // This gate covers every branch below; the class branch is additionally
+    // gated by `dotted_to_class_path`, which checks the CONVERTED segments.
+    if !segments
+        .iter()
+        .all(|seg| crate::naming::is_safe_path_segment(seg))
+    {
+        return None;
+    }
     let parents = &segments[..segments.len() - 1];
     let sub = parents_to_path(parents);
 

--- a/laravel-lsp/src/livewire_resolver.rs
+++ b/laravel-lsp/src/livewire_resolver.rs
@@ -693,7 +693,7 @@ fn try_namespaced_class(
 ) -> Option<LivewireComponent> {
     let class_file = reg
         .class_path
-        .join(naming::dotted_to_class_path(bare))
+        .join(naming::dotted_to_class_path(bare)?)
         .with_extension("php");
     if !class_file.is_file() {
         return None;
@@ -707,7 +707,7 @@ fn try_namespaced_class(
 fn try_v3_class(bare: &str, config: &LivewireConfig) -> Option<LivewireComponent> {
     let class_path = config
         .class_path
-        .join(naming::dotted_to_class_path(bare))
+        .join(naming::dotted_to_class_path(bare)?)
         .with_extension("php");
     if !class_path.is_file() {
         return None;

--- a/laravel-lsp/src/livewire_resolver/tests.rs
+++ b/laravel-lsp/src/livewire_resolver/tests.rs
@@ -915,3 +915,40 @@ fn an_absolute_component_name_cannot_escape_the_class_path() {
         "an un-namespaced absolute name must not resolve outside the class path"
     );
 }
+
+#[test]
+fn absolute_parent_segments_cannot_escape_via_the_v4_branch() {
+    // The V4 SFC/MFC/Volt branch runs BEFORE the class branch and builds its
+    // search directory with `parents_to_path`, which uses `PathBuf::push` —
+    // and an ABSOLUTE segment replaces the whole path. So gating only the
+    // class branch left the first branch wide open: the parent segments of a
+    // dotted name could name any directory on disk.
+    let proj = tempfile::Builder::new().prefix("zzproj").tempdir().unwrap();
+    let ext = tempfile::Builder::new().prefix("zzext").tempdir().unwrap();
+    let root = proj.path();
+    fs::create_dir_all(root.join("resources/views/livewire")).unwrap();
+
+    // A real V4 SFC sitting entirely outside the project root.
+    let outside = ext.path().join("resources/views/livewire");
+    let decoy = outside.join(format!("{}secret.blade.php", naming::LIVEWIRE_EMOJI));
+    write(
+        &decoy,
+        "<?php new class extends Component {}; ?><div></div>",
+    );
+
+    let cfg = config_for(root);
+    let name = format!("{}.secret", outside.display());
+
+    assert!(
+        decoy.is_file(),
+        "precondition: the decoy resolves if the guard is absent"
+    );
+    assert!(
+        !name.contains(char::is_whitespace),
+        "precondition: the probe name is a single component name"
+    );
+    assert!(
+        resolve_component(&name, &cfg, LivewireVersion::V4).is_none(),
+        "absolute parent segments must not re-root the V4 component search"
+    );
+}

--- a/laravel-lsp/src/livewire_resolver/tests.rs
+++ b/laravel-lsp/src/livewire_resolver/tests.rs
@@ -866,3 +866,52 @@ fn namespaced_component_resolution_with_negative_controls() {
         "true negative: a missing component under the valid namespace stays missing"
     );
 }
+
+#[test]
+fn an_absolute_component_name_cannot_escape_the_class_path() {
+    // Regression: `bare` is discovered data — whatever follows `::` in a
+    // `<livewire:…>` tag or an `@livewire('…')` literal. Because
+    // `Path::join` replaces the base on an absolute right-hand side, an
+    // absolute name resolved to a file completely outside the registered
+    // class directory and was handed back as a goto-definition target.
+    // A dot-free temp prefix matters: `TempDir::new()` names its directory
+    // `.tmpXXXX`, and splitting the name on `.` would mangle the probe path
+    // before it could escape — making this test pass for the wrong reason.
+    let tmp = tempfile::Builder::new().prefix("zz").tempdir().unwrap();
+    let root = tmp.path();
+    let mut cfg = config_for(root);
+
+    // A decoy outside every configured location.
+    let outside = tmp.path().join("outside");
+    let decoy = outside.join("Secret.php");
+    write(&decoy, "<?php // not yours");
+
+    cfg.class_namespaces.insert(
+        "ui".to_string(),
+        crate::livewire_namespaces::LivewireClassNamespace {
+            class_namespace: "App\\UiKit\\Livewire".to_string(),
+            class_path: root.join("app/UiKit/Livewire"),
+        },
+    );
+
+    let absolute = outside.join("Secret");
+    let absolute = absolute.to_string_lossy();
+
+    assert!(
+        decoy.is_file(),
+        "precondition: the decoy exists, so only the guard can refuse it"
+    );
+    assert!(
+        !absolute.contains('.'),
+        "precondition: the probe name must be dot-free, or `split_dotted` mangles \
+         it and this test passes without exercising the guard at all"
+    );
+    assert!(
+        resolve_component(&format!("ui::{absolute}"), &cfg, LivewireVersion::V3).is_none(),
+        "a namespaced absolute name must not resolve outside the class path"
+    );
+    assert!(
+        resolve_component(&absolute, &cfg, LivewireVersion::V3).is_none(),
+        "an un-namespaced absolute name must not resolve outside the class path"
+    );
+}

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -9126,10 +9126,16 @@ impl LaravelLanguageServer {
             let Ok(provider_source) = std::fs::read_to_string(&provider_path) else {
                 continue;
             };
+            // A module provider's registrations are contained by its own
+            // module directory (a symlinked composer path repo resolves
+            // outside the root); an app provider's by the root.
+            let module_dir = laravel_lsp::config::owning_module(&module_dirs, &provider_path)
+                .map(|(_rank, dir)| dir);
             for (prefix, reg) in laravel_lsp::livewire_namespaces::extract_livewire_namespaces(
                 &provider_source,
                 &provider_path,
                 root,
+                module_dir,
                 &registrars,
             ) {
                 config.class_namespaces.insert(prefix, reg);

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -6164,7 +6164,7 @@ impl LaravelLanguageServer {
     /// with Salsa, which parses them using the tracked `parse_service_provider_source`
     /// function. Salsa handles caching and incremental updates automatically.
     ///
-    /// Priority: framework=0, packages=1, app=2 (higher wins)
+    /// Priority: framework=0, packages=1, modules=2, app=3 (higher wins)
     async fn register_service_provider_files_with_salsa(&self, root: &Path) {
         let documents = self.documents.read().await;
         let mut registered_count = 0;
@@ -6259,7 +6259,7 @@ impl LaravelLanguageServer {
             }
         }
 
-        // Priority 2: Application providers (app/Providers/)
+        // Priority 3: Application providers (app/Providers/)
         let app_providers_path = root.join("app/Providers");
         if app_providers_path.exists() {
             for entry in WalkDir::new(&app_providers_path)
@@ -6354,7 +6354,7 @@ impl LaravelLanguageServer {
             }
         }
 
-        // Priority 2: bootstrap/app.php (Laravel 11+)
+        // Priority 3: bootstrap/app.php (Laravel 11+)
         let bootstrap_app = root.join("bootstrap/app.php");
         if bootstrap_app.exists() {
             let content = if let Ok(uri) = Url::from_file_path(&bootstrap_app) {
@@ -6405,7 +6405,7 @@ impl LaravelLanguageServer {
             }
         }
 
-        // Priority 2: app/Http/Kernel.php (Laravel 10)
+        // Priority 3: app/Http/Kernel.php (Laravel 10)
         let kernel_path = root.join("app/Http/Kernel.php");
         if kernel_path.exists() {
             let content = if let Ok(uri) = Url::from_file_path(&kernel_path) {
@@ -6737,7 +6737,7 @@ impl LaravelLanguageServer {
         let documents = self.documents.read().await;
         let mut registered_count = 0;
 
-        // Priority 2: Application providers (app/Providers/)
+        // Priority 3: Application providers (app/Providers/)
         let app_providers_path = root.join("app/Providers");
         if app_providers_path.exists() {
             for entry in WalkDir::new(&app_providers_path)
@@ -6828,7 +6828,7 @@ impl LaravelLanguageServer {
             }
         }
 
-        // Priority 2: bootstrap/app.php (Laravel 11+)
+        // Priority 3: bootstrap/app.php (Laravel 11+)
         let bootstrap_app = root.join("bootstrap/app.php");
         if bootstrap_app.exists() {
             let content = if let Ok(uri) = Url::from_file_path(&bootstrap_app) {
@@ -6878,7 +6878,7 @@ impl LaravelLanguageServer {
             }
         }
 
-        // Priority 2: app/Http/Kernel.php (Laravel 10)
+        // Priority 3: app/Http/Kernel.php (Laravel 10)
         let kernel_path = root.join("app/Http/Kernel.php");
         if kernel_path.exists() {
             let content = if let Ok(uri) = Url::from_file_path(&kernel_path) {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4824,6 +4824,10 @@ impl LaravelLanguageServer {
             .salsa
             .set_translation_provider_extras(module_providers)
             .await;
+        // The Salsa-side registration merge breaks an equal-priority tie by
+        // `modules.paths` rank, which only this order carries — a module
+        // provider's PATH sorts lexicographically, which is a different rule.
+        let _ = self.salsa.set_module_dirs(expanded.to_vec()).await;
         expanded
     }
 

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -9110,8 +9110,20 @@ impl LaravelLanguageServer {
         // wins.
         let registrars = self.module_livewire_registrars.read().await.clone();
         let module_dirs = self.module_dirs_for(root).await;
-        let mut provider_files: Vec<PathBuf> =
-            laravel_lsp::config::module_provider_files(&module_dirs);
+        // Carry each provider's OWNING MODULE from the discovery that found
+        // it, rather than re-deriving ownership from a path prefix later. A
+        // `modules.paths` glob such as `app/*` expands to include
+        // `app/Providers`, so a prefix match would call an APP provider a
+        // module provider and gate its registrations against `app/Providers`
+        // — silently dropping the ordinary
+        // `loadLivewireComponentsFrom(__DIR__.'/../Livewire')`. Provenance is
+        // known here and exact; the prefix match was a guess.
+        let mut provider_files: Vec<(PathBuf, Option<PathBuf>)> = Vec::new();
+        for module_dir in module_dirs.iter() {
+            for p in laravel_lsp::config::module_provider_files(std::slice::from_ref(module_dir)) {
+                provider_files.push((p, Some(module_dir.clone())));
+            }
+        }
         let app_providers = root.join("app/Providers");
         if app_providers.is_dir() {
             for entry in WalkDir::new(&app_providers)
@@ -9121,25 +9133,23 @@ impl LaravelLanguageServer {
             {
                 let p = entry.path();
                 if p.is_file() && p.extension().is_some_and(|ext| ext == "php") {
-                    provider_files.push(p.to_path_buf());
+                    provider_files.push((p.to_path_buf(), None));
                 }
             }
         }
 
-        for provider_path in provider_files {
+        for (provider_path, module_dir) in provider_files {
             let Ok(provider_source) = std::fs::read_to_string(&provider_path) else {
                 continue;
             };
             // A module provider's registrations are contained by its own
             // module directory (a symlinked composer path repo resolves
             // outside the root); an app provider's by the root.
-            let module_dir = laravel_lsp::config::owning_module(&module_dirs, &provider_path)
-                .map(|(_rank, dir)| dir);
             for (prefix, reg) in laravel_lsp::livewire_namespaces::extract_livewire_namespaces(
                 &provider_source,
                 &provider_path,
                 root,
-                module_dir,
+                module_dir.as_deref(),
                 &registrars,
             ) {
                 config.class_namespaces.insert(prefix, reg);
@@ -24003,6 +24013,15 @@ impl LanguageServer for LaravelLanguageServer {
         // resolves, so a stale one is a wrong answer, not just an old one.
         if providers_changed {
             self.invalidate_vendor_translation_namespaces().await;
+            // The Livewire class-namespace map is built from these same
+            // providers, and its registrations are gated on the class
+            // DIRECTORY existing. A provider added or changed on disk —
+            // `artisan module:make-livewire` creating the first component
+            // (and `Livewire/` with it), a `git pull`, a branch switch —
+            // otherwise left the map stale until the user edited a provider
+            // in the editor or restarted the server: a registration that
+            // failed the gate at index time stayed failed forever.
+            *self.cached_livewire.write().await = None;
         }
 
         // A Command class changed on disk — rebuild the Artisan command index so

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -25160,11 +25160,16 @@ impl LanguageServer for LaravelLanguageServer {
                             trimmed_new,
                             &config,
                         );
-                    if &target_class != current_class {
-                        file_renames.push(laravel_lsp::rename::FileRename {
-                            old_path: current_class.clone(),
-                            new_path: target_class.clone(),
-                        });
+                    // `None` when the new name can't form a safe relative
+                    // path — refuse to move the file rather than compute an
+                    // arbitrary destination for it.
+                    if let Some(target_class) = target_class.as_ref() {
+                        if target_class != current_class {
+                            file_renames.push(laravel_lsp::rename::FileRename {
+                                old_path: current_class.clone(),
+                                new_path: target_class.clone(),
+                            });
+                        }
                     }
 
                     // Class name rewrite — fires whenever the leaf Pascal-
@@ -25186,10 +25191,12 @@ impl LanguageServer for LaravelLanguageServer {
 
                     // Namespace rewrite — only when the file moved into a
                     // different conventional namespace.
-                    if let Some(root) = root_path.as_ref() {
+                    if let (Some(root), Some(target_class)) =
+                        (root_path.as_ref(), target_class.as_ref())
+                    {
                         let new_namespace =
                             laravel_lsp::component_declaration_locator::conventional_namespace_for(
-                                &target_class,
+                                target_class,
                                 root,
                             );
                         if let Some(span) = &current.namespace_declaration {

--- a/laravel-lsp/src/member_resolver.rs
+++ b/laravel-lsp/src/member_resolver.rs
@@ -1363,8 +1363,11 @@ fn resolve_helper_receiver(
 ///   guessing among equals.
 /// - **no implementer** → `None`.
 ///
-/// Package priority follows the project-wide convention (App=2 > Package=1 >
-/// Framework=0): a project's own implementation of a framework contract wins
+/// Package priority here is its own two-value scale read off the resolved
+/// file path (in-project = 2, under `vendor/` = 0) — not the four-tier
+/// service-provider scale (`0=framework, 1=package, 2=module, 3=app`), which
+/// a bare class file carries no way to determine. Higher wins either way: a
+/// project's own implementation of a framework contract wins
 /// over the vendor default. The priority is read from the resolved file path
 /// (`vendor/` segment ⇒ Framework/Package, otherwise App) since the
 /// [`ClassFileResolver`] seam carries file paths, not parsed package metadata.
@@ -1396,10 +1399,13 @@ fn resolve_interface_concrete(
     }
 }
 
-/// Package priority of an implementing class for disambiguation: App=2 (the
-/// project's own code) outranks vendor code=0. Derived from the resolved file
-/// path — a `vendor/` segment marks framework/package code. An unresolvable
-/// file (not in the index) is treated as lowest priority.
+/// Package priority of an implementing class for disambiguation, on this
+/// function's own two-value scale: in-project code scores 2 and outranks
+/// vendor code at 0. (It is not the four-tier service-provider scale —
+/// `0=framework, 1=package, 2=module, 3=app` — which a resolved class file
+/// carries no way to determine.) Derived from the resolved file path: a
+/// `vendor/` segment marks framework/package code. An unresolvable file (not
+/// in the index) is treated as lowest priority.
 fn impl_priority(fqcn: &str, resolver: &impl ClassFileResolver) -> u8 {
     match resolver.class_file(fqcn) {
         Some(path) => {

--- a/laravel-lsp/src/naming.rs
+++ b/laravel-lsp/src/naming.rs
@@ -87,13 +87,39 @@ pub fn dotted_to_namespace(s: &str) -> String {
     join_pascal_segments(s, '\\')
 }
 
-/// Convert a dotted component name to a forward-slash file path with each
-/// segment in PascalCase.
+/// Convert a dotted component name to a forward-slash **relative** file path
+/// with each segment in PascalCase.
 ///
-/// `"admin.user-list"` → `"Admin/UserList"`. The caller appends `.php` or
-/// joins with a root directory.
-pub fn dotted_to_class_path(s: &str) -> String {
-    join_pascal_segments(s, '/')
+/// `"admin.user-list"` → `Some("Admin/UserList")`.
+///
+/// Returns `None` when any segment is not a valid single path segment, so the
+/// result is always safe to hand to `Path::join`. Every caller joins this onto
+/// a trusted base directory, and `Path::join` REPLACES the base when the
+/// right-hand side is absolute — so `"/etc/passwd"` reaching this function
+/// unchecked made `class_path.join(..)` resolve to `/etc/passwd`, escaping the
+/// registered directory entirely. The component name is discovered data (it
+/// comes from a `<livewire:…>` tag or an `@livewire('…')` literal), so it is
+/// exactly the kind of input that must not be able to name a path.
+///
+/// Splitting on `.` already destroys `..` (it becomes two empty segments), so
+/// the traversal that remains is a separator or an absolute/drive prefix. A
+/// segment is rejected when it is empty or contains `/`, `\\`, or `:`.
+/// Rejecting rather than sanitizing keeps this total: there is no "cleaned"
+/// name that silently resolves somewhere the author did not write.
+pub fn dotted_to_class_path(s: &str) -> Option<String> {
+    let segments = split_dotted(s);
+    if !segments.iter().all(|seg| is_safe_path_segment(seg)) {
+        return None;
+    }
+    Some(join_pascal_segments(s, '/'))
+}
+
+/// True if `s` is usable as exactly ONE path segment: non-empty, and free of
+/// any separator or prefix that `Path::join` would treat as re-rooting.
+/// `\\` and `:` matter on Windows (`C:`, `\\\\server\\share`, NTFS streams) and are
+/// refused on every platform so behaviour does not diverge by host.
+fn is_safe_path_segment(s: &str) -> bool {
+    !s.is_empty() && !s.contains(['/', '\\', ':'])
 }
 
 fn join_pascal_segments(s: &str, sep: char) -> String {

--- a/laravel-lsp/src/naming.rs
+++ b/laravel-lsp/src/naming.rs
@@ -103,22 +103,36 @@ pub fn dotted_to_namespace(s: &str) -> String {
 ///
 /// Splitting on `.` already destroys `..` (it becomes two empty segments), so
 /// the traversal that remains is a separator or an absolute/drive prefix. A
-/// segment is rejected when it is empty or contains `/`, `\\`, or `:`.
+/// segment is rejected when it is empty or contains `/`, `\\`, or `:`, and the
+/// check runs on the PascalCase-converted segments — the ones actually joined
+/// — because `kebab_to_pascal` collapses an all-dashes segment to nothing.
 /// Rejecting rather than sanitizing keeps this total: there is no "cleaned"
 /// name that silently resolves somewhere the author did not write.
 pub fn dotted_to_class_path(s: &str) -> Option<String> {
-    let segments = split_dotted(s);
+    // Check the segments that are actually JOINED, not the raw ones.
+    // `kebab_to_pascal` splits on `-` and maps every empty part to an empty
+    // string, so a segment of only dashes passes a raw check (non-empty, no
+    // separator) and collapses to `""` here — and an empty FIRST segment
+    // makes the join start with `/`, i.e. absolute, which is the exact shape
+    // this guard exists to refuse. `"-.foo"` was minting `"/Foo"`.
+    let segments: Vec<String> = split_dotted(s).into_iter().map(kebab_to_pascal).collect();
     if !segments.iter().all(|seg| is_safe_path_segment(seg)) {
         return None;
     }
-    Some(join_pascal_segments(s, '/'))
+    Some(segments.join("/"))
 }
 
 /// True if `s` is usable as exactly ONE path segment: non-empty, and free of
 /// any separator or prefix that `Path::join` would treat as re-rooting.
+///
+/// Public because component names become path components in two different
+/// shapes: [`dotted_to_class_path`] checks the PascalCase-CONVERTED segments
+/// it joins, while `livewire_resolver::resolve_component` checks the RAW
+/// segments, which it pushes verbatim as directory names and file stems.
+/// Both need the same answer to "is this one segment, or is it path syntax?"
 /// `\\` and `:` matter on Windows (`C:`, `\\\\server\\share`, NTFS streams) and are
 /// refused on every platform so behaviour does not diverge by host.
-fn is_safe_path_segment(s: &str) -> bool {
+pub fn is_safe_path_segment(s: &str) -> bool {
     !s.is_empty() && !s.contains(['/', '\\', ':'])
 }
 

--- a/laravel-lsp/src/naming/tests.rs
+++ b/laravel-lsp/src/naming/tests.rs
@@ -301,3 +301,20 @@ fn dotted_to_class_path_still_accepts_ordinary_names() {
         Some("V2Widget")
     );
 }
+
+#[test]
+fn dotted_to_class_path_refuses_a_segment_that_collapses_to_nothing() {
+    // `kebab_to_pascal` splits on `-` and maps every empty part to `""`, so an
+    // all-dashes segment survives a check of the RAW segments (non-empty, no
+    // separator) and then vanishes from the join. An empty leading segment
+    // makes the result absolute, and `Path::join` discards its base — the very
+    // escape this guard exists to stop. `"-.foo"` minted `"/Foo"`, which the
+    // rename path turned into a class file written to `/Foo.php`.
+    assert_eq!(dotted_to_class_path("-"), None);
+    assert_eq!(dotted_to_class_path("-.foo"), None);
+    assert_eq!(dotted_to_class_path("--.foo"), None);
+    assert_eq!(dotted_to_class_path("-.etc.passwd"), None);
+    // A collapsing segment in the middle is refused too: it would double the
+    // separator rather than re-root, but it is still not a component name.
+    assert_eq!(dotted_to_class_path("foo.-.bar"), None);
+}

--- a/laravel-lsp/src/naming/tests.rs
+++ b/laravel-lsp/src/naming/tests.rs
@@ -84,19 +84,22 @@ fn dotted_to_namespace_nested() {
 
 #[test]
 fn dotted_to_class_path_single() {
-    assert_eq!(dotted_to_class_path("counter"), "Counter");
+    assert_eq!(dotted_to_class_path("counter").as_deref(), Some("Counter"));
 }
 
 #[test]
 fn dotted_to_class_path_nested() {
-    assert_eq!(dotted_to_class_path("admin.user-list"), "Admin/UserList");
+    assert_eq!(
+        dotted_to_class_path("admin.user-list").as_deref(),
+        Some("Admin/UserList")
+    );
 }
 
 #[test]
 fn dotted_to_class_path_deep() {
     assert_eq!(
-        dotted_to_class_path("admin.users.show-profile"),
-        "Admin/Users/ShowProfile"
+        dotted_to_class_path("admin.users.show-profile").as_deref(),
+        Some("Admin/Users/ShowProfile")
     );
 }
 
@@ -252,5 +255,49 @@ fn validate_dotted_rejects_invalid_characters() {
     assert_eq!(
         validate_dotted_name("users@profile", true),
         Err(DottedNameError::InvalidCharacter('@'))
+    );
+}
+
+#[test]
+fn dotted_to_class_path_refuses_an_absolute_name() {
+    // `Path::join` REPLACES the base when the right-hand side is absolute, so
+    // an absolute name made `class_path.join(..)` resolve to the name itself,
+    // escaping the registered directory entirely.
+    assert_eq!(dotted_to_class_path("/etc/passwd"), None);
+    assert_eq!(dotted_to_class_path("/tmp/Secret"), None);
+}
+
+#[test]
+fn dotted_to_class_path_refuses_separators_inside_a_segment() {
+    // A component name is dotted segments of kebab identifiers. Anything
+    // carrying its own separator is not a name, and must not become a path.
+    assert_eq!(dotted_to_class_path("admin/users"), None);
+    assert_eq!(dotted_to_class_path("admin.users/show"), None);
+    assert_eq!(dotted_to_class_path("admin\\users"), None);
+    assert_eq!(dotted_to_class_path("C:windows"), None);
+}
+
+#[test]
+fn dotted_to_class_path_refuses_an_empty_segment() {
+    // Splitting on `.` turns `..` into empty segments, so this is also what
+    // stops classic dot-dot traversal from surviving the conversion.
+    assert_eq!(dotted_to_class_path("admin..users"), None);
+    assert_eq!(dotted_to_class_path(".users"), None);
+    assert_eq!(dotted_to_class_path("users."), None);
+    assert_eq!(dotted_to_class_path(""), None);
+}
+
+#[test]
+fn dotted_to_class_path_still_accepts_ordinary_names() {
+    // The guard must not cost a legitimate name — including digits and the
+    // deep nesting Laravel conventions produce.
+    assert_eq!(dotted_to_class_path("counter").as_deref(), Some("Counter"));
+    assert_eq!(
+        dotted_to_class_path("admin.users.show-profile").as_deref(),
+        Some("Admin/Users/ShowProfile")
+    );
+    assert_eq!(
+        dotted_to_class_path("v2-widget").as_deref(),
+        Some("V2Widget")
     );
 }

--- a/laravel-lsp/src/path_containment.rs
+++ b/laravel-lsp/src/path_containment.rs
@@ -5,7 +5,7 @@
 //! `slot_navigation.rs`, and an inline `retain` in `salsa_impl.rs`), each with
 //! its own fallback behaviour that could drift apart (issue #156). They are
 //! consolidated here behind one canonical-first core ([`canonical_containment`])
-//! and **three** public entry points that differ only in what they do when a
+//! and **five** public entry points that differ only in what they do when a
 //! path can't be canonicalized:
 //!
 //! - [`path_within_root`] is **fail-closed**: an unverifiable path is refused.
@@ -52,6 +52,19 @@
 //!   the root passes, and anything that escapes (or can't be canonicalized) is
 //!   refused. Used by `scan_dir` in `component_completion.rs` and the
 //!   `controllers_dir` walk in `main.rs`.
+//! - [`path_within_root_registration`] is the fail-closed guard for a path
+//!   **minted from discovered provider source that will be READ downstream**
+//!   (issue #354 item 1). It is the missing combination of the two axes above:
+//!   it refuses an out-of-root candidate lexically, with no disk probe (#145),
+//!   AND fail-closes on anything it cannot canonicalize (#134/#155) — a
+//!   dangling under-root symlink, an unsearchable parent, a path with nothing
+//!   on disk. [`path_within_root_lexical`] admits all three and
+//!   [`path_within_root_emit_safe`] admits the last, which is correct for a
+//!   speculative *create target* and wrong for a value that becomes a read
+//!   primitive. Gate against the provider's OWNING MODULE rather than the
+//!   project root and a symlinked composer path repository still passes: both
+//!   sides canonicalize to the real target. Used by `contained_class_path` in
+//!   `livewire_namespaces.rs`.
 
 use std::path::Path;
 
@@ -190,9 +203,40 @@ pub fn path_within_root_emit_safe(path: &Path, root: &Path) -> bool {
     }
 }
 
-/// The lexical containment gate shared by [`path_within_root_lexical`] and
-/// [`path_within_root_emit_safe`]. True when `path`, with interior `..`/`.`
-/// collapsed by `normalize_path`, is a `starts_with` prefix-match of `root` —
+/// True if `path` is contained within `root` and its real target is **proven**
+/// so — the guard for a path that is minted from *discovered* source data and
+/// then READ (issue #354 item 1).
+///
+/// Two invariants meet at such a call site, and the four guards above each
+/// satisfy only one of them:
+///
+/// - The candidate comes from provider source, so canonicalizing it upfront
+///   would leak an out-of-root existence oracle (#145). Hence the
+///   [`lexically_in_root`] pre-gate: an out-of-root candidate is refused with
+///   no `stat`/`realpath` probe of it.
+/// - The value is consumed as a read primitive, so an unverifiable path must
+///   be refused, not admitted (#134/#155). Hence `unwrap_or(false)`: a
+///   dangling under-root symlink, an `EACCES`/`ELOOP` parent, or a path with
+///   nothing on disk all yield `false`.
+///
+/// [`path_within_root_lexical`] fails the second (it admits every
+/// unverifiable in-root path) and [`path_within_root_emit_safe`] fails it for
+/// the genuinely-absent case — correct when the path is a speculative
+/// *create target*, wrong when it becomes a directory that gets walked and
+/// read. [`path_within_root`] satisfies the second but fails the first.
+///
+/// Gate against the provider's owning module rather than the project root and
+/// a symlinked composer path repository still passes: `canonical_containment`
+/// canonicalizes BOTH sides, so the module's real target contains its own
+/// registrations.
+pub fn path_within_root_registration(path: &Path, root: &Path) -> bool {
+    lexically_in_root(path, root) && canonical_containment(path, root).unwrap_or(false)
+}
+
+/// The lexical containment gate shared by [`path_within_root_lexical`],
+/// [`path_within_root_emit_safe`] and [`path_within_root_registration`]. True
+/// when `path`, with interior `..`/`.` collapsed by `normalize_path`, is a
+/// `starts_with` prefix-match of `root` —
 /// first against the root as given, then (only if that fails) against the root's
 /// canonicalized form. **Never canonicalizes the candidate**, so an out-of-root
 /// candidate is refused before any `stat`/`realpath` probe of it (the existence
@@ -807,5 +851,165 @@ mod tests {
         std::fs::write(&escapee, "<?php\n").unwrap();
 
         assert!(!path_within_root_walk_entry(&escapee, &root));
+    }
+
+    #[test]
+    fn registration_admits_in_root_existing_dir() {
+        // The ordinary case: a real directory under the gate dir. Both sides
+        // canonicalize and the real path starts with the real gate dir.
+        let root = TempDir::new().unwrap();
+        let classes = root.path().join("src").join("Livewire");
+        std::fs::create_dir_all(&classes).unwrap();
+
+        assert!(path_within_root_registration(&classes, root.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn registration_admits_classes_under_a_symlinked_gate_dir() {
+        // #354 item 1: a composer path-repo module symlinked into the project
+        // canonicalizes OUTSIDE the project root, which is why the gate dir is
+        // the OWNING MODULE and not the root. `canonical_containment`
+        // canonicalizes both sides, so the module's real target contains its
+        // own registrations and the registration survives.
+        let tmp = TempDir::new().unwrap();
+        let real_module = tmp.path().join("packages").join("ui-kit");
+        let classes = real_module.join("src").join("Livewire");
+        std::fs::create_dir_all(&classes).unwrap();
+
+        let root = tmp.path().join("project");
+        std::fs::create_dir_all(root.join("app")).unwrap();
+        let module_link = root.join("app").join("UiKit");
+        std::os::unix::fs::symlink(&real_module, &module_link).unwrap();
+
+        // Precondition: the module's real target escapes the project root, so
+        // gating against the ROOT is what used to drop this registration.
+        assert!(
+            !module_link
+                .canonicalize()
+                .unwrap()
+                .starts_with(root.canonicalize().unwrap()),
+            "the symlinked module resolves outside the project root"
+        );
+
+        assert!(
+            path_within_root_registration(&module_link.join("src").join("Livewire"), &module_link),
+            "a symlinked path-repo module contains its own registrations"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn registration_refuses_dangling_under_root_symlink() {
+        // The #134/#155 case this guard exists for: the link path is lexically
+        // inside the gate dir, but the target is missing so `canonicalize`
+        // cannot prove where it resolves. `path_within_root_lexical` ADMITS
+        // this (it falls back to the lexical result) — which is why that guard
+        // is wrong for a value that becomes a read primitive.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("project");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let dangling = root.join("Livewire");
+        std::os::unix::fs::symlink(root.join("NEVER_CREATED"), &dangling).unwrap();
+
+        assert!(
+            dangling.starts_with(&root),
+            "the link path is lexically inside the gate dir"
+        );
+        assert!(
+            dangling.canonicalize().is_err(),
+            "the dangling link cannot be canonicalized"
+        );
+
+        assert!(
+            path_within_root_lexical(&dangling, &root),
+            "precondition: the lexical guard admits it — the behaviour this guard corrects"
+        );
+        assert!(
+            !path_within_root_registration(&dangling, &root),
+            "a dangling under-root symlink is unverifiable and must be refused"
+        );
+    }
+
+    #[test]
+    fn registration_refuses_genuinely_absent_candidate() {
+        // Where this guard deliberately parts company with
+        // `path_within_root_emit_safe`: nothing on disk is a legitimate
+        // *create target*, but not a legitimate directory to walk and read.
+        // Fail closed, matching the pre-#354 behaviour of this call site.
+        let root = TempDir::new().unwrap();
+        let absent = root.path().join("src").join("Livewire");
+
+        assert!(
+            path_within_root_emit_safe(&absent, root.path()),
+            "precondition: emit_safe admits a genuinely-absent path"
+        );
+        assert!(
+            !path_within_root_registration(&absent, root.path()),
+            "an absent path proves nothing about where it will resolve — refuse it"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn registration_refuses_out_of_root_candidate_without_probing() {
+        // Issue #145: the candidate is provider-source-derived, so an upfront
+        // `canonicalize()` of it would leak an out-of-root existence oracle.
+        // The candidate here is an out-of-root symlink that WOULD resolve back
+        // inside the gate dir — so only a lexical-first check can refuse it,
+        // and `false` proves no disk probe of the out-of-root path decided it.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("project");
+        let classes = root.join("src").join("Livewire");
+        std::fs::create_dir_all(&classes).unwrap();
+
+        let outside_link = tmp.path().join("outside-link");
+        std::os::unix::fs::symlink(&classes, &outside_link).unwrap();
+
+        assert!(
+            !outside_link.starts_with(&root),
+            "the link path is lexically outside the gate dir"
+        );
+        assert_eq!(
+            outside_link.canonicalize().unwrap(),
+            classes.canonicalize().unwrap(),
+            "the link resolves back inside the gate dir"
+        );
+
+        assert!(
+            !path_within_root_registration(&outside_link, &root),
+            "an out-of-root candidate must be refused lexically, before any disk probe"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn registration_refuses_in_root_symlink_escaping_the_gate_dir() {
+        // No containment downgrade (#55/#134): a link path lexically inside
+        // the gate dir whose real target escapes it is refused by the
+        // canonicalize step. This is the sibling-module reach in #354 item 1.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("project");
+        std::fs::create_dir_all(&root).unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+
+        let escaping = root.join("Livewire");
+        std::os::unix::fs::symlink(&outside, &escaping).unwrap();
+
+        assert!(escaping.starts_with(&root));
+        assert!(
+            !escaping
+                .canonicalize()
+                .unwrap()
+                .starts_with(root.canonicalize().unwrap()),
+            "the link's real target escapes the gate dir"
+        );
+
+        assert!(
+            !path_within_root_registration(&escaping, &root),
+            "an in-root symlink whose target escapes the gate dir must be refused"
+        );
     }
 }

--- a/laravel-lsp/src/path_containment.rs
+++ b/laravel-lsp/src/path_containment.rs
@@ -52,7 +52,7 @@
 //!   the root passes, and anything that escapes (or can't be canonicalized) is
 //!   refused. Used by `scan_dir` in `component_completion.rs` and the
 //!   `controllers_dir` walk in `main.rs`.
-//! - [`path_within_root_registration`] is the fail-closed guard for a path
+//! - [`canonical_within_root_registration`] is the fail-closed guard for a path
 //!   **minted from discovered provider source that will be READ downstream**
 //!   (issue #354 item 1). It is the missing combination of the two axes above:
 //!   it refuses an out-of-root candidate lexically, with no disk probe (#145),
@@ -66,7 +66,7 @@
 //!   sides canonicalize to the real target. Used by `contained_class_path` in
 //!   `livewire_namespaces.rs`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::route_discovery::normalize_path;
 
@@ -226,15 +226,24 @@ pub fn path_within_root_emit_safe(path: &Path, root: &Path) -> bool {
 /// read. [`path_within_root`] satisfies the second but fails the first.
 ///
 /// Gate against the provider's owning module rather than the project root and
-/// a symlinked composer path repository still passes: `canonical_containment`
-/// canonicalizes BOTH sides, so the module's real target contains its own
-/// registrations.
-pub fn path_within_root_registration(path: &Path, root: &Path) -> bool {
-    lexically_in_root(path, root) && canonical_containment(path, root).unwrap_or(false)
+/// a symlinked composer path repository still passes: both sides are
+/// canonicalized, so the module's real target contains its own registrations.
+///
+/// Returns the VERIFIED canonical path rather than a bool, so the caller
+/// stores exactly what was checked. Handing back a bool invited the caller to
+/// canonicalize a second time to obtain the value, and a symlink swapped
+/// between the two calls would store a path the guard never approved.
+pub fn canonical_within_root_registration(path: &Path, root: &Path) -> Option<PathBuf> {
+    if !lexically_in_root(path, root) {
+        return None;
+    }
+    let real_path = path.canonicalize().ok()?;
+    let real_root = root.canonicalize().ok()?;
+    real_path.starts_with(&real_root).then_some(real_path)
 }
 
 /// The lexical containment gate shared by [`path_within_root_lexical`],
-/// [`path_within_root_emit_safe`] and [`path_within_root_registration`]. True
+/// [`path_within_root_emit_safe`] and [`canonical_within_root_registration`]. True
 /// when `path`, with interior `..`/`.` collapsed by `normalize_path`, is a
 /// `starts_with` prefix-match of `root` —
 /// first against the root as given, then (only if that fails) against the root's
@@ -861,7 +870,7 @@ mod tests {
         let classes = root.path().join("src").join("Livewire");
         std::fs::create_dir_all(&classes).unwrap();
 
-        assert!(path_within_root_registration(&classes, root.path()));
+        assert!(canonical_within_root_registration(&classes, root.path()).is_some());
     }
 
     #[cfg(unix)]
@@ -893,7 +902,11 @@ mod tests {
         );
 
         assert!(
-            path_within_root_registration(&module_link.join("src").join("Livewire"), &module_link),
+            canonical_within_root_registration(
+                &module_link.join("src").join("Livewire"),
+                &module_link
+            )
+            .is_some(),
             "a symlinked path-repo module contains its own registrations"
         );
     }
@@ -927,7 +940,7 @@ mod tests {
             "precondition: the lexical guard admits it — the behaviour this guard corrects"
         );
         assert!(
-            !path_within_root_registration(&dangling, &root),
+            canonical_within_root_registration(&dangling, &root).is_none(),
             "a dangling under-root symlink is unverifiable and must be refused"
         );
     }
@@ -946,7 +959,7 @@ mod tests {
             "precondition: emit_safe admits a genuinely-absent path"
         );
         assert!(
-            !path_within_root_registration(&absent, root.path()),
+            canonical_within_root_registration(&absent, root.path()).is_none(),
             "an absent path proves nothing about where it will resolve — refuse it"
         );
     }
@@ -978,7 +991,7 @@ mod tests {
         );
 
         assert!(
-            !path_within_root_registration(&outside_link, &root),
+            canonical_within_root_registration(&outside_link, &root).is_none(),
             "an out-of-root candidate must be refused lexically, before any disk probe"
         );
     }
@@ -1008,7 +1021,7 @@ mod tests {
         );
 
         assert!(
-            !path_within_root_registration(&escaping, &root),
+            canonical_within_root_registration(&escaping, &root).is_none(),
             "an in-root symlink whose target escapes the gate dir must be refused"
         );
     }

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -3560,8 +3560,9 @@ struct ProviderMacro {
 /// ## Coverage boundaries (be honest about the caps)
 ///
 /// - **Which files**: every file registered as a [`ServiceProviderFile`] Salsa
-///   input — app providers (priority 2), framework providers (0), and package
-///   providers (1), the last two discovered by the vendor scan
+///   input — app providers (priority 3), module providers (2, from the
+///   `modules.paths` globs), package providers (1), and framework providers
+///   (0), the last two discovered by the vendor scan
 ///   (`rescan_vendor_providers`). Priority merging happens in
 ///   [`SalsaActor::build_macro_registry`], not here.
 /// - **Which calls**: only a STATIC `Receiver::macro(...)` / `Receiver::mixin(...)`

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -6696,7 +6696,7 @@ pub enum SalsaRequest {
     RegisterServiceProviderSource {
         path: PathBuf,
         text: String,
-        priority: u8, // 0=framework, 1=package, 2=app
+        priority: u8, // 0=framework, 1=package, 2=module, 3=app
         root_path: PathBuf,
         reply: oneshot::Sender<()>,
     },
@@ -10364,7 +10364,8 @@ impl SalsaActor {
                     let prefix = cn.prefix(&self.db).namespace(&self.db).clone();
                     let rank = (cn.priority(&self.db), module_rank);
                     if wins(component_namespaces.get(&prefix).map(|(r, _)| r), rank) {
-                        component_namespaces.insert(prefix, (rank, cn.php_namespace(&self.db).clone()));
+                        component_namespaces
+                            .insert(prefix, (rank, cn.php_namespace(&self.db).clone()));
                     }
                 }
 
@@ -11535,7 +11536,8 @@ impl SalsaActor {
 
     /// Build the macro registry — `(receiver_fqcn, macro_name)` → registration —
     /// by merging every Salsa-parsed service provider's `macros`, highest
-    /// priority winning on key collision (framework=0 < package=1 < app=2). Built
+    /// priority winning on key collision (framework=0 < package=1 < module=2 <
+    /// app=3). Built
     /// fresh each call from the tracked-query outputs (mirrors
     /// [`Self::build_facade_alias_snapshot`]); macros number in the dozens-to-
     /// hundreds, with no cache to invalidate on a provider edit.
@@ -12231,7 +12233,7 @@ impl SalsaActor {
                 file_path: class_file.map(PathBuf::from),
                 source_file: source_file.map(PathBuf::from),
                 source_line: Some(line as usize),
-                priority: 2, // Cache entries have highest priority (app level)
+                priority: 3, // Cache entries are app tier — the highest
             },
         );
     }
@@ -12263,7 +12265,7 @@ impl SalsaActor {
                 binding_type: bt,
                 source_file: source_file.map(PathBuf::from),
                 source_line: Some(line as usize),
-                priority: 2, // Cache entries have highest priority (app level)
+                priority: 3, // Cache entries are app tier — the highest
             },
         );
     }

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -6681,6 +6681,13 @@ pub enum SalsaRequest {
         files: Vec<PathBuf>,
         reply: oneshot::Sender<()>,
     },
+    /// Replace the configured module directories, in `modules.paths`
+    /// glob-match order. The registration merge reads their order as the
+    /// equal-priority tie-break rank.
+    SetModuleDirs {
+        dirs: Vec<PathBuf>,
+        reply: oneshot::Sender<()>,
+    },
     /// How many times the translation cache has touched disk
     LangDiskReads { reply: oneshot::Sender<usize> },
 
@@ -8050,6 +8057,23 @@ impl SalsaHandle {
             .map_err(|_| "Salsa actor dropped reply channel")
     }
 
+    /// Hand the actor the configured module directories in `modules.paths`
+    /// order, so the registration merge can break an equal-priority tie by
+    /// module rank instead of by provider path.
+    pub async fn set_module_dirs(&self, dirs: Vec<PathBuf>) -> Result<(), &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::SetModuleDirs {
+                dirs,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
     /// Drop everything derived from service providers after one changed.
     pub async fn invalidate_translation_providers(&self) -> Result<(), &'static str> {
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -8609,6 +8633,11 @@ pub struct SalsaActor {
     // === Salsa-based Service Provider Tracking (New) ===
     /// Service provider files registered with Salsa for incremental parsing
     salsa_sp_files: HashMap<PathBuf, ServiceProviderFile>,
+
+    /// Configured module directories in `modules.paths` glob-match order —
+    /// the rank the registration merge breaks equal-priority ties on. Empty
+    /// when the modular-monolith feature is off.
+    module_dirs: Vec<PathBuf>,
     /// Version counter for service provider files
     salsa_sp_version: i32,
     /// Project root for service provider resolution
@@ -8625,6 +8654,13 @@ const PATTERN_CACHE_INITIAL_CAPACITY: usize = 1024;
 /// covers files that appear afterwards without forcing an immediate rehash
 /// (a `composer update`, new app files created mid-session).
 const PATTERN_CACHE_CAPACITY_PADDING: usize = 1000;
+
+/// One provider registration's standing in the merge performed by
+/// [`SalsaActor::handle_get_laravel_config`]: its tier priority
+/// (`0=framework, 1=package, 2=module, 3=app`) and, for a module provider,
+/// its 1-based rank in `modules.paths` order (`0` = not a module provider).
+/// Ordered as a plain tuple, which IS the documented rule.
+type MergeRank = (u8, usize);
 
 impl SalsaActor {
     /// Spawn the actor on a dedicated thread and return a handle for communication
@@ -8707,6 +8743,7 @@ impl SalsaActor {
                 translations: TranslationCache::default(),
                 // Salsa-based service provider tracking
                 salsa_sp_files: HashMap::with_capacity(32),
+                module_dirs: Vec::new(),
                 salsa_sp_version: 0,
                 salsa_sp_root: None,
             };
@@ -9307,6 +9344,13 @@ impl SalsaActor {
                 }
                 SalsaRequest::SetTranslationProviderExtras { files, reply } => {
                     self.translations.set_extra_provider_files(files);
+                    let _ = reply.send(());
+                }
+                SalsaRequest::SetModuleDirs { dirs, reply } => {
+                    // The merge tie-break reads these, and the merged config
+                    // is memoized — a changed module list has to invalidate it.
+                    self.module_dirs = dirs;
+                    self.config_cache = None;
                     let _ = reply.send(());
                 }
                 SalsaRequest::LangDiskReads { reply } => {
@@ -10272,85 +10316,90 @@ impl SalsaActor {
             livewire_config,
         );
 
-        // Collect view namespaces from all parsed service providers.
-        // Both maps carry (priority, value) while merging — app > module >
-        // package > framework, last-wins on ties — and drop the priority
-        // once the winner is settled.
-        let mut view_namespaces: HashMap<String, (u8, PathBuf)> = HashMap::new();
-        let mut component_namespaces: HashMap<String, (u8, String)> = HashMap::new();
-        let mut anonymous_component_paths: HashMap<String, PathBuf> = HashMap::new();
-        let mut anonymous_component_namespaces: HashMap<String, String> = HashMap::new();
-        // tag → (priority, class file); higher priority (app > package >
-        // framework) wins since sp-file iteration order is arbitrary.
-        let mut class_component_files: HashMap<String, (u8, PathBuf)> = HashMap::new();
+        // THE MERGE RULE, for all five registries below: the highest
+        // [`MergeRank`] wins — tier priority first (the app boots last, so
+        // app > module > package > framework), then `modules.paths` rank, and
+        // a full tie goes to the later provider in the deterministic
+        // lexicographic order (last-wins). Every map carries its winner's
+        // rank while merging and drops it once the winner is settled; none of
+        // them restates the rule locally.
+        let mut view_namespaces: HashMap<String, (MergeRank, PathBuf)> = HashMap::new();
+        let mut component_namespaces: HashMap<String, (MergeRank, String)> = HashMap::new();
+        let mut anonymous_component_paths: HashMap<String, (MergeRank, PathBuf)> = HashMap::new();
+        let mut anonymous_component_namespaces: HashMap<String, (MergeRank, String)> =
+            HashMap::new();
+        let mut class_component_files: HashMap<String, (MergeRank, PathBuf)> = HashMap::new();
+
+        /// Does `candidate` take the key from the current holder? The single
+        /// comparison every merge below routes through, so the five registries
+        /// cannot drift into five rules again (#354 item 4).
+        fn wins(existing: Option<&MergeRank>, candidate: MergeRank) -> bool {
+            existing.is_none_or(|held| candidate >= *held)
+        }
 
         if let Some(sp_root) = self.salsa_sp_root.as_ref() {
             // Lexicographic provider order (`sorted_sp_files`) so the
-            // first-wins / priority tiebreaks below are deterministic (#255).
+            // last-wins tie-break below is deterministic (#255).
             for sp_file in self.sorted_sp_files() {
+                // `modules.paths` rank of the module that owns this provider,
+                // read through the one shared ownership lookup — a module's
+                // provider path sorts lexicographically, which is NOT the
+                // configured order the docs promise (#354 item 3).
+                let module_rank =
+                    crate::config::owning_module(&self.module_dirs, sp_file.path(&self.db))
+                        .map_or(0, |(rank, _)| rank);
                 let parsed = parse_service_provider_source(&self.db, sp_file, sp_root.clone());
 
-                // Collect view namespaces. Higher priority wins (the app
-                // boots last, so app > module > package); on EQUAL priority
-                // the later provider in the deterministic lexicographic
-                // order wins — matching the documented last-registered-wins
-                // rule and the translation-namespace merge.
                 for vn in parsed.view_namespaces(&self.db) {
                     let ns = vn.namespace(&self.db).namespace(&self.db).clone();
-                    let prio = vn.priority(&self.db);
+                    let rank = (vn.priority(&self.db), module_rank);
                     if let Some(path) = vn.view_path(&self.db).clone() {
-                        match view_namespaces.get(&ns) {
-                            Some((existing_prio, _)) if *existing_prio > prio => {}
-                            _ => {
-                                view_namespaces.insert(ns, (prio, path));
-                            }
+                        if wins(view_namespaces.get(&ns).map(|(r, _)| r), rank) {
+                            view_namespaces.insert(ns, (rank, path));
                         }
                     }
                 }
 
-                // Collect component namespaces — same precedence rule as the
-                // view namespaces above.
                 for cn in parsed.component_namespaces(&self.db) {
                     let prefix = cn.prefix(&self.db).namespace(&self.db).clone();
-                    let prio = cn.priority(&self.db);
-                    let php_ns = cn.php_namespace(&self.db).clone();
-                    match component_namespaces.get(&prefix) {
-                        Some((existing_prio, _)) if *existing_prio > prio => {}
-                        _ => {
-                            component_namespaces.insert(prefix, (prio, php_ns));
-                        }
+                    let rank = (cn.priority(&self.db), module_rank);
+                    if wins(component_namespaces.get(&prefix).map(|(r, _)| r), rank) {
+                        component_namespaces.insert(prefix, (rank, cn.php_namespace(&self.db).clone()));
                     }
                 }
 
-                // Collect anonymous component paths (Blade::anonymousComponentPath)
+                // Blade::anonymousComponentPath
                 for acp in parsed.anonymous_component_paths(&self.db) {
                     let prefix = acp.prefix(&self.db).namespace(&self.db).clone();
-                    let directory = acp.directory(&self.db).clone();
-                    anonymous_component_paths.entry(prefix).or_insert(directory);
+                    let rank = (acp.priority(&self.db), module_rank);
+                    if wins(anonymous_component_paths.get(&prefix).map(|(r, _)| r), rank) {
+                        anonymous_component_paths
+                            .insert(prefix, (rank, acp.directory(&self.db).clone()));
+                    }
                 }
 
-                // Collect anonymous component namespaces (Blade::anonymousComponentNamespace)
+                // Blade::anonymousComponentNamespace
                 for acn in parsed.anonymous_component_namespaces(&self.db) {
                     let prefix = acn.prefix(&self.db).namespace(&self.db).clone();
-                    let directory = acn.directory(&self.db).clone();
-                    anonymous_component_namespaces
-                        .entry(prefix)
-                        .or_insert(directory);
+                    let rank = (acn.priority(&self.db), module_rank);
+                    if wins(
+                        anonymous_component_namespaces.get(&prefix).map(|(r, _)| r),
+                        rank,
+                    ) {
+                        anonymous_component_namespaces
+                            .insert(prefix, (rank, acn.directory(&self.db).clone()));
+                    }
                 }
 
-                // Collect class-backed component registrations
-                // (Blade::component('tag', Class::class), either form/order)
+                // Blade::component('tag', Class::class), either form/order
                 for bc in parsed.blade_components(&self.db) {
                     let Some(file) = bc.file_path(&self.db).clone() else {
                         continue;
                     };
                     let tag = bc.tag_name(&self.db).name(&self.db).clone();
-                    let prio = bc.priority(&self.db);
-                    match class_component_files.get(&tag) {
-                        Some((existing_prio, _)) if *existing_prio >= prio => {}
-                        _ => {
-                            class_component_files.insert(tag, (prio, file));
-                        }
+                    let rank = (bc.priority(&self.db), module_rank);
+                    if wins(class_component_files.get(&tag).map(|(r, _)| r), rank) {
+                        class_component_files.insert(tag, (rank, file));
                     }
                 }
             }
@@ -10362,19 +10411,19 @@ impl SalsaActor {
             if let Some(path) = &data.view_path {
                 view_namespaces
                     .entry(ns.clone())
-                    .or_insert_with(|| (0, path.clone()));
+                    .or_insert_with(|| ((0, 0), path.clone()));
             }
         }
         for (prefix, data) in &self.sp_component_namespaces {
             component_namespaces
                 .entry(prefix.clone())
-                .or_insert_with(|| (0, data.php_namespace.clone()));
+                .or_insert_with(|| ((0, 0), data.php_namespace.clone()));
         }
         for (tag, data) in &self.sp_blade_components {
             if let Some(file) = &data.file_path {
                 class_component_files
                     .entry(tag.clone())
-                    .or_insert_with(|| (data.priority, file.clone()));
+                    .or_insert_with(|| ((data.priority, 0), file.clone()));
             }
         }
 
@@ -10387,7 +10436,7 @@ impl SalsaActor {
         // arrives transitively (Flux, Filament, MaryUI); the loader
         // self-gates on the config files existing.
         for (ns, dir) in crate::config::livewire_component_namespaces(&root) {
-            anonymous_component_paths.entry(ns).or_insert(dir);
+            anonymous_component_paths.entry(ns).or_insert(((0, 0), dir));
         }
 
         // Convert to data transfer type
@@ -10402,19 +10451,25 @@ impl SalsaActor {
             has_livewire: config_ref.has_livewire(&self.db),
             view_namespaces: view_namespaces
                 .into_iter()
-                .map(|(ns, (_prio, path))| (ns, path))
+                .map(|(ns, (_rank, path))| (ns, path))
                 .collect(),
             component_namespaces: component_namespaces
                 .into_iter()
-                .map(|(prefix, (_prio, php_ns))| (prefix, php_ns))
+                .map(|(prefix, (_rank, php_ns))| (prefix, php_ns))
                 .collect(),
-            anonymous_component_paths,
-            anonymous_component_namespaces,
+            anonymous_component_paths: anonymous_component_paths
+                .into_iter()
+                .map(|(prefix, (_rank, dir))| (prefix, dir))
+                .collect(),
+            anonymous_component_namespaces: anonymous_component_namespaces
+                .into_iter()
+                .map(|(prefix, (_rank, dir))| (prefix, dir))
+                .collect(),
             component_aliases,
             icon_aliases,
             class_component_files: class_component_files
                 .into_iter()
-                .map(|(tag, (_prio, file))| (tag, file))
+                .map(|(tag, (_rank, file))| (tag, file))
                 .collect(),
         };
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -5385,8 +5385,10 @@ pub fn component_candidate_paths(
     // Windows and a wasted `stat` on POSIX. Namespaced forms resolve via the
     // PSR-4 `componentNamespace` block below instead, so skip them here.
     if !name.contains(':') {
-        candidates
-            .push(crate::component_declaration_locator::conventional_class_file_path(name, config));
+        // A name that can't form a safe relative path yields no candidate.
+        candidates.extend(
+            crate::component_declaration_locator::conventional_class_file_path(name, config),
+        );
     }
 
     // Explicit class-backed registration: Blade::component('tag', Class::class)

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -3706,10 +3706,11 @@ class AppServiceProvider extends ServiceProvider {
 
 #[tokio::test]
 async fn snapshot_macros_priority_merges_vendor_and_app() {
-    // A package provider (priority 1) and an app provider (priority 2) both
+    // A package provider (priority 1) and an app provider (priority 3) both
     // register `Str::shared`; the app's site wins on key collision. The package
     // also ships `Str::pkgOnly`, which is resolvable on its own. This is the
-    // framework=0 < package=1 < app=2 merge the binding registry uses, applied to
+    // framework=0 < package=1 < module=2 < app=3 merge the binding registry uses,
+    // applied to
     // macros — vendor providers are already `ServiceProviderFile` Salsa inputs,
     // so the same plumbing covers them.
     use tempfile::TempDir;
@@ -3730,7 +3731,7 @@ class PkgServiceProvider extends ServiceProvider {
 }
 "#;
 
-    // App provider (priority 2): overrides `shared`.
+    // App provider (priority 3): overrides `shared`.
     let app = root.join("app/Providers/AppServiceProvider.php");
     let app_src = r#"<?php
 namespace App\Providers;
@@ -3753,7 +3754,7 @@ class AppServiceProvider extends ServiceProvider {
         .await
         .unwrap();
     handle
-        .register_service_provider_source(app.clone(), app_src.to_string(), 2, root.clone())
+        .register_service_provider_source(app.clone(), app_src.to_string(), 3, root.clone())
         .await
         .unwrap();
 

--- a/laravel-lsp/src/tests/module_livewire_namespaces.rs
+++ b/laravel-lsp/src/tests/module_livewire_namespaces.rs
@@ -14,16 +14,35 @@ use std::path::{Path, PathBuf};
 use tower_lsp::LspService;
 
 async fn backend_for(root: &Path) -> LaravelLanguageServer {
+    backend_with_patterns(root, vec!["app/*/*".to_string()]).await
+}
+
+async fn backend_with_patterns(root: &Path, patterns: Vec<String>) -> LaravelLanguageServer {
     let (service, _socket) = LspService::new(LaravelLanguageServer::new);
     let backend = service.inner().clone();
     *backend.root_path.write().await = Some(root.to_path_buf());
-    *backend.module_path_patterns.write().await = vec!["app/*/*".to_string()];
+    *backend.module_path_patterns.write().await = patterns;
     backend
 }
 
 /// A module registering `prefix` for its own `app/Livewire` directory.
 fn registering_module(root: &Path, parent: &str, name: &str, prefix: &str) -> PathBuf {
     let module = root.join(format!("app/{parent}/{name}"));
+    write_module(&module, parent, name, prefix, "__DIR__.'/../Livewire'");
+    module
+}
+
+/// Write one module — composer manifest, provider, `app/Livewire` — into
+/// `module`, wherever that directory lives. `class_path_expr` is the PHP
+/// expression the provider passes as `Livewire::addNamespace`'s third
+/// argument, so a test can aim a registration outside its own module.
+fn write_module(
+    module: &Path,
+    parent: &str,
+    name: &str,
+    prefix: &str,
+    class_path_expr: &str,
+) -> PathBuf {
     fs::create_dir_all(module.join("app/Providers")).unwrap();
     fs::create_dir_all(module.join("app/Livewire")).unwrap();
     fs::write(
@@ -51,14 +70,14 @@ class Registrar
 {{
     public function boot(): void
     {{
-        Livewire::addNamespace('{prefix}', 'App\\{parent}\\{name}\\Livewire', __DIR__.'/../Livewire');
+        Livewire::addNamespace('{prefix}', 'App\\{parent}\\{name}\\Livewire', {class_path_expr});
     }}
 }}
 "#
         ),
     )
     .unwrap();
-    module
+    module.to_path_buf()
 }
 
 async fn resolved_class_namespace(
@@ -160,5 +179,136 @@ class Registrar
             .await
             .is_none(),
         "an out-of-root class path yields no registration"
+    );
+}
+
+// ---- containment: the owning module, not the project root (#354 item 1) ----
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlinked_path_repo_module_keeps_its_livewire_registration() {
+    // A composer path repository symlinked into the module tree canonicalizes
+    // OUTSIDE the project root, so gating the canonical class path against
+    // the root dropped the registration silently. `expand_module_dirs`
+    // deliberately admits this layout; the Livewire gate has to agree.
+    //
+    // The in-root module is the control: same builder, same provider shape,
+    // the ONLY difference is that one module dir is a symlink. It resolving
+    // while the symlinked one does not is what isolates the gate as the cause.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().join("proj");
+
+    let real = tmp.path().join("packages/ui-kit");
+    write_module(&real, "Common", "UiKit", "ui-kit", "__DIR__.'/../Livewire'");
+    fs::create_dir_all(root.join("app/Common")).unwrap();
+    std::os::unix::fs::symlink(&real, root.join("app/Common/UiKit")).unwrap();
+
+    write_module(
+        &root.join("app/Common/InRoot"),
+        "Common",
+        "InRoot",
+        "in-root",
+        "__DIR__.'/../Livewire'",
+    );
+
+    let backend = backend_with_patterns(&root, vec!["app/Common/*".to_string()]).await;
+    assert_eq!(
+        resolved_class_namespace(&backend, &root, "in-root")
+            .await
+            .as_deref(),
+        Some("App\\Common\\InRoot\\Livewire"),
+        "control: an in-root module registers"
+    );
+    assert_eq!(
+        resolved_class_namespace(&backend, &root, "ui-kit")
+            .await
+            .as_deref(),
+        Some("App\\Common\\UiKit\\Livewire"),
+        "a symlinked composer path-repo module keeps its registration too"
+    );
+}
+
+#[tokio::test]
+async fn module_class_path_reaching_outside_its_own_module_is_dropped() {
+    // The other half of gating against the owning module: a module provider
+    // whose class path lands INSIDE the project root but outside its own
+    // module is not registering its own components. Dropping it is what
+    // proves ownership is genuinely resolved and consulted — a gate stubbed
+    // to always fall back to the root would admit this.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    write_module(
+        &root.join("app/Legal/Owner"),
+        "Legal",
+        "Owner",
+        "own-ui",
+        "__DIR__.'/../Livewire'",
+    );
+    write_module(
+        &root.join("app/Legal/Reacher"),
+        "Legal",
+        "Reacher",
+        "reach-ui",
+        "__DIR__.'/../../../Owner/app/Livewire'",
+    );
+
+    let backend = backend_for(root).await;
+    assert_eq!(
+        resolved_class_namespace(&backend, root, "own-ui")
+            .await
+            .as_deref(),
+        Some("App\\Legal\\Owner\\Livewire"),
+        "control: a module registering its OWN directory still resolves"
+    );
+    assert!(
+        resolved_class_namespace(&backend, root, "reach-ui")
+            .await
+            .is_none(),
+        "a sibling module's directory is in-root but outside the owning module"
+    );
+}
+
+#[tokio::test]
+async fn app_provider_class_path_is_still_gated_by_the_project_root() {
+    // An app provider has no owning module, so the gate falls back to the
+    // root exactly as before — the escape case must not have been widened.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    fs::create_dir_all(root.join("app/Providers")).unwrap();
+    fs::create_dir_all(root.join("app/Livewire")).unwrap();
+    fs::create_dir_all(tmp.path().join("outside")).unwrap();
+    fs::write(
+        root.join("app/Providers/AppServiceProvider.php"),
+        r#"<?php
+
+namespace App\Providers;
+
+use Livewire\Livewire;
+
+class AppServiceProvider
+{
+    public function boot(): void
+    {
+        Livewire::addNamespace('app-ui', 'App\\Livewire', __DIR__.'/../Livewire');
+        Livewire::addNamespace('escape-ui', 'App\\Escape', __DIR__.'/../../../outside');
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let backend = backend_for(&root).await;
+    assert_eq!(
+        resolved_class_namespace(&backend, &root, "app-ui")
+            .await
+            .as_deref(),
+        Some("App\\Livewire"),
+        "control: the app's own in-root registration resolves"
+    );
+    assert!(
+        resolved_class_namespace(&backend, &root, "escape-ui")
+            .await
+            .is_none(),
+        "an app provider reaching outside the root yields no registration"
     );
 }

--- a/laravel-lsp/src/tests/module_livewire_namespaces.rs
+++ b/laravel-lsp/src/tests/module_livewire_namespaces.rs
@@ -94,18 +94,29 @@ async fn resolved_class_namespace(
 
 #[tokio::test]
 async fn later_module_livewire_namespace_wins_over_an_earlier_one() {
+    // Three modules listed Alpha, Gamma, Beta — so the winner (Beta) is
+    // neither the lexicographically first nor the last of the three. The
+    // previous two-module fixture used one `app/*/*` glob, which made
+    // configured order and path-sort order coincide: it passed under either
+    // rule and could not tell them apart (#354 item 3).
     let tmp = tempfile::TempDir::new().unwrap();
     let root = tmp.path();
-    registering_module(root, "Legal", "Alpha", "shared-ui");
-    registering_module(root, "Legal", "Beta", "shared-ui");
+    let order = ["Alpha", "Gamma", "Beta"];
+    for name in order {
+        registering_module(root, "Legal", name, "shared-ui");
+    }
 
-    let backend = backend_for(root).await;
+    let backend = backend_with_patterns(
+        root,
+        order.iter().map(|n| format!("app/Legal/{n}")).collect(),
+    )
+    .await;
     assert_eq!(
         resolved_class_namespace(&backend, root, "shared-ui")
             .await
             .as_deref(),
         Some("App\\Legal\\Beta\\Livewire"),
-        "the later module (higher modules.paths precedence) wins"
+        "the last module in modules.paths order wins — not the last by path sort"
     );
 }
 

--- a/laravel-lsp/src/tests/module_livewire_namespaces.rs
+++ b/laravel-lsp/src/tests/module_livewire_namespaces.rs
@@ -323,3 +323,51 @@ class AppServiceProvider
         "an app provider reaching outside the root yields no registration"
     );
 }
+
+#[tokio::test]
+async fn an_app_provider_keeps_its_registration_when_modules_paths_covers_app_providers() {
+    // Regression: the gate used to re-derive a provider's owning module by
+    // PATH PREFIX. `modules.paths` patterns are user-written, and the
+    // settings doc itself offers `app/*/*` — so `app/*` is a shape people
+    // write. It expands to include `app/Providers`, which made an APP
+    // provider look like a module provider and gated its registrations
+    // against `app/Providers`. The result: the most ordinary registration
+    // there is — `__DIR__.'/../Livewire'`, i.e. `app/Livewire` — fell
+    // outside its own "module" and was dropped, silently, with no
+    // diagnostic and no log. Provenance now comes from the discovery that
+    // found the provider, so an app provider is never gated by a module.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    fs::create_dir_all(root.join("app/Providers")).unwrap();
+    fs::create_dir_all(root.join("app/Livewire")).unwrap();
+    fs::create_dir_all(root.join("app/Models")).unwrap();
+    fs::write(
+        root.join("app/Providers/AppServiceProvider.php"),
+        r#"<?php
+
+namespace App\Providers;
+
+use Livewire\Livewire;
+
+class AppServiceProvider
+{
+    public function boot(): void
+    {
+        Livewire::addNamespace('app-ui', 'App\\Livewire', __DIR__.'/../Livewire');
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    // `app/*` sweeps `app/Providers` in as if it were a module.
+    let backend = backend_with_patterns(&root, vec!["app/*".to_string()]).await;
+    assert_eq!(
+        resolved_class_namespace(&backend, &root, "app-ui")
+            .await
+            .as_deref(),
+        Some("App\\Livewire"),
+        "an app provider is gated by the ROOT even when a modules.paths glob \
+         happens to cover app/Providers"
+    );
+}

--- a/laravel-lsp/src/tests/module_view_namespaces.rs
+++ b/laravel-lsp/src/tests/module_view_namespaces.rs
@@ -8,15 +8,20 @@
 //! so resolution succeeding proves the module-provider path did it.
 
 use crate::LaravelLanguageServer;
+use laravel_lsp::salsa_impl::LaravelConfigData;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tower_lsp::LspService;
 
 async fn backend_for(root: &Path) -> LaravelLanguageServer {
+    backend_with_patterns(root, vec!["app/*/*".to_string()]).await
+}
+
+async fn backend_with_patterns(root: &Path, patterns: Vec<String>) -> LaravelLanguageServer {
     let (service, _socket) = LspService::new(LaravelLanguageServer::new);
     let backend = service.inner().clone();
     *backend.root_path.write().await = Some(root.to_path_buf());
-    *backend.module_path_patterns.write().await = vec!["app/*/*".to_string()];
+    *backend.module_path_patterns.write().await = patterns;
     backend
 }
 
@@ -330,23 +335,244 @@ class AppServiceProvider
     );
 }
 
+/// Three modules, all claiming one key, listed in `modules.paths` as
+/// Alpha, Gamma, Beta. The winner is therefore **Beta** — and Beta is
+/// neither the lexicographically first nor the last of the three, so
+/// neither the old lexicographic provider sort nor a "just reverse the
+/// sort" shortcut can produce it. Only a real `modules.paths` rank lookup
+/// picks Beta.
+const DISCRIMINATING_ORDER: [&str; 3] = ["Alpha", "Gamma", "Beta"];
+
+fn discriminating_patterns() -> Vec<String> {
+    DISCRIMINATING_ORDER
+        .iter()
+        .map(|name| format!("app/Legal/{name}"))
+        .collect()
+}
+
 #[tokio::test]
 async fn later_module_view_namespace_wins_over_an_earlier_one() {
-    // Two modules claiming one namespace: the LAST-registered (higher
-    // `modules.paths` precedence) wins, matching the documented rule and
-    // the translation-namespace merge.
+    // Three modules claiming one namespace: the one listed LAST in
+    // `modules.paths` wins, matching the documented rule and the
+    // translation-namespace merge. The previous two-module fixture used a
+    // single `app/*/*` glob, which made lexicographic provider order and
+    // configured order coincide — it passed under either rule and so
+    // certified the wrong one (#354 item 3).
     let tmp = tempfile::TempDir::new().unwrap();
     let root = tmp.path();
-    registering_module(root, "Legal", "Alpha", "shared-ns");
-    let beta = registering_module(root, "Legal", "Beta", "shared-ns");
+    for name in DISCRIMINATING_ORDER {
+        registering_module(root, "Legal", name, "shared-ns");
+    }
+    let winner = root.join("app/Legal/Beta");
 
-    let backend = backend_for(root).await;
+    let backend = backend_with_patterns(root, discriminating_patterns()).await;
     let dir = view_namespace_dir_named(&backend, root, "shared-ns")
         .await
         .expect("shared-ns registered");
     assert_eq!(
         dir.canonicalize().unwrap(),
-        beta.join("resources/views").canonicalize().unwrap(),
-        "the later module wins"
+        winner.join("resources/views").canonicalize().unwrap(),
+        "the last module in modules.paths order wins — not the last by path sort"
     );
+}
+
+// ---- one tie-break rule across all five registries (#354 items 2 and 4) ----
+
+/// A module registering the SAME key in all five provider-registration
+/// registries the config merge builds, so one fixture can prove they resolve
+/// a collision identically. The class-backed component's target file is
+/// written where `App\` → `app/` resolution looks for it.
+fn module_registering_everything(root: &Path, name: &str) -> PathBuf {
+    let module = root.join(format!("app/Legal/{name}"));
+    fs::create_dir_all(module.join("app/Providers")).unwrap();
+    fs::create_dir_all(module.join("resources/views/components")).unwrap();
+    fs::create_dir_all(module.join("View/Components")).unwrap();
+    fs::write(module.join("View/Components/Card.php"), "<?php class Card {}").unwrap();
+    fs::write(
+        module.join("composer.json"),
+        format!(
+            r#"{{
+    "autoload": {{ "psr-4": {{ "App\\Legal\\{name}\\": "app/" }} }},
+    "extra": {{ "laravel": {{ "providers": [
+        "App\\Legal\\{name}\\Providers\\Registrar"
+    ] }} }}
+}}"#
+        ),
+    )
+    .unwrap();
+    fs::write(
+        module.join("app/Providers/Registrar.php"),
+        format!(
+            r#"<?php
+
+namespace App\Legal\{name}\Providers;
+
+use Illuminate\Support\Facades\Blade;
+
+class Registrar
+{{
+    public function boot(): void
+    {{
+        $this->loadViewsFrom(__DIR__.'/../../resources/views', 'shared-ns');
+        Blade::componentNamespace('App\\Legal\\{name}\\View\\Components', 'shared-ns');
+        Blade::anonymousComponentPath(__DIR__.'/../../resources/views/components', 'shared-ns');
+        Blade::anonymousComponentNamespace('components.{name}', 'shared-ns');
+        Blade::component('shared-tag', \App\Legal\{name}\View\Components\Card::class);
+    }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+    module
+}
+
+async fn config_for(backend: &LaravelLanguageServer, root: &Path) -> LaravelConfigData {
+    backend
+        .salsa
+        .register_config_files(root.to_path_buf(), None, None, None)
+        .await
+        .expect("salsa actor accepts config root");
+    backend
+        .register_service_provider_files_with_salsa(root)
+        .await;
+    backend
+        .salsa
+        .get_laravel_config()
+        .await
+        .ok()
+        .flatten()
+        .expect("salsa config")
+}
+
+/// The five registries, each reduced to the name of the module that won
+/// `shared-ns` / `shared-tag`. `None` means the key never registered.
+fn winners(config: &LaravelConfigData) -> Vec<(&'static str, Option<String>)> {
+    fn module_of(path: &Path) -> Option<String> {
+        path.components()
+            .map(|c| c.as_os_str().to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+            .windows(2)
+            .find(|w| w[0] == "Legal")
+            .map(|w| w[1].clone())
+    }
+    vec![
+        (
+            "view_namespaces",
+            config.view_namespaces.get("shared-ns").and_then(|p| module_of(p)),
+        ),
+        (
+            "component_namespaces",
+            config
+                .component_namespaces
+                .get("shared-ns")
+                // The extractor stores the literal PHP text, so the
+                // separators are still escaped (`App\\Legal\\Beta\\…`).
+                .and_then(|ns| {
+                    ns.split('\\')
+                        .filter(|seg| !seg.is_empty())
+                        .nth(2)
+                        .map(str::to_string)
+                }),
+        ),
+        (
+            "anonymous_component_paths",
+            config
+                .anonymous_component_paths
+                .get("shared-ns")
+                .and_then(|p| module_of(p)),
+        ),
+        (
+            "anonymous_component_namespaces",
+            config
+                .anonymous_component_namespaces
+                .get("shared-ns")
+                .and_then(|d| d.rsplit('/').next().map(str::to_string)),
+        ),
+        (
+            "class_component_files",
+            config
+                .class_component_files
+                .get("shared-tag")
+                .and_then(|p| module_of(p)),
+        ),
+    ]
+}
+
+#[tokio::test]
+async fn every_registry_breaks_an_equal_priority_tie_the_same_way() {
+    // Item 4: four registries used to run three different tie-break rules —
+    // last-wins, first-wins, and priority ignored entirely. One collision,
+    // constructed once, must now resolve to the same module in all five.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    for name in DISCRIMINATING_ORDER {
+        module_registering_everything(root, name);
+    }
+
+    let backend = backend_with_patterns(root, discriminating_patterns()).await;
+    let config = config_for(&backend, root).await;
+
+    for (registry, winner) in winners(&config) {
+        assert_eq!(
+            winner.as_deref(),
+            Some("Beta"),
+            "{registry}: the last module in modules.paths order wins, like every other registry"
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_app_registration_beats_a_module_in_every_registry() {
+    // Item 2: the anonymous-component maps ignored priority entirely, so a
+    // module's registration beat the app's whenever the module provider
+    // sorted first — which it always does under `app/Legal/…` vs
+    // `app/Providers/…`. docs/configuration.md promises the opposite.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    module_registering_everything(root, "Alpha");
+
+    fs::create_dir_all(root.join("app/Providers")).unwrap();
+    fs::create_dir_all(root.join("resources/views/components")).unwrap();
+    fs::create_dir_all(root.join("app/Legal/AppOwned/View/Components")).unwrap();
+    fs::write(
+        root.join("app/Legal/AppOwned/View/Components/Card.php"),
+        "<?php class Card {}",
+    )
+    .unwrap();
+    fs::write(
+        root.join("app/Providers/AppServiceProvider.php"),
+        r#"<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Blade;
+
+class AppServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadViewsFrom(__DIR__.'/../../app/Legal/AppOwned/resources/views', 'shared-ns');
+        Blade::componentNamespace('App\\Legal\\AppOwned\\View\\Components', 'shared-ns');
+        Blade::anonymousComponentPath(__DIR__.'/../../app/Legal/AppOwned/components', 'shared-ns');
+        Blade::anonymousComponentNamespace('components.AppOwned', 'shared-ns');
+        Blade::component('shared-tag', \App\Legal\AppOwned\View\Components\Card::class);
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    // Only Alpha is a module; `app/Legal/AppOwned` is plain app code the
+    // app provider points at, so the app tier is the one under test.
+    let backend = backend_with_patterns(root, vec!["app/Legal/Alpha".to_string()]).await;
+    let config = config_for(&backend, root).await;
+
+    for (registry, winner) in winners(&config) {
+        assert_eq!(
+            winner.as_deref(),
+            Some("AppOwned"),
+            "{registry}: the app boots last, so its registration wins over the module's"
+        );
+    }
 }

--- a/laravel-lsp/src/tests/module_view_namespaces.rs
+++ b/laravel-lsp/src/tests/module_view_namespaces.rs
@@ -387,7 +387,11 @@ fn module_registering_everything(root: &Path, name: &str) -> PathBuf {
     fs::create_dir_all(module.join("app/Providers")).unwrap();
     fs::create_dir_all(module.join("resources/views/components")).unwrap();
     fs::create_dir_all(module.join("View/Components")).unwrap();
-    fs::write(module.join("View/Components/Card.php"), "<?php class Card {}").unwrap();
+    fs::write(
+        module.join("View/Components/Card.php"),
+        "<?php class Card {}",
+    )
+    .unwrap();
     fs::write(
         module.join("composer.json"),
         format!(
@@ -459,7 +463,10 @@ fn winners(config: &LaravelConfigData) -> Vec<(&'static str, Option<String>)> {
     vec![
         (
             "view_namespaces",
-            config.view_namespaces.get("shared-ns").and_then(|p| module_of(p)),
+            config
+                .view_namespaces
+                .get("shared-ns")
+                .and_then(|p| module_of(p)),
         ),
         (
             "component_namespaces",

--- a/laravel-lsp/src/tests/rename_integration.rs
+++ b/laravel-lsp/src/tests/rename_integration.rs
@@ -205,7 +205,10 @@ fn component_rename_class_based_locates_both_files() {
         root.join("resources/views/components/alert-button.blade.php")
     );
     let new_class = conventional_class_file_path("alert-button", &config);
-    assert_eq!(new_class, root.join("app/View/Components/AlertButton.php"));
+    assert_eq!(
+        new_class,
+        Some(root.join("app/View/Components/AlertButton.php"))
+    );
 }
 
 #[test]

--- a/laravel-lsp/src/tests/watched_files_magic.rs
+++ b/laravel-lsp/src/tests/watched_files_magic.rs
@@ -1236,3 +1236,48 @@ async fn app_file_open_does_not_trigger_vendor_refresh() {
         "an app open must not occupy a vendor-LRU slot"
     );
 }
+
+/// A provider changing ON DISK must drop the cached Livewire class-namespace
+/// map, not just the vendor translation namespaces.
+///
+/// The map's registrations are gated on the class DIRECTORY existing, so a
+/// registration that failed that gate at index time stayed failed for the rest
+/// of the session. `artisan module:make-livewire Counter Blog` creates the
+/// first component — and `Livewire/` with it — through the watcher, never the
+/// editor, so `<livewire:blog::counter>` stayed dead until the user happened
+/// to edit a provider in the editor or restarted the server. Same for a
+/// `git pull` or a branch switch that adds a provider.
+#[tokio::test]
+async fn a_watched_provider_change_drops_the_cached_livewire_config() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::write(root.join("composer.json"), COMPOSER).unwrap();
+    let backend = backend_for(root).await;
+
+    let provider = write_file(
+        root,
+        "app/Providers/AppServiceProvider.php",
+        "<?php\nnamespace App\\Providers;\nclass AppServiceProvider {}\n",
+    );
+
+    // Prime the cache the way `get_cached_livewire` does.
+    *backend.cached_livewire.write().await = Some((
+        root.to_path_buf(),
+        laravel_lsp::livewire_config::LivewireConfig::defaults(root),
+        laravel_lsp::livewire_version::LivewireVersion::V3,
+    ));
+    assert!(
+        backend.cached_livewire.read().await.is_some(),
+        "precondition: the cache is primed"
+    );
+
+    backend
+        .did_change_watched_files(watched(&provider, FileChangeType::CHANGED))
+        .await;
+    drain_batch(&backend).await;
+
+    assert!(
+        backend.cached_livewire.read().await.is_none(),
+        "a provider change on disk must invalidate the Livewire namespace map"
+    );
+}

--- a/laravel-lsp/tests/integration_tests.rs
+++ b/laravel-lsp/tests/integration_tests.rs
@@ -1332,18 +1332,31 @@ mod env_parsing {
 
 mod priority_merging {
 
-    /// Test that priority ordering is documented and followed
-    /// Priority: app (2) > package (1) > framework (0)
+    /// The service-provider tier scale, as a readable anchor:
+    /// app (3) > module (2) > package (1) > framework (0).
+    ///
+    /// This is a documentation test — the constants are local, so it records
+    /// the order rather than observing it. The order is *enforced* against the
+    /// real merge elsewhere: `module_view_namespaces` and
+    /// `module_livewire_namespaces` pin app-over-module and module-vs-module
+    /// with discriminating fixtures, and the former's
+    /// `every_registry_breaks_an_equal_priority_tie_the_same_way` pins the
+    /// shared tie-break across all five registries. Keep the numbers here in
+    /// step with `register_service_provider_files_with_salsa`.
     #[test]
     fn test_priority_ordering_constants() {
-        // Document the expected priority values
         const FRAMEWORK_PRIORITY: u8 = 0;
         const PACKAGE_PRIORITY: u8 = 1;
-        const APP_PRIORITY: u8 = 2;
+        const MODULE_PRIORITY: u8 = 2;
+        const APP_PRIORITY: u8 = 3;
 
         const _: () = assert!(
-            APP_PRIORITY > PACKAGE_PRIORITY,
-            "App should have higher priority than package"
+            APP_PRIORITY > MODULE_PRIORITY,
+            "App should have higher priority than module"
+        );
+        const _: () = assert!(
+            MODULE_PRIORITY > PACKAGE_PRIORITY,
+            "Module should have higher priority than package"
         );
         const _: () = assert!(
             PACKAGE_PRIORITY > FRAMEWORK_PRIORITY,

--- a/laravel-lsp/tests/integration_tests.rs
+++ b/laravel-lsp/tests/integration_tests.rs
@@ -1383,12 +1383,26 @@ mod priority_merging {
         assert!(env_priority(".env.local") > env_priority(".env.example"));
     }
 
-    /// Test that service provider locations map to correct priorities
+    /// The path-classifiable half of the tier scale: app (3) > package (1) >
+    /// framework (0), keyed the way `register_service_provider_files_with_salsa`
+    /// keys them.
+    ///
+    /// Module providers (2) are deliberately absent: no path substring
+    /// identifies one. They are discovered from the `modules.paths` globs plus
+    /// each module's composer `extra.laravel.providers`, via
+    /// `config::module_provider_files` — so a `contains("modules/")` branch here
+    /// would encode a rule the real classifier does not implement.
+    ///
+    /// Like `test_priority_ordering_constants` above, this is a documentation
+    /// test — the mapping is local, so it records the classification rather than
+    /// observing it. The module tier is enforced against the real merge by
+    /// `module_view_namespaces` and `module_livewire_namespaces`. Keep the
+    /// numbers here in step with `register_service_provider_files_with_salsa`.
     #[test]
     fn test_service_provider_priority_by_location() {
         fn provider_priority(path: &str) -> u8 {
             if path.contains("app/Providers") {
-                2 // App providers
+                3 // App providers
             } else if path.contains("vendor") && !path.contains("laravel/framework") {
                 1 // Package providers
             } else {
@@ -1396,7 +1410,7 @@ mod priority_merging {
             }
         }
 
-        assert_eq!(provider_priority("app/Providers/AppServiceProvider.php"), 2);
+        assert_eq!(provider_priority("app/Providers/AppServiceProvider.php"), 3);
         assert_eq!(
             provider_priority("vendor/some-package/src/ServiceProvider.php"),
             1


### PR DESCRIPTION
## Summary
Implements #354 — the seven precedence and containment follow-ups from the round-three review sweep of #336.

**Items 1–3 are behavioural and release-blocking** per the issue. **Items 4–7 are cleanup** surfaced by the same sweep. They ship together because 1, 2 and 3 are one mistake three times: a precedence or containment rule re-implemented away from the helper that owns it.

## Changes
- **Shared lookup** — `config::owning_module` answers "which configured module owns this file, and where does it sit in `modules.paths` order". Item 1 and item 3 both need exactly that, so they read one implementation instead of two path-prefix copies.
- **Item 1** — the Livewire containment gate no longer canonicalizes-then-checks against the project root. It gates lexically against the provider's owning module (what `resolve_provider_class_file` already does), falling back to the root for app providers. A symlinked composer path-repo module keeps its registrations; a module reaching into a sibling module loses them.
- **Item 2** — `anonymous_component_paths` / `anonymous_component_namespaces` stop ignoring priority.
- **Item 3** — equal-priority ties break on `modules.paths` rank, not lexicographic provider path. The Salsa actor now holds the configured module directories.
- **Item 4** — all five registries route through one `wins()` comparison on one `MergeRank` (priority → `modules.paths` rank → last-wins), stated once above the loop. `class_component_files` flips from first-wins to match.
- **Item 5** — swept the crate for the stale pre-#336 order, not just the three sites the issue named. Re-swept on the *semantic* claim after round 1 (see below); two prose-form sites were hiding from the literal patterns.
- **Item 6** — cached middleware/binding entries move from the module tier to the app tier.
- **Item 7** — the PSR-4 traversal case now reaches its decoy.
- **Docs** — `docs/configuration.md` and `CLAUDE.md` updated to match the new containment and tie-break rules.

## Acceptance Criteria
- [x] **Item 1** — module-scoped lexical gate; two regression tests (symlinked path-repo module keeps its registration, with an in-root control; a within-root/outside-own-module class path is dropped). A third pins that app providers are still root-gated.
- [x] **Shared module-ownership lookup** — one `owning_module` consumed by the Livewire gate and the Salsa tie-break.
- [x] **Item 2** — both anonymous maps are priority-aware; app-over-module and module-vs-module both pinned.
- [x] **Item 3** — both "later module wins" tests rewritten; new `component_namespaces` coverage.
- [x] **Item 4** — one direction, one key, one shared comparison, one comment; one parametrized test across all five maps.
- [x] **Item 5** — swept on the claim, not the spelling: `priority[ :=]+2`, `2=app`/`app=2`, and a tier-word-next-to-a-digit pattern, over the whole tree including `tests/` and `docs/`. Every surviving hit is classified in the round-2 note below.
- [x] **Item 6** — both literals are `3`, comments corrected.
- [x] **Item 7** — four levels of `../`; the absolute-path case is unchanged.
- [x] **Suite green, no skips** — 3413 tests pass under plain `cargo test`; no `#[ignore]`. `cargo clippy --all-targets` and `cargo fmt --check` clean.
- [x] **PR notes which items are behavioural vs cleanup** — above.

### Two judgement calls worth your attention
1. **Item 3's fixture is stronger than the AC's example.** The AC suggested modules listed Beta, Gamma, Alpha — but there the correct winner (Alpha) is also what a "reverse the sort" shortcut produces. I used **Alpha, Gamma, Beta**, so the winner (Beta) is neither first nor last by name and neither sort direction can produce it.
2. **Item 5 has two sites I did not renumber.** `command_index` and `member_resolver::impl_priority` each run their own path-derived 0/1/2 scale that has nothing to do with service-provider tiers; renumbering them to `app=3` would have made the prose wrong about the code. What was stale there was the claim to be *following the service-provider convention*, so that is what I corrected. Say the word if you would rather they carried the four-tier numbers anyway.

## Test Plan
- [x] All existing tests pass (3413 total, up from the 3332 baseline at `78c5012`)
- [x] New tests cover the changes — every new test mutation-verified: the pre-#354 gate, a stubbed ownership lookup, a dropped `modules.paths` rank, a restored `or_insert`, a deleted PSR-4 gate, and three mutations of `owning_module` itself each turn the relevant test red
- [x] `cargo clippy --all-targets` and `cargo fmt --check` clean

Fixes #354

---

## Round 2 — item 5 re-swept on the semantic claim

Round 1 was right about the trap: `app=2` / `2=app` / `App=2` cannot see a tier claim written as prose. Re-swept on the claim itself and found **two** stale sites, not one.

- **`laravel-lsp/src/salsa_impl.rs:3563`** (the one you named) — the macro/mixin walk's coverage-boundaries doc carried the pre-#336 three-tier order, four lines above a cross-reference to `build_macro_registry`, whose docstring was already corrected. Now names all four tiers; "the last two" still points at the vendor-scanned pair.
- **`laravel-lsp/tests/integration_tests.rs:1336`** (not named, found by the re-sweep) — `mod priority_merging` both documented *and encoded* `app (2) > package (1) > framework (0)`: no module tier, and `APP_PRIORITY = 2`, which is now the module value. A stale tier oracle living in the test tree, which a `src/`-scoped sweep is structurally blind to.

That second one is a documentation test — its constants are local, so it records the order rather than observing it. I did not convert it into a behavioural test: app-over-module, module-vs-module and the shared tie-break are already pinned discriminatingly by `module_view_namespaces`, `module_livewire_namespaces`, and `every_registry_breaks_an_equal_priority_tie_the_same_way`. Duplicating that here would add a second oracle to keep in step, which is the defect being fixed. Its doc now states the limitation and points at the tests that do enforce the order. The new module assertion is mutation-verified: swapping the app and module constants fails the build with `App should have higher priority than module`.

**Surviving `priority 2` hits, each checked and deliberately left:**

| Site | Why it stays |
|---|---|
| `main.rs:6301`, `:6778` | "Priority 2: Module providers" — correct post-#336 |
| `salsa_impl.rs:11945`, `:11951` | the env scale (`0=.env.example, 1=.env.local, 2=.env`), unrelated to provider tiers |
| `tests/env_value_redaction.rs:93`, `tests/env_completion_system_leak.rs:123` | same env scale — as you noted, renumbering would make them wrong |
| `command_index.rs:62` | its own path-derived three-tier scale, which already disclaims the four-tier one in prose |
| `route_discovery.rs:68-70` | an independent route-name scale; claims no parity with provider tiers |
| `salsa_impl/tests.rs:933`, `:984`, `tests/watched_files_magic.rs:100` | `BindingRegistrationData` fixture literals; they assert no tier semantics and binding priority is never read |

Suite still green: 3413 tests, 0 failed, 0 ignored. `cargo clippy --all-targets` and `cargo fmt --check` clean.
