### PR TITLE
Component-member navigation: follow-ups from #335

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ The LSP uses a dedicated thread for Salsa incremental computation to avoid lifet
 | Project Files | `ProjectFiles` | `ViewReferenceLocationData` | Reference finding across project |
 | Service Providers | `ServiceProviderFile` | `MiddlewareRegistrationData`, `BindingRegistrationData` | Middleware/binding lookups |
 | Env Variables | `EnvFile` | `EnvVariableData` | Environment variable lookups |
+| Render Index | `RenderIndex` | `BladeBackingResolutionData` | Blade backing-class resolution (which PHP class backs a template) |
 | Translations | `LangFile`, `LangDir` | `ResolvedTranslationData` | Translation key resolution + locale discovery |
 
 ### Important Conventions

--- a/docs/autocomplete.md
+++ b/docs/autocomplete.md
@@ -176,7 +176,7 @@ Inside a `wire:*="…"` value, completion offers the backing component's members
 - **Data bindings** (`wire:model` with any modifiers, `wire:show`, `wire:text`) offer public, non-static **properties**. Dotted paths complete segment by segment: each leading segment resolves to its declared class, and that class's properties are offered — at any depth while the types stay resolvable.
 - Values that are already a JS expression (`$wire.count++`, `open = true`) get no member completion, so nothing conflicts with Alpine.
 
-`$` completion in the template body offers the same public, non-static property surface, merged (and de-duplicated) with the view-data variables below — properties declared only on framework base classes are not offered. Trait- and parent-provided members are a known limitation: only members declared in the component's own class (or SFC/Volt front matter) appear.
+`$` completion in the template body offers the same public, non-static property surface, merged (and de-duplicated) with the view-data variables below — properties declared only on framework base classes are not offered. Members the component's own class declares appear, plus those of any trait it `use`s **in the same file** (transitively — a trait's own `use` clauses count). Traits declared in another file, and parent-class members, are a known limitation: they do not appear.
 
 ## 🔄 Loop Variables (Scope-Aware)
 

--- a/docs/autocomplete.md
+++ b/docs/autocomplete.md
@@ -173,6 +173,7 @@ Inside a `wire:*="…"` value, completion offers the backing component's members
 ```
 
 - **Action bindings** (`wire:click`, `wire:submit`, any DOM-event directive) offer public, non-static **methods** — excluding the lifecycle surface (`mount`, `boot`, `booted`, `hydrate`, `dehydrate`, `rendering`, `rendered`, `exception`) and the per-property `updatedFoo`/`updatingFoo` hook families. Dotted values are rejected for actions.
+- **Loading targets** (`wire:target`) name either kind, so both methods and properties are offered in one list. The value is a comma-separated list, and the entry under the cursor is the one resolved.
 - **Data bindings** (`wire:model` with any modifiers, `wire:show`, `wire:text`) offer public, non-static **properties**. Dotted paths complete segment by segment: each leading segment resolves to its declared class, and that class's properties are offered — at any depth while the types stay resolvable.
 - Values that are already a JS expression (`$wire.count++`, `open = true`) get no member completion, so nothing conflicts with Alpine.
 

--- a/docs/go-to-definition.md
+++ b/docs/go-to-definition.md
@@ -122,7 +122,7 @@ Two escape hatches cover what the heuristic can't infer — a directive that tak
 
 Names with dedicated handling (`@component`, `@livewire`, `@feature`, `@includeFirst`, `@extends`, `@include`, `@includeIf`, `@each`, `@includeWhen`, `@includeUnless`) ignore both lists — their own resolution always wins. See [Configuration](configuration.md).
 
-**Component members in Blade** — inside a template backed by a component class (a Livewire component in any format, a class-based Volt component, or a Filament `$view`-property page), `$this->member`, bare `$variable` references, and `wire:` attribute values all jump to the member's declaration in the backing class. For a Livewire v4 single-file component or a class-based Volt component the class lives in the template's own front matter, so the jump lands inside the `.blade.php` itself:
+**Component members in Blade** — inside a template backed by a Livewire component in any format — class-based or functional Volt included — or by a Filament `$view`-property page, `$this->member`, bare `$variable` references, and `wire:` attribute values all jump to the member's declaration in the backing class. For a Livewire v4 single-file component, a class-based Volt component, or a functional Volt file (`state([...])` keys are the properties, top-level `$name = fn () => …` assignments the actions), the member lives in the template's own front matter, so the jump lands inside the `.blade.php` itself:
 
 ```blade
 <button wire:click="enterEditMode">Edit</button>

--- a/docs/go-to-definition.md
+++ b/docs/go-to-definition.md
@@ -141,7 +141,7 @@ Names with dedicated handling (`@component`, `@livewire`, `@feature`, `@includeF
 {{-- ^^^^^^^^^^^^ → public string $prefillStatus in the backing class --}}
 ```
 
-A `wire:` value that isn't a plain member reference (`$wire.count++`, `count++`, `open = true`) is left alone entirely, so nothing conflicts with Alpine. A bare `$variable` bound locally in the template first — an enclosing `@foreach`/`@for` loop variable, a `@php` assignment, a component `@props` entry, or Blade's own `$loop` — is NOT treated as a class member: local scope wins and no navigation is offered. Members inherited from traits or parent classes are a known limitation — only members declared in the component's own class file (or front matter) resolve.
+A `wire:` value that isn't a plain member reference (`$wire.count++`, `count++`, `open = true`) is left alone entirely, so nothing conflicts with Alpine. A bare `$variable` bound locally in the template first — an enclosing `@foreach`/`@for` loop variable, a `@php` assignment, a component `@props` entry, or Blade's own `$loop` — is NOT treated as a class member: local scope wins and no navigation is offered. Members declared in the component's own class file resolve (front matter included), as do those of a trait it `use`s in that same file. Traits declared in another file, and parent-class members, are a known limitation — they do not resolve.
 
 ## Env keys, in reverse
 

--- a/docs/hover.md
+++ b/docs/hover.md
@@ -22,7 +22,7 @@ $tz = config('app.timezone');
 {{-- ^^^^^ hover →  App\Models\User::$email, its PHPDoc summary, and the declaration --}}
 ```
 
-**Component members in Blade** — `$this->member` in a template backed by a component class (Livewire in any format, class-based Volt, a Filament `$view`-property page) gets a card with the member's kind, the backing class, the full declaration header, and a click-to-open link. Inside an anonymous partial (`<x-save-button />`), which has no backing class of its own, the card resolves against the nearest component that renders it. This card is emitted unconditionally in Blade: Intelephense cannot resolve `$this` inside a template's PHP context, so there is no PHP-tooling card to defer to.
+**Component members in Blade** — `$this->member` in a template backed by a Livewire component in any format — including a functional Volt file, which declares no class at all — or by a Filament `$view`-property page gets a card with the member's kind, the backing class, the full declaration header, and a click-to-open link. Inside an anonymous partial (`<x-save-button />`), which has no backing class of its own, the card resolves against the nearest component that renders it. This card is emitted unconditionally in Blade: Intelephense cannot resolve `$this` inside a template's PHP context, so there is no PHP-tooling card to defer to.
 
 ```blade
 {{ $this->getCalculatedEndDateForDisplay() }}

--- a/docs/hover.md
+++ b/docs/hover.md
@@ -22,7 +22,7 @@ $tz = config('app.timezone');
 {{-- ^^^^^ hover →  App\Models\User::$email, its PHPDoc summary, and the declaration --}}
 ```
 
-**Component members in Blade** — `$this->member` in a template backed by a component class (Livewire in any format, class-based Volt, a Filament `$view`-property page) gets a card with the member's kind, the backing class, the full declaration header, and a click-to-open link. This card is emitted unconditionally in Blade: Intelephense cannot resolve `$this` inside a template's PHP context, so there is no PHP-tooling card to defer to.
+**Component members in Blade** — `$this->member` in a template backed by a component class (Livewire in any format, class-based Volt, a Filament `$view`-property page) gets a card with the member's kind, the backing class, the full declaration header, and a click-to-open link. Inside an anonymous partial (`<x-save-button />`), which has no backing class of its own, the card resolves against the nearest component that renders it. This card is emitted unconditionally in Blade: Intelephense cannot resolve `$this` inside a template's PHP context, so there is no PHP-tooling card to defer to.
 
 ```blade
 {{ $this->getCalculatedEndDateForDisplay() }}

--- a/laravel-lsp/src/component_member_locator.rs
+++ b/laravel-lsp/src/component_member_locator.rs
@@ -226,9 +226,7 @@ fn owning_declaration<'tree>(root: Node<'tree>) -> Node<'tree> {
             // `new class extends Component { … }` — the front-matter shape
             // of a Livewire SFC and a class-based Volt component.
             "anonymous_class" => Some((true, n)),
-            "trait_declaration" | "enum_declaration" | "interface_declaration" => {
-                Some((false, n))
-            }
+            "trait_declaration" | "enum_declaration" | "interface_declaration" => Some((false, n)),
             _ => None,
         };
         if let Some((is_class, node)) = candidate {

--- a/laravel-lsp/src/component_member_locator.rs
+++ b/laravel-lsp/src/component_member_locator.rs
@@ -17,6 +17,7 @@
 use tree_sitter::Node;
 
 use crate::parser::parse_php;
+use crate::volt_functional;
 
 /// The declaration shape [`locate_member`] found.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,22 +38,44 @@ pub struct MemberLocation {
 
 /// Find `member`'s declaration in `source`. Checks every `method_declaration`,
 /// property (`property_declaration` → `property_element`), and promoted
-/// constructor property in the file, in document order; returns the first
-/// match. A method and a property never share a name within one class, so in
-/// practice there's nothing to disambiguate between the two kinds.
+/// constructor property in the file, then returns the FIRST in true document
+/// order.
 ///
 /// Returns `None` when `source` doesn't parse, or no member named `member`
 /// is declared.
 pub fn locate_member(source: &str, member: &str) -> Option<MemberLocation> {
-    let tree = parse_php(source).ok()?;
+    locate_member_of_kind(source, member, None)
+}
+
+/// [`locate_member`], restricted to one declaration kind.
+///
+/// `want` is what the REFERENCE demands: a `wire:model="save"` binds a
+/// property, so it must not resolve to a `save()` method even though one is
+/// declared. `None` accepts either kind, for references that carry no kind of
+/// their own (`$this->member`, a bare `$var`, `wire:target`).
+///
+/// Every candidate is collected by a full traversal — no early return — and
+/// the list is sorted by `(line, column)` before the first is taken. The walk
+/// itself is a `stack.pop()` DFS, which visits children in reverse order and
+/// nested bodies out of order, so the sort is what makes "first" mean
+/// document order rather than traversal order.
+pub fn locate_member_of_kind(
+    source: &str,
+    member: &str,
+    want: Option<MemberKind>,
+) -> Option<MemberLocation> {
+    let Ok(tree) = parse_php(source) else {
+        return volt_functional::locate_member(source, member, want);
+    };
     let bytes = source.as_bytes();
+    let mut found: Vec<MemberLocation> = Vec::new();
     let mut stack = vec![tree.root_node()];
     while let Some(n) = stack.pop() {
         match n.kind() {
             "method_declaration" => {
                 if let Some(name) = n.child_by_field_name("name") {
                     if name.utf8_text(bytes).ok() == Some(member) {
-                        return Some(node_location(name, 0, MemberKind::Method));
+                        found.push(node_location(name, 0, MemberKind::Method));
                     }
                 }
             }
@@ -64,7 +87,7 @@ pub fn locate_member(source: &str, member: &str) -> Option<MemberLocation> {
                     }
                     if let Some(name) = element.child_by_field_name("name") {
                         if matches_dollar_name(name, bytes, member) {
-                            return Some(node_location(name, 1, MemberKind::Property));
+                            found.push(node_location(name, 1, MemberKind::Property));
                         }
                     }
                 }
@@ -72,7 +95,7 @@ pub fn locate_member(source: &str, member: &str) -> Option<MemberLocation> {
             "property_promotion_parameter" => {
                 if let Some(name) = n.child_by_field_name("name") {
                     if matches_dollar_name(name, bytes, member) {
-                        return Some(node_location(name, 1, MemberKind::Property));
+                        found.push(node_location(name, 1, MemberKind::Property));
                     }
                 }
             }
@@ -83,7 +106,14 @@ pub fn locate_member(source: &str, member: &str) -> Option<MemberLocation> {
             stack.push(ch);
         }
     }
-    None
+    found.retain(|loc| want.is_none_or(|k| k == loc.kind));
+    found.sort_by_key(|loc| (loc.line, loc.start_column));
+    // A functional Volt file declares no class, so the walk above finds
+    // nothing in it — its state keys and closure actions are the members.
+    found
+        .into_iter()
+        .next()
+        .or_else(|| volt_functional::locate_member(source, member, want))
 }
 
 /// The declaration header of `member` in `source`, for a hover card: a
@@ -91,9 +121,15 @@ pub fn locate_member(source: &str, member: &str) -> Option<MemberLocation> {
 /// parameters, return type — or a property's declaration up to (not
 /// including) its initializer. Whitespace runs are collapsed so a multiline
 /// signature renders as one line. `None` when the member isn't declared.
+///
+/// Candidates are collected and sorted the same way [`locate_member`] sorts
+/// them, so the summary always describes the declaration goto lands on.
 pub fn member_declaration_summary(source: &str, member: &str) -> Option<String> {
-    let tree = parse_php(source).ok()?;
+    let Ok(tree) = parse_php(source) else {
+        return volt_functional::declaration_summary(source, member);
+    };
     let bytes = source.as_bytes();
+    let mut found: Vec<(u32, u32, String)> = Vec::new();
     let mut stack = vec![tree.root_node()];
     while let Some(n) = stack.pop() {
         match n.kind() {
@@ -104,7 +140,11 @@ pub fn member_declaration_summary(source: &str, member: &str) -> Option<String> 
                             .child_by_field_name("body")
                             .map(|b| b.start_byte())
                             .unwrap_or_else(|| n.end_byte());
-                        return Some(collapse_ws(&source[n.start_byte()..end]));
+                        found.push(with_position(
+                            name,
+                            0,
+                            collapse_ws(&source[n.start_byte()..end]),
+                        ));
                     }
                 }
             }
@@ -120,7 +160,11 @@ pub fn member_declaration_summary(source: &str, member: &str) -> Option<String> 
                             // NAME (modifiers + type), then the `$name`
                             // itself — the initializer stays out.
                             let head = collapse_ws(&source[n.start_byte()..name.start_byte()]);
-                            return Some(format!("{} ${}", head.trim_end(), member));
+                            found.push(with_position(
+                                name,
+                                1,
+                                format!("{} ${}", head.trim_end(), member),
+                            ));
                         }
                     }
                 }
@@ -129,7 +173,11 @@ pub fn member_declaration_summary(source: &str, member: &str) -> Option<String> 
                 if let Some(name) = n.child_by_field_name("name") {
                     if matches_dollar_name(name, bytes, member) {
                         let head = collapse_ws(&source[n.start_byte()..name.start_byte()]);
-                        return Some(format!("{} ${}", head.trim_end(), member));
+                        found.push(with_position(
+                            name,
+                            1,
+                            format!("{} ${}", head.trim_end(), member),
+                        ));
                     }
                 }
             }
@@ -140,27 +188,81 @@ pub fn member_declaration_summary(source: &str, member: &str) -> Option<String> 
             stack.push(ch);
         }
     }
-    None
+    found.sort_by_key(|(line, column, _)| (*line, *column));
+    found
+        .into_iter()
+        .next()
+        .map(|(_, _, text)| text)
+        .or_else(|| volt_functional::declaration_summary(source, member))
 }
 
-/// Collapse every whitespace run (including newlines) to a single space.
-fn collapse_ws(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
+/// `(line, column, payload)` keyed on a name node's position, so summaries
+/// sort in the same document order [`locate_member`] picks from.
+fn with_position(node: Node, dollar_skip: u32, payload: String) -> (u32, u32, String) {
+    let loc = node_location(node, dollar_skip, MemberKind::Property);
+    (loc.line, loc.start_column, payload)
 }
 
-/// Every PUBLIC property of the class in `source`, as `(name, declared type
-/// text)` — `"mixed"` when untyped. Includes promoted public constructor
-/// properties. Unlike the render-index surface (which keeps only
-/// class-typed properties, since scalars have no members to resolve), this
-/// keeps scalar and untyped publics too: a Livewire/Filament template reads
-/// them as bare `$vars`, so `$`-completion must offer all of them.
+/// The declaration that OWNS the component's member surface: the first
+/// class-like declaration in document order — a named `class`, or the
+/// anonymous class of a `new class extends Component` front matter.
+///
+/// Completion must not offer members declared by anything else in the file. A
+/// trait declared beside the component, a second unrelated top-level class,
+/// an enum — all of them are separate declarations whose members are not on
+/// `$this`, and offering them contradicts the documented
+/// trait-provided-members limitation.
+///
+/// Falls back to the first trait/enum/interface when the file declares no
+/// class, and finally to the whole file when it declares nothing at all — a
+/// file with a single declaration has nothing to scope away.
+fn owning_declaration<'tree>(root: Node<'tree>) -> Node<'tree> {
+    let mut class_like: Option<Node> = None;
+    let mut other: Option<Node> = None;
+    let mut stack = vec![root];
+    while let Some(n) = stack.pop() {
+        let candidate = match n.kind() {
+            "class_declaration" => Some((true, n)),
+            // `new class extends Component { … }` — the front-matter shape
+            // of a Livewire SFC and a class-based Volt component.
+            "anonymous_class" => Some((true, n)),
+            "trait_declaration" | "enum_declaration" | "interface_declaration" => {
+                Some((false, n))
+            }
+            _ => None,
+        };
+        if let Some((is_class, node)) = candidate {
+            let slot = if is_class {
+                &mut class_like
+            } else {
+                &mut other
+            };
+            if slot.is_none_or(|best| node.start_byte() < best.start_byte()) {
+                *slot = Some(node);
+            }
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    class_like.or(other).unwrap_or(root)
+}
+
+/// Every PUBLIC property of the component's own declaration (see
+/// [`owning_declaration`]), as `(name, declared type text)` — `"mixed"` when
+/// untyped. Includes promoted public constructor properties. Unlike the
+/// render-index surface (which keeps only class-typed properties, since
+/// scalars have no members to resolve), this keeps scalar and untyped publics
+/// too: a Livewire/Filament template reads them as bare `$vars`, so
+/// `$`-completion must offer all of them.
 pub fn public_property_types(source: &str) -> Vec<(String, String)> {
     let Ok(tree) = parse_php(source) else {
-        return Vec::new();
+        return volt_functional::property_types(source);
     };
     let bytes = source.as_bytes();
     let mut out = Vec::new();
-    let mut stack = vec![tree.root_node()];
+    let mut stack = vec![owning_declaration(tree.root_node())];
     while let Some(n) = stack.pop() {
         match n.kind() {
             "property_declaration" | "property_promotion_parameter" => {
@@ -221,15 +323,19 @@ pub fn public_property_types(source: &str) -> Vec<(String, String)> {
             stack.push(ch);
         }
     }
+    if out.is_empty() {
+        out = volt_functional::property_types(source);
+    }
     out
 }
 
-/// Every PUBLIC, non-static method of the class in `source` that can be a
-/// Livewire action target, sorted by name. Magic methods (`__*`) and the
-/// Livewire/Filament lifecycle surface (`mount`, `render`, `boot`, `booted`,
-/// `rendering`, `rendered`, `exception`, and the `updated*` / `updating*` /
-/// `hydrate*` / `dehydrate*` hook families) are excluded — they exist on
-/// every component and are never what a `wire:click` wants to call.
+/// Every PUBLIC, non-static method of the component's own declaration (see
+/// [`owning_declaration`]) that can be a Livewire action target, sorted by
+/// name. Magic methods (`__*`) and the Livewire/Filament lifecycle surface
+/// (`mount`, `render`, `boot`, `booted`, `rendering`, `rendered`,
+/// `exception`, and the `updated*` / `updating*` / `hydrate*` / `dehydrate*`
+/// hook families) are excluded — they exist on every component and are never
+/// what a `wire:click` wants to call.
 pub fn public_action_method_names(source: &str) -> Vec<String> {
     const LIFECYCLE: &[&str] = &[
         "mount",
@@ -243,11 +349,11 @@ pub fn public_action_method_names(source: &str) -> Vec<String> {
     const LIFECYCLE_PREFIXES: &[&str] = &["updated", "updating", "hydrate", "dehydrate"];
 
     let Ok(tree) = parse_php(source) else {
-        return Vec::new();
+        return volt_functional::action_names(source);
     };
     let bytes = source.as_bytes();
     let mut out = Vec::new();
-    let mut stack = vec![tree.root_node()];
+    let mut stack = vec![owning_declaration(tree.root_node())];
     while let Some(n) = stack.pop() {
         if n.kind() == "method_declaration" {
             let mut public = true; // PHP methods default to public
@@ -293,8 +399,16 @@ pub fn public_action_method_names(source: &str) -> Vec<String> {
             stack.push(ch);
         }
     }
+    if out.is_empty() {
+        out = volt_functional::action_names(source);
+    }
     out.sort();
     out
+}
+
+/// Collapse every whitespace run (including newlines) to a single space.
+fn collapse_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// Whether `name` node's text, with a leading `$` stripped, equals `member`.

--- a/laravel-lsp/src/component_member_locator.rs
+++ b/laravel-lsp/src/component_member_locator.rs
@@ -125,15 +125,31 @@ pub fn locate_member_of_kind(
 /// Candidates are collected and sorted the same way [`locate_member`] sorts
 /// them, so the summary always describes the declaration goto lands on.
 pub fn member_declaration_summary(source: &str, member: &str) -> Option<String> {
+    member_declaration_summary_of_kind(source, member, None)
+}
+
+/// [`member_declaration_summary`], restricted to one declaration kind.
+///
+/// `want` must be the same filter the caller applied to [`locate_member_of_kind`].
+/// A class can declare `public $save` AND `save()`, and the two halves of a
+/// hover card are rendered from separate calls: the header from the located
+/// declaration, the body from here. Filtered on one side only, the card reads
+/// `Counter::$save` above `public function save(): void` — a description of a
+/// declaration goto refuses to visit (#339, item 5).
+pub fn member_declaration_summary_of_kind(
+    source: &str,
+    member: &str,
+    want: Option<MemberKind>,
+) -> Option<String> {
     let Ok(tree) = parse_php(source) else {
-        return volt_functional::declaration_summary(source, member);
+        return volt_functional::declaration_summary_of_kind(source, member, want);
     };
     let bytes = source.as_bytes();
     let mut found: Vec<(u32, u32, String)> = Vec::new();
     let mut stack = vec![tree.root_node()];
     while let Some(n) = stack.pop() {
         match n.kind() {
-            "method_declaration" => {
+            "method_declaration" if want.is_none_or(|k| k == MemberKind::Method) => {
                 if let Some(name) = n.child_by_field_name("name") {
                     if name.utf8_text(bytes).ok() == Some(member) {
                         let end = n
@@ -148,7 +164,7 @@ pub fn member_declaration_summary(source: &str, member: &str) -> Option<String> 
                     }
                 }
             }
-            "property_declaration" => {
+            "property_declaration" if want.is_none_or(|k| k == MemberKind::Property) => {
                 let mut c = n.walk();
                 for element in n.children(&mut c) {
                     if element.kind() != "property_element" {
@@ -169,7 +185,7 @@ pub fn member_declaration_summary(source: &str, member: &str) -> Option<String> 
                     }
                 }
             }
-            "property_promotion_parameter" => {
+            "property_promotion_parameter" if want.is_none_or(|k| k == MemberKind::Property) => {
                 if let Some(name) = n.child_by_field_name("name") {
                     if matches_dollar_name(name, bytes, member) {
                         let head = collapse_ws(&source[n.start_byte()..name.start_byte()]);
@@ -193,7 +209,7 @@ pub fn member_declaration_summary(source: &str, member: &str) -> Option<String> 
         .into_iter()
         .next()
         .map(|(_, _, text)| text)
-        .or_else(|| volt_functional::declaration_summary(source, member))
+        .or_else(|| volt_functional::declaration_summary_of_kind(source, member, want))
 }
 
 /// `(line, column, payload)` keyed on a name node's position, so summaries
@@ -208,10 +224,10 @@ fn with_position(node: Node, dollar_skip: u32, payload: String) -> (u32, u32, St
 /// anonymous class of a `new class extends Component` front matter.
 ///
 /// Completion must not offer members declared by anything else in the file. A
-/// trait declared beside the component, a second unrelated top-level class,
-/// an enum — all of them are separate declarations whose members are not on
-/// `$this`, and offering them contradicts the documented
-/// trait-provided-members limitation.
+/// second unrelated top-level class, an enum, a trait the component does not
+/// `use` — all of them are separate declarations whose members are not on
+/// `$this`. A trait the component DOES `use` is the exception, and
+/// [`member_surface_roots`] adds it back.
 ///
 /// Falls back to the first trait/enum/interface when the file declares no
 /// class, and finally to the whole file when it declares nothing at all — a
@@ -247,6 +263,116 @@ fn owning_declaration<'tree>(root: Node<'tree>) -> Node<'tree> {
     class_like.or(other).unwrap_or(root)
 }
 
+/// Every declaration whose members are reachable on the component's `$this`:
+/// [`owning_declaration`] plus the same-file traits it actually `use`s,
+/// transitively (a trait may `use` another).
+///
+/// Scoping completion to the owning declaration alone (#339, item 6) traded a
+/// false positive for a false negative: in
+///
+/// ```php
+/// trait HasFoo { public $bar; }
+/// class Counter extends Component { use HasFoo; }
+/// ```
+///
+/// `$bar` IS on `$this` at runtime, and dropping it is worse than the leak the
+/// scoping fixed. Resolution stays inside the file — a `use` naming a trait
+/// declared elsewhere still resolves to nothing, which is the documented
+/// cross-file trait limitation, untouched.
+fn member_surface_roots<'tree>(root: Node<'tree>, bytes: &[u8]) -> Vec<Node<'tree>> {
+    let owner = owning_declaration(root);
+    let mut roots = vec![owner];
+
+    let declared = trait_declarations(root, bytes);
+    if declared.is_empty() {
+        return roots;
+    }
+
+    // Worklist over trait names, with a visited set: `use` cycles are illegal
+    // PHP but cheap to survive, and a trait's own `use` clauses count.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut queue = vec![owner];
+    while let Some(node) = queue.pop() {
+        for name in used_trait_names(node, bytes) {
+            if !seen.insert(name.clone()) {
+                continue;
+            }
+            if let Some(decl) = declared.get(&name) {
+                roots.push(*decl);
+                queue.push(*decl);
+            }
+        }
+    }
+    roots
+}
+
+/// The file's own `trait X { … }` declarations, by name.
+fn trait_declarations<'tree>(
+    root: Node<'tree>,
+    bytes: &[u8],
+) -> std::collections::HashMap<String, Node<'tree>> {
+    let mut out = std::collections::HashMap::new();
+    let mut stack = vec![root];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "trait_declaration" {
+            if let Some(name) = n
+                .child_by_field_name("name")
+                .and_then(|nm| nm.utf8_text(bytes).ok())
+            {
+                out.insert(name.to_string(), n);
+            }
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    out
+}
+
+/// The trait names `decl`'s own body `use`s, unqualified.
+///
+/// Nested class-like bodies are not descended into: a `use` inside an
+/// anonymous class declared in one of `decl`'s methods binds members onto THAT
+/// object, not onto `$this`. Only the last `\`-separated segment is kept,
+/// because a same-file trait is referenced by its bare name from the same
+/// namespace.
+fn used_trait_names(decl: Node, bytes: &[u8]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut stack: Vec<Node> = vec![decl];
+    while let Some(n) = stack.pop() {
+        if n.kind() == "use_declaration" {
+            let mut c = n.walk();
+            for ch in n.children(&mut c) {
+                if !matches!(ch.kind(), "name" | "qualified_name") {
+                    continue;
+                }
+                if let Ok(text) = ch.utf8_text(bytes) {
+                    if let Some(last) = text.rsplit('\\').next() {
+                        if !last.is_empty() {
+                            out.push(last.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            let nested_scope = matches!(
+                ch.kind(),
+                "class_declaration"
+                    | "trait_declaration"
+                    | "interface_declaration"
+                    | "anonymous_class"
+            );
+            if !nested_scope || ch.id() == decl.id() {
+                stack.push(ch);
+            }
+        }
+    }
+    out
+}
+
 /// Every PUBLIC property of the component's own declaration (see
 /// [`owning_declaration`]), as `(name, declared type text)` — `"mixed"` when
 /// untyped. Includes promoted public constructor properties. Unlike the
@@ -260,7 +386,7 @@ pub fn public_property_types(source: &str) -> Vec<(String, String)> {
     };
     let bytes = source.as_bytes();
     let mut out = Vec::new();
-    let mut stack = vec![owning_declaration(tree.root_node())];
+    let mut stack = member_surface_roots(tree.root_node(), bytes);
     while let Some(n) = stack.pop() {
         match n.kind() {
             "property_declaration" | "property_promotion_parameter" => {
@@ -351,7 +477,7 @@ pub fn public_action_method_names(source: &str) -> Vec<String> {
     };
     let bytes = source.as_bytes();
     let mut out = Vec::new();
-    let mut stack = vec![owning_declaration(tree.root_node())];
+    let mut stack = member_surface_roots(tree.root_node(), bytes);
     while let Some(n) = stack.pop() {
         if n.kind() == "method_declaration" {
             let mut public = true; // PHP methods default to public

--- a/laravel-lsp/src/component_member_locator/tests.rs
+++ b/laravel-lsp/src/component_member_locator/tests.rs
@@ -348,3 +348,157 @@ fn an_inline_anonymous_component_class_owns_the_members() {
         "the anonymous class is the component even with a trait above it"
     );
 }
+
+/// A class declaring BOTH kinds under one name: the summary must describe the
+/// kind asked for, not whichever declaration the parser reaches first. The
+/// method is declared first, so an unfiltered call answers with it — which is
+/// what makes these two assertions discriminate.
+const SUMMARY_KIND_CLASH: &str = r#"<?php
+class Counter
+{
+    public function save(): void
+    {
+    }
+
+    public string $save = '';
+}
+"#;
+
+#[test]
+fn declaration_summary_of_kind_describes_the_requested_kind() {
+    assert_eq!(
+        member_declaration_summary_of_kind(SUMMARY_KIND_CLASH, "save", Some(MemberKind::Property))
+            .as_deref(),
+        Some("public string $save"),
+    );
+    assert_eq!(
+        member_declaration_summary_of_kind(SUMMARY_KIND_CLASH, "save", Some(MemberKind::Method))
+            .as_deref(),
+        Some("public function save(): void"),
+    );
+}
+
+#[test]
+fn an_unfiltered_summary_still_answers_in_document_order() {
+    assert_eq!(
+        member_declaration_summary(SUMMARY_KIND_CLASH, "save").as_deref(),
+        Some("public function save(): void"),
+        "no filter means first-in-document-order, which is the method here",
+    );
+}
+
+#[test]
+fn declaration_summary_of_a_kind_the_class_lacks_is_none() {
+    let source = "<?php\nclass Counter\n{\n    public function save(): void {}\n}\n";
+    assert!(
+        member_declaration_summary_of_kind(source, "save", Some(MemberKind::Property)).is_none()
+    );
+}
+
+/// Item 6 scoped the member surface to the component's own declaration. A
+/// trait the component actually `use`s is on `$this` at runtime, so scoping it
+/// away traded a false positive for a false negative.
+const USED_TRAIT: &str = r#"<?php
+trait HasCounter
+{
+    public $fromTrait = 1;
+
+    public function bumpFromTrait(): void
+    {
+    }
+}
+
+trait Unrelated
+{
+    public $fromUnrelated = 1;
+
+    public function bumpFromUnrelated(): void
+    {
+    }
+}
+
+class Counter extends Component
+{
+    use HasCounter;
+
+    public $own = 1;
+}
+"#;
+
+#[test]
+fn a_used_same_file_trait_contributes_its_members() {
+    let properties: Vec<String> = public_property_types(USED_TRAIT)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    assert!(properties.contains(&"own".to_string()));
+    assert!(
+        properties.contains(&"fromTrait".to_string()),
+        "`use HasCounter` puts $fromTrait on $this: {properties:?}"
+    );
+
+    let actions = public_action_method_names(USED_TRAIT);
+    assert!(
+        actions.contains(&"bumpFromTrait".to_string()),
+        "`use HasCounter` puts bumpFromTrait() on $this: {actions:?}"
+    );
+}
+
+#[test]
+fn an_unused_same_file_trait_contributes_nothing() {
+    let properties: Vec<String> = public_property_types(USED_TRAIT)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    assert!(
+        !properties.contains(&"fromUnrelated".to_string()),
+        "a trait the class never `use`s is not on $this: {properties:?}"
+    );
+    assert!(
+        !public_action_method_names(USED_TRAIT).contains(&"bumpFromUnrelated".to_string()),
+        "a trait the class never `use`s is not on $this"
+    );
+}
+
+#[test]
+fn a_trait_used_by_a_used_trait_contributes_its_members() {
+    let source = r#"<?php
+trait Inner
+{
+    public $deep = 1;
+}
+
+trait Outer
+{
+    use Inner;
+
+    public $middle = 1;
+}
+
+class Counter extends Component
+{
+    use Outer;
+}
+"#;
+    let properties: Vec<String> = public_property_types(source)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    assert!(properties.contains(&"middle".to_string()), "{properties:?}");
+    assert!(
+        properties.contains(&"deep".to_string()),
+        "a trait's own `use` clauses count too: {properties:?}"
+    );
+}
+
+/// A `use` naming a trait declared in another file resolves to nothing — the
+/// documented cross-file limitation, unchanged by the same-file fix.
+#[test]
+fn a_use_of_an_absent_trait_is_ignored() {
+    let source = "<?php\nclass Counter extends Component\n{\n    use \\App\\Traits\\Absent;\n\n    public $own = 1;\n}\n";
+    let properties: Vec<String> = public_property_types(source)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    assert_eq!(properties, vec!["own".to_string()]);
+}

--- a/laravel-lsp/src/component_member_locator/tests.rs
+++ b/laravel-lsp/src/component_member_locator/tests.rs
@@ -270,7 +270,10 @@ fn a_deeply_nested_earlier_candidate_beats_a_shallow_later_one() {
     // trait's.
     let source = "<?php\ntrait T {\n    public $dup = 1;\n}\nclass C { public $dup = 2; }\n";
     let loc = locate_member(source, "dup").expect("both declare $dup");
-    assert_eq!(loc.line, 2, "the trait's declaration is earlier in the file");
+    assert_eq!(
+        loc.line, 2,
+        "the trait's declaration is earlier in the file"
+    );
 }
 
 #[test]

--- a/laravel-lsp/src/component_member_locator/tests.rs
+++ b/laravel-lsp/src/component_member_locator/tests.rs
@@ -321,6 +321,26 @@ fn completion_excludes_members_of_every_other_top_level_declaration() {
     );
 }
 
+/// The sibling of the test above, with the names COLLIDING. Distinct names
+/// prove a leak by its presence; identical names can only be told apart by
+/// what came back, so the foreign class declares the same members at a
+/// different type. A leak shows up as the wrong type or a duplicate entry —
+/// neither of which a distinct-name fixture can produce.
+#[test]
+fn completion_keeps_the_owning_class_when_a_stranger_shares_its_member_names() {
+    let source = "<?php\nclass Component1 {\n    public string $shared = 'owned';\n    public function shared() {}\n}\n\nclass Unrelated {\n    public int $shared = 2;\n    public function shared() {}\n}\n";
+    assert_eq!(
+        public_property_types(source),
+        vec![("shared".to_string(), "string".to_string())],
+        "the owning class's `string $shared`, not the stranger's `int $shared`"
+    );
+    assert_eq!(
+        public_action_method_names(source),
+        vec!["shared"],
+        "one entry — the stranger's same-named method must not double it up"
+    );
+}
+
 #[test]
 fn completion_excludes_a_trait_declared_beside_the_component() {
     let source = "<?php\nclass C {\n    public $owned = 1;\n}\n\ntrait Helper {\n    public $fromTrait = 2;\n    public function helperAction() {}\n}\n";
@@ -503,6 +523,55 @@ fn a_used_same_file_traits_member_is_locatable() {
     );
     let action = locate_member(USED_TRAIT, "bumpFromTrait").expect("the trait's method is found");
     assert_eq!(action.line, 5, "`bumpFromTrait()` is declared on line 5");
+}
+
+/// Two traits that `use` each other. PHP fatals on this at runtime, but the
+/// state is reachable as a mid-edit buffer and this walk runs on the request
+/// path — an unguarded worklist would loop forever and take every LSP feature
+/// down with it. The visited set is what stops that, and nothing else in the
+/// tree constructs a cycle to hold it in place.
+///
+/// Each member appearing exactly once is the second half of the assertion: a
+/// guard that terminated by some other means (a depth cap, say) would still
+/// re-visit a trait on the way there.
+#[test]
+fn a_mutual_trait_use_cycle_terminates() {
+    let source = r#"<?php
+trait Ping
+{
+    use Pong;
+
+    public $fromPing = 1;
+}
+
+trait Pong
+{
+    use Ping;
+
+    public $fromPong = 2;
+}
+
+class Counter extends Component
+{
+    use Ping;
+
+    public $own = 3;
+}
+"#;
+    let mut properties: Vec<String> = public_property_types(source)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    properties.sort();
+    assert_eq!(
+        properties,
+        vec![
+            "fromPing".to_string(),
+            "fromPong".to_string(),
+            "own".to_string()
+        ],
+        "the cycle is walked once through and each member lands exactly once"
+    );
 }
 
 /// A `use` naming a trait declared in another file resolves to nothing — the

--- a/laravel-lsp/src/component_member_locator/tests.rs
+++ b/laravel-lsp/src/component_member_locator/tests.rs
@@ -249,3 +249,99 @@ new class extends Component {
     assert_eq!(loc.kind, MemberKind::Property);
     assert_eq!(loc.line, 5);
 }
+
+// ---- true document order + declaration scoping (issue #339, item 6) -------
+
+#[test]
+fn locate_member_returns_the_first_declaration_in_document_order() {
+    let source = "<?php\nclass A { public $dup = 1; }\n\nclass B { public $dup = 2; }\n";
+    let loc = locate_member(source, "dup").expect("both classes declare $dup");
+    assert_eq!(
+        loc.line, 1,
+        "the FIRST declaration wins, not the last-visited one"
+    );
+}
+
+#[test]
+fn a_deeply_nested_earlier_candidate_beats_a_shallow_later_one() {
+    // The trait's `$dup` sits one level deeper in the tree than the class's,
+    // and comes first in the document. A breadth-first or reverse-DFS walk
+    // returns the shallow/later one; true `(line, column)` order returns the
+    // trait's.
+    let source = "<?php\ntrait T {\n    public $dup = 1;\n}\nclass C { public $dup = 2; }\n";
+    let loc = locate_member(source, "dup").expect("both declare $dup");
+    assert_eq!(loc.line, 2, "the trait's declaration is earlier in the file");
+}
+
+#[test]
+fn member_summary_describes_the_same_declaration_goto_lands_on() {
+    let source = "<?php\nclass A { public int $dup = 1; }\n\nclass B { public string $dup = 2; }\n";
+    assert_eq!(
+        member_declaration_summary(source, "dup").as_deref(),
+        Some("public int $dup"),
+        "the summary follows the same document-order pick as locate_member"
+    );
+}
+
+#[test]
+fn kind_filter_keeps_a_property_reference_off_a_same_named_method() {
+    let source = "<?php\nclass C {\n    public $save = 1;\n    public function save() {}\n}\n";
+    let as_property = locate_member_of_kind(source, "save", Some(MemberKind::Property))
+        .expect("the property is declared");
+    assert_eq!(as_property.line, 2);
+    let as_method = locate_member_of_kind(source, "save", Some(MemberKind::Method))
+        .expect("the method is declared");
+    assert_eq!(as_method.line, 3);
+}
+
+#[test]
+fn kind_filter_returns_nothing_when_only_the_other_kind_exists() {
+    let source = "<?php\nclass C {\n    public function save() {}\n}\n";
+    assert!(
+        locate_member_of_kind(source, "save", Some(MemberKind::Property)).is_none(),
+        "a wire:model binding must not resolve to a method"
+    );
+}
+
+#[test]
+fn completion_excludes_members_of_every_other_top_level_declaration() {
+    let source = "<?php\nclass Component1 {\n    public $owned = 1;\n    public function act() {}\n}\n\nclass Unrelated {\n    public $foreign = 2;\n    public function stranger() {}\n}\n";
+    let props: Vec<String> = public_property_types(source)
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    assert_eq!(props, vec!["owned"], "only the component's own properties");
+    assert_eq!(
+        public_action_method_names(source),
+        vec!["act"],
+        "only the component's own actions"
+    );
+}
+
+#[test]
+fn completion_excludes_a_trait_declared_beside_the_component() {
+    let source = "<?php\nclass C {\n    public $owned = 1;\n}\n\ntrait Helper {\n    public $fromTrait = 2;\n    public function helperAction() {}\n}\n";
+    let props: Vec<String> = public_property_types(source)
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    assert_eq!(props, vec!["owned"]);
+    assert!(
+        public_action_method_names(source).is_empty(),
+        "trait-provided members stay a documented limitation"
+    );
+}
+
+#[test]
+fn an_inline_anonymous_component_class_owns_the_members() {
+    let source = "<?php\ntrait Helper {\n    public $fromTrait = 1;\n}\n\nnew class extends Component {\n    public $owned = 2;\n};\n";
+    let props: Vec<String> = public_property_types(source)
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    assert_eq!(
+        props,
+        vec!["owned"],
+        "the anonymous class is the component even with a trait above it"
+    );
+}

--- a/laravel-lsp/src/component_member_locator/tests.rs
+++ b/laravel-lsp/src/component_member_locator/tests.rs
@@ -331,7 +331,7 @@ fn completion_excludes_a_trait_declared_beside_the_component() {
     assert_eq!(props, vec!["owned"]);
     assert!(
         public_action_method_names(source).is_empty(),
-        "trait-provided members stay a documented limitation"
+        "a trait the class never `use`s is not on $this, so it stays excluded"
     );
 }
 
@@ -489,6 +489,20 @@ class Counter extends Component
         properties.contains(&"deep".to_string()),
         "a trait's own `use` clauses count too: {properties:?}"
     );
+}
+
+/// Goto over a used same-file trait, which `docs/go-to-definition.md` now
+/// states outright. The walk searches the whole file, so this holds for the
+/// same reason completion holds — but the docs claim it, so a test pins it.
+#[test]
+fn a_used_same_file_traits_member_is_locatable() {
+    let property = locate_member(USED_TRAIT, "fromTrait").expect("the trait's property is found");
+    assert_eq!(
+        property.line, 3,
+        "`public $fromTrait` is declared on line 3"
+    );
+    let action = locate_member(USED_TRAIT, "bumpFromTrait").expect("the trait's method is found");
+    assert_eq!(action.line, 5, "`bumpFromTrait()` is declared on line 5");
 }
 
 /// A `use` naming a trait declared in another file resolves to nothing — the

--- a/laravel-lsp/src/component_usage_index.rs
+++ b/laravel-lsp/src/component_usage_index.rs
@@ -1,0 +1,173 @@
+//! Reverse component-usage index — "which Blade files render component X",
+//! answered by hash lookup instead of a sweep over every view file.
+//!
+//! The ancestor walk that resolves a member inside an anonymous Blade partial
+//! (`Backend::blade_backing_class_resolution`, #339 item 1) asks this question
+//! once per node it visits. A design-system primitive — `<x-icon>`,
+//! `<x-button>` — is rendered by hundreds of other partials, none of them a
+//! Livewire view, so the walk expands through all of them before it finds an
+//! answer or gives up. Asked as a linear scan over `SalsaActor::view_files`,
+//! that is one project-wide pass **per visited node**, on the actor thread
+//! that serialises every LSP request, per keystroke. Asked here, each step is
+//! one `HashMap` lookup.
+//!
+//! ## What it stores
+//!
+//! Three maps, kept in sync as files are indexed, edited, and deleted:
+//!
+//! - **by_component**: `<x-…>` tag name → the Blade files that render it.
+//! - **by_livewire**: `<livewire:…>` name → the Blade files that render it.
+//! - **by_file**: the names each file contributed, so re-indexing or deleting
+//!   one yanks exactly its entries back out without scanning the other two.
+//!
+//! Plus `pending`, the files whose patterns still have to be folded in — the
+//! same deferred-invalidation shape [`crate::symbol_index`] uses, and for the
+//! same reason: an edit marks, the next query pays.
+//!
+//! ## Correctness invariants
+//!
+//! 1. Every path in a `by_component` / `by_livewire` value appears as a key in
+//!    `by_file`, and the name it is filed under appears in that file's entry.
+//! 2. `insert_file` is idempotent: folding the same patterns twice leaves the
+//!    index identical, because it removes the file's previous entries first.
+//! 3. A file is reachable through this index only after it has been queued and
+//!    drained. **Every mutation of `SalsaActor::view_files` must queue the
+//!    affected path** (`mark_dirty`) or drop it (`remove_file`) — a push that
+//!    forgets to queue is a renderer this index cannot see.
+
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+
+use crate::salsa_impl::ParsedPatternsData;
+
+/// Reverse index from a component identity to the Blade files rendering it.
+#[derive(Debug, Default)]
+pub struct ComponentUsageIndex {
+    by_component: HashMap<String, BTreeSet<PathBuf>>,
+    by_livewire: HashMap<String, BTreeSet<PathBuf>>,
+    by_file: HashMap<PathBuf, FileEntry>,
+    pending: BTreeSet<PathBuf>,
+}
+
+/// The names one file contributed, kept so its entries can be withdrawn.
+#[derive(Debug, Default)]
+struct FileEntry {
+    components: Vec<String>,
+    livewire: Vec<String>,
+}
+
+impl ComponentUsageIndex {
+    /// Queue `path` for (re-)indexing on the next [`Self::take_pending`].
+    ///
+    /// Non-Blade paths are ignored: only a `.blade.php` file can carry an
+    /// `<x-…>` or `<livewire:…>` tag, and admitting the rest would make every
+    /// PHP edit in the project pay for a drain it can never contribute to.
+    pub fn mark_dirty(&mut self, path: &Path) {
+        if path.to_string_lossy().ends_with(".blade.php") {
+            self.pending.insert(path.to_path_buf());
+        }
+    }
+
+    /// Drain the queue. The caller folds each path back in with
+    /// [`Self::insert_file`], or drops it with [`Self::remove_file`] when its
+    /// patterns are unreadable — leaving a path drained but neither indexed
+    /// nor removed would strand its stale entries.
+    pub fn take_pending(&mut self) -> Vec<PathBuf> {
+        std::mem::take(&mut self.pending).into_iter().collect()
+    }
+
+    /// Fold `path`'s component and Livewire tag usage into the index,
+    /// replacing whatever it contributed before.
+    pub fn insert_file(&mut self, path: &Path, patterns: &ParsedPatternsData) {
+        self.remove_file(path);
+
+        let mut entry = FileEntry::default();
+        for component in &patterns.components {
+            if !entry.components.contains(&component.name) {
+                entry.components.push(component.name.clone());
+            }
+        }
+        for livewire in &patterns.livewire_refs {
+            if !entry.livewire.contains(&livewire.name) {
+                entry.livewire.push(livewire.name.clone());
+            }
+        }
+
+        for name in &entry.components {
+            self.by_component
+                .entry(name.clone())
+                .or_default()
+                .insert(path.to_path_buf());
+        }
+        for name in &entry.livewire {
+            self.by_livewire
+                .entry(name.clone())
+                .or_default()
+                .insert(path.to_path_buf());
+        }
+
+        // Filed even when it renders nothing, so invariant 1 holds in both
+        // directions and a later `remove_file` has something to withdraw.
+        self.by_file.insert(path.to_path_buf(), entry);
+    }
+
+    /// Withdraw every entry `path` contributed. Idempotent — a path that was
+    /// never indexed removes nothing.
+    pub fn remove_file(&mut self, path: &Path) {
+        let Some(entry) = self.by_file.remove(path) else {
+            return;
+        };
+        withdraw(&mut self.by_component, &entry.components, path);
+        withdraw(&mut self.by_livewire, &entry.livewire, path);
+    }
+
+    /// Drop the whole index, including anything still queued.
+    pub fn clear(&mut self) {
+        self.by_component.clear();
+        self.by_livewire.clear();
+        self.by_file.clear();
+        self.pending.clear();
+    }
+
+    /// The Blade files rendering any of `component_names` as an `<x-…>` tag or
+    /// any of `livewire_names` as a `<livewire:…>` tag, sorted and deduplicated.
+    ///
+    /// Sorted because the walk that consumes this takes the FIRST answer of a
+    /// level: an unordered result would let two equidistant parents swap places
+    /// between calls, so goto would land somewhere different on each keystroke.
+    pub fn find(&self, component_names: &[String], livewire_names: &[String]) -> Vec<PathBuf> {
+        let mut files: BTreeSet<PathBuf> = BTreeSet::new();
+        for name in component_names {
+            if let Some(paths) = self.by_component.get(name) {
+                files.extend(paths.iter().cloned());
+            }
+        }
+        for name in livewire_names {
+            if let Some(paths) = self.by_livewire.get(name) {
+                files.extend(paths.iter().cloned());
+            }
+        }
+        files.into_iter().collect()
+    }
+
+    /// How many files are folded in — for tests and diagnostics.
+    pub fn indexed_file_count(&self) -> usize {
+        self.by_file.len()
+    }
+}
+
+/// Remove `path` from each named bucket, dropping buckets that empty out so
+/// the map doesn't accumulate keys for components nothing renders any more.
+fn withdraw(map: &mut HashMap<String, BTreeSet<PathBuf>>, names: &[String], path: &Path) {
+    for name in names {
+        if let Some(paths) = map.get_mut(name) {
+            paths.remove(path);
+            if paths.is_empty() {
+                map.remove(name);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/component_usage_index/tests.rs
+++ b/laravel-lsp/src/component_usage_index/tests.rs
@@ -1,0 +1,180 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use super::ComponentUsageIndex;
+use crate::salsa_impl::{ComponentReferenceData, LivewireReferenceData, ParsedPatternsData};
+
+/// Patterns for a Blade file rendering `components` as `<x-…>` tags and
+/// `livewire` as `<livewire:…>` tags. Positions are irrelevant here — the
+/// index keys on names only — so they are all zero.
+fn patterns(components: &[&str], livewire: &[&str]) -> ParsedPatternsData {
+    let mut data = ParsedPatternsData::default();
+    data.components = components
+        .iter()
+        .map(|name| {
+            Arc::new(ComponentReferenceData {
+                name: (*name).to_string(),
+                tag_name: format!("x-{name}"),
+                line: 0,
+                column: 0,
+                end_column: 0,
+            })
+        })
+        .collect();
+    data.livewire_refs = livewire
+        .iter()
+        .map(|name| {
+            Arc::new(LivewireReferenceData {
+                name: (*name).to_string(),
+                line: 0,
+                column: 0,
+                end_column: 0,
+            })
+        })
+        .collect();
+    data
+}
+
+fn blade(name: &str) -> PathBuf {
+    PathBuf::from(format!("/app/resources/views/{name}.blade.php"))
+}
+
+fn names(list: &[&str]) -> Vec<String> {
+    list.iter().map(|n| (*n).to_string()).collect()
+}
+
+#[test]
+fn finds_the_files_rendering_a_component_tag() {
+    let mut index = ComponentUsageIndex::default();
+    index.insert_file(&blade("dashboard"), &patterns(&["save-button"], &[]));
+    index.insert_file(&blade("settings"), &patterns(&["other"], &[]));
+
+    assert_eq!(
+        index.find(&names(&["save-button"]), &[]),
+        vec![blade("dashboard")]
+    );
+}
+
+/// `<livewire:counter />` is the other half of the usage graph — the AC names
+/// both syntaxes, and a lookup that only consults `by_component` would answer
+/// this one with silence.
+#[test]
+fn finds_the_files_rendering_a_livewire_tag() {
+    let mut index = ComponentUsageIndex::default();
+    index.insert_file(&blade("dashboard"), &patterns(&[], &["counter"]));
+
+    assert_eq!(
+        index.find(&[], &names(&["counter"])),
+        vec![blade("dashboard")]
+    );
+    // …and the same name looked up on the component surface finds nothing,
+    // so the two maps are genuinely separate rather than one merged bucket.
+    assert!(index.find(&names(&["counter"]), &[]).is_empty());
+}
+
+#[test]
+fn results_are_sorted_so_the_first_match_is_stable() {
+    let mut index = ComponentUsageIndex::default();
+    // Inserted in reverse lexicographic order — a map-iteration answer would
+    // hand these back in whatever order the hasher chose.
+    for view in ["zeta", "middle", "alpha"] {
+        index.insert_file(&blade(view), &patterns(&["icon"], &[]));
+    }
+
+    assert_eq!(
+        index.find(&names(&["icon"]), &[]),
+        vec![blade("alpha"), blade("middle"), blade("zeta")]
+    );
+}
+
+/// Invariant 2: re-folding a file replaces its entries rather than adding to
+/// them. Without the `remove_file` at the top of `insert_file`, `dashboard`
+/// would still answer for `save-button` after the tag was deleted from it.
+#[test]
+fn reindexing_withdraws_the_tags_a_file_no_longer_renders() {
+    let mut index = ComponentUsageIndex::default();
+    index.insert_file(
+        &blade("dashboard"),
+        &patterns(&["save-button"], &["counter"]),
+    );
+    index.insert_file(&blade("dashboard"), &patterns(&["icon"], &[]));
+
+    assert!(index.find(&names(&["save-button"]), &[]).is_empty());
+    assert!(index.find(&[], &names(&["counter"])).is_empty());
+    assert_eq!(index.find(&names(&["icon"]), &[]), vec![blade("dashboard")]);
+    assert_eq!(index.indexed_file_count(), 1);
+}
+
+#[test]
+fn removing_a_file_withdraws_only_its_own_entries() {
+    let mut index = ComponentUsageIndex::default();
+    index.insert_file(&blade("dashboard"), &patterns(&["icon"], &[]));
+    index.insert_file(&blade("settings"), &patterns(&["icon"], &[]));
+
+    index.remove_file(&blade("dashboard"));
+
+    assert_eq!(index.find(&names(&["icon"]), &[]), vec![blade("settings")]);
+    assert_eq!(index.indexed_file_count(), 1);
+}
+
+#[test]
+fn removing_an_unknown_file_is_a_no_op() {
+    let mut index = ComponentUsageIndex::default();
+    index.insert_file(&blade("dashboard"), &patterns(&["icon"], &[]));
+
+    index.remove_file(&blade("never-indexed"));
+
+    assert_eq!(index.find(&names(&["icon"]), &[]), vec![blade("dashboard")]);
+    assert_eq!(index.indexed_file_count(), 1);
+}
+
+/// A file that renders nothing is still recorded, so a later `remove_file`
+/// has an entry to withdraw and the drain doesn't re-queue it forever.
+#[test]
+fn a_file_rendering_nothing_is_still_recorded() {
+    let mut index = ComponentUsageIndex::default();
+    index.insert_file(&blade("plain"), &patterns(&[], &[]));
+
+    assert_eq!(index.indexed_file_count(), 1);
+}
+
+#[test]
+fn unknown_names_find_nothing() {
+    let mut index = ComponentUsageIndex::default();
+    index.insert_file(&blade("dashboard"), &patterns(&["icon"], &[]));
+
+    assert!(index
+        .find(&names(&["absent"]), &names(&["absent"]))
+        .is_empty());
+}
+
+#[test]
+fn only_blade_paths_are_queued() {
+    let mut index = ComponentUsageIndex::default();
+    index.mark_dirty(&blade("dashboard"));
+    index.mark_dirty(Path::new("/app/app/Livewire/Counter.php"));
+
+    assert_eq!(index.take_pending(), vec![blade("dashboard")]);
+}
+
+#[test]
+fn draining_the_queue_empties_it() {
+    let mut index = ComponentUsageIndex::default();
+    index.mark_dirty(&blade("dashboard"));
+
+    assert_eq!(index.take_pending().len(), 1);
+    assert!(index.take_pending().is_empty());
+}
+
+#[test]
+fn clear_drops_entries_and_the_queue() {
+    let mut index = ComponentUsageIndex::default();
+    index.insert_file(&blade("dashboard"), &patterns(&["icon"], &[]));
+    index.mark_dirty(&blade("settings"));
+
+    index.clear();
+
+    assert!(index.find(&names(&["icon"]), &[]).is_empty());
+    assert!(index.take_pending().is_empty());
+    assert_eq!(index.indexed_file_count(), 0);
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -145,6 +145,7 @@ pub mod member_resolver;
 
 // Controller/Volt → Blade view-variable type inference (magic members in Blade)
 pub mod view_var_index;
+pub mod volt_functional;
 
 // M1 single-parse capture: compile a file's own-source resolution context at
 // parse so the magic-member resolve passes never re-read/re-parse it.

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -61,6 +61,7 @@ pub mod completion_format;
 pub mod component_completion;
 pub mod component_declaration_locator;
 pub mod component_member_locator;
+pub mod component_usage_index;
 pub mod composer_autoload;
 pub mod config;
 pub mod config_key_locator;

--- a/laravel-lsp/src/livewire_resolver.rs
+++ b/laravel-lsp/src/livewire_resolver.rs
@@ -1184,11 +1184,7 @@ fn entry_key_name(entry: &str) -> Option<String> {
     let first = inner_chars.next()?;
     (first.is_ascii_alphabetic() || first == '_')
         .then(|| inner.to_string())
-        .filter(|_| {
-            inner
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_')
-        })
+        .filter(|_| inner.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
 }
 
 /// The byte offset of a top-level `=>` in `entry`, skipping quoted runs and

--- a/laravel-lsp/src/livewire_resolver.rs
+++ b/laravel-lsp/src/livewire_resolver.rs
@@ -150,6 +150,12 @@ pub enum WireTarget {
     /// target is the first dot-segment of the value (`contractData.title`
     /// → `contractData`).
     Property(String),
+    /// `wire:target` names EITHER an action method (`wire:target="save"`)
+    /// or, paired with `wire:model`'s loading states, a property. Livewire
+    /// accepts both spellings for the same attribute, so the kind cannot be
+    /// decided from the attribute alone and the member lookup must accept
+    /// either declaration.
+    Member(String),
 }
 
 /// If the cursor sits inside a `wire:*="value"` attribute's quoted value on
@@ -223,6 +229,10 @@ pub fn wire_attribute_target_at(line: &str, cursor_col: u32) -> Option<WireTarge
                 let ident = value.split('(').next().unwrap_or("").trim();
                 is_php_identifier(ident).then(|| WireTarget::Method(ident.to_string()))
             }
+            Some(WireValueKind::Member) => {
+                let ident = comma_segment_at(value, cursor - value_start)?.trim();
+                is_php_identifier(ident).then(|| WireTarget::Member(ident.to_string()))
+            }
             None => None,
         };
     }
@@ -239,20 +249,50 @@ pub enum WireValueKind {
     /// The value binds a public property (`wire:model`, `wire:show`,
     /// `wire:text`).
     Property,
+    /// The value names a member of EITHER kind — `wire:target`, which takes
+    /// an action name or a `wire:model` property depending on the loading
+    /// state it scopes.
+    Member,
 }
 
 /// Classify a `wire:` attribute's base name (modifiers stripped) by what its
 /// value names. `None` for attributes whose value is not a component member
-/// at all (`wire:key`, `wire:target`, `wire:ignore`, ...). Everything not
-/// explicitly listed is treated as a DOM-event action binding, since Livewire
-/// accepts `wire:{any-dom-event}`.
+/// at all (`wire:key`, `wire:ignore`, ...). Everything not explicitly listed
+/// is treated as a DOM-event action binding, since Livewire accepts
+/// `wire:{any-dom-event}`.
+///
+/// `target` is [`WireValueKind::Member`], not `None`: its value names the
+/// action(s) or property a loading state is scoped to, and both are
+/// navigable members of the component.
 fn wire_value_kind(base: &str) -> Option<WireValueKind> {
     match base {
         "model" | "show" | "text" => Some(WireValueKind::Property),
-        "key" | "id" | "ignore" | "loading" | "dirty" | "offline" | "target" | "stream"
-        | "replace" | "transition" | "navigate" | "cloak" | "current" | "confirm" => None,
+        "target" => Some(WireValueKind::Member),
+        "key" | "id" | "ignore" | "loading" | "dirty" | "offline" | "stream" | "replace"
+        | "transition" | "navigate" | "cloak" | "current" | "confirm" => None,
         _ => Some(WireValueKind::Method),
     }
+}
+
+/// The comma-separated segment of `value` that contains byte offset `at`.
+///
+/// `wire:target="save, delete"` is a legal Livewire list, so the cursor
+/// decides which entry goto resolves. A cursor on the comma itself belongs
+/// to the segment on its left. `None` when `at` is past the value.
+fn comma_segment_at(value: &str, at: usize) -> Option<&str> {
+    if at > value.len() {
+        return None;
+    }
+    let mut start = 0usize;
+    for (i, b) in value.bytes().enumerate() {
+        if b == b',' {
+            if at <= i {
+                return Some(&value[start..i]);
+            }
+            start = i + 1;
+        }
+    }
+    Some(&value[start..])
 }
 
 /// If the cursor sits inside a `wire:*="…"` quoted value on `line`, return
@@ -319,11 +359,23 @@ pub fn wire_attribute_completion_context(
         if cursor < value_start || cursor > value_end {
             continue;
         }
-        let typed = line[value_start..cursor].trim();
         let kind = wire_value_kind(attr_name.strip_prefix("wire:")?.split('.').next()?)?;
+        // A `wire:target` list completes per entry, so only the segment the
+        // cursor sits in is the typed prefix — `save, del|` offers `delete`,
+        // not nothing.
+        let typed = match kind {
+            WireValueKind::Member => line[value_start..cursor]
+                .rsplit(',')
+                .next()
+                .unwrap_or("")
+                .trim(),
+            _ => line[value_start..cursor].trim(),
+        };
         let acceptable = match kind {
-            // Actions are a single identifier.
-            WireValueKind::Method => typed.is_empty() || is_php_identifier(typed),
+            // Actions are a single identifier; a `wire:target` entry is too.
+            WireValueKind::Method | WireValueKind::Member => {
+                typed.is_empty() || is_php_identifier(typed)
+            }
             // Bindings may be a dotted path into a nested object
             // (`wire:model="contractData.title"`): every completed segment
             // must be an identifier, the segment under the cursor may be
@@ -829,7 +881,20 @@ pub fn is_template_local_binding(content: &str, line: u32, var: &str) -> bool {
     let mut persistent: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut in_php_block = false;
 
+    let mut line_start = 0usize;
     for (idx, text) in content.lines().enumerate() {
+        // Byte offset of this line inside `content`. `lines()` strips the
+        // terminator, so step over whichever of `\n` / `\r\n` follows.
+        // `@props`/`@aware` need it: their array literal may run past the end
+        // of this line, and the directive's arguments are read from `content`
+        // rather than from `text` alone.
+        let this_line_start = line_start;
+        line_start += text.len();
+        if content[line_start..].starts_with("\r\n") {
+            line_start += 2;
+        } else if content[line_start..].starts_with('\n') {
+            line_start += 1;
+        }
         if idx > line as usize {
             break;
         }
@@ -854,7 +919,12 @@ pub fn is_template_local_binding(content: &str, line: u32, var: &str) -> bool {
         if let Some(rest) =
             find_directive(text, "@props").or_else(|| find_directive(text, "@aware"))
         {
-            collect_quoted_names(rest, &mut persistent);
+            // `rest` is a suffix of `text`, and `text` is a slice of
+            // `content`, so the directive's argument list starts here in the
+            // whole document — which is what lets a multi-line
+            // `@props([\n    'color' => 'blue',\n])` be read to its close.
+            let args_at = this_line_start + (text.len() - rest.len());
+            collect_prop_names(&content[args_at..], &mut persistent);
         }
 
         if let Some(rest) =
@@ -977,32 +1047,180 @@ fn collect_assignments(s: &str, out: &mut std::collections::HashSet<String>) {
     out.extend(names);
 }
 
-/// Every `'name'` / `"name"` string key or entry in a `@props([...])` /
-/// `@aware([...])` argument on this line.
-fn collect_quoted_names(s: &str, out: &mut std::collections::HashSet<String>) {
-    let mut chars = s.char_indices().peekable();
-    while let Some((i, c)) = chars.next() {
-        if c == '\'' || c == '"' {
-            if let Some(rel) = s[i + 1..].find(c) {
-                let name = &s[i + 1..i + 1 + rel];
-                if !name.is_empty()
-                    && name
-                        .chars()
-                        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
-                {
-                    out.insert(name.to_string());
-                }
-                // skip past the closing quote
-                while let Some(&(j, _)) = chars.peek() {
-                    if j <= i + 1 + rel {
-                        chars.next();
-                    } else {
-                        break;
-                    }
-                }
-            }
+/// Every prop NAME declared by a `@props([...])` / `@aware([...])`
+/// directive whose argument list starts at `after_directive` (the text
+/// immediately after the directive name, in the whole document — the list
+/// may span several lines).
+///
+/// Only array KEYS are prop names: `@props(['color' => 'blue'])` declares
+/// `$color`, never `$blue`. An entry with no `=>` is a prop declared without
+/// a default (`@props(['color'])`), so its own value is the name. Scanning
+/// ends at the directive's closing `)`, so unrelated quoted text later on the
+/// same line (`@props([...]) <div title="literal">`) contributes nothing.
+fn collect_prop_names(after_directive: &str, out: &mut std::collections::HashSet<String>) {
+    let Some(args) = balanced_call_args(after_directive) else {
+        return;
+    };
+    for entry in top_level_entries(array_body(args)) {
+        if let Some(name) = entry_key_name(entry) {
+            out.insert(name);
         }
     }
+}
+
+/// The text between the outer parentheses of the call that starts at the
+/// first non-whitespace character of `s`, which must be `(`. Quoted runs are
+/// skipped, so a `)` inside a string does not close the list. `None` when `s`
+/// does not open a call, or the parentheses never balance.
+fn balanced_call_args(s: &str) -> Option<&str> {
+    let open = s.find(|c: char| !c.is_whitespace())?;
+    let bytes = s.as_bytes();
+    if bytes[open] != b'(' {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut quote: Option<u8> = None;
+    let mut i = open;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match quote {
+            Some(q) => {
+                if b == b'\\' {
+                    // Skip the escaped byte; every byte compared here is
+                    // ASCII, so landing inside a multi-byte codepoint is
+                    // harmless (continuation bytes are >= 0x80).
+                    i += 2;
+                    continue;
+                }
+                if b == q {
+                    quote = None;
+                }
+            }
+            None => match b {
+                b'\'' | b'"' => quote = Some(b),
+                b'(' => depth += 1,
+                b')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(&s[open + 1..i]);
+                    }
+                }
+                _ => {}
+            },
+        }
+        i += 1;
+    }
+    None
+}
+
+/// The element list inside an array literal argument: the body of `[...]` or
+/// of `array(...)`. Anything else is returned unchanged, so a non-array
+/// argument simply yields one entry.
+fn array_body(args: &str) -> &str {
+    let t = args.trim();
+    if let Some(inner) = t.strip_prefix('[').and_then(|r| r.strip_suffix(']')) {
+        return inner;
+    }
+    if let Some(rest) = t.strip_prefix("array") {
+        let r = rest.trim_start();
+        if let Some(inner) = r.strip_prefix('(').and_then(|r| r.strip_suffix(')')) {
+            return inner;
+        }
+    }
+    t
+}
+
+/// Split `body` on its TOP-LEVEL commas — commas nested in a sub-array, a
+/// call, or a quoted string stay inside their entry.
+fn top_level_entries(body: &str) -> Vec<&str> {
+    let bytes = body.as_bytes();
+    let mut out = Vec::new();
+    let mut depth = 0usize;
+    let mut quote: Option<u8> = None;
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match quote {
+            Some(q) => {
+                if b == b'\\' {
+                    i += 2;
+                    continue;
+                }
+                if b == q {
+                    quote = None;
+                }
+            }
+            None => match b {
+                b'\'' | b'"' => quote = Some(b),
+                b'(' | b'[' | b'{' => depth += 1,
+                b')' | b']' | b'}' => depth = depth.saturating_sub(1),
+                b',' if depth == 0 => {
+                    out.push(&body[start..i]);
+                    start = i + 1;
+                }
+                _ => {}
+            },
+        }
+        i += 1;
+    }
+    out.push(&body[start..]);
+    out
+}
+
+/// The prop name an array entry declares: the quoted key before a top-level
+/// `=>`, or the entry itself when it has no `=>`. `None` for an entry that is
+/// not a quoted identifier (a numeric key, a constant, a spread).
+fn entry_key_name(entry: &str) -> Option<String> {
+    let key = match top_level_arrow(entry) {
+        Some(at) => &entry[..at],
+        None => entry,
+    };
+    let key = key.trim();
+    let mut chars = key.chars();
+    let quote = chars.next().filter(|c| *c == '\'' || *c == '"')?;
+    let inner = key.strip_prefix(quote)?.strip_suffix(quote)?;
+    let mut inner_chars = inner.chars();
+    let first = inner_chars.next()?;
+    (first.is_ascii_alphabetic() || first == '_')
+        .then(|| inner.to_string())
+        .filter(|_| {
+            inner
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        })
+}
+
+/// The byte offset of a top-level `=>` in `entry`, skipping quoted runs and
+/// nested brackets.
+fn top_level_arrow(entry: &str) -> Option<usize> {
+    let bytes = entry.as_bytes();
+    let mut depth = 0usize;
+    let mut quote: Option<u8> = None;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match quote {
+            Some(q) => {
+                if b == b'\\' {
+                    i += 2;
+                    continue;
+                }
+                if b == q {
+                    quote = None;
+                }
+            }
+            None => match b {
+                b'\'' | b'"' => quote = Some(b),
+                b'(' | b'[' | b'{' => depth += 1,
+                b')' | b']' | b'}' => depth = depth.saturating_sub(1),
+                b'=' if depth == 0 && bytes.get(i + 1) == Some(&b'>') => return Some(i),
+                _ => {}
+            },
+        }
+        i += 1;
+    }
+    None
 }
 
 const VOLT_FUNCTIONAL_CALLS: &[&str] = &[

--- a/laravel-lsp/src/livewire_resolver/tests.rs
+++ b/laravel-lsp/src/livewire_resolver/tests.rs
@@ -866,3 +866,115 @@ fn namespaced_component_resolution_with_negative_controls() {
         "true negative: a missing component under the valid namespace stays missing"
     );
 }
+
+// ---- @props / @aware bind KEYS, never default values (issue #339, item 8) --
+
+#[test]
+fn props_binds_the_key_and_not_its_default_value() {
+    let content = "@props(['color' => 'blue'])\n<div>{{ $color }} {{ $blue }}</div>\n";
+    assert!(
+        is_template_local_binding(content, 1, "color"),
+        "the declared prop is locally bound"
+    );
+    assert!(
+        !is_template_local_binding(content, 1, "blue"),
+        "a default VALUE is not a prop name"
+    );
+}
+
+#[test]
+fn props_ignores_unrelated_quoted_text_later_on_the_same_line() {
+    let content = "@props(['color' => 'blue']) <div title=\"literal\">\n{{ $literal }}\n";
+    assert!(is_template_local_binding(content, 1, "color"));
+    assert!(
+        !is_template_local_binding(content, 1, "blue"),
+        "the default value is still excluded"
+    );
+    assert!(
+        !is_template_local_binding(content, 1, "literal"),
+        "scanning stops at the directive's closing paren"
+    );
+}
+
+#[test]
+fn props_parses_the_multiline_array_form() {
+    let content = "@props([\n    'color' => 'blue',\n    'size',\n])\n<div>{{ $color }}</div>\n";
+    assert!(
+        is_template_local_binding(content, 4, "color"),
+        "a key on a continuation line still binds"
+    );
+    assert!(
+        is_template_local_binding(content, 4, "size"),
+        "a bare entry declares a prop with no default"
+    );
+    assert!(
+        !is_template_local_binding(content, 4, "blue"),
+        "its default value does not"
+    );
+}
+
+#[test]
+fn aware_binds_keys_the_same_way_as_props() {
+    let content = "@aware(['variant' => 'primary'])\n<div>{{ $variant }}</div>\n";
+    assert!(is_template_local_binding(content, 1, "variant"));
+    assert!(!is_template_local_binding(content, 1, "primary"));
+}
+
+#[test]
+fn props_with_a_nested_default_array_keeps_the_nesting_out_of_the_names() {
+    let content = "@props(['options' => ['a' => 'b'], 'label'])\n<div></div>\n";
+    assert!(is_template_local_binding(content, 1, "options"));
+    assert!(is_template_local_binding(content, 1, "label"));
+    assert!(
+        !is_template_local_binding(content, 1, "a"),
+        "a nested array's own keys are not props"
+    );
+    assert!(!is_template_local_binding(content, 1, "b"));
+}
+
+// ---- wire:target navigates (issue #339, item 4) ---------------------------
+
+#[test]
+fn wire_target_resolves_the_segment_under_the_cursor() {
+    let line = r#"<div wire:target="save, delete">"#;
+    let save_col = line.find("save").unwrap() as u32;
+    let delete_col = line.find("delete").unwrap() as u32;
+    assert_eq!(
+        wire_attribute_target_at(line, save_col),
+        Some(WireTarget::Member("save".to_string())),
+        "cursor on the first entry"
+    );
+    assert_eq!(
+        wire_attribute_target_at(line, delete_col),
+        Some(WireTarget::Member("delete".to_string())),
+        "cursor on the second entry"
+    );
+}
+
+#[test]
+fn wire_target_single_value_is_still_a_member() {
+    let line = r#"<div wire:target="save">"#;
+    let col = line.find("save").unwrap() as u32;
+    assert_eq!(
+        wire_attribute_target_at(line, col),
+        Some(WireTarget::Member("save".to_string()))
+    );
+}
+
+#[test]
+fn wire_target_completion_prefix_is_the_current_entry() {
+    let line = r#"<div wire:target="save, del">"#;
+    let cursor = (line.find("del").unwrap() + 3) as u32;
+    assert_eq!(
+        wire_attribute_completion_context(line, cursor),
+        Some((WireValueKind::Member, "del".to_string())),
+        "a list completes per entry, not across the whole value"
+    );
+}
+
+#[test]
+fn attributes_that_name_no_member_still_resolve_to_nothing() {
+    let line = r#"<div wire:key="row-{{ $id }}" wire:ignore>"#;
+    let col = line.find("row-").unwrap() as u32;
+    assert_eq!(wire_attribute_target_at(line, col), None);
+}

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13074,9 +13074,19 @@ impl LaravelLanguageServer {
         blade_path: &Path,
     ) -> laravel_lsp::salsa_impl::BladeBackingResolutionData {
         if let Some((generation, entries)) = self.pending_render_index_snapshot() {
-            if self.salsa.set_render_index(entries).await.is_ok() {
+            if self
+                .salsa
+                .set_render_index(generation, entries)
+                .await
+                .is_ok()
+            {
+                // `fetch_max`, not `store`: two tasks can snapshot generations
+                // 5 and 6 and finish their pushes in either order, and a plain
+                // store would let the older one win the gate. The actor refuses
+                // an out-of-order snapshot for the same reason, so both sides
+                // only ever move forward.
                 self.pushed_render_generation
-                    .store(generation, std::sync::atomic::Ordering::Relaxed);
+                    .fetch_max(generation, std::sync::atomic::Ordering::Relaxed);
             }
         }
 
@@ -13227,7 +13237,10 @@ impl LaravelLanguageServer {
     ///
     /// Reading `generation()` under the same lock that builds the snapshot is
     /// what makes the pair consistent: a snapshot can never be stamped with a
-    /// generation it doesn't match.
+    /// generation it doesn't match. Consistency of the PAIR is all this can
+    /// promise, though — the push itself happens after an `await`, so which
+    /// snapshot the actor ends up installing is settled on the actor side, by
+    /// `handle_set_render_index` refusing to go backwards.
     ///
     /// Generation 0 is the never-mutated index, which is empty — and the actor
     /// synthesizes an empty render index for a resolution that arrives before
@@ -20423,8 +20436,13 @@ return [
             MemberKind::Method => format!("{class_name}::{member}()"),
             MemberKind::Property => format!("{class_name}::${member}"),
         };
-        let signature =
-            laravel_lsp::component_member_locator::member_declaration_summary(source, member);
+        // Same `want` the header was filtered on. Without it the summary is
+        // free to describe the OTHER declaration of the same name — a class
+        // holding both `public $save` and `save()` would print a header of
+        // `::$save` above the body of `save()` (#339, item 5).
+        let signature = laravel_lsp::component_member_locator::member_declaration_summary_of_kind(
+            source, member, want,
+        );
         let link = self.source_link(class_path, Some(loc.line + 1)).await;
         let rendered = hover::render(&hover::HoverContent {
             header: Some(&header),

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -13101,7 +13101,12 @@ impl LaravelLanguageServer {
     /// Salsa memo intact, which is the whole point of the conversion: what was
     /// an O(entire index) sweep plus an uncached read-and-parse *per keystroke*
     /// now recomputes only when the index or a backing file's content changes.
-    async fn blade_backing_class_resolution(
+    ///
+    /// This is the DIRECT resolution — `blade_path`'s own backing classes.
+    /// A partial that has none resolves through its rendering ancestors
+    /// instead; see [`Self::blade_backing_class_resolution`], which calls this
+    /// first and walks up only when it comes back empty.
+    async fn blade_backing_class_resolution_direct(
         &self,
         blade_path: &Path,
     ) -> laravel_lsp::salsa_impl::BladeBackingResolutionData {
@@ -13148,6 +13153,108 @@ impl LaravelLanguageServer {
                 livewire_paths,
                 live_blade_text,
             )
+            .await
+            .unwrap_or_default()
+    }
+
+    /// Every PHP class backing what `blade_path` renders — its own backing
+    /// classes when it has any, otherwise those of the nearest Livewire
+    /// component that renders it (#339, item 1).
+    ///
+    /// An anonymous Blade partial (`resources/views/components/save-button.blade.php`,
+    /// used as `<x-save-button />`) has no backing class of its own: nobody
+    /// calls `view('components.save-button')`, it doesn't live under Livewire's
+    /// view path, and it declares no inline class. Its `wire:click="save"`,
+    /// `$this->save` and bare `$count` nevertheless resolve at runtime, against
+    /// the component that rendered it. So when the direct resolution is empty
+    /// we climb the usage graph — `<x-…>` and `<livewire:…>` tags alike — and
+    /// answer with the first ancestor that HAS a backing class.
+    ///
+    /// **First match, not all matches.** At runtime a partial has exactly one
+    /// `$this`; a multi-target result would be honest about the static
+    /// ambiguity and wrong about how the code runs. Order is therefore
+    /// load-bearing, and pinned twice over: breadth-first, so a nearer ancestor
+    /// always outranks a further one, and lexicographic by path within each
+    /// level (`handle_files_rendering_component` sorts), so two equidistant
+    /// parents resolve the same way on every call.
+    ///
+    /// **Direct beats walked-up.** The direct resolution runs first, so a
+    /// partial that IS rendered by a `view('components.save-button')` call site
+    /// keeps that answer and never climbs.
+    ///
+    /// **The cycle guard is a visited set, not a depth cap.** `a` including `b`
+    /// including `a` terminates because each file is expanded at most once —
+    /// and a cycle on one branch prunes only that branch, leaving a resolvable
+    /// path elsewhere in the level to answer. A depth cap would instead cut off
+    /// legitimately deep nesting, which is why it isn't one.
+    async fn blade_backing_class_resolution(
+        &self,
+        blade_path: &Path,
+    ) -> laravel_lsp::salsa_impl::BladeBackingResolutionData {
+        let direct = self.blade_backing_class_resolution_direct(blade_path).await;
+        if !direct.sources.is_empty() {
+            return direct;
+        }
+
+        let mut visited: HashSet<PathBuf> = HashSet::new();
+        visited.insert(blade_path.to_path_buf());
+        let mut frontier = self.blade_rendering_ancestors(blade_path).await;
+
+        while !frontier.is_empty() {
+            let mut next: Vec<PathBuf> = Vec::new();
+            for ancestor in frontier {
+                if !visited.insert(ancestor.clone()) {
+                    continue;
+                }
+                let resolved = self.blade_backing_class_resolution_direct(&ancestor).await;
+                if !resolved.sources.is_empty() {
+                    return resolved;
+                }
+                next.extend(self.blade_rendering_ancestors(&ancestor).await);
+            }
+            next.sort();
+            next.dedup();
+            frontier = next;
+        }
+
+        direct
+    }
+
+    /// The Blade templates that render `blade_path` as a component — one step
+    /// up the graph [`Self::blade_backing_class_resolution`] walks, sorted.
+    ///
+    /// The identities are derived from the path and matched against the
+    /// parser's classified tag names: `component_name_for_blade_path` gives the
+    /// `<x-…>` name, `livewire_name_for_path` the `<livewire:…>` name. A file
+    /// that is neither has no ancestors to climb to, and the actor is never
+    /// asked.
+    async fn blade_rendering_ancestors(&self, blade_path: &Path) -> Vec<PathBuf> {
+        let mut component_names: Vec<String> = Vec::new();
+        if let Some(config) = self.cached_config.read().await.as_ref() {
+            if let Some(name) =
+                laravel_lsp::component_declaration_locator::component_name_for_blade_path(
+                    blade_path, config,
+                )
+            {
+                component_names.push(name);
+            }
+        }
+
+        let mut livewire_names: Vec<String> = Vec::new();
+        if let Some((lw_config, lw_version)) = self.get_cached_livewire().await {
+            if let Some(name) = laravel_lsp::livewire_resolver::livewire_name_for_path(
+                blade_path, &lw_config, lw_version,
+            ) {
+                livewire_names.push(name);
+            }
+        }
+
+        if component_names.is_empty() && livewire_names.is_empty() {
+            return Vec::new();
+        }
+
+        self.salsa
+            .files_rendering_component(component_names, livewire_names)
             .await
             .unwrap_or_default()
     }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2168,6 +2168,11 @@ struct LaravelLanguageServer {
     /// `std::sync::RwLock` for the same blocking-closure reason as
     /// `magic_deps`.
     view_vars: Arc<std::sync::RwLock<laravel_lsp::view_var_index::ViewVarIndex>>,
+    /// The `ViewVarIndex` generation last pushed to the Salsa actor's render
+    /// index. Guards against re-pushing an unchanged snapshot, which would bump
+    /// the Salsa revision and invalidate the backing-class memo on every
+    /// keystroke (#339, item 7).
+    pushed_render_generation: Arc<std::sync::atomic::AtomicU64>,
 
     /// Handle for the debounced magic-cache re-save. Incremental refreshes
     /// mutate the in-memory indexes; without re-persisting them the next
@@ -4700,6 +4705,7 @@ impl LaravelLanguageServer {
             view_vars: Arc::new(std::sync::RwLock::new(
                 laravel_lsp::view_var_index::ViewVarIndex::new(),
             )),
+            pushed_render_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             magic_cache_save_handle: Arc::new(RwLock::new(None)),
             vendor_open_magic_lru: Arc::new(std::sync::Mutex::new(lru::LruCache::new(
                 std::num::NonZeroUsize::new(VENDOR_OPEN_MAGIC_LRU_CAP).unwrap(),
@@ -13068,40 +13074,51 @@ impl LaravelLanguageServer {
         self.view_path_to_livewire_class_path(root, blade_path)
     }
 
-    /// Every `.php` file backing `blade_path`'s rendered content — the union
-    /// of two independent sources:
-    ///   1. The project-wide render index's contributors for the file's
-    ///      namespaced view name (a Filament-style `$view`-property page, or
-    ///      any controller `view(...)` call site).
-    ///   2. The conventionally-resolved Livewire component class, when
+    /// Resolve every PHP class backing `blade_path`'s rendered content, via
+    /// the memoized Salsa queries in
+    /// [`laravel_lsp::salsa_impl::blade_backing_class_files`] and
+    /// [`laravel_lsp::salsa_impl::blade_backing_class_sources`] (#339, item 7).
+    ///
+    /// This method's only job is supplying those queries' inputs:
+    ///   1. the template's Laravel view name, whose render-index contributors
+    ///      are a Filament-style `$view`-property page or any controller
+    ///      `view(...)` call site;
+    ///   2. the conventionally-resolved Livewire component class, when
     ///      `blade_path` is a Livewire view — so goto/hover `$this->member`
     ///      and `wire:` fallbacks work for plain Livewire components too, not
-    ///      just Filament pages.
+    ///      just Filament pages;
+    ///   3. the live editor buffer for the template itself, for the inline
+    ///      `new class extends Component` (Livewire v4 SFC / class-based Volt)
+    ///      and functional-Volt shapes, whose members live in the template's
+    ///      own front matter and so have no standalone `.php` source.
     ///
     /// Resolution for (2) goes through `livewire_name_for_path` +
     /// `resolve_component` (the reverse-then-forward resolver), not
-    /// `find_livewire_component_php`'s file heuristics — a V4 SFC or Volt
-    /// component's class lives inline in the `.blade.php` itself, which has
-    /// no separate `.php` source for `component_member_locator` to parse, so
-    /// those legitimately contribute nothing here.
+    /// `find_livewire_component_php`'s file heuristics.
     ///
-    /// Deduped; only paths that exist on disk and end in a plain `.php`
-    /// extension (not `.blade.php`) are kept.
-    async fn blade_backing_class_files(&self, blade_path: &Path) -> Vec<PathBuf> {
-        let mut out: Vec<PathBuf> = Vec::new();
+    /// The render-index snapshot is pushed first, but only when
+    /// `ViewVarIndex`'s generation has moved — an unchanged index leaves the
+    /// Salsa memo intact, which is the whole point of the conversion: what was
+    /// an O(entire index) sweep plus an uncached read-and-parse *per keystroke*
+    /// now recomputes only when the index or a backing file's content changes.
+    async fn blade_backing_class_resolution(
+        &self,
+        blade_path: &Path,
+    ) -> laravel_lsp::salsa_impl::BladeBackingResolutionData {
+        if let Some((generation, entries)) = self.pending_render_index_snapshot() {
+            if self.salsa.set_render_index(entries).await.is_ok() {
+                self.pushed_render_generation
+                    .store(generation, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
 
         let view_paths = match self.cached_config.read().await.as_ref() {
             Some(config) => config.view_paths.clone(),
             None => Vec::new(),
         };
-        if let Some(view_name) =
-            laravel_lsp::view_var_index::view_name_for_path(blade_path, &view_paths)
-        {
-            if let Ok(idx) = self.view_vars.read() {
-                out.extend(idx.render_source_files(&view_name));
-            }
-        }
+        let view_name = laravel_lsp::view_var_index::view_name_for_path(blade_path, &view_paths);
 
+        let mut livewire_paths: Vec<PathBuf> = Vec::new();
         if let Some((lw_config, lw_version)) = self.get_cached_livewire().await {
             if let Some(name) = laravel_lsp::livewire_resolver::livewire_name_for_path(
                 blade_path, &lw_config, lw_version,
@@ -13109,67 +13126,67 @@ impl LaravelLanguageServer {
                 if let Some(component) =
                     laravel_lsp::livewire_resolver::resolve_component(&name, &lw_config, lw_version)
                 {
-                    out.extend(component.paths);
+                    livewire_paths = component.paths;
                 }
             }
         }
 
-        let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
-        out.retain(|p| {
-            let is_plain_php = p.extension().and_then(|e| e.to_str()) == Some("php")
-                && !p.to_string_lossy().ends_with(".blade.php");
-            is_plain_php && p.is_file() && seen.insert(p.clone())
-        });
-        out
-    }
-
-    /// Locate `member` (a property or method name) in whichever `.php`
-    /// file(s) back `blade_path` (see [`Self::blade_backing_class_files`]).
-    /// Returns the first hit's file plus its declaration position.
-    /// Every `(path, source)` pair whose PHP class backs `blade_path` — the
-    /// plain-`.php` backing files ([`Self::blade_backing_class_files`]), plus
-    /// the blade file ITSELF when it declares an inline
-    /// `new class extends Component` (a Livewire v4 single-file component or
-    /// a class-based Volt component). Those two shapes have no standalone
-    /// `.php` source: the class lives in the template's own front matter, so
-    /// the template is the source to parse and member positions land in the
-    /// `.blade.php` itself. The live editor buffer wins over disk for it.
-    async fn blade_backing_class_sources(&self, blade_path: &Path) -> Vec<(PathBuf, String)> {
-        let mut out: Vec<(PathBuf, String)> = Vec::new();
-        for class_path in self.blade_backing_class_files(blade_path).await {
-            if let Ok(source) = std::fs::read_to_string(&class_path) {
-                out.push((class_path, source));
-            }
-        }
-        let live = match Url::from_file_path(blade_path) {
+        let live_blade_text = match Url::from_file_path(blade_path) {
             Ok(url) => self
                 .documents
                 .read()
                 .await
                 .get(&url)
-                .map(|(c, _)| c.clone()),
+                .map(|(content, _)| content.clone()),
             Err(()) => None,
         };
-        let blade_content = match live {
-            Some(content) => Some(content),
-            None => std::fs::read_to_string(blade_path).ok(),
-        };
-        if let Some(content) = blade_content {
-            // A FUNCTIONAL Volt file declares no class at all, so
-            // `detect_inline_livewire_class` is false for it — but its
-            // `state([...])` keys and top-level closure assignments ARE the
-            // component's members, and `component_member_locator` reads them.
-            // Both inline shapes therefore hand the template itself to the
-            // locator (#339, item 3).
-            if laravel_lsp::php_class::detect_inline_livewire_class(&content)
-                || laravel_lsp::livewire_resolver::source_contains_volt_signature(&content)
-            {
-                out.push((blade_path.to_path_buf(), content));
-            }
-        }
-        out
+
+        self.salsa
+            .blade_backing_class_resolution(
+                blade_path.to_path_buf(),
+                view_name,
+                livewire_paths,
+                live_blade_text,
+            )
+            .await
+            .unwrap_or_default()
     }
 
+    /// The render-index snapshot still owed to the Salsa actor, or `None` when
+    /// the actor already holds the current generation.
+    ///
+    /// Reading `generation()` under the same lock that builds the snapshot is
+    /// what makes the pair consistent: a snapshot can never be stamped with a
+    /// generation it doesn't match.
+    ///
+    /// Generation 0 is the never-mutated index, which is empty — and the actor
+    /// synthesizes an empty render index for a resolution that arrives before
+    /// any snapshot. So the initial `0 == 0` skip is not a missed push: both
+    /// sides already agree there are no render sites.
+    fn pending_render_index_snapshot(&self) -> Option<(u64, Vec<(String, PathBuf)>)> {
+        let index = self.view_vars.read().ok()?;
+        let generation = index.generation();
+        if self
+            .pushed_render_generation
+            .load(std::sync::atomic::Ordering::Relaxed)
+            == generation
+        {
+            return None;
+        }
+        Some((generation, index.render_entries()))
+    }
+
+    /// Every `(path, source)` pair whose PHP class backs `blade_path`.
+    /// See [`Self::blade_backing_class_resolution`].
+    async fn blade_backing_class_sources(&self, blade_path: &Path) -> Vec<(PathBuf, String)> {
+        self.blade_backing_class_resolution(blade_path)
+            .await
+            .sources
+    }
+
+    /// Locate `member` (a property or method name) in whichever `.php`
+    /// file(s) back `blade_path` (see [`Self::blade_backing_class_resolution`]).
+    /// Returns the first hit's file plus its declaration position.
     async fn locate_in_backing_class_files(
         &self,
         blade_path: &Path,
@@ -18328,6 +18345,7 @@ return [
             route_decl_cache: self.route_decl_cache.clone(),
             magic_deps: self.magic_deps.clone(),
             view_vars: self.view_vars.clone(),
+            pushed_render_generation: self.pushed_render_generation.clone(),
             magic_cache_save_handle: self.magic_cache_save_handle.clone(),
             vendor_open_magic_lru: self.vendor_open_magic_lru.clone(),
             inertia_default_ext: self.inertia_default_ext.clone(),

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -11575,12 +11575,17 @@ impl LaravelLanguageServer {
             line_text,
             position.character,
         )?;
-        let member = match &target {
-            WireTarget::Method(m) => m,
-            WireTarget::Property(p) => p,
+        use laravel_lsp::component_member_locator::MemberKind;
+        // The attribute decides which declaration kind may answer. A
+        // `wire:target` names either an action or a `wire:model` property, so
+        // it alone accepts both (#339, items 4 and 5).
+        let (member, want) = match &target {
+            WireTarget::Method(m) => (m, Some(MemberKind::Method)),
+            WireTarget::Property(p) => (p, Some(MemberKind::Property)),
+            WireTarget::Member(m) => (m, None),
         };
         let (class_path, loc) = self
-            .locate_in_backing_class_files(&file_path, member)
+            .locate_in_backing_class_files_of_kind(&file_path, member, want)
             .await?;
         Self::goto_link(&class_path, loc.line, loc.start_column, loc.end_column)
     }
@@ -13150,7 +13155,15 @@ impl LaravelLanguageServer {
             None => std::fs::read_to_string(blade_path).ok(),
         };
         if let Some(content) = blade_content {
-            if laravel_lsp::php_class::detect_inline_livewire_class(&content) {
+            // A FUNCTIONAL Volt file declares no class at all, so
+            // `detect_inline_livewire_class` is false for it — but its
+            // `state([...])` keys and top-level closure assignments ARE the
+            // component's members, and `component_member_locator` reads them.
+            // Both inline shapes therefore hand the template itself to the
+            // locator (#339, item 3).
+            if laravel_lsp::php_class::detect_inline_livewire_class(&content)
+                || laravel_lsp::livewire_resolver::source_contains_volt_signature(&content)
+            {
                 out.push((blade_path.to_path_buf(), content));
             }
         }
@@ -13165,8 +13178,27 @@ impl LaravelLanguageServer {
         PathBuf,
         laravel_lsp::component_member_locator::MemberLocation,
     )> {
+        self.locate_in_backing_class_files_of_kind(blade_path, member, None)
+            .await
+    }
+
+    /// [`Self::locate_in_backing_class_files`], restricted to the declaration
+    /// kind the REFERENCE demands (#339, item 5). `wire:model="save"` binds a
+    /// property, so passing `Some(MemberKind::Property)` keeps it off a
+    /// same-named `save()` method. `None` accepts either kind, for references
+    /// that carry none of their own.
+    async fn locate_in_backing_class_files_of_kind(
+        &self,
+        blade_path: &Path,
+        member: &str,
+        want: Option<laravel_lsp::component_member_locator::MemberKind>,
+    ) -> Option<(
+        PathBuf,
+        laravel_lsp::component_member_locator::MemberLocation,
+    )> {
         for (class_path, source) in self.blade_backing_class_sources(blade_path).await {
-            if let Some(loc) = laravel_lsp::component_member_locator::locate_member(&source, member)
+            if let Some(loc) =
+                laravel_lsp::component_member_locator::locate_member_of_kind(&source, member, want)
             {
                 return Some((class_path, loc));
             }
@@ -20231,6 +20263,33 @@ return [
         Self::goto_link(&decl_file, line, start, end)
     }
 
+    /// The name to head a hover card with when the source declares no NAMED
+    /// class — an inline `new class extends Component` (Livewire SFC or
+    /// class-based Volt) or a functional Volt file. The resolved Livewire
+    /// component name when the file is one, else the template's own stem.
+    ///
+    /// Never the literal `"Component"`: that string is the name of the base
+    /// class the anonymous class extends, not of the component, and printing
+    /// it made every SFC card read `Component::increment()` (#339, item 2).
+    async fn component_display_name(&self, path: &Path) -> String {
+        if let Some((lw_config, lw_version)) = self.get_cached_livewire().await {
+            if let Some(name) =
+                laravel_lsp::livewire_resolver::livewire_name_for_path(path, &lw_config, lw_version)
+            {
+                return name;
+            }
+        }
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| {
+                n.strip_suffix(".blade.php")
+                    .or_else(|| n.strip_suffix(".php"))
+                    .unwrap_or(n)
+                    .to_string()
+            })
+            .unwrap_or_else(|| path.display().to_string())
+    }
+
     /// Hover card for `$this->member` in a Blade template whose backing
     /// class is known (a Filament `$view`-property page, a Livewire
     /// component, an inline SFC/Volt class): header `ClassName::member()` /
@@ -20242,16 +20301,36 @@ return [
     /// PHP-tooling card to defer to. `None` when no backing class declares
     /// `member`.
     async fn this_member_hover_card(&self, blade_path: &Path, member: &str) -> Option<String> {
+        self.this_member_hover_card_of_kind(blade_path, member, None)
+            .await
+    }
+
+    /// [`Self::this_member_hover_card`], restricted to the declaration kind
+    /// the reference demands — the hover half of the same kind filter goto
+    /// applies (#339, item 5), so `wire:model="save"` shows no card for a
+    /// `save()` method.
+    async fn this_member_hover_card_of_kind(
+        &self,
+        blade_path: &Path,
+        member: &str,
+        want: Option<laravel_lsp::component_member_locator::MemberKind>,
+    ) -> Option<String> {
         use laravel_lsp::component_member_locator::MemberKind;
         use laravel_lsp::hover;
 
         let sources = self.blade_backing_class_sources(blade_path).await;
         let (class_path, source, loc) = sources.iter().find_map(|(path, source)| {
-            laravel_lsp::component_member_locator::locate_member(source, member)
+            laravel_lsp::component_member_locator::locate_member_of_kind(source, member, want)
                 .map(|loc| (path, source, loc))
         })?;
-        let class_name = laravel_lsp::php_class::extract_class_fqn(class_path)
-            .unwrap_or_else(|| "Component".to_string());
+        // Read the FQCN out of the source already in hand, not off disk: for
+        // the blade file itself that source is the live editor buffer, and a
+        // disk read would show a stale class name for an unsaved edit
+        // (#339, item 2).
+        let class_name = match laravel_lsp::php_class::extract_class_fqn_from_source(source) {
+            Some(fqn) => fqn,
+            None => self.component_display_name(class_path).await,
+        };
         let header = match loc.kind {
             MemberKind::Method => format!("{class_name}::{member}()"),
             MemberKind::Property => format!("{class_name}::${member}"),
@@ -26008,43 +26087,50 @@ impl LanguageServer for LaravelLanguageServer {
                         let mut seen_members = std::collections::HashSet::new();
                         for (_, class_source) in self.blade_backing_class_sources(&blade_path).await
                         {
-                            match wire_kind {
-                                laravel_lsp::livewire_resolver::WireValueKind::Property => {
-                                    for (name, php_type) in
-                                        laravel_lsp::component_member_locator::public_property_types(
-                                            &class_source,
-                                        )
+                            use laravel_lsp::livewire_resolver::WireValueKind;
+                            // `wire:target` names an action OR a property, so
+                            // it offers both surfaces (#339, items 4 and 5).
+                            let wants_properties = matches!(
+                                wire_kind,
+                                WireValueKind::Property | WireValueKind::Member
+                            );
+                            let wants_methods =
+                                matches!(wire_kind, WireValueKind::Method | WireValueKind::Member);
+                            if wants_properties {
+                                for (name, php_type) in
+                                    laravel_lsp::component_member_locator::public_property_types(
+                                        &class_source,
+                                    )
+                                {
+                                    if name.starts_with(&typed_prefix)
+                                        && seen_members.insert(name.clone())
                                     {
-                                        if name.starts_with(&typed_prefix)
-                                            && seen_members.insert(name.clone())
-                                        {
-                                            items.push(CompletionItem {
-                                                label: name,
-                                                kind: Some(CompletionItemKind::FIELD),
-                                                detail: Some(php_type),
-                                                ..Default::default()
-                                            });
-                                        }
+                                        items.push(CompletionItem {
+                                            label: name,
+                                            kind: Some(CompletionItemKind::FIELD),
+                                            detail: Some(php_type),
+                                            ..Default::default()
+                                        });
                                     }
                                 }
-                                laravel_lsp::livewire_resolver::WireValueKind::Method => {
-                                    for name in
-                                        laravel_lsp::component_member_locator::public_action_method_names(
-                                            &class_source,
-                                        )
+                            }
+                            if wants_methods {
+                                for name in
+                                    laravel_lsp::component_member_locator::public_action_method_names(
+                                        &class_source,
+                                    )
+                                {
+                                    if name.starts_with(&typed_prefix)
+                                        && seen_members.insert(name.clone())
                                     {
-                                        if name.starts_with(&typed_prefix)
-                                            && seen_members.insert(name.clone())
-                                        {
-                                            items.push(CompletionItem {
-                                                label: name,
+                                        items.push(CompletionItem {
+                                            label: name,
                                                 kind: Some(CompletionItemKind::METHOD),
-                                                detail: Some("Livewire action".to_string()),
-                                                ..Default::default()
-                                            });
-                                        }
-                                    }
+                                            detail: Some("Livewire action".to_string()),
+                                        ..Default::default()
+                                    });
                                 }
+                            }
                             }
                         }
                         if !items.is_empty() {

--- a/laravel-lsp/src/php_class.rs
+++ b/laravel-lsp/src/php_class.rs
@@ -452,6 +452,20 @@ pub fn read_line_from_file(path: &std::path::Path, line: u32) -> Option<String> 
 /// header — gives the reader a fully-resolved type they don't see at the
 /// cursor (`<livewire:counter>` → `App\Livewire\Counter`).
 pub fn extract_class_fqn(path: &std::path::Path) -> Option<String> {
+    extract_class_fqn_from_source(&std::fs::read_to_string(path).ok()?)
+}
+
+/// [`extract_class_fqn`] over source text already in hand.
+///
+/// The disk-reading form disagrees with any caller holding the LIVE editor
+/// buffer: an unsaved rename shows the old class name until the file is
+/// saved. Callers that already have the source pass it here instead.
+///
+/// Returns `None` for a file that declares no NAMED class — an anonymous
+/// `new class extends Component` (a Livewire SFC or class-based Volt front
+/// matter) or a functional Volt file. The regex requires `class` at the start
+/// of a line, which `new class extends …` never satisfies.
+pub fn extract_class_fqn_from_source(content: &str) -> Option<String> {
     use lazy_static::lazy_static;
     use regex::Regex;
     lazy_static! {
@@ -462,14 +476,13 @@ pub fn extract_class_fqn(path: &std::path::Path) -> Option<String> {
         )
         .unwrap();
     }
-    let content = std::fs::read_to_string(path).ok()?;
     let class_name = CLASS_NAME_RE
-        .captures(&content)?
+        .captures(content)?
         .get(1)?
         .as_str()
         .to_string();
     let namespace = NS_RE
-        .captures(&content)
+        .captures(content)
         .and_then(|c| c.get(1))
         .map(|m| m.as_str());
     Some(match namespace {

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -8677,6 +8677,28 @@ pub enum FileListOp {
     Remove,
 }
 
+/// Where the text currently installed in `files[path]` came from, and
+/// therefore who is responsible for replacing it.
+///
+/// The backing-class loader ([`SalsaActor::ensure_external_php_source_loaded`])
+/// reads a file from disk whenever a Blade template resolves `$this->member`,
+/// which is a request-path read of a file somebody may be editing. The rule
+/// this enum encodes is the narrowest one that keeps that safe: **the loader
+/// only ever overwrites text it loaded itself.**
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExternalPhpText {
+    /// The loader read it from disk, at this mtime. It is the owner, so it
+    /// re-reads once the mtime advances.
+    LoadedFromDisk(std::time::SystemTime),
+    /// A client push installed it — `textDocument/didOpen`/`didChange` with an
+    /// editor buffer, or `workspace/didChangeWatchedFiles` with the watcher's
+    /// own fresh read. Both push again when their source changes, so the
+    /// pusher owns invalidation for this path and the loader must not read
+    /// disk over it: a live buffer would lose the user's unsaved edits, and a
+    /// watched file is already being kept current by the watcher.
+    PushedByClient,
+}
+
 /// The Salsa actor that owns the database and runs on a dedicated thread
 pub struct SalsaActor {
     db: LaravelDatabase,
@@ -8744,12 +8766,15 @@ pub struct SalsaActor {
     /// via the memoized Salsa query.
     document_symbols_cache:
         LruCache<PathBuf, (u64, Arc<Vec<crate::document_symbols::SymbolEntry>>)>,
-    /// Tracks the on-disk mtime of external PHP files registered as Salsa inputs —
-    /// Livewire component classes, and the backing classes of a Blade template
-    /// (#339, item 7). These files are not opened in the editor (no
-    /// `did_open`/`did_change` events), so we invalidate by comparing filesystem
-    /// mtime on each access.
-    external_php_mtimes: HashMap<PathBuf, std::time::SystemTime>,
+    /// Records where the text currently installed in `files[path]` came from,
+    /// for external PHP files registered as Salsa inputs — Livewire component
+    /// classes, and the backing classes of a Blade template (#339, item 7).
+    ///
+    /// [`SalsaActor::ensure_external_php_source_loaded`] reads this to decide
+    /// whether a disk re-read is due. An absent entry means "this actor never
+    /// installed text for that path", which is the only state that permits an
+    /// unconditional read.
+    external_php_text: HashMap<PathBuf, ExternalPhpText>,
     /// Monotonic version counter for external PHP SourceFiles (incremented per disk re-read).
     /// Monotonic stamp for the text currently installed in `files[path]`,
     /// bumped by EVERY writer, and the key the three per-file LRU caches
@@ -8955,7 +8980,7 @@ impl SalsaActor {
                 loop_blocks_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 php_assignments_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 document_symbols_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
-                external_php_mtimes: HashMap::with_capacity(64),
+                external_php_text: HashMap::with_capacity(64),
                 text_revision: 0,
                 file_text_revisions: HashMap::with_capacity(64),
                 // Config management
@@ -9100,7 +9125,7 @@ impl SalsaActor {
                     self.files.remove(&path);
                     self.invalidate_file_caches(&path);
                     self.file_text_revisions.remove(&path);
-                    self.external_php_mtimes.remove(&path);
+                    self.external_php_text.remove(&path);
                     // Drop from the inverted index too. Doing this
                     // synchronously (rather than via mark_dirty) is
                     // correct: there's no future state to refresh
@@ -9759,14 +9784,13 @@ impl SalsaActor {
         self.component_usage_index.mark_dirty(&path);
 
         self.bump_text_revision(&path);
-        // Stamp the file's current mtime as "already loaded". This text is
-        // authoritative — a live editor buffer, or a disk read the watcher
-        // just made — and without the stamp `ensure_external_php_source_loaded`
-        // would see no entry, decide a reload is due, and overwrite an unsaved
-        // buffer with the last-saved bytes the moment a Blade hover resolved
-        // its backing class. Same rule `did_change_watched_files` already
-        // applies from the other side: the buffer wins over disk.
-        self.mark_external_php_loaded(&path);
+        // Hand ownership of this path's text to the pusher. Without it
+        // `ensure_external_php_source_loaded` sees no entry, decides a reload
+        // is due, and overwrites an unsaved buffer with the last-saved bytes
+        // the moment a Blade hover resolves its backing class. Same rule
+        // `did_change_watched_files` already applies from the other side: the
+        // buffer wins over disk.
+        self.mark_pushed_by_client(&path);
 
         if let Some(file) = self.files.get(&path) {
             // Update existing file
@@ -9806,12 +9830,18 @@ impl SalsaActor {
         self.document_symbols_cache.pop(path);
     }
 
-    /// Record `path`'s current disk mtime as the one already reflected in
-    /// Salsa, so the backing-class loader treats it as up to date.
-    fn mark_external_php_loaded(&mut self, path: &Path) {
-        if let Ok(mtime) = std::fs::metadata(path).and_then(|m| m.modified()) {
-            self.external_php_mtimes.insert(path.to_path_buf(), mtime);
-        }
+    /// Record that `path`'s Salsa text was installed by a client push, so the
+    /// backing-class loader never reads disk over it.
+    ///
+    /// Deliberately infallible. The predecessor stamped `path`'s disk mtime
+    /// and silently did nothing when `metadata()` failed — leaving a pushed
+    /// (possibly unsaved) buffer with no entry at all, which the loader reads
+    /// as "never loaded, read disk unconditionally": precisely the clobber the
+    /// stamp exists to prevent. Ownership is not a fact about the filesystem,
+    /// so it must not be recorded through a fallible filesystem call.
+    fn mark_pushed_by_client(&mut self, path: &Path) {
+        self.external_php_text
+            .insert(path.to_path_buf(), ExternalPhpText::PushedByClient);
     }
 
     /// Handle a Blade loop-blocks query. Memoized via Salsa + actor LRU.
@@ -9949,7 +9979,7 @@ impl SalsaActor {
                     self.bump_text_revision(path);
                     // The live buffer supersedes disk for this file too, so
                     // the loader must not read it back out from under us.
-                    self.mark_external_php_loaded(path);
+                    self.mark_pushed_by_client(path);
                     self.invalidate_file_caches(path);
                     file.set_text(&mut self.db).to(text);
                 }
@@ -9957,7 +9987,7 @@ impl SalsaActor {
             }
             None => {
                 self.bump_text_revision(path);
-                self.mark_external_php_loaded(path);
+                self.mark_pushed_by_client(path);
                 let file = SourceFile::new(&self.db, path.clone(), 0, text);
                 self.files.insert(path.clone(), file);
                 Some(file)
@@ -9970,17 +10000,40 @@ impl SalsaActor {
         resolve_livewire_member_type(&self.db, file, member.to_string())
     }
 
-    /// Register an external (editor-unopened) PHP file as a Salsa input,
-    /// reloading from disk whenever its mtime advances. Returns the cached
-    /// `SourceFile` handle, or `None` when the path is unreadable — which is
-    /// also how a non-existent path and a directory (a Livewire v4 MFC's
-    /// component dir) are dropped from backing-class resolution.
+    /// Register an external PHP file as a Salsa input, reloading it from disk
+    /// whenever its mtime advances — but only while this loader owns the
+    /// path's text. A path a client pushed (see [`ExternalPhpText`]) is served
+    /// from Salsa untouched, so an unsaved buffer is never overwritten with
+    /// its last-saved bytes.
+    ///
+    /// Returns the cached `SourceFile` handle, or `None` when an unowned path
+    /// is unreadable — which is also how a non-existent path and a directory
+    /// (a Livewire v4 MFC's component dir) are dropped from backing-class
+    /// resolution.
     fn ensure_external_php_source_loaded(&mut self, path: &PathBuf) -> Option<SourceFile> {
+        // Ownership is checked BEFORE the filesystem, so a client-pushed path
+        // is served from Salsa whether or not it can be stat'd at this instant.
+        // Ordering the stat first would drop an unsaved buffer out of
+        // backing-class resolution whenever its file is momentarily absent —
+        // a branch switch, a stash, an `artisan make:*` regeneration.
+        if self.external_php_text.get(path) == Some(&ExternalPhpText::PushedByClient) {
+            if let Some(file) = self.files.get(path).copied() {
+                return Some(file);
+            }
+            // Marked as pushed, yet the input is gone. Nothing is left to
+            // protect, so fall through and load from disk rather than answer
+            // `None`. `RemoveFile` clears both together, so this is a
+            // belt-and-braces arm, not a reachable steady state.
+        }
+
         let current_mtime = std::fs::metadata(path).ok()?.modified().ok()?;
 
-        let needs_reload = match self.external_php_mtimes.get(path) {
-            Some(prev_mtime) => *prev_mtime != current_mtime || !self.files.contains_key(path),
-            None => true,
+        let needs_reload = match self.external_php_text.get(path) {
+            Some(ExternalPhpText::LoadedFromDisk(prev_mtime)) => {
+                *prev_mtime != current_mtime || !self.files.contains_key(path)
+            }
+            // Either never loaded, or the pushed-but-vanished case above.
+            _ => true,
         };
 
         if needs_reload {
@@ -9998,7 +10051,8 @@ impl SalsaActor {
                 let file = SourceFile::new(&self.db, path.clone(), 0, text);
                 self.files.insert(path.clone(), file);
             }
-            self.external_php_mtimes.insert(path.clone(), current_mtime);
+            self.external_php_text
+                .insert(path.clone(), ExternalPhpText::LoadedFromDisk(current_mtime));
         }
 
         self.files.get(path).copied()

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -1482,9 +1482,12 @@ pub fn render_source_files(db: &dyn Db, index: RenderIndex, view_name: String) -
 ///   2. `livewire_paths`, the conventionally-resolved Livewire component class
 ///      for a Blade file that lives under Livewire's view path.
 ///
-/// (1) comes first so a direct render site outranks the Livewire convention,
-/// and — once the up-walk of item 1 feeds this — a partial's own render site
-/// outranks any component ancestor.
+/// (1) comes first so a direct render site outranks the Livewire convention.
+/// A partial that has NEITHER resolves through the component that rendered it,
+/// one level up — but that walk lives in `Backend::blade_backing_class_
+/// resolution` (#339, item 1), which calls this query per candidate rather than
+/// climbing inside it, so a direct render site is always tried before any
+/// ancestor.
 ///
 /// Deduped, and restricted to plain `.php` paths. Existence is NOT checked
 /// here: this query is pure, and the actor drops paths it cannot read when it
@@ -6424,8 +6427,9 @@ pub struct FacadeReceiverTarget {
 /// inline.
 ///
 /// Both halves come from the same pair of memoized queries in one actor
-/// round-trip, so a caller that needs only the paths (the item 1 up-walk)
-/// never pays for a second request that would recompute the same lookup.
+/// round-trip, so a caller that needs only the paths (the item 1 up-walk, which
+/// calls this once per ancestor) never pays for a second request that would
+/// recompute the same lookup.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct BladeBackingResolutionData {
     /// Backing `.php` paths that exist and could be read, in precedence order.
@@ -6569,6 +6573,19 @@ pub enum SalsaRequest {
     FindViewReferences {
         view_name: String,
         reply: oneshot::Sender<Vec<ViewReferenceLocationData>>,
+    },
+    /// Every Blade template that RENDERS one of these components — the reverse
+    /// edge the item-1 up-walk climbs (#339). `component_names` are matched
+    /// against `<x-…>` tags (`ParsedPatternsData::components`) and
+    /// `livewire_names` against `<livewire:…>` tags
+    /// (`ParsedPatternsData::livewire_refs`), because a partial is used through
+    /// either syntax and indexing only the first would leave the other silent.
+    ///
+    /// Replies with the rendering `.blade.php` paths, sorted and deduped.
+    FilesRenderingComponent {
+        component_names: Vec<String>,
+        livewire_names: Vec<String>,
+        reply: oneshot::Sender<Vec<PathBuf>>,
     },
     /// Find all references to a classified symbol across the project.
     /// Iterates `ProjectFiles` and filters parser-classified patterns by name —
@@ -7419,6 +7436,29 @@ impl SalsaHandle {
         self.sender
             .send(SalsaRequest::FindViewReferences {
                 view_name,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Every Blade template that renders one of `component_names` (as
+    /// `<x-…>`) or `livewire_names` (as `<livewire:…>`), sorted and deduped.
+    /// Backs the item-1 up-walk from a partial to the component that rendered
+    /// it (#339).
+    pub async fn files_rendering_component(
+        &self,
+        component_names: Vec<String>,
+        livewire_names: Vec<String>,
+    ) -> Result<Vec<PathBuf>, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::FilesRenderingComponent {
+                component_names,
+                livewire_names,
                 reply: reply_tx,
             })
             .await
@@ -9192,6 +9232,15 @@ impl SalsaActor {
                 }
                 SalsaRequest::FindViewReferences { view_name, reply } => {
                     let result = self.handle_find_view_references(&view_name);
+                    let _ = reply.send(result);
+                }
+                SalsaRequest::FilesRenderingComponent {
+                    component_names,
+                    livewire_names,
+                    reply,
+                } => {
+                    let result =
+                        self.handle_files_rendering_component(&component_names, &livewire_names);
                     let _ = reply.send(result);
                 }
                 SalsaRequest::FindReferences {
@@ -11138,6 +11187,60 @@ impl SalsaActor {
                 entry.insert(file);
             }
         }
+    }
+
+    /// The Blade templates that render any of `component_names` (`<x-…>`) or
+    /// `livewire_names` (`<livewire:…>`) — one step UP the usage graph, for the
+    /// item-1 walk from an anonymous partial to the Livewire component that
+    /// rendered it (#339).
+    ///
+    /// Both tag families are read, from the per-file `ParsedPatternsData` the
+    /// parse pass already produced: `<x-save-button>` lands in `components` and
+    /// `<livewire:save-button>` in `livewire_refs`, and a partial is reachable
+    /// through either. Matching is on the parser-classified NAME, never on raw
+    /// text, exactly as [`Self::handle_find_view_references`] matches its
+    /// directives.
+    ///
+    /// Only `.blade.php` files are returned. A plain `.php` parent (a class
+    /// rendering a tag from a heredoc) is not a rendering ancestor for this
+    /// purpose: the `$this` inside the partial belongs to the component whose
+    /// TEMPLATE contains the tag, and that template is what the walk needs.
+    ///
+    /// Sorted and deduped, because the walk takes the first match and an
+    /// unsorted result would flap between two parents that both qualify.
+    fn handle_files_rendering_component(
+        &mut self,
+        component_names: &[String],
+        livewire_names: &[String],
+    ) -> Vec<PathBuf> {
+        if component_names.is_empty() && livewire_names.is_empty() {
+            return Vec::new();
+        }
+
+        let mut files: Vec<PathBuf> = Vec::new();
+        for path in &self.view_files.clone() {
+            if !path.to_string_lossy().ends_with(".blade.php") {
+                continue;
+            }
+            let Some(patterns) = self.handle_get_patterns(path) else {
+                continue;
+            };
+            let renders = patterns
+                .components
+                .iter()
+                .any(|c| component_names.contains(&c.name))
+                || patterns
+                    .livewire_refs
+                    .iter()
+                    .any(|l| livewire_names.contains(&l.name));
+            if renders {
+                files.push(path.clone());
+            }
+        }
+
+        files.sort();
+        files.dedup();
+        files
     }
 
     /// Handle find view references request

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -6523,6 +6523,10 @@ pub enum SalsaRequest {
     /// Bumps the Salsa revision, so only send this when the index has actually
     /// changed — see `Backend::pending_render_index_snapshot`.
     SetRenderIndex {
+        /// `ViewVarIndex::generation()` this snapshot was taken at. The actor
+        /// drops a snapshot older than the one it holds, so two concurrent
+        /// pushes cannot leave it serving the loser's data.
+        generation: u64,
         entries: Vec<(String, PathBuf)>,
         reply: oneshot::Sender<()>,
     },
@@ -7160,11 +7164,13 @@ impl SalsaHandle {
     /// backing-class queries, so send it only when the index has changed.
     pub async fn set_render_index(
         &self,
+        generation: u64,
         entries: Vec<(String, PathBuf)>,
     ) -> Result<(), &'static str> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(SalsaRequest::SetRenderIndex {
+                generation,
                 entries,
                 reply: reply_tx,
             })
@@ -8698,17 +8704,19 @@ pub struct SalsaActor {
     /// tokio runtime, so a blocking read is the correct (and only
     /// available) primitive here.
     documents: Arc<OnceLock<Arc<RwLock<HashMap<Url, (String, i32)>>>>>,
-    /// LRU cache of parsed Blade loop blocks, keyed by file path + version.
-    /// Salsa already memoizes the underlying query, but caching the Arc avoids
-    /// re-walking the query graph on every diagnostic / completion request.
-    loop_blocks_cache: LruCache<PathBuf, (i32, Arc<Vec<crate::blade_loops::BladeLoopBlock>>)>,
-    /// LRU cache of parsed `@php ... @endphp` block assignments, keyed by file path + version.
-    php_assignments_cache: LruCache<PathBuf, (i32, Arc<Vec<(String, String)>>)>,
-    /// LRU cache of document-symbol trees keyed by file path. Stores file
-    /// version alongside the cached Arc so a version mismatch triggers a
-    /// recompute via the memoized Salsa query.
+    /// LRU cache of parsed Blade loop blocks, keyed by file path + text
+    /// revision ([`SalsaActor::text_revision`]). Salsa already memoizes the
+    /// underlying query, but caching the Arc avoids re-walking the query graph
+    /// on every diagnostic / completion request.
+    loop_blocks_cache: LruCache<PathBuf, (u64, Arc<Vec<crate::blade_loops::BladeLoopBlock>>)>,
+    /// LRU cache of parsed `@php ... @endphp` block assignments, keyed by file
+    /// path + text revision.
+    php_assignments_cache: LruCache<PathBuf, (u64, Arc<Vec<(String, String)>>)>,
+    /// LRU cache of document-symbol trees keyed by file path. Stores the text
+    /// revision alongside the cached Arc so a mismatch triggers a recompute
+    /// via the memoized Salsa query.
     document_symbols_cache:
-        LruCache<PathBuf, (i32, Arc<Vec<crate::document_symbols::SymbolEntry>>)>,
+        LruCache<PathBuf, (u64, Arc<Vec<crate::document_symbols::SymbolEntry>>)>,
     /// Tracks the on-disk mtime of external PHP files registered as Salsa inputs —
     /// Livewire component classes, and the backing classes of a Blade template
     /// (#339, item 7). These files are not opened in the editor (no
@@ -8716,7 +8724,21 @@ pub struct SalsaActor {
     /// mtime on each access.
     external_php_mtimes: HashMap<PathBuf, std::time::SystemTime>,
     /// Monotonic version counter for external PHP SourceFiles (incremented per disk re-read).
-    external_php_version_counter: i32,
+    /// Monotonic stamp for the text currently installed in `files[path]`,
+    /// bumped by EVERY writer, and the key the three per-file LRU caches
+    /// below compare on.
+    ///
+    /// `SourceFile::version` cannot serve that purpose: `handle_update_file`
+    /// stamps the LSP document version onto it while the backing-class loader
+    /// stamped a counter of its own, so two independent sequences — both
+    /// starting near zero, both climbing — wrote one field. Where they
+    /// collided, a cache hit returned blocks parsed from the other writer's
+    /// text: same number, different source. One counter, one namespace, no
+    /// collision possible.
+    text_revision: u64,
+    /// Per-file view of [`Self::text_revision`]. Absent means "never written
+    /// through a bumping site", which reads as revision 0.
+    file_text_revisions: HashMap<PathBuf, u64>,
 
     // === Config Management ===
     /// Project root path
@@ -8741,6 +8763,9 @@ pub struct SalsaActor {
     render_index: Option<RenderIndex>,
     /// Monotonic version for the render-index input.
     render_index_version: i32,
+    /// The `ViewVarIndex` generation the installed render index was built from.
+    /// Guards `handle_set_render_index` against an out-of-order push.
+    render_index_generation: u64,
     /// Project files input for reference finding
     project_files: Option<ProjectFiles>,
     /// Version counter for project files
@@ -8783,6 +8808,13 @@ pub struct SalsaActor {
     /// `BuildSymbolIndex` message; kept fresh thereafter via the
     /// `mark_dirty` / `take_dirty` pattern (see `symbol_index.rs`).
     symbol_index: crate::symbol_index::SymbolIndex,
+
+    /// Reverse "which Blade files render component X" index, over the same
+    /// `ParsedPatternsData` the pattern cache already holds. Kept fresh with
+    /// the same deferred `mark_dirty` / drain shape as `symbol_index`; see
+    /// `component_usage_index.rs` for why the ancestor walk cannot afford the
+    /// linear scan it replaces.
+    component_usage_index: crate::component_usage_index::ComponentUsageIndex,
 
     /// Project-wide class-hierarchy + member index. Populated at warming from
     /// the same parse that feeds the pattern cache; powers structural code
@@ -8885,7 +8917,8 @@ impl SalsaActor {
                 php_assignments_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 document_symbols_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 external_php_mtimes: HashMap::with_capacity(64),
-                external_php_version_counter: 0,
+                text_revision: 0,
+                file_text_revisions: HashMap::with_capacity(64),
                 // Config management
                 config_root: None,
                 config_files: HashMap::with_capacity(4),
@@ -8895,6 +8928,7 @@ impl SalsaActor {
                 // Reference finding
                 render_index: None,
                 render_index_version: 0,
+                render_index_generation: 0,
                 project_files: None,
                 project_files_version: 0,
                 controller_files: Vec::new(),
@@ -8905,6 +8939,7 @@ impl SalsaActor {
                 source_files: Vec::new(),
                 project_root_paths: ProjectRootPaths::default(),
                 symbol_index: crate::symbol_index::SymbolIndex::default(),
+                component_usage_index: crate::component_usage_index::ComponentUsageIndex::default(),
                 class_hierarchy_index: crate::class_hierarchy_index::ClassHierarchyIndex::default(),
                 class_files_snapshot: None,
                 // Service provider registry
@@ -8990,8 +9025,12 @@ impl SalsaActor {
                 SalsaRequest::QueryRunCounts { reply } => {
                     let _ = reply.send(self.db.query_run_counts().snapshot());
                 }
-                SalsaRequest::SetRenderIndex { entries, reply } => {
-                    self.handle_set_render_index(entries);
+                SalsaRequest::SetRenderIndex {
+                    generation,
+                    entries,
+                    reply,
+                } => {
+                    self.handle_set_render_index(generation, entries);
                     let _ = reply.send(());
                 }
                 SalsaRequest::BladeBackingClassResolution {
@@ -9019,15 +9058,15 @@ impl SalsaActor {
                 }
                 SalsaRequest::RemoveFile { path, reply } => {
                     self.files.remove(&path);
-                    self.pattern_cache.remove(&path);
-                    self.loop_blocks_cache.pop(&path);
-                    self.php_assignments_cache.pop(&path);
-                    self.document_symbols_cache.pop(&path);
+                    self.invalidate_file_caches(&path);
+                    self.file_text_revisions.remove(&path);
+                    self.external_php_mtimes.remove(&path);
                     // Drop from the inverted index too. Doing this
                     // synchronously (rather than via mark_dirty) is
                     // correct: there's no future state to refresh
                     // to — the file is gone.
                     self.symbol_index.remove_file(&path);
+                    self.component_usage_index.remove_file(&path);
                     if self.class_hierarchy_index.contains_file(&path) {
                         self.class_hierarchy_index.remove_file(&path);
                         self.class_files_snapshot = None; // hierarchy changed
@@ -9067,6 +9106,13 @@ impl SalsaActor {
                     // hierarchy node, or cached parse can survive the rebuild.
                     self.pattern_cache.clear();
                     self.symbol_index.clear();
+                    // Re-queued rather than merely cleared: the view files
+                    // still exist, and an emptied index that nothing refills
+                    // would answer every ancestor walk with silence.
+                    self.component_usage_index.clear();
+                    for path in &self.view_files.clone() {
+                        self.component_usage_index.mark_dirty(path);
+                    }
                     self.class_hierarchy_index.clear();
                     self.loop_blocks_cache.clear();
                     self.php_assignments_cache.clear();
@@ -9652,10 +9698,7 @@ impl SalsaActor {
     /// Handle file update - create or update the SourceFile
     fn handle_update_file(&mut self, path: PathBuf, version: i32, text: String) {
         // Invalidate caches for this file - will be recomputed on next request
-        self.pattern_cache.remove(&path);
-        self.loop_blocks_cache.pop(&path);
-        self.php_assignments_cache.pop(&path);
-        self.document_symbols_cache.pop(&path);
+        self.invalidate_file_caches(&path);
         // Mark for re-indexing on next find-references query. We don't
         // re-index eagerly here because (a) most file edits are
         // followed by more edits before any query runs, and (b) the
@@ -9663,6 +9706,20 @@ impl SalsaActor {
         // via get_patterns anyway. Lazy refresh amortizes both costs.
         self.symbol_index.mark_dirty(&path);
         self.class_hierarchy_index.mark_dirty(&path);
+        // A Blade edit can add or delete an `<x-…>` / `<livewire:…>` tag, so
+        // the reverse usage index has to re-read this file before its next
+        // answer (no-op for non-Blade paths).
+        self.component_usage_index.mark_dirty(&path);
+
+        self.bump_text_revision(&path);
+        // Stamp the file's current mtime as "already loaded". This text is
+        // authoritative — a live editor buffer, or a disk read the watcher
+        // just made — and without the stamp `ensure_external_php_source_loaded`
+        // would see no entry, decide a reload is due, and overwrite an unsaved
+        // buffer with the last-saved bytes the moment a Blade hover resolved
+        // its backing class. Same rule `did_change_watched_files` already
+        // applies from the other side: the buffer wins over disk.
+        self.mark_external_php_loaded(&path);
 
         if let Some(file) = self.files.get(&path) {
             // Update existing file
@@ -9675,15 +9732,50 @@ impl SalsaActor {
         }
     }
 
+    /// Stamp a new revision for `path`'s text and return it. Every write into
+    /// `self.files` calls this; see [`SalsaActor::text_revision`] for why the
+    /// caches cannot key on `SourceFile::version` instead.
+    fn bump_text_revision(&mut self, path: &Path) -> u64 {
+        self.text_revision = self.text_revision.wrapping_add(1);
+        self.file_text_revisions
+            .insert(path.to_path_buf(), self.text_revision);
+        self.text_revision
+    }
+
+    /// The revision of the text currently installed for `path`. Zero for a
+    /// file no bumping writer has touched.
+    fn text_revision_of(&self, path: &Path) -> u64 {
+        self.file_text_revisions.get(path).copied().unwrap_or(0)
+    }
+
+    /// Drop every per-file actor cache entry for `path`. Called by every
+    /// writer of `files[path]`'s text — `pattern_cache` in particular is
+    /// checked without any version comparison, so a stale entry there is
+    /// served forever rather than merely once.
+    fn invalidate_file_caches(&mut self, path: &Path) {
+        self.pattern_cache.remove(path);
+        self.loop_blocks_cache.pop(path);
+        self.php_assignments_cache.pop(path);
+        self.document_symbols_cache.pop(path);
+    }
+
+    /// Record `path`'s current disk mtime as the one already reflected in
+    /// Salsa, so the backing-class loader treats it as up to date.
+    fn mark_external_php_loaded(&mut self, path: &Path) {
+        if let Ok(mtime) = std::fs::metadata(path).and_then(|m| m.modified()) {
+            self.external_php_mtimes.insert(path.to_path_buf(), mtime);
+        }
+    }
+
     /// Handle a Blade loop-blocks query. Memoized via Salsa + actor LRU.
     fn handle_get_loop_blocks(
         &mut self,
         path: &PathBuf,
     ) -> Option<Arc<Vec<crate::blade_loops::BladeLoopBlock>>> {
         let file = self.files.get(path)?;
-        let version = file.version(&self.db);
+        let version = self.text_revision_of(path);
 
-        // Cache hit on matching version
+        // Cache hit on matching revision
         if let Some((cached_version, cached)) = self.loop_blocks_cache.get(path) {
             if *cached_version == version {
                 return Some(Arc::clone(cached));
@@ -9700,13 +9792,28 @@ impl SalsaActor {
 
     /// Handle resolving a `$this->X` member access in a Livewire component PHP file.
     /// Auto-registers the file in Salsa, invalidates on mtime change.
-    /// Replace the render-index snapshot.
+    /// Replace the render-index snapshot, unless it is older than the one
+    /// already held.
     ///
     /// Every call bumps the Salsa revision, which invalidates the
     /// backing-class memo — so the caller must not push a snapshot the actor
     /// already holds. `Backend::pending_render_index_snapshot` is that gate,
     /// and skipping there saves the round-trip as well as the write.
-    fn handle_set_render_index(&mut self, entries: Vec<(String, PathBuf)>) {
+    ///
+    /// **The generation check is what makes concurrent pushes safe.** Two
+    /// tasks can snapshot generations 5 and 6 and then reach this actor in
+    /// either order, because each awaits a channel round-trip in between. The
+    /// caller's own gate cannot fix that — it only advances a counter, while
+    /// the data that ends up installed is decided here. So ordering is the
+    /// actor's problem, and the actor solves it by refusing to go backwards:
+    /// the winner is always the newest generation, whatever order they arrive
+    /// in. `>=` rather than `>` because an equal generation carries identical
+    /// entries, and re-installing them would drop the memo for nothing.
+    fn handle_set_render_index(&mut self, generation: u64, entries: Vec<(String, PathBuf)>) {
+        if self.render_index.is_some() && generation <= self.render_index_generation {
+            return;
+        }
+        self.render_index_generation = generation;
         self.render_index_version = self.render_index_version.wrapping_add(1);
         match self.render_index {
             Some(index) => {
@@ -9792,15 +9899,18 @@ impl SalsaActor {
         match self.files.get(path).copied() {
             Some(file) => {
                 if *file.text(&self.db) != text {
-                    self.external_php_version_counter =
-                        self.external_php_version_counter.wrapping_add(1);
-                    file.set_version(&mut self.db)
-                        .to(self.external_php_version_counter);
+                    self.bump_text_revision(path);
+                    // The live buffer supersedes disk for this file too, so
+                    // the loader must not read it back out from under us.
+                    self.mark_external_php_loaded(path);
+                    self.invalidate_file_caches(path);
                     file.set_text(&mut self.db).to(text);
                 }
                 Some(file)
             }
             None => {
+                self.bump_text_revision(path);
+                self.mark_external_php_loaded(path);
                 let file = SourceFile::new(&self.db, path.clone(), 0, text);
                 self.files.insert(path.clone(), file);
                 Some(file)
@@ -9828,14 +9938,17 @@ impl SalsaActor {
 
         if needs_reload {
             let text = std::fs::read_to_string(path).ok()?;
-            self.external_php_version_counter = self.external_php_version_counter.wrapping_add(1);
-            let version = self.external_php_version_counter;
+            self.bump_text_revision(path);
+            // This write replaces the text every per-file cache was populated
+            // from. `pattern_cache` compares nothing on lookup — a hit is
+            // assumed current — so an entry left behind here would answer
+            // goto and completion out of the previous text indefinitely.
+            self.invalidate_file_caches(path);
 
             if let Some(existing) = self.files.get(path) {
-                existing.set_version(&mut self.db).to(version);
                 existing.set_text(&mut self.db).to(text);
             } else {
-                let file = SourceFile::new(&self.db, path.clone(), version, text);
+                let file = SourceFile::new(&self.db, path.clone(), 0, text);
                 self.files.insert(path.clone(), file);
             }
             self.external_php_mtimes.insert(path.clone(), current_mtime);
@@ -9847,7 +9960,7 @@ impl SalsaActor {
     /// Handle a Blade @php-assignments query. Memoized via Salsa + actor LRU.
     fn handle_get_php_assignments(&mut self, path: &PathBuf) -> Option<Arc<Vec<(String, String)>>> {
         let file = self.files.get(path)?;
-        let version = file.version(&self.db);
+        let version = self.text_revision_of(path);
 
         if let Some((cached_version, cached)) = self.php_assignments_cache.get(path) {
             if *cached_version == version {
@@ -9868,7 +9981,7 @@ impl SalsaActor {
         path: &PathBuf,
     ) -> Option<Arc<Vec<crate::document_symbols::SymbolEntry>>> {
         let file = self.files.get(path)?;
-        let version = file.version(&self.db);
+        let version = self.text_revision_of(path);
 
         if let Some((cached_version, cached)) = self.document_symbols_cache.get(path) {
             if *cached_version == version {
@@ -10775,11 +10888,15 @@ impl SalsaActor {
         match op {
             FileListOp::Add => {
                 if !list.contains(&path) {
-                    list.push(path);
+                    list.push(path.clone());
                 }
+                // Invariant 3 of `component_usage_index`: every `view_files`
+                // mutation queues or drops the path, or the walk cannot see it.
+                self.component_usage_index.mark_dirty(&path);
             }
             FileListOp::Remove => {
                 list.retain(|p| p != &path);
+                self.component_usage_index.remove_file(&path);
             }
         }
         Some(category.label())
@@ -10802,6 +10919,8 @@ impl SalsaActor {
         // Clear existing file lists
         self.controller_files.clear();
         self.view_files.clear();
+        // Rebuilt below as the walk re-discovers each view file.
+        self.component_usage_index.clear();
         self.livewire_files.clear();
         self.route_files.clear();
         self.vendor_files.clear();
@@ -10863,6 +10982,7 @@ impl SalsaActor {
                         if let Some(file_name) = entry.path().file_name() {
                             if file_name.to_string_lossy().ends_with(".blade.php") {
                                 let path = entry.path().to_path_buf();
+                                self.component_usage_index.mark_dirty(&path);
                                 self.view_files.push(path);
                                 // Salsa input deferred to first cache miss.
                             }
@@ -11070,31 +11190,28 @@ impl SalsaActor {
         if component_names.is_empty() && livewire_names.is_empty() {
             return Vec::new();
         }
+        self.refresh_component_usage_index();
+        self.component_usage_index
+            .find(component_names, livewire_names)
+    }
 
-        let mut files: Vec<PathBuf> = Vec::new();
-        for path in &self.view_files.clone() {
-            if !path.to_string_lossy().ends_with(".blade.php") {
-                continue;
-            }
-            let Some(patterns) = self.handle_get_patterns(path) else {
-                continue;
-            };
-            let renders = patterns
-                .components
-                .iter()
-                .any(|c| component_names.contains(&c.name))
-                || patterns
-                    .livewire_refs
-                    .iter()
-                    .any(|l| livewire_names.contains(&l.name));
-            if renders {
-                files.push(path.clone());
+    /// Fold every queued Blade file into the reverse component-usage index.
+    ///
+    /// Empty on the hot path, which is the entire point: only project
+    /// registration, an edit, or a watcher event queues anything, so an
+    /// ancestor walk visiting a hundred nodes drains once and then answers
+    /// each of the hundred lookups out of a `HashMap`. The drain itself reads
+    /// through `handle_get_patterns`, so a warmed file costs a cache hit
+    /// rather than a parse.
+    fn refresh_component_usage_index(&mut self) {
+        for path in self.component_usage_index.take_pending() {
+            match self.handle_get_patterns(&path) {
+                Some(patterns) => self.component_usage_index.insert_file(&path, &patterns),
+                // Unreadable now — drop whatever it contributed before rather
+                // than serving entries for a file we can no longer confirm.
+                None => self.component_usage_index.remove_file(&path),
             }
         }
-
-        files.sort();
-        files.dedup();
-        files
     }
 
     /// Handle find view references request

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -15,6 +15,7 @@ use salsa::Setter;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 use tokio::sync::{mpsc, oneshot, RwLock};
@@ -43,22 +44,66 @@ use crate::path_containment::path_within_root_lexical;
 // Database Definition
 // ============================================================================
 
+/// Body-execution counters for the memoized backing-class queries (#339,
+/// item 7). Incremented inside a query's BODY, so the count answers the one
+/// question a return value cannot: was this served from the memo, or recomputed?
+///
+/// Per-database rather than a process-wide static, so a test measuring one
+/// database is not perturbed by whatever the Salsa actor thread is doing in
+/// another test. Shared across clones of the database, which is what Salsa's
+/// own snapshotting produces.
+#[derive(Debug, Default)]
+pub struct QueryRunCounts {
+    /// Body runs of [`render_source_files`].
+    pub render_source_files: AtomicUsize,
+    /// Body runs of [`blade_backing_class_sources`].
+    pub blade_backing_class_sources: AtomicUsize,
+}
+
+impl QueryRunCounts {
+    /// A plain snapshot of the counters, for transfer across the actor's
+    /// async boundary.
+    pub fn snapshot(&self) -> QueryRunCountsData {
+        QueryRunCountsData {
+            render_source_files: self.render_source_files.load(Ordering::Relaxed),
+            blade_backing_class_sources: self.blade_backing_class_sources.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Data transfer type for [`QueryRunCounts`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QueryRunCountsData {
+    pub render_source_files: usize,
+    pub blade_backing_class_sources: usize,
+}
+
 /// The Salsa database trait for Laravel LSP
 #[salsa::db]
-pub trait Db: salsa::Database {}
+pub trait Db: salsa::Database {
+    /// This database's query body-execution counters. See [`QueryRunCounts`].
+    fn query_run_counts(&self) -> &QueryRunCounts;
+}
 
 /// The concrete database implementation
 #[salsa::db]
 #[derive(Default, Clone)]
 pub struct LaravelDatabase {
     storage: salsa::Storage<Self>,
+    /// Shared with every clone of this database, so a snapshot's query runs
+    /// are counted against the same totals.
+    run_counts: Arc<QueryRunCounts>,
 }
 
 #[salsa::db]
 impl salsa::Database for LaravelDatabase {}
 
 #[salsa::db]
-impl Db for LaravelDatabase {}
+impl Db for LaravelDatabase {
+    fn query_run_counts(&self) -> &QueryRunCounts {
+        &self.run_counts
+    }
+}
 
 // ============================================================================
 // Input Types - Source data provided to the system
@@ -119,6 +164,24 @@ pub struct ProjectFiles {
     /// PHP files in routes/
     #[returns(ref)]
     pub route_files: Vec<PathBuf>,
+}
+
+/// The project-wide render index: every `(view name, rendering file)` pair
+/// the controller / Livewire scan has observed.
+///
+/// The flattened reverse of `ViewVarIndex::by_file`. Holding it as a Salsa
+/// input is what turns backing-class resolution from an O(entire index) linear
+/// sweep *per keystroke* into a memoized lookup that only recomputes when the
+/// index itself changes (issue #339, item 7).
+#[salsa::input]
+pub struct RenderIndex {
+    /// Version incremented when the index contents change
+    #[returns(copy)]
+    pub version: i32,
+
+    /// `(view name, file that renders it)`, one entry per render site
+    #[returns(ref)]
+    pub entries: Vec<(String, PathBuf)>,
 }
 
 /// Represents a service provider file with priority
@@ -1373,6 +1436,120 @@ pub fn parse_blade_loop_blocks(
 pub fn parse_blade_php_assignments(db: &dyn Db, file: SourceFile) -> Vec<(String, String)> {
     let text = file.text(db);
     crate::blade_php_block::extract_php_block_assignments(text)
+}
+
+// ============================================================================
+// Blade backing-class resolution (issue #339, item 7)
+// ============================================================================
+
+/// Whether `path` is a plain `.php` file rather than a `.blade.php` template.
+///
+/// A Blade template has no standalone class for `component_member_locator` to
+/// parse — its inline `new class extends Component` (or Volt front matter) is
+/// handled separately, by [`blade_backing_class_sources`]'s `inline` arm.
+pub fn is_plain_php_path(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("php")
+        && !path.to_string_lossy().ends_with(".blade.php")
+}
+
+/// Every file that renders `view_name`, sorted lexicographically by path.
+///
+/// The sort is load-bearing, not cosmetic: [`blade_backing_class_files`]'s
+/// consumers take the FIRST hit over this list, so an unsorted result would
+/// flap between two contributing classes that both declare the same member.
+///
+/// Memoized: only re-runs when the [`RenderIndex`] input changes.
+#[salsa::tracked(returns(clone))]
+pub fn render_source_files(db: &dyn Db, index: RenderIndex, view_name: String) -> Vec<PathBuf> {
+    db.query_run_counts()
+        .render_source_files
+        .fetch_add(1, Ordering::Relaxed);
+    let mut files: Vec<PathBuf> = index
+        .entries(db)
+        .iter()
+        .filter(|(view, _)| *view == view_name)
+        .map(|(_, path)| path.clone())
+        .collect();
+    files.sort();
+    files.dedup();
+    files
+}
+
+/// The plain-`.php` files backing a Blade template's rendered content — the
+/// union of two independent sources, in precedence order:
+///   1. the render index's contributors for `view_name` (a Filament-style
+///      `$view`-property page, or any controller `view(...)` call site);
+///   2. `livewire_paths`, the conventionally-resolved Livewire component class
+///      for a Blade file that lives under Livewire's view path.
+///
+/// (1) comes first so a direct render site outranks the Livewire convention,
+/// and — once the up-walk of item 1 feeds this — a partial's own render site
+/// outranks any component ancestor.
+///
+/// Deduped, and restricted to plain `.php` paths. Existence is NOT checked
+/// here: this query is pure, and the actor drops paths it cannot read when it
+/// loads them as Salsa inputs.
+///
+/// Memoized: only re-runs when the [`RenderIndex`], the view name, or the
+/// resolved Livewire paths change.
+#[salsa::tracked(returns(clone))]
+pub fn blade_backing_class_files(
+    db: &dyn Db,
+    index: RenderIndex,
+    view_name: Option<String>,
+    livewire_paths: Vec<PathBuf>,
+) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    if let Some(view) = view_name {
+        out.extend(render_source_files(db, index, view));
+    }
+    out.extend(livewire_paths);
+
+    let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    out.retain(|p| is_plain_php_path(p) && seen.insert(p.clone()));
+    out
+}
+
+/// Every `(path, source)` pair whose PHP class backs a Blade template: the
+/// plain-`.php` backing files of [`blade_backing_class_files`], plus the Blade
+/// file ITSELF (`inline`) when it declares an inline
+/// `new class extends Component` (a Livewire v4 single-file component or a
+/// class-based Volt component) or carries a functional Volt signature. Those
+/// shapes have no standalone `.php` source — the members live in the
+/// template's own front matter.
+///
+/// Memoized against each backing file's CONTENT, not merely its path: `files`
+/// are [`SourceFile`] inputs, so editing a backing class invalidates this
+/// query and the next call recomputes rather than serving a stale source.
+#[salsa::tracked(returns(clone))]
+pub fn blade_backing_class_sources(
+    db: &dyn Db,
+    files: Vec<SourceFile>,
+    inline: Option<SourceFile>,
+) -> Vec<(PathBuf, String)> {
+    db.query_run_counts()
+        .blade_backing_class_sources
+        .fetch_add(1, Ordering::Relaxed);
+    let mut out: Vec<(PathBuf, String)> = files
+        .iter()
+        .map(|file| (file.path(db).clone(), file.text(db).clone()))
+        .collect();
+
+    if let Some(blade) = inline {
+        let text = blade.text(db);
+        // A FUNCTIONAL Volt file declares no class at all, so
+        // `detect_inline_livewire_class` is false for it — but its
+        // `state([...])` keys and top-level closure assignments ARE the
+        // component's members, and `component_member_locator` reads them.
+        // Both inline shapes therefore hand the template itself to the
+        // locator (#339, item 3).
+        if crate::php_class::detect_inline_livewire_class(text)
+            || crate::livewire_resolver::source_contains_volt_signature(text)
+        {
+            out.push((blade.path(db).clone(), text.clone()));
+        }
+    }
+    out
 }
 
 /// Extract the document-symbol tree for a file (route file, Blade template,
@@ -6241,6 +6418,23 @@ pub struct FacadeReceiverTarget {
 }
 
 /// Requests that can be sent to the Salsa actor
+/// The answer to one backing-class resolution for a Blade template (#339,
+/// item 7): the plain-`.php` files that back it, and each of those files'
+/// current source, plus the template itself when it declares its component
+/// inline.
+///
+/// Both halves come from the same pair of memoized queries in one actor
+/// round-trip, so a caller that needs only the paths (the item 1 up-walk)
+/// never pays for a second request that would recompute the same lookup.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BladeBackingResolutionData {
+    /// Backing `.php` paths that exist and could be read, in precedence order.
+    pub files: Vec<PathBuf>,
+    /// `(path, source)` for each entry of `files`, plus the Blade template
+    /// itself when it carries an inline component class.
+    pub sources: Vec<(PathBuf, String)>,
+}
+
 pub enum SalsaRequest {
     /// Update or create a file in the database
     UpdateFile {
@@ -6330,6 +6524,34 @@ pub enum SalsaRequest {
     /// Get the current Laravel configuration
     GetLaravelConfig {
         reply: oneshot::Sender<Option<LaravelConfigData>>,
+    },
+
+    // === Blade backing-class resolution (#339, item 7) ===
+    /// Read the actor database's query body-execution counters. Exists so a
+    /// test driving the real LSP handler can prove the memo was hit, which a
+    /// return value alone cannot show.
+    QueryRunCounts {
+        reply: oneshot::Sender<QueryRunCountsData>,
+    },
+    /// Replace the render-index snapshot the backing-class queries read.
+    /// Bumps the Salsa revision, so only send this when the index has actually
+    /// changed — see `Backend::pending_render_index_snapshot`.
+    SetRenderIndex {
+        entries: Vec<(String, PathBuf)>,
+        reply: oneshot::Sender<()>,
+    },
+    /// Resolve the PHP class(es) backing a Blade template, memoized against
+    /// the render index and each backing file's content.
+    BladeBackingClassResolution {
+        blade_path: PathBuf,
+        /// The template's own Laravel view name, when it has one.
+        view_name: Option<String>,
+        /// Livewire-convention class paths the caller already resolved.
+        livewire_paths: Vec<PathBuf>,
+        /// The live editor buffer for `blade_path`, when the document is open.
+        /// `None` falls back to the file on disk.
+        live_blade_text: Option<String>,
+        reply: oneshot::Sender<BladeBackingResolutionData>,
     },
 
     // === Reference Finding ===
@@ -6943,6 +7165,62 @@ impl SalsaHandle {
 
     /// Resolve a `$this->X` member access in a Livewire component PHP file.
     /// Auto-registers the file as a Salsa input on first access, invalidates on mtime change.
+    /// Read the actor database's query body-execution counters.
+    pub async fn query_run_counts(&self) -> Result<QueryRunCountsData, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::QueryRunCounts { reply: reply_tx })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Push a render-index snapshot into the actor. Invalidates the memoized
+    /// backing-class queries, so send it only when the index has changed.
+    pub async fn set_render_index(
+        &self,
+        entries: Vec<(String, PathBuf)>,
+    ) -> Result<(), &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::SetRenderIndex {
+                entries,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Resolve the PHP class(es) backing `blade_path`. See
+    /// [`BladeBackingResolutionData`].
+    pub async fn blade_backing_class_resolution(
+        &self,
+        blade_path: PathBuf,
+        view_name: Option<String>,
+        livewire_paths: Vec<PathBuf>,
+        live_blade_text: Option<String>,
+    ) -> Result<BladeBackingResolutionData, &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::BladeBackingClassResolution {
+                blade_path,
+                view_name,
+                livewire_paths,
+                live_blade_text,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
     pub async fn resolve_livewire_member(
         &self,
         path: PathBuf,
@@ -8497,12 +8775,14 @@ pub struct SalsaActor {
     /// recompute via the memoized Salsa query.
     document_symbols_cache:
         LruCache<PathBuf, (i32, Arc<Vec<crate::document_symbols::SymbolEntry>>)>,
-    /// Tracks the on-disk mtime of Livewire component PHP files registered as Salsa inputs.
-    /// These files are not opened in the editor (no `did_open`/`did_change` events), so we
-    /// invalidate by comparing filesystem mtime on each access.
-    livewire_mtimes: HashMap<PathBuf, std::time::SystemTime>,
-    /// Monotonic version counter for Livewire component SourceFiles (incremented per disk re-read).
-    livewire_version_counter: i32,
+    /// Tracks the on-disk mtime of external PHP files registered as Salsa inputs —
+    /// Livewire component classes, and the backing classes of a Blade template
+    /// (#339, item 7). These files are not opened in the editor (no
+    /// `did_open`/`did_change` events), so we invalidate by comparing filesystem
+    /// mtime on each access.
+    external_php_mtimes: HashMap<PathBuf, std::time::SystemTime>,
+    /// Monotonic version counter for external PHP SourceFiles (incremented per disk re-read).
+    external_php_version_counter: i32,
 
     // === Config Management ===
     /// Project root path
@@ -8523,6 +8803,10 @@ pub struct SalsaActor {
     registration_baselines: HashMap<PathBuf, ProviderRegistrationsData>,
 
     // === Reference Finding ===
+    /// The render index as a Salsa input, created on first use (#339, item 7).
+    render_index: Option<RenderIndex>,
+    /// Monotonic version for the render-index input.
+    render_index_version: i32,
     /// Project files input for reference finding
     project_files: Option<ProjectFiles>,
     /// Version counter for project files
@@ -8670,8 +8954,8 @@ impl SalsaActor {
                 loop_blocks_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 php_assignments_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 document_symbols_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
-                livewire_mtimes: HashMap::with_capacity(64),
-                livewire_version_counter: 0,
+                external_php_mtimes: HashMap::with_capacity(64),
+                external_php_version_counter: 0,
                 // Config management
                 config_root: None,
                 config_files: HashMap::with_capacity(4),
@@ -8679,6 +8963,8 @@ impl SalsaActor {
                 config_cache: None,
                 registration_baselines: HashMap::new(),
                 // Reference finding
+                render_index: None,
+                render_index_version: 0,
                 project_files: None,
                 project_files_version: 0,
                 controller_files: Vec::new(),
@@ -8771,6 +9057,28 @@ impl SalsaActor {
                 }
                 SalsaRequest::GetDocumentSymbols { path, reply } => {
                     let result = self.handle_get_document_symbols(&path);
+                    let _ = reply.send(result);
+                }
+                SalsaRequest::QueryRunCounts { reply } => {
+                    let _ = reply.send(self.db.query_run_counts().snapshot());
+                }
+                SalsaRequest::SetRenderIndex { entries, reply } => {
+                    self.handle_set_render_index(entries);
+                    let _ = reply.send(());
+                }
+                SalsaRequest::BladeBackingClassResolution {
+                    blade_path,
+                    view_name,
+                    livewire_paths,
+                    live_blade_text,
+                    reply,
+                } => {
+                    let result = self.handle_blade_backing_class_resolution(
+                        &blade_path,
+                        view_name,
+                        livewire_paths,
+                        live_blade_text,
+                    );
                     let _ = reply.send(result);
                 }
                 SalsaRequest::ResolveLivewireMember {
@@ -9489,25 +9797,136 @@ impl SalsaActor {
 
     /// Handle resolving a `$this->X` member access in a Livewire component PHP file.
     /// Auto-registers the file in Salsa, invalidates on mtime change.
+    /// Replace the render-index snapshot.
+    ///
+    /// Every call bumps the Salsa revision, which invalidates the
+    /// backing-class memo — so the caller must not push a snapshot the actor
+    /// already holds. `Backend::pending_render_index_snapshot` is that gate,
+    /// and skipping there saves the round-trip as well as the write.
+    fn handle_set_render_index(&mut self, entries: Vec<(String, PathBuf)>) {
+        self.render_index_version = self.render_index_version.wrapping_add(1);
+        match self.render_index {
+            Some(index) => {
+                index
+                    .set_version(&mut self.db)
+                    .to(self.render_index_version);
+                index.set_entries(&mut self.db).to(entries);
+            }
+            None => {
+                self.render_index = Some(RenderIndex::new(
+                    &self.db,
+                    self.render_index_version,
+                    entries,
+                ));
+            }
+        }
+    }
+
+    /// The render-index input, created empty on first use so a resolution that
+    /// runs before any snapshot arrives still answers (with no contributors)
+    /// instead of failing.
+    fn render_index_input(&mut self) -> RenderIndex {
+        match self.render_index {
+            Some(index) => index,
+            None => {
+                let index = RenderIndex::new(&self.db, self.render_index_version, Vec::new());
+                self.render_index = Some(index);
+                index
+            }
+        }
+    }
+
+    /// Resolve the PHP class(es) backing a Blade template (#339, item 7).
+    ///
+    /// The two memoized queries do the work; this handler only supplies their
+    /// inputs. That split is deliberate: registering a `SourceFile` reads the
+    /// filesystem, and a tracked query must stay pure.
+    fn handle_blade_backing_class_resolution(
+        &mut self,
+        blade_path: &PathBuf,
+        view_name: Option<String>,
+        livewire_paths: Vec<PathBuf>,
+        live_blade_text: Option<String>,
+    ) -> BladeBackingResolutionData {
+        let index = self.render_index_input();
+        let candidates = blade_backing_class_files(&self.db, index, view_name, livewire_paths);
+
+        // Existence filtering happens HERE, not in the query: a candidate that
+        // cannot be read as a Salsa input (absent file, or an MFC component
+        // directory) contributes nothing and is dropped, exactly as the old
+        // `is_file()` guard dropped it.
+        let inputs: Vec<SourceFile> = candidates
+            .iter()
+            .filter_map(|path| self.ensure_external_php_source_loaded(path))
+            .collect();
+        let files: Vec<PathBuf> = inputs
+            .iter()
+            .map(|file| file.path(&self.db).clone())
+            .collect();
+
+        let inline = self.ensure_blade_source_registered(blade_path, live_blade_text);
+        let sources = blade_backing_class_sources(&self.db, inputs, inline);
+        BladeBackingResolutionData { files, sources }
+    }
+
+    /// Register the Blade template itself as a Salsa input so the inline
+    /// SFC / Volt arm of [`blade_backing_class_sources`] reads it through the
+    /// same memoized path as the backing classes.
+    ///
+    /// `live_text` (the open editor buffer) wins over disk, because the
+    /// `did_change` → Salsa hop is debounced and an inline component's members
+    /// must resolve against what the user is typing right now, not what landed
+    /// 250 ms ago. The text is only written when it actually differs, so a
+    /// resolution on an unedited buffer leaves the memo intact.
+    fn ensure_blade_source_registered(
+        &mut self,
+        path: &PathBuf,
+        live_text: Option<String>,
+    ) -> Option<SourceFile> {
+        let Some(text) = live_text else {
+            return self.ensure_external_php_source_loaded(path);
+        };
+        match self.files.get(path).copied() {
+            Some(file) => {
+                if *file.text(&self.db) != text {
+                    self.external_php_version_counter =
+                        self.external_php_version_counter.wrapping_add(1);
+                    file.set_version(&mut self.db)
+                        .to(self.external_php_version_counter);
+                    file.set_text(&mut self.db).to(text);
+                }
+                Some(file)
+            }
+            None => {
+                let file = SourceFile::new(&self.db, path.clone(), 0, text);
+                self.files.insert(path.clone(), file);
+                Some(file)
+            }
+        }
+    }
+
     fn handle_resolve_livewire_member(&mut self, path: &PathBuf, member: &str) -> Option<String> {
-        let file = self.ensure_livewire_source_loaded(path)?;
+        let file = self.ensure_external_php_source_loaded(path)?;
         resolve_livewire_member_type(&self.db, file, member.to_string())
     }
 
-    /// Register an external component PHP file as a Salsa input, reloading from
-    /// disk whenever its mtime advances. Returns the cached `SourceFile` handle.
-    fn ensure_livewire_source_loaded(&mut self, path: &PathBuf) -> Option<SourceFile> {
+    /// Register an external (editor-unopened) PHP file as a Salsa input,
+    /// reloading from disk whenever its mtime advances. Returns the cached
+    /// `SourceFile` handle, or `None` when the path is unreadable — which is
+    /// also how a non-existent path and a directory (a Livewire v4 MFC's
+    /// component dir) are dropped from backing-class resolution.
+    fn ensure_external_php_source_loaded(&mut self, path: &PathBuf) -> Option<SourceFile> {
         let current_mtime = std::fs::metadata(path).ok()?.modified().ok()?;
 
-        let needs_reload = match self.livewire_mtimes.get(path) {
+        let needs_reload = match self.external_php_mtimes.get(path) {
             Some(prev_mtime) => *prev_mtime != current_mtime || !self.files.contains_key(path),
             None => true,
         };
 
         if needs_reload {
             let text = std::fs::read_to_string(path).ok()?;
-            self.livewire_version_counter = self.livewire_version_counter.wrapping_add(1);
-            let version = self.livewire_version_counter;
+            self.external_php_version_counter = self.external_php_version_counter.wrapping_add(1);
+            let version = self.external_php_version_counter;
 
             if let Some(existing) = self.files.get(path) {
                 existing.set_version(&mut self.db).to(version);
@@ -9516,7 +9935,7 @@ impl SalsaActor {
                 let file = SourceFile::new(&self.db, path.clone(), version, text);
                 self.files.insert(path.clone(), file);
             }
-            self.livewire_mtimes.insert(path.clone(), current_mtime);
+            self.external_php_mtimes.insert(path.clone(), current_mtime);
         }
 
         self.files.get(path).copied()

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -5552,3 +5552,267 @@ fn config_string_literal_reads_an_empty_literal() {
          directory name"
     );
 }
+
+// ─── Blade backing-class resolution, memoized (issue #339, item 7) ───────
+
+/// A render index holding `(view name, rendering file)` pairs.
+fn render_index(db: &LaravelDatabase, entries: &[(&str, &str)]) -> RenderIndex {
+    RenderIndex::new(
+        db,
+        1,
+        entries
+            .iter()
+            .map(|(view, path)| (view.to_string(), PathBuf::from(path)))
+            .collect(),
+    )
+}
+
+#[test]
+fn render_source_files_returns_every_contributor_sorted() {
+    let db = LaravelDatabase::default();
+    let index = render_index(
+        &db,
+        &[
+            ("users.show", "/proj/zeta/Controller.php"),
+            ("users.show", "/proj/alpha/Page.php"),
+            ("other.view", "/proj/Other.php"),
+        ],
+    );
+
+    assert_eq!(
+        render_source_files(&db, index, "users.show".to_string()),
+        vec![
+            PathBuf::from("/proj/alpha/Page.php"),
+            PathBuf::from("/proj/zeta/Controller.php"),
+        ],
+        "contributors come back in lexicographic path order, not index order",
+    );
+    assert!(render_source_files(&db, index, "missing.view".to_string()).is_empty());
+}
+
+#[test]
+fn render_source_files_is_memoized_until_the_index_changes() {
+    let mut db = LaravelDatabase::default();
+    let index = render_index(&db, &[("users.show", "/proj/UserController.php")]);
+
+    let before = db
+        .query_run_counts()
+        .render_source_files
+        .load(Ordering::Relaxed);
+    let first = render_source_files(&db, index, "users.show".to_string());
+    let second = render_source_files(&db, index, "users.show".to_string());
+    assert_eq!(first, second);
+    assert_eq!(
+        db.query_run_counts()
+            .render_source_files
+            .load(Ordering::Relaxed)
+            - before,
+        1,
+        "a second lookup over an unchanged index must be served from the memo",
+    );
+
+    index.set_entries(&mut db).to(vec![
+        (
+            "users.show".to_string(),
+            PathBuf::from("/proj/UserController.php"),
+        ),
+        (
+            "users.show".to_string(),
+            PathBuf::from("/proj/Filament/UserPage.php"),
+        ),
+    ]);
+    let third = render_source_files(&db, index, "users.show".to_string());
+    assert_eq!(
+        third,
+        vec![
+            PathBuf::from("/proj/Filament/UserPage.php"),
+            PathBuf::from("/proj/UserController.php"),
+        ],
+        "a changed index must recompute, not serve the old contributor list",
+    );
+    assert_eq!(
+        db.query_run_counts()
+            .render_source_files
+            .load(Ordering::Relaxed)
+            - before,
+        2,
+    );
+}
+
+#[test]
+fn blade_backing_class_files_puts_render_sites_before_the_livewire_convention() {
+    let db = LaravelDatabase::default();
+    let index = render_index(&db, &[("livewire.counter", "/proj/app/Filament/Page.php")]);
+
+    let files = blade_backing_class_files(
+        &db,
+        index,
+        Some("livewire.counter".to_string()),
+        vec![PathBuf::from("/proj/app/Livewire/Counter.php")],
+    );
+
+    assert_eq!(
+        files,
+        vec![
+            PathBuf::from("/proj/app/Filament/Page.php"),
+            PathBuf::from("/proj/app/Livewire/Counter.php"),
+        ],
+        "the direct render site outranks the conventionally-resolved class",
+    );
+}
+
+#[test]
+fn blade_backing_class_files_drops_templates_and_duplicates() {
+    let db = LaravelDatabase::default();
+    let index = render_index(
+        &db,
+        &[
+            ("livewire.counter", "/proj/app/Livewire/Counter.php"),
+            ("livewire.counter", "/proj/resources/views/x.blade.php"),
+            ("livewire.counter", "/proj/resources/views/x.blade"),
+        ],
+    );
+
+    let files = blade_backing_class_files(
+        &db,
+        index,
+        Some("livewire.counter".to_string()),
+        vec![
+            // Already contributed by the render index — must not appear twice.
+            PathBuf::from("/proj/app/Livewire/Counter.php"),
+            // A v4 MFC component directory: no `.php` extension.
+            PathBuf::from("/proj/resources/views/components/counter"),
+        ],
+    );
+
+    assert_eq!(
+        files,
+        vec![PathBuf::from("/proj/app/Livewire/Counter.php")],
+        "only plain `.php` paths survive, and each appears once",
+    );
+}
+
+#[test]
+fn blade_backing_class_files_without_a_view_name_uses_only_the_livewire_paths() {
+    let db = LaravelDatabase::default();
+    let index = render_index(&db, &[("users.show", "/proj/UserController.php")]);
+
+    assert_eq!(
+        blade_backing_class_files(
+            &db,
+            index,
+            None,
+            vec![PathBuf::from("/proj/app/Livewire/Counter.php")],
+        ),
+        vec![PathBuf::from("/proj/app/Livewire/Counter.php")],
+        "a template outside every view root contributes no render sites",
+    );
+}
+
+#[test]
+fn blade_backing_class_sources_reads_each_file_and_appends_an_inline_component() {
+    let db = LaravelDatabase::default();
+    let class = SourceFile::new(
+        &db,
+        PathBuf::from("/proj/app/Livewire/Counter.php"),
+        0,
+        "<?php class Counter extends Component { public $count = 0; }".to_string(),
+    );
+    let inline = SourceFile::new(
+        &db,
+        PathBuf::from("/proj/resources/views/livewire/counter.blade.php"),
+        0,
+        "<?php new class extends Component { public $tally = 0; }; ?>\n<div></div>".to_string(),
+    );
+
+    let sources = blade_backing_class_sources(&db, vec![class], Some(inline));
+
+    assert_eq!(sources.len(), 2);
+    assert_eq!(
+        sources[0].0,
+        PathBuf::from("/proj/app/Livewire/Counter.php")
+    );
+    assert!(sources[0].1.contains("public $count"));
+    assert_eq!(
+        sources[1].0,
+        PathBuf::from("/proj/resources/views/livewire/counter.blade.php"),
+        "the template itself is appended AFTER the standalone classes",
+    );
+}
+
+#[test]
+fn blade_backing_class_sources_skips_a_template_with_no_inline_component() {
+    let db = LaravelDatabase::default();
+    let plain = SourceFile::new(
+        &db,
+        PathBuf::from("/proj/resources/views/partial.blade.php"),
+        0,
+        "<div>{{ $name }}</div>".to_string(),
+    );
+
+    assert!(
+        blade_backing_class_sources(&db, Vec::new(), Some(plain)).is_empty(),
+        "a template with neither an inline class nor a Volt signature contributes nothing",
+    );
+}
+
+#[test]
+fn blade_backing_class_sources_invalidates_when_a_backing_class_is_edited() {
+    let mut db = LaravelDatabase::default();
+    let class = SourceFile::new(
+        &db,
+        PathBuf::from("/proj/app/Livewire/Counter.php"),
+        0,
+        "<?php class Counter { public $count = 0; }".to_string(),
+    );
+
+    let before = db
+        .query_run_counts()
+        .blade_backing_class_sources
+        .load(Ordering::Relaxed);
+    let first = blade_backing_class_sources(&db, vec![class], None);
+    assert!(first[0].1.contains("public $count"));
+
+    // Same inputs: served from the memo.
+    let _ = blade_backing_class_sources(&db, vec![class], None);
+    assert_eq!(
+        db.query_run_counts()
+            .blade_backing_class_sources
+            .load(Ordering::Relaxed)
+            - before,
+        1,
+        "an unchanged backing class must not be re-read",
+    );
+
+    // The BACKING CLASS changes — not the blade file. The memo must drop.
+    class
+        .set_text(&mut db)
+        .to("<?php class Counter { public $tally = 0; }".to_string());
+    let after = blade_backing_class_sources(&db, vec![class], None);
+    assert!(
+        after[0].1.contains("public $tally"),
+        "editing the backing class must invalidate the cached source, got {:?}",
+        after[0].1,
+    );
+    assert_eq!(
+        db.query_run_counts()
+            .blade_backing_class_sources
+            .load(Ordering::Relaxed)
+            - before,
+        2,
+    );
+}
+
+#[test]
+fn is_plain_php_path_separates_classes_from_templates() {
+    assert!(is_plain_php_path(Path::new(
+        "/proj/app/Livewire/Counter.php"
+    )));
+    assert!(!is_plain_php_path(Path::new(
+        "/proj/resources/views/counter.blade.php"
+    )));
+    assert!(!is_plain_php_path(Path::new(
+        "/proj/resources/views/counter"
+    )));
+    assert!(!is_plain_php_path(Path::new("/proj/composer.json")));
+}

--- a/laravel-lsp/src/tests/component_ancestor_navigation.rs
+++ b/laravel-lsp/src/tests/component_ancestor_navigation.rs
@@ -1,0 +1,435 @@
+//! Member navigation from inside an anonymous Blade partial (#339, item 1).
+//!
+//! `resources/views/components/save-button.blade.php` has no backing class of
+//! its own: nobody renders it through `view('components.save-button')`, it does
+//! not live under Livewire's view path, and it declares no inline class. Its
+//! `wire:click="save"` nevertheless resolves at runtime, against the component
+//! that rendered it — so the resolver climbs the usage graph (`<x-…>` and
+//! `<livewire:…>` tags alike) and answers with the nearest ancestor that HAS a
+//! backing class.
+//!
+//! Every test drives a real LSP entry point — `wire_attribute_goto_definition`,
+//! `this_member_hover_card`, `locate_in_backing_class_files` — against a
+//! tempdir project registered with the Salsa actor, and asserts the exact
+//! declaration line rather than merely that something resolved.
+
+use crate::LaravelLanguageServer;
+use laravel_lsp::salsa_impl::LaravelConfigData;
+use laravel_lsp::view_var_index::ViewRender;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Position, Url};
+use tower_lsp::LspService;
+
+/// A Livewire component's template, as a v4 single-file component: the class
+/// lives in the blade's own front matter, so this file resolves DIRECTLY and
+/// is a valid walk destination.
+const PARENT_SFC: &str = r#"<?php
+
+use Livewire\Component;
+
+new class extends Component {
+    public int $count = 0;
+
+    public function save(): void
+    {
+        $this->count++;
+    }
+};
+?>
+
+<div>
+    <x-save-button />
+</div>
+"#;
+
+/// The anonymous partial. No front matter, no backing class, no render site —
+/// only a `wire:` value that has to resolve through whoever rendered it.
+const PARTIAL: &str = "<button wire:click=\"save\">Save</button>\n";
+
+fn config_for(root: &Path) -> LaravelConfigData {
+    LaravelConfigData {
+        root: root.to_path_buf(),
+        view_paths: vec![root.join("resources/views")],
+        component_paths: vec![("".to_string(), root.join("resources/views/components"))],
+        livewire_path: Some(root.join("resources/views/livewire")),
+        has_livewire: true,
+        view_namespaces: HashMap::new(),
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+        class_component_files: HashMap::new(),
+    }
+}
+
+/// A server wired to `root`: config cached (the walk needs `view_paths` to
+/// name the partial) and the project registered with the Salsa actor (the
+/// reverse lookup sweeps the actor's view-file list).
+async fn backend_for(root: &Path) -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    let backend = service.inner().clone();
+    *backend.root_path.write().await = Some(root.to_path_buf());
+    *backend.cached_config.write().await = Some(Arc::new(config_for(root)));
+    backend
+        .salsa
+        .register_project_files(
+            root.to_path_buf(),
+            vec![PathBuf::from("app/Http/Controllers")],
+            vec![root.join("resources/views")],
+            Some(root.join("resources/views/livewire")),
+            PathBuf::from("routes"),
+        )
+        .await
+        .expect("actor registers the tempdir project");
+    backend
+}
+
+fn write(path: &Path, contents: &str) -> PathBuf {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+    path.to_path_buf()
+}
+
+/// Write the partial at `resources/views/components/<name>.blade.php`.
+fn write_partial(root: &Path, name: &str, contents: &str) -> PathBuf {
+    write(
+        &root
+            .join("resources/views/components")
+            .join(format!("{name}.blade.php")),
+        contents,
+    )
+}
+
+/// Goto-definition on the `save` inside the partial's `wire:click="save"`,
+/// through the real handler. The document is opened first, because
+/// `wire_attribute_goto_definition` reads the live buffer.
+async fn goto_wire_click(
+    backend: &LaravelLanguageServer,
+    partial: &Path,
+) -> Option<(PathBuf, u32)> {
+    let uri = Url::from_file_path(partial).unwrap();
+    let content = fs::read_to_string(partial).unwrap();
+    let line = content
+        .lines()
+        .position(|l| l.contains("wire:click="))
+        .expect("fixture carries a wire:click") as u32;
+    let character = content
+        .lines()
+        .nth(line as usize)
+        .unwrap()
+        .find("save\"")
+        .expect("fixture carries the member name") as u32
+        + 1;
+    backend
+        .documents
+        .write()
+        .await
+        .insert(uri.clone(), (content, 0));
+
+    let response = backend
+        .wire_attribute_goto_definition(&uri, Position { line, character })
+        .await?;
+    match response {
+        // A member declaration is ONE place, so the handler answers with a
+        // single link. Anything else means the walk stopped modelling
+        // Livewire's single `$this` and is a failure, not a shape to tolerate.
+        GotoDefinitionResponse::Link(links) if links.len() == 1 => Some((
+            links[0].target_uri.to_file_path().unwrap(),
+            links[0].target_range.start.line,
+        )),
+        other => panic!("expected exactly one target, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn x_tag_ancestor_backs_the_partials_wire_value() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let parent = write(
+        &root.join("resources/views/livewire/dashboard.blade.php"),
+        PARENT_SFC,
+    );
+    let partial = write_partial(root, "save-button", PARTIAL);
+    let backend = backend_for(root).await;
+
+    assert_eq!(
+        goto_wire_click(&backend, &partial).await,
+        Some((parent, 7)),
+        "`<x-save-button />` in the SFC makes its save() the partial's target"
+    );
+}
+
+#[tokio::test]
+async fn livewire_tag_ancestor_backs_the_partials_wire_value() {
+    // Same walk, reached through `<livewire:…>` instead of `<x-…>`. The
+    // partial lives under Livewire's view path, so it resolves as an anonymous
+    // Volt component by NAME — but has no class of its own, so navigation
+    // still has to climb to the parent.
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let parent = write(
+        &root.join("resources/views/livewire/dashboard.blade.php"),
+        &PARENT_SFC.replace("<x-save-button />", "<livewire:save-button />"),
+    );
+    let partial = write(
+        &root.join("resources/views/livewire/save-button.blade.php"),
+        PARTIAL,
+    );
+    let backend = backend_for(root).await;
+
+    assert_eq!(
+        goto_wire_click(&backend, &partial).await,
+        Some((parent, 7)),
+        "a `<livewire:…>` usage is a rendering edge too, not just `<x-…>`"
+    );
+}
+
+#[tokio::test]
+async fn hover_card_for_a_partial_member_names_the_ancestor_component() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("resources/views/livewire/dashboard.blade.php"),
+        PARENT_SFC,
+    );
+    let partial = write_partial(root, "save-button", PARTIAL);
+    let backend = backend_for(root).await;
+
+    let card = backend
+        .this_member_hover_card(&partial, "save")
+        .await
+        .expect("the ancestor declares save(), so a card must be emitted");
+    assert!(
+        card.contains("dashboard::save()"),
+        "the card names the ancestor component, not the partial: {card}"
+    );
+    assert!(
+        card.contains("public function save(): void"),
+        "the card carries the ancestor's signature: {card}"
+    );
+}
+
+#[tokio::test]
+async fn walk_is_transitive_across_five_levels_of_nesting() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let parent = write(
+        &root.join("resources/views/livewire/dashboard.blade.php"),
+        &PARENT_SFC.replace("<x-save-button />", "<x-level-1 />"),
+    );
+    // level-1 → level-2 → … → level-5 → save-button, none of them backed.
+    for level in 1..=4 {
+        write_partial(
+            root,
+            &format!("level-{level}"),
+            &format!("<div><x-level-{} /></div>\n", level + 1),
+        );
+    }
+    write_partial(root, "level-5", "<div><x-save-button /></div>\n");
+    let partial = write_partial(root, "save-button", PARTIAL);
+    let backend = backend_for(root).await;
+
+    assert_eq!(
+        goto_wire_click(&backend, &partial).await,
+        Some((parent, 7)),
+        "six hops up an acyclic chain still reach the component"
+    );
+}
+
+#[tokio::test]
+async fn a_cycle_terminates_instead_of_hanging() {
+    // `alpha` renders `beta`, `beta` renders `alpha`, and `alpha` renders the
+    // partial. Nothing in the loop is backed, so the answer is None — the
+    // point of the test is that it ARRIVES, rather than looping forever.
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    write_partial(root, "alpha", "<div><x-beta /><x-save-button /></div>\n");
+    write_partial(root, "beta", "<div><x-alpha /></div>\n");
+    let partial = write_partial(root, "save-button", PARTIAL);
+    let backend = backend_for(root).await;
+
+    assert_eq!(
+        tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            goto_wire_click(&backend, &partial),
+        )
+        .await
+        .expect("the visited set terminates the walk"),
+        None,
+        "an unbacked cycle resolves to nothing"
+    );
+}
+
+#[tokio::test]
+async fn a_cycle_on_one_branch_does_not_hide_a_resolvable_branch() {
+    // Two independent parents render the partial: `alpha` sits in a cycle with
+    // `beta` and is never backed; `zulu` is a plain unbacked partial rendered
+    // by the SFC. Pruning the cyclic branch must not prune the other one.
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let parent = write(
+        &root.join("resources/views/livewire/dashboard.blade.php"),
+        &PARENT_SFC.replace("<x-save-button />", "<x-zulu />"),
+    );
+    write_partial(root, "alpha", "<div><x-beta /><x-save-button /></div>\n");
+    write_partial(root, "beta", "<div><x-alpha /></div>\n");
+    write_partial(root, "zulu", "<div><x-save-button /></div>\n");
+    let partial = write_partial(root, "save-button", PARTIAL);
+    let backend = backend_for(root).await;
+
+    assert_eq!(
+        goto_wire_click(&backend, &partial).await,
+        Some((parent, 7)),
+        "the cyclic branch is pruned; the acyclic one still answers"
+    );
+}
+
+#[tokio::test]
+async fn equidistant_ancestors_resolve_lexicographically_and_stably() {
+    // Two components at the same distance both declare save(). The winner is
+    // the lexicographically smaller PATH, on every call — not whichever the
+    // file walk happened to yield first.
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let alpha = write(
+        &root.join("resources/views/livewire/alpha.blade.php"),
+        PARENT_SFC,
+    );
+    write(
+        &root.join("resources/views/livewire/zulu.blade.php"),
+        PARENT_SFC,
+    );
+    let partial = write_partial(root, "save-button", PARTIAL);
+    let backend = backend_for(root).await;
+
+    for attempt in 0..3 {
+        assert_eq!(
+            goto_wire_click(&backend, &partial).await,
+            Some((alpha.clone(), 7)),
+            "attempt {attempt}: the lexicographically first parent wins every time"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_nearer_ancestor_outranks_a_further_one() {
+    // `zulu-near` renders the partial directly; `alpha-far` renders it one hop
+    // further away, through the unbacked `mid`. Both declare save(). Distance
+    // decides, so the further-but-lexicographically-earlier `alpha-far` loses
+    // — which a depth-first walk (it would descend `mid` before finishing the
+    // level) or a flat lexicographic pick would both get wrong.
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let near = write(
+        &root.join("resources/views/livewire/zulu-near.blade.php"),
+        PARENT_SFC,
+    );
+    write(
+        &root.join("resources/views/livewire/alpha-far.blade.php"),
+        &PARENT_SFC.replace("<x-save-button />", "<x-mid />"),
+    );
+    write_partial(root, "mid", "<div><x-save-button /></div>\n");
+    let partial = write_partial(root, "save-button", PARTIAL);
+    let backend = backend_for(root).await;
+
+    assert_eq!(
+        goto_wire_click(&backend, &partial).await,
+        Some((near, 7)),
+        "the nearest rendering component wins, not the first one reachable"
+    );
+}
+
+#[tokio::test]
+async fn a_direct_render_site_outranks_a_component_ancestor() {
+    // The partial has BOTH: a controller that renders it by view name, and an
+    // SFC that renders it as `<x-save-button />`. The direct render site is
+    // the runtime truth for `view('components.save-button')`, so it wins.
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("resources/views/livewire/dashboard.blade.php"),
+        PARENT_SFC,
+    );
+    let controller = write(
+        &root.join("app/Http/Controllers/SaveButtonController.php"),
+        "<?php\n\nclass SaveButtonController\n{\n    public function save(): void\n    {\n    }\n}\n",
+    );
+    let partial = write_partial(root, "save-button", PARTIAL);
+    let backend = backend_for(root).await;
+    backend.view_vars.write().unwrap().insert_file(
+        controller.clone(),
+        &[ViewRender {
+            view_name: "components.save-button".to_string(),
+            vars: HashMap::new(),
+        }],
+    );
+
+    assert_eq!(
+        goto_wire_click(&backend, &partial).await,
+        Some((controller, 4)),
+        "the render site answers; the walk never runs"
+    );
+}
+
+#[tokio::test]
+async fn a_plain_php_file_under_the_view_root_is_not_a_rendering_ancestor() {
+    // The watcher classifies a created file into `view_files` by PATH PREFIX
+    // alone, so a plain `.php` under `resources/views` lands there — and its
+    // `'<x-save-button />'` string literal IS indexed as a component reference.
+    // It still isn't a rendering ancestor: the partial's `$this` belongs to the
+    // component whose TEMPLATE renders the tag. Sorting first must not let it
+    // answer ahead of the real parent.
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let parent = write(
+        &root.join("resources/views/livewire/dashboard.blade.php"),
+        PARENT_SFC,
+    );
+    let legacy = write(
+        &root.join("resources/views/aaa-legacy.php"),
+        "<?php\n\nuse Livewire\\Component;\n\n$markup = '<x-save-button />';\n\nnew class extends Component {\n    public function save(): void\n    {\n    }\n};\n",
+    );
+    let partial = write_partial(root, "save-button", PARTIAL);
+    let backend = backend_for(root).await;
+    backend
+        .salsa
+        .update_project_file_list(legacy, laravel_lsp::salsa_impl::FileListOp::Add)
+        .await
+        .expect("the watcher files it under the view root");
+
+    assert_eq!(
+        goto_wire_click(&backend, &partial).await,
+        Some((parent, 7)),
+        "the Blade parent answers, not the `.php` file that merely mentions the tag"
+    );
+}
+
+#[tokio::test]
+async fn a_partial_with_no_livewire_ancestor_resolves_to_nothing() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    // Rendered, but only by templates that are themselves unbacked.
+    write(
+        &root.join("resources/views/pages/home.blade.php"),
+        "<div><x-save-button /></div>\n",
+    );
+    let partial = write_partial(root, "save-button", PARTIAL);
+    let backend = backend_for(root).await;
+
+    assert_eq!(
+        goto_wire_click(&backend, &partial).await,
+        None,
+        "no ancestor has a backing class, so there is nothing to navigate to"
+    );
+    assert!(
+        backend
+            .locate_in_backing_class_files(&partial, "save")
+            .await
+            .is_none(),
+        "and the underlying resolution is empty, not a wrong guess"
+    );
+}

--- a/laravel-lsp/src/tests/component_ancestor_navigation.rs
+++ b/laravel-lsp/src/tests/component_ancestor_navigation.rs
@@ -67,8 +67,9 @@ fn config_for(root: &Path) -> LaravelConfigData {
 }
 
 /// A server wired to `root`: config cached (the walk needs `view_paths` to
-/// name the partial) and the project registered with the Salsa actor (the
-/// reverse lookup sweeps the actor's view-file list).
+/// name the partial) and the project registered with the Salsa actor, which
+/// queues each view file into the reverse component-usage index the walk
+/// reads.
 async fn backend_for(root: &Path) -> LaravelLanguageServer {
     let (service, _socket) = LspService::new(LaravelLanguageServer::new);
     let backend = service.inner().clone();
@@ -86,6 +87,14 @@ async fn backend_for(root: &Path) -> LaravelLanguageServer {
         .await
         .expect("actor registers the tempdir project");
     backend
+}
+
+/// A hover header as it is RENDERED. `main` escapes inline markdown in card
+/// headers, so `Counter::increment()` reaches the client as
+/// `Counter\:\:increment\(\)`. Routing the expected text through the same
+/// helper keeps these assertions honest without pinning their escaping.
+fn rendered(text: &str) -> String {
+    laravel_lsp::markdown_safety::escape_inline(text).into_owned()
 }
 
 fn write(path: &Path, contents: &str) -> PathBuf {
@@ -204,7 +213,7 @@ async fn hover_card_for_a_partial_member_names_the_ancestor_component() {
         .await
         .expect("the ancestor declares save(), so a card must be emitted");
     assert!(
-        card.contains("dashboard::save()"),
+        card.contains(&rendered("dashboard::save()")),
         "the card names the ancestor component, not the partial: {card}"
     );
     assert!(

--- a/laravel-lsp/src/tests/component_member_navigation.rs
+++ b/laravel-lsp/src/tests/component_member_navigation.rs
@@ -236,3 +236,441 @@ async fn local_loop_binding_shadows_class_property_navigation() {
         "outside the loop the class property is the target"
     );
 }
+
+// ─── issue #339 ───────────────────────────────────────────────────────────
+//
+// Items 2, 3, 4 and 5 driven through the real handlers: the goto entry point
+// (`wire_attribute_goto_definition`), the hover-card entry point
+// (`this_member_hover_card_of_kind`) and the shared member lookup — not the
+// pure helpers alone.
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Position, Url};
+
+/// Register `content` as the live editor buffer for `path`, the way
+/// `did_open` would, so handlers reading `self.documents` see it.
+async fn open_document(backend: &LaravelLanguageServer, path: &Path, content: &str) -> Url {
+    let uri = Url::from_file_path(path).unwrap();
+    backend
+        .documents
+        .write()
+        .await
+        .insert(uri.clone(), (content.to_string(), 1));
+    uri
+}
+
+/// A component that declares BOTH a `$save` property and a `save()` method,
+/// so a kind-blind lookup cannot tell which one a reference meant.
+const KIND_CLASH: &str = r#"<?php
+
+use Livewire\Component;
+
+new class extends Component {
+    public $save = '';
+
+    public function save(): void
+    {
+    }
+};
+?>
+
+<div>
+    <input wire:model="save">
+    <button wire:click="save">Go</button>
+    <span wire:target="save, reset"></span>
+</div>
+"#;
+
+fn write_blade(root: &Path, rel: &str, source: &str) -> PathBuf {
+    let path = root.join(rel);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, source).unwrap();
+    path
+}
+
+/// A config whose only interesting field is the view root, so
+/// `view_name_for_path` can turn a template path into a view name and reach
+/// the render index.
+fn config_with_view_root(root: &Path) -> laravel_lsp::salsa_impl::LaravelConfigData {
+    use std::collections::HashMap;
+    laravel_lsp::salsa_impl::LaravelConfigData {
+        root: root.to_path_buf(),
+        view_paths: vec![root.join("resources/views")],
+        component_paths: Vec::new(),
+        livewire_path: None,
+        has_livewire: false,
+        view_namespaces: HashMap::new(),
+        component_namespaces: HashMap::new(),
+        anonymous_component_paths: HashMap::new(),
+        anonymous_component_namespaces: HashMap::new(),
+        component_aliases: HashMap::new(),
+        icon_aliases: HashMap::new(),
+        class_component_files: HashMap::new(),
+    }
+}
+
+/// The 0-based line the single goto target points at. `goto_link` answers
+/// with a one-element `Link`, so that is the shape asserted here.
+fn goto_line(response: &GotoDefinitionResponse) -> u32 {
+    match response {
+        GotoDefinitionResponse::Link(links) => {
+            assert_eq!(links.len(), 1, "goto answers with exactly one target");
+            links[0].target_range.start.line
+        }
+        GotoDefinitionResponse::Scalar(loc) => loc.range.start.line,
+        other => panic!("expected a single location, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn wire_model_goto_resolves_the_property_not_the_same_named_method() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_blade(dir.path(), "resources/views/clash.blade.php", KIND_CLASH);
+    let uri = open_document(&backend, &blade, KIND_CLASH).await;
+
+    let model_line = 14;
+    let col = KIND_CLASH.lines().nth(model_line as usize).unwrap();
+    let character = col.find("save").unwrap() as u32;
+    let response = backend
+        .wire_attribute_goto_definition(
+            &uri,
+            Position {
+                line: model_line,
+                character,
+            },
+        )
+        .await
+        .expect("a data binding resolves to the property");
+    assert_eq!(
+        goto_line(&response),
+        5,
+        "wire:model binds `public $save`, declared on line 5 — not `save()` on line 7"
+    );
+}
+
+#[tokio::test]
+async fn wire_click_goto_resolves_the_method_not_the_same_named_property() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_blade(dir.path(), "resources/views/clash.blade.php", KIND_CLASH);
+    let uri = open_document(&backend, &blade, KIND_CLASH).await;
+
+    let click_line = 15;
+    let text = KIND_CLASH.lines().nth(click_line as usize).unwrap();
+    let character = text.find("save").unwrap() as u32;
+    let response = backend
+        .wire_attribute_goto_definition(
+            &uri,
+            Position {
+                line: click_line,
+                character,
+            },
+        )
+        .await
+        .expect("an action binding resolves to the method");
+    assert_eq!(
+        goto_line(&response),
+        7,
+        "wire:click calls `save()`, declared on line 7"
+    );
+}
+
+#[tokio::test]
+async fn wire_target_navigates_the_entry_under_the_cursor() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_blade(dir.path(), "resources/views/clash.blade.php", KIND_CLASH);
+    let uri = open_document(&backend, &blade, KIND_CLASH).await;
+
+    let target_line = 16;
+    let text = KIND_CLASH.lines().nth(target_line as usize).unwrap();
+    // `wire:target="save, reset"` — the first entry names the component's
+    // member, and `wire:target` accepts either kind, so the property answers.
+    let character = text.find("save,").unwrap() as u32;
+    let response = backend
+        .wire_attribute_goto_definition(
+            &uri,
+            Position {
+                line: target_line,
+                character,
+            },
+        )
+        .await
+        .expect("wire:target names a navigable member");
+    assert_eq!(goto_line(&response), 5);
+
+    // The second entry is declared nowhere, so it resolves to nothing rather
+    // than falling back to the first — proof the cursor picks the segment.
+    let character = text.find("reset").unwrap() as u32;
+    assert!(
+        backend
+            .wire_attribute_goto_definition(
+                &uri,
+                Position {
+                    line: target_line,
+                    character,
+                },
+            )
+            .await
+            .is_none(),
+        "the cursor's own entry decides what is resolved"
+    );
+}
+
+#[tokio::test]
+async fn hover_card_for_a_binding_ignores_the_same_named_method() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_blade(dir.path(), "resources/views/clash.blade.php", KIND_CLASH);
+
+    let card = backend
+        .this_member_hover_card_of_kind(&blade, "save", Some(MemberKind::Property))
+        .await
+        .expect("the property is declared");
+    assert!(
+        card.contains("::$save"),
+        "a property card names the property: {card}"
+    );
+    assert!(
+        !card.contains("::save()"),
+        "the method must not answer a property reference: {card}"
+    );
+}
+
+#[tokio::test]
+async fn hover_card_of_a_kind_absent_from_the_component_is_not_emitted() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let source = "<?php\nuse Livewire\\Component;\nnew class extends Component {\n    public function save(): void {}\n};\n?>\n<div></div>\n";
+    let blade = write_blade(dir.path(), "resources/views/only-method.blade.php", source);
+
+    assert!(
+        backend
+            .this_member_hover_card_of_kind(&blade, "save", Some(MemberKind::Property))
+            .await
+            .is_none(),
+        "no property is declared, so a binding gets no card at all"
+    );
+}
+
+#[tokio::test]
+async fn inline_class_hover_card_names_the_component_not_the_base_class() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_sfc(dir.path());
+
+    let card = backend
+        .this_member_hover_card(&blade, "increment")
+        .await
+        .expect("the inline class declares increment()");
+    assert!(
+        !card.contains("Component::"),
+        "an anonymous `new class extends Component` is not called `Component`: {card}"
+    );
+    assert!(
+        card.contains("counter::increment()"),
+        "the card names the component: {card}"
+    );
+}
+
+#[tokio::test]
+async fn a_named_backing_class_still_shows_its_fqcn() {
+    use laravel_lsp::view_var_index::ViewRender;
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let class_path = dir.path().join("app/Livewire/Counter.php");
+    fs::create_dir_all(class_path.parent().unwrap()).unwrap();
+    fs::write(
+        &class_path,
+        "<?php\n\nnamespace App\\Livewire;\n\nclass Counter extends Component\n{\n    public function increment(): void {}\n}\n",
+    )
+    .unwrap();
+    let blade = write_blade(
+        dir.path(),
+        "resources/views/counter-page.blade.php",
+        "<div wire:click=\"increment\"></div>\n",
+    );
+
+    // Point the render index at the class, the way a `view('counter-page')`
+    // call site would.
+    {
+        *backend.cached_config.write().await =
+            Some(std::sync::Arc::new(config_with_view_root(dir.path())));
+    }
+    backend.view_vars.write().unwrap().insert_file(
+        class_path.clone(),
+        &[ViewRender {
+            view_name: "counter-page".to_string(),
+            vars: Default::default(),
+        }],
+    );
+
+    let card = backend
+        .this_member_hover_card(&blade, "increment")
+        .await
+        .expect("the backing class declares increment()");
+    assert!(
+        card.contains("App\\Livewire\\Counter::increment()"),
+        "a NAMED class keeps its FQCN — the component-name fallback is only \
+         for anonymous and functional shapes: {card}"
+    );
+}
+
+#[tokio::test]
+async fn the_hover_card_reads_the_live_buffer_not_the_saved_file() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let saved = "<?php\n\nnamespace App\\Livewire;\n\nclass OldName extends Component\n{\n    public function increment(): void {}\n}\n";
+    let class_path = dir.path().join("app/Livewire/Counter.php");
+    fs::create_dir_all(class_path.parent().unwrap()).unwrap();
+    fs::write(&class_path, saved).unwrap();
+    let blade = write_blade(
+        dir.path(),
+        "resources/views/counter-page.blade.php",
+        "<div wire:click=\"increment\"></div>\n",
+    );
+    *backend.cached_config.write().await =
+        Some(std::sync::Arc::new(config_with_view_root(dir.path())));
+    backend.view_vars.write().unwrap().insert_file(
+        class_path.clone(),
+        &[laravel_lsp::view_var_index::ViewRender {
+            view_name: "counter-page".to_string(),
+            vars: Default::default(),
+        }],
+    );
+
+    let card = backend
+        .this_member_hover_card(&blade, "increment")
+        .await
+        .expect("the backing class declares increment()");
+    assert!(
+        card.contains("OldName"),
+        "sanity: the saved file names OldName: {card}"
+    );
+}
+
+// ---- functional Volt (item 3) --------------------------------------------
+
+const VOLT_FUNCTIONAL: &str = r#"<?php
+use function Livewire\Volt\{state, action};
+
+state(['count' => 0]);
+
+$increment = fn () => $this->count++;
+$reset = action(fn () => $this->count = 0);
+?>
+
+<div wire:click="increment">{{ $count }}</div>
+<button wire:click="reset">reset</button>
+"#;
+
+#[tokio::test]
+async fn functional_volt_action_goto_lands_on_the_assignment() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_blade(
+        dir.path(),
+        "resources/views/pages/counter.blade.php",
+        VOLT_FUNCTIONAL,
+    );
+    let uri = open_document(&backend, &blade, VOLT_FUNCTIONAL).await;
+
+    let click_line = 9;
+    let text = VOLT_FUNCTIONAL.lines().nth(click_line as usize).unwrap();
+    let character = text.find("increment").unwrap() as u32;
+    let response = backend
+        .wire_attribute_goto_definition(
+            &uri,
+            Position {
+                line: click_line,
+                character,
+            },
+        )
+        .await
+        .expect("a functional Volt action is navigable");
+    assert_eq!(
+        goto_line(&response),
+        5,
+        "goto lands on the `$increment = fn () => …` assignment"
+    );
+}
+
+#[tokio::test]
+async fn functional_volt_wrapped_action_form_resolves_too() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_blade(
+        dir.path(),
+        "resources/views/pages/counter.blade.php",
+        VOLT_FUNCTIONAL,
+    );
+    let uri = open_document(&backend, &blade, VOLT_FUNCTIONAL).await;
+
+    let click_line = 10;
+    let text = VOLT_FUNCTIONAL.lines().nth(click_line as usize).unwrap();
+    let character = text.find("reset").unwrap() as u32;
+    let response = backend
+        .wire_attribute_goto_definition(
+            &uri,
+            Position {
+                line: click_line,
+                character,
+            },
+        )
+        .await
+        .expect("`action(fn () => …)` is an action too");
+    assert_eq!(goto_line(&response), 6);
+}
+
+#[tokio::test]
+async fn functional_volt_state_key_is_a_property() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_blade(
+        dir.path(),
+        "resources/views/pages/counter.blade.php",
+        VOLT_FUNCTIONAL,
+    );
+
+    let (path, loc) = backend
+        .locate_in_backing_class_files_of_kind(&blade, "count", Some(MemberKind::Property))
+        .await
+        .expect("`state(['count' => 0])` declares a property");
+    assert_eq!(
+        path, blade,
+        "the state lives in the template's front matter"
+    );
+    assert_eq!(loc.line, 3, "the `state([...])` call's own line");
+    assert!(
+        backend
+            .locate_in_backing_class_files_of_kind(&blade, "count", Some(MemberKind::Method))
+            .await
+            .is_none(),
+        "state is never an action"
+    );
+}
+
+#[tokio::test]
+async fn functional_volt_hover_card_names_the_component() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_blade(
+        dir.path(),
+        "resources/views/pages/counter.blade.php",
+        VOLT_FUNCTIONAL,
+    );
+
+    let card = backend
+        .this_member_hover_card(&blade, "increment")
+        .await
+        .expect("a functional Volt action gets a card");
+    assert!(
+        !card.contains("Component::"),
+        "a functional Volt file declares no class called `Component`: {card}"
+    );
+    assert!(
+        card.contains("counter::increment()"),
+        "the card names the component: {card}"
+    );
+}

--- a/laravel-lsp/src/tests/component_member_navigation.rs
+++ b/laravel-lsp/src/tests/component_member_navigation.rs
@@ -260,18 +260,25 @@ async fn open_document(backend: &LaravelLanguageServer, path: &Path, content: &s
     uri
 }
 
-/// A component that declares BOTH a `$save` property and a `save()` method,
+/// A component that declares BOTH a `save()` method and a `$save` property,
 /// so a kind-blind lookup cannot tell which one a reference meant.
+///
+/// **The METHOD is declared first on purpose.** Every lookup here picks the
+/// first candidate in document order, so with the property first a kind filter
+/// that only reaches half a result — a hover header filtered while its body is
+/// not — still shows the property and the tests still pass. Method-first makes
+/// the unfiltered path answer `save()` and the filtered path answer `$save`,
+/// which is what lets these assertions discriminate at all.
 const KIND_CLASH: &str = r#"<?php
 
 use Livewire\Component;
 
 new class extends Component {
-    public $save = '';
-
     public function save(): void
     {
     }
+
+    public $save = '';
 };
 ?>
 
@@ -281,6 +288,14 @@ new class extends Component {
     <span wire:target="save, reset"></span>
 </div>
 "#;
+
+/// A hover header as it is RENDERED. `main` escapes inline markdown in card
+/// headers, so `Counter::increment()` reaches the client as
+/// `Counter\:\:increment\(\)`. Routing the expected text through the same
+/// helper keeps these assertions honest without pinning their escaping.
+fn rendered(text: &str) -> String {
+    laravel_lsp::markdown_safety::escape_inline(text).into_owned()
+}
 
 fn write_blade(root: &Path, rel: &str, source: &str) -> PathBuf {
     let path = root.join(rel);
@@ -345,8 +360,8 @@ async fn wire_model_goto_resolves_the_property_not_the_same_named_method() {
         .expect("a data binding resolves to the property");
     assert_eq!(
         goto_line(&response),
-        5,
-        "wire:model binds `public $save`, declared on line 5 — not `save()` on line 7"
+        9,
+        "wire:model binds `public $save`, declared on line 9 — not `save()` on line 5"
     );
 }
 
@@ -372,8 +387,8 @@ async fn wire_click_goto_resolves_the_method_not_the_same_named_property() {
         .expect("an action binding resolves to the method");
     assert_eq!(
         goto_line(&response),
-        7,
-        "wire:click calls `save()`, declared on line 7"
+        5,
+        "wire:click calls `save()`, declared on line 5"
     );
 }
 
@@ -387,7 +402,8 @@ async fn wire_target_navigates_the_entry_under_the_cursor() {
     let target_line = 16;
     let text = KIND_CLASH.lines().nth(target_line as usize).unwrap();
     // `wire:target="save, reset"` — the first entry names the component's
-    // member, and `wire:target` accepts either kind, so the property answers.
+    // member, and `wire:target` accepts EITHER kind, so the winner is simply
+    // the first declaration in document order: `save()` on line 5.
     let character = text.find("save,").unwrap() as u32;
     let response = backend
         .wire_attribute_goto_definition(
@@ -430,12 +446,26 @@ async fn hover_card_for_a_binding_ignores_the_same_named_method() {
         .await
         .expect("the property is declared");
     assert!(
-        card.contains("::$save"),
+        card.contains(&rendered("::$save")),
         "a property card names the property: {card}"
     );
     assert!(
         !card.contains("::save()"),
         "the method must not answer a property reference: {card}"
+    );
+    // The BODY, not just the header. `member_declaration_summary` is a second,
+    // independent lookup, and unfiltered it renders whichever declaration comes
+    // first — the method, in this fixture. Asserting the absence of `::save()`
+    // cannot catch that: the rendered method reads `public function save():
+    // void`, which contains no `::` at all. Read raw, not through `rendered`:
+    // the code block is fenced PHP, and fenced content is not inline-escaped.
+    assert!(
+        card.contains("public $save"),
+        "the code block shows the property's own declaration: {card}"
+    );
+    assert!(
+        !card.contains("function save"),
+        "the code block must not show the method's signature: {card}"
     );
 }
 
@@ -466,11 +496,11 @@ async fn inline_class_hover_card_names_the_component_not_the_base_class() {
         .await
         .expect("the inline class declares increment()");
     assert!(
-        !card.contains("Component::"),
+        !card.contains(&rendered("Component::")),
         "an anonymous `new class extends Component` is not called `Component`: {card}"
     );
     assert!(
-        card.contains("counter::increment()"),
+        card.contains(&rendered("counter::increment()")),
         "the card names the component: {card}"
     );
 }
@@ -513,7 +543,7 @@ async fn a_named_backing_class_still_shows_its_fqcn() {
         .await
         .expect("the backing class declares increment()");
     assert!(
-        card.contains("App\\Livewire\\Counter::increment()"),
+        card.contains(&rendered("App\\Livewire\\Counter::increment()")),
         "a NAMED class keeps its FQCN — the component-name fallback is only \
          for anonymous and functional shapes: {card}"
     );
@@ -668,11 +698,11 @@ async fn functional_volt_hover_card_names_the_component() {
         .await
         .expect("a functional Volt action gets a card");
     assert!(
-        !card.contains("Component::"),
+        !card.contains(&rendered("Component::")),
         "a functional Volt file declares no class called `Component`: {card}"
     );
     assert!(
-        card.contains("counter::increment()"),
+        card.contains(&rendered("counter::increment()")),
         "the card names the component: {card}"
     );
 }

--- a/laravel-lsp/src/tests/component_member_navigation.rs
+++ b/laravel-lsp/src/tests/component_member_navigation.rs
@@ -435,6 +435,64 @@ async fn wire_target_navigates_the_entry_under_the_cursor() {
     );
 }
 
+/// `wire:target` also names a PROPERTY when it pairs with `wire:model`'s
+/// loading state, which is the form item 5's kind filter could silently
+/// break: classify `target` as a method and this reference resolves to
+/// nothing. `$query` is declared as a property and nothing else, so only the
+/// unfiltered classification can answer it.
+const WIRE_TARGET_PROPERTY: &str = r#"<?php
+
+use Livewire\Component;
+
+new class extends Component {
+    public function save(): void
+    {
+    }
+
+    public $query = '';
+};
+?>
+
+<div>
+    <input wire:model.live="query">
+    <span wire:target="query" wire:loading>Searching…</span>
+</div>
+"#;
+
+#[tokio::test]
+async fn wire_target_resolves_a_loading_state_property() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let blade = write_blade(
+        dir.path(),
+        "resources/views/loading.blade.php",
+        WIRE_TARGET_PROPERTY,
+    );
+    let uri = open_document(&backend, &blade, WIRE_TARGET_PROPERTY).await;
+
+    let target_line = 15;
+    let text = WIRE_TARGET_PROPERTY
+        .lines()
+        .nth(target_line as usize)
+        .unwrap();
+    let character = text.find("query\"").unwrap() as u32;
+    let response = backend
+        .wire_attribute_goto_definition(
+            &uri,
+            Position {
+                line: target_line,
+                character,
+            },
+        )
+        .await
+        .expect("wire:target resolves a property, not only an action");
+    assert_eq!(
+        goto_line(&response),
+        9,
+        "the target is the `public $query` declaration"
+    );
+}
+
 #[tokio::test]
 async fn hover_card_for_a_binding_ignores_the_same_named_method() {
     let dir = tempfile::TempDir::new().unwrap();
@@ -549,11 +607,20 @@ async fn a_named_backing_class_still_shows_its_fqcn() {
     );
 }
 
+/// The card's class name has to come from the text the user is looking at.
+///
+/// **The divergence is the whole test.** Disk keeps `OldName`; the editor's
+/// unsaved buffer renames the class to `NewName`, and only the buffer is
+/// pushed into Salsa — so a card reading the live source says `NewName` and a
+/// card re-reading the path off disk says `OldName`. Without that split the
+/// assertion passes either way, which is exactly how the first version of
+/// this test went green with the fix reverted.
 #[tokio::test]
 async fn the_hover_card_reads_the_live_buffer_not_the_saved_file() {
     let dir = tempfile::TempDir::new().unwrap();
     let backend = backend_with_root(dir.path()).await;
     let saved = "<?php\n\nnamespace App\\Livewire;\n\nclass OldName extends Component\n{\n    public function increment(): void {}\n}\n";
+    let buffer = "<?php\n\nnamespace App\\Livewire;\n\nclass NewName extends Component\n{\n    public function increment(): void {}\n}\n";
     let class_path = dir.path().join("app/Livewire/Counter.php");
     fs::create_dir_all(class_path.parent().unwrap()).unwrap();
     fs::write(&class_path, saved).unwrap();
@@ -572,13 +639,26 @@ async fn the_hover_card_reads_the_live_buffer_not_the_saved_file() {
         }],
     );
 
+    // The rename exists only in the editor. `did_open`/`did_change` push the
+    // buffer to both places, so the test does too.
+    open_document(&backend, &class_path, buffer).await;
+    backend
+        .salsa
+        .update_file(class_path.clone(), 2, buffer.to_string())
+        .await
+        .expect("the editor's buffer reaches Salsa");
+
     let card = backend
         .this_member_hover_card(&blade, "increment")
         .await
         .expect("the backing class declares increment()");
     assert!(
-        card.contains("OldName"),
-        "sanity: the saved file names OldName: {card}"
+        card.contains(&rendered("App\\Livewire\\NewName::increment()")),
+        "the card must name the class in the live buffer: {card}"
+    );
+    assert!(
+        !card.contains("OldName"),
+        "the last-saved class name must not reach the card: {card}"
     );
 }
 
@@ -837,5 +917,139 @@ async fn editing_the_backing_class_on_disk_invalidates_the_cached_source() {
     assert_eq!(
         after.1.line, 10,
         "the replacement method sits where the old one did",
+    );
+}
+
+// ---- items 6 and 8, through their real handler ---------------------------
+//
+// Both fixes were pinned by unit tests over `locate_member` and
+// `is_template_local_binding` alone. A unit test of a predicate proves nothing
+// about whether the handler consults it, and `blade_variable_goto_definition`
+// is the only consumer either one has — so it is what these drive.
+
+/// Wire a Blade template to an external backing class, the way the hover-card
+/// tests do: the config supplies the view root, and the render index says this
+/// `.php` renders that view.
+async fn backend_rendering(
+    root: &Path,
+    view_name: &str,
+    class_rel: &str,
+    class_source: &str,
+) -> (LaravelLanguageServer, PathBuf) {
+    let backend = backend_with_root(root).await;
+    let class_path = root.join(class_rel);
+    fs::create_dir_all(class_path.parent().unwrap()).unwrap();
+    fs::write(&class_path, class_source).unwrap();
+    *backend.cached_config.write().await = Some(std::sync::Arc::new(config_with_view_root(root)));
+    backend.view_vars.write().unwrap().insert_file(
+        class_path.clone(),
+        &[laravel_lsp::view_var_index::ViewRender {
+            view_name: view_name.to_string(),
+            vars: Default::default(),
+        }],
+    );
+    (backend, class_path)
+}
+
+/// `@props(['color' => 'blue'])` binds the KEY. The value `blue`, and any
+/// unrelated quoted text sharing the line, are not bindings — so `$blue` and
+/// `$literal` must still navigate to the backing class while `$color` is
+/// correctly shadowed.
+const PROPS_LINE: &str = r#"@props(['color' => 'blue']) <div title="literal">
+{{ $color }}
+{{ $blue }}
+{{ $literal }}
+</div>
+"#;
+
+const PROPS_BACKING_CLASS: &str = r#"<?php
+
+namespace App\Livewire;
+
+class Card extends Component
+{
+    public $color = '';
+    public $blue = '';
+    public $literal = '';
+}
+"#;
+
+#[tokio::test]
+async fn props_goto_binds_the_key_and_leaves_the_value_navigable() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (backend, _class) = backend_rendering(
+        dir.path(),
+        "card",
+        "app/Livewire/Card.php",
+        PROPS_BACKING_CLASS,
+    )
+    .await;
+    let blade = write_blade(dir.path(), "resources/views/card.blade.php", PROPS_LINE);
+    let uri = open_document(&backend, &blade, PROPS_LINE).await;
+
+    let goto = |line: u32, character: u32| {
+        backend.blade_variable_goto_definition(&uri, Position { line, character })
+    };
+
+    assert!(
+        goto(1, 6).await.is_none(),
+        "`color` is the @props KEY, so it is template-local and shadows the class"
+    );
+
+    let blue = goto(2, 6)
+        .await
+        .expect("`blue` is a default VALUE, not a binding — it still navigates");
+    assert_eq!(
+        goto_line(&blue),
+        7,
+        "goto lands on `public $blue` in the backing class"
+    );
+
+    let literal = goto(3, 6)
+        .await
+        .expect("unrelated quoted text on the @props line binds nothing");
+    assert_eq!(
+        goto_line(&literal),
+        8,
+        "goto lands on `public $literal` in the backing class"
+    );
+}
+
+/// The candidate declared FIRST in the file sits one level deeper in the tree
+/// than the one declared second, so a queue-based traversal reports the
+/// shallow class and a true document-order sort reports the trait. Goto is a
+/// location question over the whole file, which is why the trait wins here
+/// even though completion (a surface question) excludes it.
+const DOCUMENT_ORDER_CLASS: &str =
+    "<?php\ntrait Helper {\n    public $dup = 1;\n}\nclass Card extends Component { public $dup = 2; }\n";
+
+#[tokio::test]
+async fn goto_takes_the_first_declaration_in_document_order() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (backend, _class) = backend_rendering(
+        dir.path(),
+        "card",
+        "app/Livewire/Card.php",
+        DOCUMENT_ORDER_CLASS,
+    )
+    .await;
+    let source = "{{ $dup }}\n";
+    let blade = write_blade(dir.path(), "resources/views/card.blade.php", source);
+    let uri = open_document(&backend, &blade, source).await;
+
+    let response = backend
+        .blade_variable_goto_definition(
+            &uri,
+            Position {
+                line: 0,
+                character: 6,
+            },
+        )
+        .await
+        .expect("`$dup` is declared in the backing class file");
+    assert_eq!(
+        goto_line(&response),
+        2,
+        "the trait's `$dup` is declared first, on line 2; the class's is line 4"
     );
 }

--- a/laravel-lsp/src/tests/component_member_navigation.rs
+++ b/laravel-lsp/src/tests/component_member_navigation.rs
@@ -674,3 +674,136 @@ async fn functional_volt_hover_card_names_the_component() {
         "the card names the component: {card}"
     );
 }
+
+// ─── Backing-class resolution is memoized, and content-tracked (#339, item 7) ─
+//
+// `blade_backing_class_sources` used to re-scan the whole render index and
+// re-read every backing class from disk on EVERY keystroke inside a `wire:`
+// value. These two tests drive the real lookup handler and read the Salsa
+// database's own body-execution counters, because the return value is
+// identical whether the answer was memoized or recomputed.
+
+/// A stock Livewire v3 component: a class under `app/Livewire`, and its view
+/// under `resources/views/livewire`. The class is a STANDALONE `.php` file, so
+/// the backing-class query has real file content to track.
+fn write_v3_component(root: &Path) -> (PathBuf, PathBuf) {
+    let class_dir = root.join("app/Livewire");
+    fs::create_dir_all(&class_dir).unwrap();
+    let class = class_dir.join("Counter.php");
+    fs::write(
+        &class,
+        "<?php\n\nnamespace App\\Livewire;\n\nuse Livewire\\Component;\n\nclass Counter extends Component\n{\n    public int $count = 0;\n\n    public function increment(): void\n    {\n        $this->count++;\n    }\n}\n",
+    )
+    .unwrap();
+
+    let view_dir = root.join("resources/views/livewire");
+    fs::create_dir_all(&view_dir).unwrap();
+    let blade = view_dir.join("counter.blade.php");
+    fs::write(
+        &blade,
+        "<div><button wire:click=\"increment\">+</button></div>\n",
+    )
+    .unwrap();
+
+    (class, blade)
+}
+
+#[tokio::test]
+async fn repeating_a_lookup_serves_the_backing_class_from_the_memo() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let (class, blade) = write_v3_component(dir.path());
+    *backend.cached_config.write().await =
+        Some(std::sync::Arc::new(config_with_view_root(dir.path())));
+
+    // Both hot inputs live: an OPEN document (so the live-buffer path runs on
+    // every lookup) and a non-empty render index (so the render-index query is
+    // actually consulted). Without either, the counters below would be
+    // vacuously equal.
+    open_document(&backend, &blade, &fs::read_to_string(&blade).unwrap()).await;
+    backend.view_vars.write().unwrap().insert_file(
+        dir.path()
+            .join("app/Http/Controllers/CounterController.php"),
+        &[laravel_lsp::view_var_index::ViewRender {
+            view_name: "livewire.counter".to_string(),
+            vars: std::collections::HashMap::new(),
+        }],
+    );
+
+    let first = backend
+        .locate_in_backing_class_files(&blade, "increment")
+        .await
+        .expect("the component class backs its own view");
+    assert_eq!(first.0, class, "resolution must reach the standalone class");
+
+    let after_first = backend.salsa.query_run_counts().await.unwrap();
+    assert!(
+        after_first.render_source_files > 0 && after_first.blade_backing_class_sources > 0,
+        "both queries must have run at least once, or the deltas below prove nothing",
+    );
+    let second = backend
+        .locate_in_backing_class_files(&blade, "increment")
+        .await
+        .expect("the second lookup resolves too");
+    let after_second = backend.salsa.query_run_counts().await.unwrap();
+
+    assert_eq!(first, second, "both lookups land on the same declaration");
+    assert_eq!(
+        after_second.blade_backing_class_sources, after_first.blade_backing_class_sources,
+        "a repeat lookup with nothing edited must not re-read the backing class",
+    );
+    assert_eq!(
+        after_second.render_source_files, after_first.render_source_files,
+        "nor re-scan the render index",
+    );
+}
+
+#[tokio::test]
+async fn editing_the_backing_class_on_disk_invalidates_the_cached_source() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let backend = backend_with_root(dir.path()).await;
+    let (class, blade) = write_v3_component(dir.path());
+
+    let before = backend
+        .locate_in_backing_class_files(&blade, "increment")
+        .await
+        .expect("the original method resolves");
+    assert_eq!(before.1.line, 10, "the original declaration line");
+
+    // Rewrite the BACKING CLASS — the blade file is untouched. A cache keyed on
+    // the template alone would keep serving the stale source and resolve
+    // `decrement` to nothing.
+    //
+    // The re-read is gated on mtime, whose resolution is only one second on
+    // some filesystems; push the timestamp forward explicitly rather than
+    // sleeping, so the test is neither slow nor flaky.
+    fs::write(
+        &class,
+        "<?php\n\nnamespace App\\Livewire;\n\nuse Livewire\\Component;\n\nclass Counter extends Component\n{\n    public int $count = 0;\n\n    public function decrement(): void\n    {\n        $this->count--;\n    }\n}\n",
+    )
+    .unwrap();
+    let bumped = std::time::SystemTime::now() + std::time::Duration::from_secs(5);
+    fs::OpenOptions::new()
+        .write(true)
+        .open(&class)
+        .unwrap()
+        .set_modified(bumped)
+        .unwrap();
+
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "increment")
+            .await
+            .is_none(),
+        "the removed method must stop resolving",
+    );
+    let after = backend
+        .locate_in_backing_class_files(&blade, "decrement")
+        .await
+        .expect("the newly added method must resolve");
+    assert_eq!(after.0, class);
+    assert_eq!(
+        after.1.line, 10,
+        "the replacement method sits where the old one did",
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -55,6 +55,7 @@ mod nested_module_root_correction;
 mod post_warm_open_buffer_guard;
 mod query_chain_completion_handler;
 mod rename_integration;
+mod render_index_and_buffer_integrity;
 mod route_binding_resolution;
 mod route_diagnostics;
 mod route_hover;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod class_locator_and_properties;
 mod code_action_create_containment;
 mod code_lens_opt_in;
 mod completion_value_pipeline;
+mod component_ancestor_navigation;
 mod component_file_navigation_containment;
 mod component_member_navigation;
 mod component_navigation_containment;

--- a/laravel-lsp/src/tests/render_index_and_buffer_integrity.rs
+++ b/laravel-lsp/src/tests/render_index_and_buffer_integrity.rs
@@ -1,0 +1,345 @@
+//! Actor-side integrity of the backing-class resolution path (#339 review).
+//!
+//! Three defects live at the seam where the Blade side pushes state into the
+//! Salsa actor, and none of them is visible from a pure-function test:
+//!
+//! 1. the reverse component-usage index has to see an edit that adds or
+//!    removes an `<x-…>` tag, or the ancestor walk answers out of a stale map;
+//! 2. loading a backing class from disk must not overwrite an open editor
+//!    buffer's text, and must drop the caches populated from the old text;
+//! 3. two concurrent render-index snapshots must not leave the actor holding
+//!    the older one while the caller's gate claims the newer.
+//!
+//! Every test drives the real `SalsaHandle` API rather than actor internals.
+
+use laravel_lsp::salsa_impl::SalsaHandle;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn write(path: &Path, contents: &str) -> PathBuf {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+    path.to_path_buf()
+}
+
+/// A handle whose project is `root`, with `resources/views` registered as the
+/// view root so the Blade files below land in the actor's view-file list.
+async fn handle_for(root: &Path) -> SalsaHandle {
+    let handle = laravel_lsp::salsa_impl::SalsaActor::spawn();
+    handle
+        .register_project_files(
+            root.to_path_buf(),
+            vec![PathBuf::from("app/Http/Controllers")],
+            vec![root.join("resources/views")],
+            Some(root.join("resources/views/livewire")),
+            PathBuf::from("routes"),
+        )
+        .await
+        .expect("actor registers the tempdir project");
+    handle
+}
+
+// === 1. the reverse component-usage index tracks edits ====================
+
+#[tokio::test]
+async fn the_usage_index_sees_a_tag_added_by_an_edit() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let parent = write(
+        &root.join("resources/views/dashboard.blade.php"),
+        "<div>nothing here yet</div>\n",
+    );
+    let handle = handle_for(root).await;
+
+    assert!(
+        handle
+            .files_rendering_component(vec!["save-button".to_string()], Vec::new())
+            .await
+            .unwrap()
+            .is_empty(),
+        "nothing renders <x-save-button> yet"
+    );
+
+    handle
+        .update_file(
+            parent.clone(),
+            1,
+            "<div><x-save-button /></div>\n".to_string(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        handle
+            .files_rendering_component(vec!["save-button".to_string()], Vec::new())
+            .await
+            .unwrap(),
+        vec![parent],
+        "the edit added the tag, so the index has to answer with this file"
+    );
+}
+
+#[tokio::test]
+async fn the_usage_index_sees_a_tag_removed_by_an_edit() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let parent = write(
+        &root.join("resources/views/dashboard.blade.php"),
+        "<div><x-save-button /></div>\n",
+    );
+    let handle = handle_for(root).await;
+
+    assert_eq!(
+        handle
+            .files_rendering_component(vec!["save-button".to_string()], Vec::new())
+            .await
+            .unwrap(),
+        vec![parent.clone()],
+    );
+
+    handle
+        .update_file(parent, 1, "<div>gone</div>\n".to_string())
+        .await
+        .unwrap();
+
+    assert!(
+        handle
+            .files_rendering_component(vec!["save-button".to_string()], Vec::new())
+            .await
+            .unwrap()
+            .is_empty(),
+        "re-indexing must withdraw the tag the file no longer renders"
+    );
+}
+
+/// `<livewire:…>` is the other half of the usage graph, and it is indexed in a
+/// separate map — a lookup wired to only one of the two answers this with
+/// silence.
+#[tokio::test]
+async fn the_usage_index_answers_for_livewire_tags_too() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let parent = write(
+        &root.join("resources/views/dashboard.blade.php"),
+        "<div><livewire:counter /></div>\n",
+    );
+    let handle = handle_for(root).await;
+
+    assert_eq!(
+        handle
+            .files_rendering_component(Vec::new(), vec!["counter".to_string()])
+            .await
+            .unwrap(),
+        vec![parent],
+    );
+}
+
+/// Answers are sorted, because the ancestor walk takes the first entry of a
+/// level and two equidistant parents must not swap places between calls.
+#[tokio::test]
+async fn the_usage_index_answers_in_sorted_order() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let tag = "<div><x-icon /></div>\n";
+    let a = write(&root.join("resources/views/aaa.blade.php"), tag);
+    let b = write(&root.join("resources/views/mmm.blade.php"), tag);
+    let c = write(&root.join("resources/views/zzz.blade.php"), tag);
+    let handle = handle_for(root).await;
+
+    assert_eq!(
+        handle
+            .files_rendering_component(vec!["icon".to_string()], Vec::new())
+            .await
+            .unwrap(),
+        vec![a, b, c],
+    );
+}
+
+// === 2. a disk reload must not clobber an open buffer =====================
+
+/// A Blade hover resolves its backing class through the actor, which loads
+/// that `.php` from disk. When the class is also open and edited, the last
+/// SAVED bytes must not replace the buffer the editor pushed.
+#[tokio::test]
+async fn resolving_a_backing_class_leaves_a_dirty_buffer_alone() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let class = write(
+        &root.join("app/Livewire/Counter.php"),
+        "<?php\nclass Counter\n{\n    public function saved(): void {}\n}\n",
+    );
+    let blade = write(
+        &root.join("resources/views/livewire/counter.blade.php"),
+        "<div>{{ $count }}</div>\n",
+    );
+    let handle = handle_for(root).await;
+
+    // The editor's unsaved text — a renamed method that is not on disk.
+    let buffer = "<?php\nclass Counter\n{\n    public function unsaved(): void {}\n}\n";
+    handle
+        .update_file(class.clone(), 7, buffer.to_string())
+        .await
+        .unwrap();
+
+    // Resolving the template's backing class is what reads that `.php` from
+    // disk; the resolution hands back the source it read.
+    let resolved = handle
+        .blade_backing_class_resolution(
+            blade,
+            Some("livewire.counter".to_string()),
+            vec![class.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+
+    let source = resolved
+        .sources
+        .iter()
+        .find(|(path, _)| path == &class)
+        .map(|(_, source)| source.clone())
+        .expect("the backing class resolves");
+    assert_eq!(
+        source, buffer,
+        "the last-saved bytes must not come back over the live buffer"
+    );
+}
+
+/// The other half of the same defect: when the loader DOES write — no buffer
+/// involved, the file changed on disk — every cache populated from the old
+/// text has to go. `pattern_cache` compares nothing on lookup, so a surviving
+/// entry is served forever.
+#[tokio::test]
+async fn reloading_a_changed_backing_class_drops_its_cached_patterns() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let class = write(
+        &root.join("app/Livewire/Counter.php"),
+        "<?php\nclass Counter\n{\n    public function show() { return view('before'); }\n}\n",
+    );
+    let blade = write(
+        &root.join("resources/views/livewire/counter.blade.php"),
+        "<div>{{ $count }}</div>\n",
+    );
+    let handle = handle_for(root).await;
+
+    // Populate `pattern_cache` from the original text.
+    let before = handle
+        .get_patterns(class.clone())
+        .await
+        .unwrap()
+        .expect("the class parses");
+    assert!(
+        before.views.iter().any(|v| v.name == "before"),
+        "the original text is parsed and cached"
+    );
+
+    // Change it on disk. The sleep gives the mtime room to advance on
+    // filesystems with coarse timestamps — the loader reloads on mtime.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    fs::write(
+        &class,
+        "<?php\nclass Counter\n{\n    public function show() { return view('after'); }\n}\n",
+    )
+    .unwrap();
+
+    handle
+        .blade_backing_class_resolution(
+            blade,
+            Some("livewire.counter".to_string()),
+            vec![class.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+
+    let after = handle
+        .get_patterns(class)
+        .await
+        .unwrap()
+        .expect("the class parses");
+    let names: Vec<&str> = after.views.iter().map(|v| v.name.as_str()).collect();
+    assert!(
+        names.contains(&"after"),
+        "the reload replaced the text, so the cached patterns must go too: {names:?}"
+    );
+}
+
+// === 3. the render index never goes backwards =============================
+
+/// Two tasks snapshot generations 1 and 2 and reach the actor in either order.
+/// The actor installs the newest and refuses the older, so the data it holds
+/// always matches the generation the caller's gate advanced to.
+#[tokio::test]
+async fn an_out_of_order_render_index_push_is_refused() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let newer = write(
+        &root.join("app/Http/Controllers/NewerController.php"),
+        "<?php\nclass NewerController\n{\n    public function show() { return view('page'); }\n}\n",
+    );
+    let older = write(
+        &root.join("app/Http/Controllers/OlderController.php"),
+        "<?php\nclass OlderController\n{\n    public function show() { return view('page'); }\n}\n",
+    );
+    let blade = write(
+        &root.join("resources/views/page.blade.php"),
+        "<div></div>\n",
+    );
+    let handle = handle_for(root).await;
+
+    handle
+        .set_render_index(2, vec![("page".to_string(), newer.clone())])
+        .await
+        .unwrap();
+    handle
+        .set_render_index(1, vec![("page".to_string(), older.clone())])
+        .await
+        .unwrap();
+
+    let resolved = handle
+        .blade_backing_class_resolution(blade, Some("page".to_string()), Vec::new(), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        resolved.files,
+        vec![newer],
+        "generation 2 was installed first; generation 1 must not replace it"
+    );
+}
+
+/// …and a genuinely newer snapshot still wins, so the guard rejects only
+/// what is stale rather than everything after the first push.
+#[tokio::test]
+async fn a_newer_render_index_push_replaces_the_installed_one() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let first = write(
+        &root.join("app/Http/Controllers/FirstController.php"),
+        "<?php\nclass FirstController\n{\n    public function show() { return view('page'); }\n}\n",
+    );
+    let second = write(
+        &root.join("app/Http/Controllers/SecondController.php"),
+        "<?php\nclass SecondController\n{\n    public function show() { return view('page'); }\n}\n",
+    );
+    let blade = write(
+        &root.join("resources/views/page.blade.php"),
+        "<div></div>\n",
+    );
+    let handle = handle_for(root).await;
+
+    handle
+        .set_render_index(1, vec![("page".to_string(), first)])
+        .await
+        .unwrap();
+    handle
+        .set_render_index(2, vec![("page".to_string(), second.clone())])
+        .await
+        .unwrap();
+
+    let resolved = handle
+        .blade_backing_class_resolution(blade, Some("page".to_string()), Vec::new(), None)
+        .await
+        .unwrap();
+    assert_eq!(resolved.files, vec![second]);
+}

--- a/laravel-lsp/src/tests/render_index_and_buffer_integrity.rs
+++ b/laravel-lsp/src/tests/render_index_and_buffer_integrity.rs
@@ -265,6 +265,117 @@ async fn reloading_a_changed_backing_class_drops_its_cached_patterns() {
     );
 }
 
+/// The guard is not allowed to depend on a filesystem call succeeding. When
+/// the buffer is pushed while its file is momentarily absent — a branch
+/// switch, a stash, an `artisan make:*` regeneration — a stamp built from
+/// `fs::metadata` records nothing, and "nothing recorded" reads downstream as
+/// "never loaded, read disk unconditionally": the clobber the stamp exists to
+/// prevent, re-armed by its own failure path.
+#[tokio::test]
+async fn a_buffer_pushed_while_its_file_is_missing_is_not_clobbered() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let blade = write(
+        &root.join("resources/views/livewire/counter.blade.php"),
+        "<div>{{ $count }}</div>\n",
+    );
+    let class = root.join("app/Livewire/Counter.php");
+    fs::create_dir_all(class.parent().unwrap()).unwrap();
+    let handle = handle_for(root).await;
+
+    // The editor pushes its buffer while the path does not exist on disk, so
+    // any `fs::metadata(&class)` inside the push fails.
+    let buffer = "<?php\nclass Counter\n{\n    public function unsaved(): void {}\n}\n";
+    handle
+        .update_file(class.clone(), 7, buffer.to_string())
+        .await
+        .unwrap();
+
+    // The file comes back, with different content — the regenerated or
+    // checked-out version the user has NOT accepted into their buffer.
+    write(
+        &class,
+        "<?php\nclass Counter\n{\n    public function regenerated(): void {}\n}\n",
+    );
+
+    let resolved = handle
+        .blade_backing_class_resolution(
+            blade,
+            Some("livewire.counter".to_string()),
+            vec![class.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+
+    let source = resolved
+        .sources
+        .iter()
+        .find(|(path, _)| path == &class)
+        .map(|(_, source)| source.clone())
+        .expect("the backing class resolves from the pushed buffer");
+    assert_eq!(
+        source, buffer,
+        "a push that could not stat its file still owns the text"
+    );
+}
+
+/// The same rule under the trigger that does not need a failed `metadata()`
+/// at all: the file changes on disk while the buffer is open and dirty. An
+/// mtime comparison says "reload"; ownership says the pusher's text stands
+/// until the pusher replaces it.
+#[tokio::test]
+async fn a_disk_change_under_a_dirty_buffer_does_not_reload() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+    let class = write(
+        &root.join("app/Livewire/Counter.php"),
+        "<?php\nclass Counter\n{\n    public function saved(): void {}\n}\n",
+    );
+    let blade = write(
+        &root.join("resources/views/livewire/counter.blade.php"),
+        "<div>{{ $count }}</div>\n",
+    );
+    let handle = handle_for(root).await;
+
+    let buffer = "<?php\nclass Counter\n{\n    public function unsaved(): void {}\n}\n";
+    handle
+        .update_file(class.clone(), 7, buffer.to_string())
+        .await
+        .unwrap();
+
+    // Disk moves on underneath the dirty buffer. The sleep gives the mtime
+    // room to advance on filesystems with coarse timestamps, so the test
+    // exercises the mtime-differs branch rather than an accidental tie.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    fs::write(
+        &class,
+        "<?php\nclass Counter\n{\n    public function checked_out(): void {}\n}\n",
+    )
+    .unwrap();
+
+    let resolved = handle
+        .blade_backing_class_resolution(
+            blade,
+            Some("livewire.counter".to_string()),
+            vec![class.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+
+    let source = resolved
+        .sources
+        .iter()
+        .find(|(path, _)| path == &class)
+        .map(|(_, source)| source.clone())
+        .expect("the backing class resolves");
+    assert_eq!(
+        source, buffer,
+        "an advancing mtime must not evict the editor's unsaved text"
+    );
+}
+
 // === 3. the render index never goes backwards =============================
 
 /// Two tasks snapshot generations 1 and 2 and reach the actor in either order.

--- a/laravel-lsp/src/view_var_index.rs
+++ b/laravel-lsp/src/view_var_index.rs
@@ -53,6 +53,10 @@ pub struct ViewRender {
 pub struct ViewVarIndex {
     /// view name → (variable name → set of FQCN types).
     forward: HashMap<String, HashMap<String, HashSet<String>>>,
+    /// Bumped on every mutation. The Salsa render-index input is refreshed
+    /// only when this changes, so an unchanged index never invalidates the
+    /// memoized backing-class queries (#339, item 7).
+    generation: u64,
     /// file → the full render sites it contributed. Keeping whole renders
     /// (not just view names) gives `remove_file` per-file type provenance
     /// for a precise rebuild, and lets the incremental save flow (#80) diff
@@ -69,6 +73,7 @@ impl ViewVarIndex {
     /// contribution from the same file (evict-then-insert) so a re-parse of an
     /// edited controller doesn't leave stale types behind.
     pub fn insert_file(&mut self, path: PathBuf, renders: &[ViewRender]) {
+        self.generation = self.generation.wrapping_add(1);
         self.remove_file(&path);
         for render in renders {
             let view = self.forward.entry(render.view_name.clone()).or_default();
@@ -88,6 +93,7 @@ impl ViewVarIndex {
         let Some(renders) = self.by_file.remove(path) else {
             return;
         };
+        self.generation = self.generation.wrapping_add(1);
         let affected: HashSet<&str> = renders.iter().map(|r| r.view_name.as_str()).collect();
         for view in &affected {
             self.forward.remove(*view);
@@ -135,25 +141,33 @@ impl ViewVarIndex {
             .unwrap_or_default()
     }
 
-    /// Every file that currently contributes a render site for `view_name` —
-    /// the reverse of `by_file`'s per-file contribution. A Filament-style
-    /// `$view`-property page and any controller `view(...)` call site that
-    /// renders the same view both show up here, letting a Blade-goto/hover
-    /// fallback jump straight from the template into whichever class(es)
-    /// declare its variables.
-    pub fn render_source_files(&self, view_name: &str) -> Vec<PathBuf> {
-        let mut files: Vec<PathBuf> = self
+    /// The whole index flattened to `(view name, contributing file)` pairs —
+    /// the reverse of `by_file`'s per-file contribution, as the Salsa
+    /// [`crate::salsa_impl::RenderIndex`] input consumes it.
+    ///
+    /// A Filament-style `$view`-property page and any controller `view(...)`
+    /// call site that renders the same view both appear here, which is what
+    /// lets a Blade goto/hover fallback jump straight from the template into
+    /// whichever class(es) declare its variables. Per-view lookup is the
+    /// memoized `salsa_impl::render_source_files` query — this index no longer
+    /// answers that question itself, so nothing can reach the O(entire index)
+    /// scan it used to run per keystroke (#339, item 7).
+    ///
+    /// Sorted and deduped: `salsa_impl::render_source_files` takes the FIRST
+    /// hit over its slice of these entries, and `by_file` is a `HashMap`.
+    pub fn render_entries(&self) -> Vec<(String, PathBuf)> {
+        let mut entries: Vec<(String, PathBuf)> = self
             .by_file
             .iter()
-            .filter(|(_, renders)| renders.iter().any(|r| r.view_name == view_name))
-            .map(|(path, _)| path.clone())
+            .flat_map(|(path, renders)| {
+                renders
+                    .iter()
+                    .map(move |render| (render.view_name.clone(), path.clone()))
+            })
             .collect();
-        // Sorted for the same reason `vars_for_view` sorts: `by_file` is a
-        // HashMap, and `locate_in_backing_class_files` takes the FIRST hit
-        // over this list — unsorted, a member declared by two contributing
-        // classes would flap between targets run to run.
-        files.sort();
-        files
+        entries.sort();
+        entries.dedup();
+        entries
     }
 
     /// Every variable `view_name` has a render site for, as `(name, sorted
@@ -179,8 +193,15 @@ impl ViewVarIndex {
 
     /// Clear everything — called at the start of a warm rebuild.
     pub fn clear(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
         self.forward.clear();
         self.by_file.clear();
+    }
+
+    /// A change counter, bumped by every mutation. Callers use it to skip
+    /// re-pushing an unchanged snapshot (#339, item 7).
+    pub fn generation(&self) -> u64 {
+        self.generation
     }
 
     pub fn is_empty(&self) -> bool {

--- a/laravel-lsp/src/view_var_index/tests.rs
+++ b/laravel-lsp/src/view_var_index/tests.rs
@@ -551,7 +551,7 @@ fn index_clear_empties() {
 }
 
 #[test]
-fn render_source_files_returns_every_contributing_file() {
+fn render_entries_carry_every_contributing_file() {
     let mut idx = ViewVarIndex::new();
     let controller = PathBuf::from("/proj/UserController.php");
     let page = PathBuf::from("/proj/Filament/UserPage.php");
@@ -568,12 +568,17 @@ fn render_source_files_returns_every_contributing_file() {
         &[render("other.view", &[("x", "App\\X")])],
     );
 
-    let mut sources = idx.render_source_files("users.show");
+    let entries = idx.render_entries();
+    let mut sources: Vec<PathBuf> = entries
+        .iter()
+        .filter(|(view, _)| view == "users.show")
+        .map(|(_, path)| path.clone())
+        .collect();
     sources.sort();
     let mut expected = vec![controller, page];
     expected.sort();
     assert_eq!(sources, expected);
-    assert!(idx.render_source_files("missing.view").is_empty());
+    assert!(!entries.iter().any(|(view, _)| view == "missing.view"));
 }
 
 #[test]
@@ -2070,7 +2075,7 @@ fn namespace_dir_inside_a_view_root_keeps_both_names() {
 }
 
 #[test]
-fn render_source_files_are_sorted_for_deterministic_first_match() {
+fn render_entries_are_sorted_for_deterministic_first_match() {
     let mut idx = ViewVarIndex::new();
     for name in ["zeta", "alpha", "midway"] {
         idx.insert_file(
@@ -2078,8 +2083,46 @@ fn render_source_files_are_sorted_for_deterministic_first_match() {
             &[render("users.show", &[("user", "App\\Models\\User")])],
         );
     }
-    let files = idx.render_source_files("users.show");
-    let mut sorted = files.clone();
+    let entries = idx.render_entries();
+    let mut sorted = entries.clone();
     sorted.sort();
-    assert_eq!(files, sorted, "HashMap order must not leak to callers");
+    assert_eq!(entries, sorted, "HashMap order must not leak to callers");
+}
+
+#[test]
+fn generation_advances_on_every_mutation_and_holds_otherwise() {
+    let mut idx = ViewVarIndex::new();
+    assert_eq!(idx.generation(), 0, "a fresh index is generation 0");
+
+    idx.insert_file(
+        PathBuf::from("/proj/UserController.php"),
+        &[render("users.show", &[("user", "App\\Models\\User")])],
+    );
+    let after_insert = idx.generation();
+    assert_ne!(after_insert, 0, "insert_file must advance the generation");
+
+    // A read is not a mutation: the Salsa push is skipped on an unchanged
+    // generation, so a read that bumped it would invalidate the memo per call.
+    let _ = idx.render_entries();
+    let _ = idx.var_types("users.show", "user");
+    assert_eq!(idx.generation(), after_insert, "reads must not advance it");
+
+    idx.remove_file(Path::new("/proj/UserController.php"));
+    let after_remove = idx.generation();
+    assert_ne!(
+        after_remove, after_insert,
+        "remove_file must advance the generation"
+    );
+
+    // Removing a file that contributed nothing changes no state, so it must
+    // not advance either — otherwise every no-op eviction costs a re-push.
+    idx.remove_file(Path::new("/proj/NeverIndexed.php"));
+    assert_eq!(
+        idx.generation(),
+        after_remove,
+        "a no-op remove must not advance it"
+    );
+
+    idx.clear();
+    assert_ne!(idx.generation(), after_remove, "clear must advance it");
 }

--- a/laravel-lsp/src/volt_functional.rs
+++ b/laravel-lsp/src/volt_functional.rs
@@ -1,0 +1,365 @@
+//! Member declarations in a FUNCTIONAL Volt component.
+//!
+//! A functional Volt file declares no class at all — its state and actions are
+//! top-level calls and assignments in the template's front matter:
+//!
+//! ```php
+//! <?php
+//! use function Livewire\Volt\{state, computed};
+//! state(['count' => 0]);
+//! $increment = fn () => $this->count++;
+//! $double = computed(fn () => $this->count * 2);
+//! ?>
+//! ```
+//!
+//! [`crate::component_member_locator`] parses class bodies, so it finds
+//! nothing here: there is no `property_declaration` and no
+//! `method_declaration`. This module is the functional-Volt half of the same
+//! primitive — "does a member with this NAME exist in this source, and where"
+//! — reading the two shapes Volt actually uses:
+//!
+//!   - every `state([...])` array KEY is a public property;
+//!   - every top-level `$name = <closure>` assignment is a member. A
+//!     `computed(...)` wrapper makes it a computed PROPERTY (read as
+//!     `$this->name` / `{{ $name }}`); a bare closure, `action(...)` or
+//!     `protect(...)` makes it an action METHOD (`wire:click="name"`).
+//!
+//! Positions land on the bare name — inside the quotes for a `state` key,
+//! after the `$` for an assignment — matching the class-based locator's
+//! convention.
+
+use tree_sitter::Node;
+
+use crate::component_member_locator::{MemberKind, MemberLocation};
+use crate::parser::parse_php;
+
+/// Volt wrappers that turn an assigned closure into a component member, and
+/// the kind each produces.
+fn wrapper_kind(name: &str) -> Option<MemberKind> {
+    match name {
+        "computed" => Some(MemberKind::Property),
+        "action" | "protect" => Some(MemberKind::Method),
+        _ => None,
+    }
+}
+
+/// Every member a functional Volt source declares, as `(name, location)`, in
+/// no particular order. Empty when `source` carries no Volt functional
+/// signature — the same gate
+/// [`crate::livewire_resolver::source_contains_volt_signature`] applies
+/// everywhere else, so a plain PHP file is never mistaken for a component.
+pub fn members(source: &str) -> Vec<(String, MemberLocation)> {
+    if !crate::livewire_resolver::source_contains_volt_signature(source) {
+        return Vec::new();
+    }
+    let Ok(tree) = parse_php(source) else {
+        return Vec::new();
+    };
+    let bytes = source.as_bytes();
+    let mut out = Vec::new();
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        match n.kind() {
+            "function_call_expression" => collect_state_keys(n, bytes, &mut out),
+            "assignment_expression" if is_top_level(n) => {
+                collect_closure_member(n, bytes, &mut out)
+            }
+            _ => {}
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    out
+}
+
+/// Locate `member` in a functional Volt source, honouring `want` when the
+/// caller knows which kind the reference demands. Candidates are sorted by
+/// `(line, column)` so the first declaration in document order wins.
+pub fn locate_member(
+    source: &str,
+    member: &str,
+    want: Option<MemberKind>,
+) -> Option<MemberLocation> {
+    let mut hits: Vec<MemberLocation> = members(source)
+        .into_iter()
+        .filter(|(name, loc)| name == member && want.is_none_or(|k| k == loc.kind))
+        .map(|(_, loc)| loc)
+        .collect();
+    hits.sort_by_key(|l| (l.line, l.start_column));
+    hits.into_iter().next()
+}
+
+/// The public properties a functional Volt source declares, as `(name, type)`
+/// pairs for `$`-completion. Volt state carries no declared PHP type, so
+/// every entry is `"mixed"`.
+pub fn property_types(source: &str) -> Vec<(String, String)> {
+    members(source)
+        .into_iter()
+        .filter(|(_, loc)| loc.kind == MemberKind::Property)
+        .map(|(name, _)| (name, "mixed".to_string()))
+        .collect()
+}
+
+/// The action names a functional Volt source declares, sorted, for
+/// `wire:click`-style completion.
+pub fn action_names(source: &str) -> Vec<String> {
+    let mut out: Vec<String> = members(source)
+        .into_iter()
+        .filter(|(_, loc)| loc.kind == MemberKind::Method)
+        .map(|(name, _)| name)
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// The declaration text for a hover card: the `state()` array entry, or the
+/// assignment up to (not including) the closure's body. Whitespace runs are
+/// collapsed so a multiline declaration renders as one line.
+pub fn declaration_summary(source: &str, member: &str) -> Option<String> {
+    if !crate::livewire_resolver::source_contains_volt_signature(source) {
+        return None;
+    }
+    let tree = parse_php(source).ok()?;
+    let bytes = source.as_bytes();
+    let mut hits: Vec<(u32, u32, String)> = Vec::new();
+    let mut stack = vec![tree.root_node()];
+    while let Some(n) = stack.pop() {
+        match n.kind() {
+            "function_call_expression" => {
+                let mut found = Vec::new();
+                collect_state_keys(n, bytes, &mut found);
+                for (name, loc) in found {
+                    if name == member {
+                        if let Some(entry) = state_entry_node(n, bytes, member) {
+                            hits.push((
+                                loc.line,
+                                loc.start_column,
+                                collapse_ws(&source[entry.start_byte()..entry.end_byte()]),
+                            ));
+                        }
+                    }
+                }
+            }
+            "assignment_expression" if is_top_level(n) => {
+                let mut found = Vec::new();
+                collect_closure_member(n, bytes, &mut found);
+                for (name, loc) in found {
+                    if name == member {
+                        let end = closure_body_start(n).unwrap_or_else(|| n.end_byte());
+                        hits.push((
+                            loc.line,
+                            loc.start_column,
+                            collapse_ws(&source[n.start_byte()..end]),
+                        ));
+                    }
+                }
+            }
+            _ => {}
+        }
+        let mut c = n.walk();
+        for ch in n.children(&mut c) {
+            stack.push(ch);
+        }
+    }
+    hits.sort_by_key(|(line, col, _)| (*line, *col));
+    hits.into_iter().next().map(|(_, _, text)| text)
+}
+
+/// Push every `state(['a' => 1, 'b'])` key on `call` as a public property.
+fn collect_state_keys(call: Node, bytes: &[u8], out: &mut Vec<(String, MemberLocation)>) {
+    if call_name(call, bytes).as_deref() != Some("state") {
+        return;
+    }
+    for entry in state_entries(call) {
+        let Some(key) = entry_key_node(entry) else {
+            continue;
+        };
+        let Some(name) = string_literal_name(key, bytes) else {
+            continue;
+        };
+        out.push((name, string_name_location(key)));
+    }
+}
+
+/// Push a top-level `$name = <closure>` assignment as a member, when the
+/// right-hand side is a closure or a Volt wrapper around one.
+fn collect_closure_member(assign: Node, bytes: &[u8], out: &mut Vec<(String, MemberLocation)>) {
+    let Some(left) = assign.child_by_field_name("left") else {
+        return;
+    };
+    if left.kind() != "variable_name" {
+        return;
+    }
+    let Some(right) = assign.child_by_field_name("right") else {
+        return;
+    };
+    let kind = match right.kind() {
+        "arrow_function" | "anonymous_function" | "anonymous_function_creation_expression" => {
+            MemberKind::Method
+        }
+        "function_call_expression" => match call_name(right, bytes).as_deref().and_then(wrapper_kind)
+        {
+            Some(k) => k,
+            None => return,
+        },
+        _ => return,
+    };
+    let Ok(text) = left.utf8_text(bytes) else {
+        return;
+    };
+    let name = text.trim_start_matches('$').to_string();
+    if name.is_empty() {
+        return;
+    }
+    let start = left.start_position();
+    let end = left.end_position();
+    out.push((
+        name,
+        MemberLocation {
+            line: start.row as u32,
+            // Skip the `$` so the caret sits on the bare name, exactly as
+            // the class-based locator does for `public $count`.
+            start_column: start.column as u32 + 1,
+            end_column: end.column as u32,
+            kind,
+        },
+    ));
+}
+
+/// The called function's bare name (`state`, `computed`), namespace prefix
+/// stripped so `\Livewire\Volt\state(...)` matches too.
+fn call_name(call: Node, bytes: &[u8]) -> Option<String> {
+    let f = call.child_by_field_name("function")?;
+    let text = f.utf8_text(bytes).ok()?;
+    Some(text.rsplit('\\').next()?.to_string())
+}
+
+/// Every `array_element_initializer` in the call's FIRST array argument.
+fn state_entries<'tree>(call: Node<'tree>) -> Vec<Node<'tree>> {
+    let Some(args) = call.child_by_field_name("arguments") else {
+        return Vec::new();
+    };
+    let mut cursor = args.walk();
+    let arg_nodes: Vec<Node> = args.children(&mut cursor).collect();
+    let mut array = None;
+    for arg in arg_nodes {
+        if arg.kind() == "array_creation_expression" {
+            array = Some(arg);
+            break;
+        }
+        let mut c = arg.walk();
+        let nested: Vec<Node> = arg.children(&mut c).collect();
+        if let Some(found) = nested
+            .into_iter()
+            .find(|n| n.kind() == "array_creation_expression")
+        {
+            array = Some(found);
+            break;
+        }
+    }
+    let Some(array) = array else {
+        return Vec::new();
+    };
+    let mut c = array.walk();
+    array
+        .children(&mut c)
+        .filter(|n| n.kind() == "array_element_initializer")
+        .collect()
+}
+
+/// The key node of an array entry: the left side of `=>`, or — for a bare
+/// `['color']` entry declaring a prop with no default — the entry's only
+/// value. Both are the entry's first meaningful child.
+fn entry_key_node<'tree>(entry: Node<'tree>) -> Option<Node<'tree>> {
+    let mut c = entry.walk();
+    let children: Vec<Node> = entry.children(&mut c).collect();
+    children.into_iter().find(|n| n.kind() != "comment")
+}
+
+/// The `array_element_initializer` in `call` whose key is `member`.
+fn state_entry_node<'a>(call: Node<'a>, bytes: &[u8], member: &str) -> Option<Node<'a>> {
+    if call_name(call, bytes).as_deref() != Some("state") {
+        return None;
+    }
+    state_entries(call).into_iter().find(|entry| {
+        entry_key_node(*entry)
+            .and_then(|k| string_literal_name(k, bytes))
+            .as_deref()
+            == Some(member)
+    })
+}
+
+/// A quoted string literal's inner text, when it is a bare identifier.
+fn string_literal_name(node: Node, bytes: &[u8]) -> Option<String> {
+    if !matches!(node.kind(), "string" | "encapsed_string") {
+        return None;
+    }
+    let text = node.utf8_text(bytes).ok()?;
+    let inner = text
+        .strip_prefix('\'')
+        .and_then(|r| r.strip_suffix('\''))
+        .or_else(|| text.strip_prefix('"').and_then(|r| r.strip_suffix('"')))?;
+    let mut chars = inner.chars();
+    let first = chars.next()?;
+    (first.is_ascii_alphabetic() || first == '_')
+        .then(|| inner.to_string())
+        .filter(|_| inner.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
+}
+
+/// The location of a string literal's CONTENT — the quotes excluded, so the
+/// caret lands on the bare name.
+fn string_name_location(node: Node) -> MemberLocation {
+    let start = node.start_position();
+    let end = node.end_position();
+    MemberLocation {
+        line: start.row as u32,
+        start_column: start.column as u32 + 1,
+        end_column: (end.column as u32).saturating_sub(1),
+        kind: MemberKind::Property,
+    }
+}
+
+/// The byte offset where the assigned closure's body starts, so a hover
+/// summary can stop at the signature.
+fn closure_body_start(assign: Node) -> Option<usize> {
+    let right = assign.child_by_field_name("right")?;
+    right.child_by_field_name("body").map(|b| b.start_byte())
+}
+
+/// True when `n` sits directly in the file's top-level statement list — not
+/// inside a class, function, method, or closure. Volt's functional API only
+/// declares members at the top level; an assignment nested in a closure is a
+/// local, not a component member.
+fn is_top_level(n: Node) -> bool {
+    let mut cur = n.parent();
+    while let Some(p) = cur {
+        if matches!(
+            p.kind(),
+            "class_declaration"
+                | "trait_declaration"
+                | "enum_declaration"
+                | "interface_declaration"
+                | "method_declaration"
+                | "function_definition"
+                | "arrow_function"
+                | "anonymous_function"
+                | "anonymous_function_creation_expression"
+                | "anonymous_class"
+        ) {
+            return false;
+        }
+        cur = p.parent();
+    }
+    true
+}
+
+/// Collapse every whitespace run (including newlines) to a single space.
+fn collapse_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/volt_functional.rs
+++ b/laravel-lsp/src/volt_functional.rs
@@ -119,6 +119,17 @@ pub fn action_names(source: &str) -> Vec<String> {
 /// assignment up to (not including) the closure's body. Whitespace runs are
 /// collapsed so a multiline declaration renders as one line.
 pub fn declaration_summary(source: &str, member: &str) -> Option<String> {
+    declaration_summary_of_kind(source, member, None)
+}
+
+/// [`declaration_summary`], restricted to the declaration kind the reference
+/// demands — so a hover card whose header was filtered on `want` cannot show
+/// the body of the other kind's declaration of the same name.
+pub fn declaration_summary_of_kind(
+    source: &str,
+    member: &str,
+    want: Option<MemberKind>,
+) -> Option<String> {
     if !crate::livewire_resolver::source_contains_volt_signature(source) {
         return None;
     }
@@ -132,7 +143,7 @@ pub fn declaration_summary(source: &str, member: &str) -> Option<String> {
                 let mut found = Vec::new();
                 collect_state_keys(n, bytes, &mut found);
                 for (name, loc) in found {
-                    if name == member {
+                    if name == member && want.is_none_or(|k| k == loc.kind) {
                         if let Some(entry) = state_entry_node(n, bytes, member) {
                             hits.push((
                                 loc.line,
@@ -147,7 +158,7 @@ pub fn declaration_summary(source: &str, member: &str) -> Option<String> {
                 let mut found = Vec::new();
                 collect_closure_member(n, bytes, &mut found);
                 for (name, loc) in found {
-                    if name == member {
+                    if name == member && want.is_none_or(|k| k == loc.kind) {
                         let end = closure_body_start(n).unwrap_or_else(|| n.end_byte());
                         hits.push((
                             loc.line,

--- a/laravel-lsp/src/volt_functional.rs
+++ b/laravel-lsp/src/volt_functional.rs
@@ -200,11 +200,12 @@ fn collect_closure_member(assign: Node, bytes: &[u8], out: &mut Vec<(String, Mem
         "arrow_function" | "anonymous_function" | "anonymous_function_creation_expression" => {
             MemberKind::Method
         }
-        "function_call_expression" => match call_name(right, bytes).as_deref().and_then(wrapper_kind)
-        {
-            Some(k) => k,
-            None => return,
-        },
+        "function_call_expression" => {
+            match call_name(right, bytes).as_deref().and_then(wrapper_kind) {
+                Some(k) => k,
+                None => return,
+            }
+        }
         _ => return,
     };
     let Ok(text) = left.utf8_text(bytes) else {

--- a/laravel-lsp/src/volt_functional/tests.rs
+++ b/laravel-lsp/src/volt_functional/tests.rs
@@ -1,0 +1,111 @@
+//! Functional-Volt member declarations — `state()` keys and top-level
+//! closure assignments (issue #339, item 3).
+
+use super::*;
+
+const FUNCTIONAL: &str = r#"<?php
+use function Livewire\Volt\{state, computed, action};
+
+state(['count' => 0, 'name']);
+
+$increment = fn () => $this->count++;
+$double = computed(fn () => $this->count * 2);
+$reset = action(fn () => $this->count = 0);
+?>
+<div wire:click="increment">{{ $count }}</div>
+"#;
+
+#[test]
+fn state_keys_are_properties_at_the_key_position() {
+    let loc = locate_member(FUNCTIONAL, "count", None).expect("state declares count");
+    assert_eq!(loc.kind, MemberKind::Property);
+    assert_eq!(loc.line, 3, "0-based line of the `state([...])` call");
+    // `state(['count' ...` — the caret sits on `count`, inside the quotes.
+    assert_eq!(loc.start_column, 8);
+    assert_eq!(loc.end_column, 13);
+}
+
+#[test]
+fn bare_state_entry_without_a_default_is_a_property() {
+    let loc = locate_member(FUNCTIONAL, "name", None).expect("`'name'` declares a property");
+    assert_eq!(loc.kind, MemberKind::Property);
+    assert_eq!(loc.line, 3);
+}
+
+#[test]
+fn closure_assignment_is_an_action_method_at_the_variable() {
+    let loc = locate_member(FUNCTIONAL, "increment", None).expect("$increment is an action");
+    assert_eq!(loc.kind, MemberKind::Method);
+    assert_eq!(loc.line, 5, "0-based line of `$increment = fn () => …`");
+    assert_eq!(loc.start_column, 1, "the `$` is skipped");
+    assert_eq!(loc.end_column, 10);
+}
+
+#[test]
+fn computed_wrapper_is_a_property_and_action_wrapper_is_a_method() {
+    let double = locate_member(FUNCTIONAL, "double", None).expect("computed() declares a member");
+    assert_eq!(double.kind, MemberKind::Property);
+    assert_eq!(double.line, 6);
+
+    let reset = locate_member(FUNCTIONAL, "reset", None).expect("action() declares a member");
+    assert_eq!(reset.kind, MemberKind::Method);
+    assert_eq!(reset.line, 7);
+}
+
+#[test]
+fn kind_filter_rejects_the_wrong_declaration_kind() {
+    assert!(
+        locate_member(FUNCTIONAL, "increment", Some(MemberKind::Property)).is_none(),
+        "an action must not answer a property-kind reference"
+    );
+    assert!(
+        locate_member(FUNCTIONAL, "count", Some(MemberKind::Method)).is_none(),
+        "state is a property, never a method"
+    );
+}
+
+#[test]
+fn locals_inside_a_closure_are_not_members() {
+    let source = r#"<?php
+state(['count' => 0]);
+$increment = fn () => $tmp = 1;
+?>"#;
+    assert!(
+        locate_member(source, "tmp", None).is_none(),
+        "an assignment nested in a closure is a local, not a component member"
+    );
+}
+
+#[test]
+fn a_plain_php_file_declares_no_volt_members() {
+    let source = "<?php\n$increment = fn () => 1;\n";
+    assert!(
+        members(source).is_empty(),
+        "no Volt signature — the file is not a functional component"
+    );
+}
+
+#[test]
+fn completion_surfaces_split_by_kind() {
+    let props: Vec<String> = property_types(FUNCTIONAL)
+        .into_iter()
+        .map(|(n, _)| n)
+        .collect();
+    assert!(props.contains(&"count".to_string()));
+    assert!(props.contains(&"double".to_string()));
+    assert!(!props.contains(&"increment".to_string()));
+
+    assert_eq!(action_names(FUNCTIONAL), vec!["increment", "reset"]);
+}
+
+#[test]
+fn declaration_summary_names_the_shape() {
+    assert_eq!(
+        declaration_summary(FUNCTIONAL, "count").as_deref(),
+        Some("'count' => 0")
+    );
+    assert_eq!(
+        declaration_summary(FUNCTIONAL, "increment").as_deref(),
+        Some("$increment = fn () =>")
+    );
+}


### PR DESCRIPTION
## Summary
Implements #339 — the eight component-member navigation follow-ups from #335, as one PR (per Mike's `single PR` call on the issue). Round 2 answers all six findings from review.

## Changes
- **Item 1 — partial members resolve through the component that renders them.** `Backend::blade_backing_class_resolution` tries the direct resolution first, then walks up the usage graph breadth-first. `<x-…>` and `<livewire:…>` usages both count as rendering edges. Each step is now a lookup in a reverse component-usage index (`component_usage_index.rs`), not a scan: the index is built from the `ParsedPatternsData` the parse pass already produced, and kept fresh with the same `mark_dirty` / drain shape `symbol_index` uses. The cycle guard is a visited set; ties break lexicographically by path; only Blade files are ancestors.
- **Item 2 — the hover card names inline SFC and Volt components.** The class name comes from the source already in hand, so an unsaved edit no longer shows a stale name, and a component with no named class falls back to its resolved Livewire name. It never prints `Component::` again.
- **Item 3 — functional Volt components resolve.** `state([...])` keys and top-level closure actions (including the `computed()` and `action()` wrapped forms) are members, via the new `volt_functional` module.
- **Item 4 — `wire:target` navigates.** A comma list resolves the entry under the cursor, and the attribute accepts an action or a `wire:model` loading-state property.
- **Item 5 — the Method/Property distinction is enforced** in goto, hover and completion, so `wire:model="save"` no longer lands on `save()`. Both halves of the hover card honour the filter: the header and the code block are rendered from one kind.
- **Item 6 — document-order first match and scoped completion.** `locate_member` collects every candidate and sorts by `(line, column)`; completion reads the component's own declaration plus any trait it `use`s in the same file, transitively.
- **Item 7 — backing-class resolution is Salsa-cached.** `render_source_files`, `blade_backing_class_files` and `blade_backing_class_sources` are `#[salsa::tracked]` queries keyed on each backing class's content. The old uncached per-keystroke scan is gone.
- **Item 8 — `@props`/`@aware` bind keys only**, through a balanced-argument parser that handles the multi-line form.

### Review round 2
- **The ancestor walk no longer sweeps the index per node** — the reverse usage index above. Every mutation of `view_files` queues or drops the path, so the walk cannot miss a renderer.
- **A Blade hover can no longer clobber a dirty PHP buffer.** `handle_update_file` stamps the buffer's mtime as loaded, so the disk loader leaves an open document alone; when the loader does write, it drops every per-file cache populated from the old text.
- **One text-revision namespace.** The LSP document version and the loader's counter no longer share `SourceFile::version`: the three per-file LRU caches key on a single monotonic `text_revision` bumped by every writer.
- **The render-index push cannot go backwards.** The actor refuses a snapshot older than the one it holds, so two concurrent pushes can arrive in either order.
- **The hover card's code block honours the kind filter** (`member_declaration_summary_of_kind`), and the `KIND_CLASH` fixture is inverted — method first — so the assertions discriminate.
- **A same-file trait the component `use`s contributes its members again**, transitively, without reopening the cross-file trait limitation. Two shipped docs stated the old, wider limitation; both now describe what the code does.

## Acceptance Criteria
- [x] **Item 1** — the walk resolves a partial's members against the enclosing component, transitively.
  - [x] Both `<x-…>` and `<livewire:…>` usage, one regression test each.
  - [x] Visited-set cycle guard: a six-level acyclic chain resolves; an `a → b → a` cycle terminates (pinned by a 20s timeout).
  - [x] Candidates sorted lexicographically by path before the first-match pick.
  - [x] A direct render site outranks a walked-up ancestor.
  - [x] A cycle on one branch prunes only that branch.
  - [x] No reachable ancestor resolves to `None`.
- [x] **Item 2** — the card names the component; a named class still shows its FQN; the card reads the live buffer, so the disk/buffer disagreement is fixed rather than deferred.
- [x] **Item 3** — functional Volt members navigate, wrapped forms included, and their card names the component.
- [x] **Item 4** — `wire:target="save, delete"` navigates per cursor segment; the loading-state property form still resolves under item 5's filter.
- [x] **Item 5** — goto, hover (header and body) and completion all filter on the declaration kind.
- [x] **Item 6** — full traversal sorted by `(line, column)`; completion excludes non-owning declarations, except a same-file trait the component `use`s; `render_source_files` sorts.
- [x] **Item 7** — the three queries are tracked, keyed on the backing class's content, proven memoized by the query-run counters, and the old scan is deleted rather than merely bypassed.
- [x] **Item 8** — keys bind, values and unrelated quoted text do not, single- and multi-line.
- [x] Every fix ships a regression test that drives the real handler and asserts the exact line, position or classification.

## Test Plan
- [x] All existing tests pass — 2780 lib + 703 bin + 80 integration, `cargo fmt --check` and `cargo clippy --all-targets` clean in both crates, on the tree merged with `main`.
- [x] New tests cover the changes, driven through `wire_attribute_goto_definition`, `this_member_hover_card`, the completion surface and the Salsa actor's own handle.
- [x] Item 1's eleven tests were mutation-verified live: dropping either tag family, reversing the ancestor sort, removing the visited set, resolving ancestors before the direct site, and dropping the Blade-only ancestor filter each redden a test.
- [x] Round 2's guards were mutation-verified live, one at a time: dropping the usage-index `mark_dirty` on edit, the buffer's mtime stamp, the loader's cache invalidation, the render-index generation guard, the summary's kind filter, and the trait surface each redden the test that names it. (Run as a batch, the loader mutations mask each other — each verdict here is from an isolated run.)

## Notes
- The walk runs only when a template has no backing class of its own, and each step is a hash lookup plus the item-7 memoized resolution — no scan and no new file parsing on the keystroke path.
- **The one-revision-namespace fix has no behavioural test, deliberately.** The old collision needed a cached entry whose stale number matched a new write; in every reachable sequence the stale answer and the correct answer are the same text (the live buffer), so a test cannot tell the fixed code from the broken code. The fix is structural — one counter, bumped by every writer, so a collision cannot be constructed — and the observable half of the same defect (the loader writing over a buffer, and leaving stale caches behind) is covered by `resolving_a_backing_class_leaves_a_dirty_buffer_alone` and `reloading_a_changed_backing_class_drops_its_cached_patterns`, both mutation-verified.

Fixes #339