### PR TITLE
fix: percent-encode userinfo in database URL construction

### DIFF
--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -2246,11 +2246,23 @@ impl DatabaseSchemaProvider {
         }
 
         if let Some(socket) = &config.unix_socket {
-            // libpq-style socket connection: `postgres://user[:pass]@/db?host=/path`.
+            // libpq-style socket connection: the socket path rides in a `host=`
+            // query parameter, not the authority.
+            //
+            // The authority still needs a literal `localhost`, the same
+            // placeholder the MySQL socket branch uses. The WHATWG URL rules
+            // sqlx's `Url::parse` implements reject an empty host that follows
+            // a userinfo component, so the shorter
+            // `postgres://user@/db?host=/path` this branch used to emit came
+            // back as *empty host* and the candidate could never connect —
+            // independent of the credential, and true for every username. sqlx
+            // reads `host=` after the authority and stores it as the socket, so
+            // `localhost` is inert: verified against sqlx 0.9, the parsed
+            // options carry socket `/tmp/.s.PGSQL.5432` with host `localhost`.
             out.push(ConnCandidate {
                 label: format!("unix_socket={socket}"),
                 url: format!(
-                    "postgres://{}@/{}?host={}",
+                    "postgres://{}@localhost/{}?host={}",
                     userinfo(&config.username, &config.password),
                     config.database,
                     socket

--- a/laravel-lsp/src/database.rs
+++ b/laravel-lsp/src/database.rs
@@ -462,15 +462,82 @@ pub enum DbBreakerEvent {
 /// the handshake skips the password packet entirely — accepted by more
 /// permissive MySQL configs.
 ///
-/// Special-character escaping is the caller's concern — Laravel's
-/// `.env` values don't typically need URL-encoding in production
-/// credentials, and adding it here would risk double-encoding.
+/// Both components are percent-encoded by [`encode_userinfo_component`], so a
+/// `.env` credential holding a delimiter cannot escape its own slot (issue
+/// #362). Splicing raw let it: sqlx routes every connection string through
+/// `Url::parse`, which ends the authority at the first `/`, `?` or `#`
+/// whether or not that character was meant as a delimiter. A password `p/ss`
+/// yields `mysql://user:p/ss@host:3306/db`, whose authority is `user:p` — host
+/// `user`, port `p` — and the connection fails with *invalid port number*.
+///
+/// Worse is the case that does not fail: when the run before the delimiter is
+/// all digits and fits a `u16`, the authority parses, so `mysql://user:12/34@host/db`
+/// connects to host `user` on port 12 and reports no password at all. Base64
+/// passwords (`openssl rand -base64`) mix digits and `/` routinely, so this is
+/// an ordinary shape, and any redactor that decides the credential span by
+/// parsing the URL is told there is nothing to mask.
 fn userinfo(user: &str, password: &str) -> String {
+    let user = encode_userinfo_component(user);
     if password.is_empty() {
-        user.to_string()
+        user
     } else {
-        format!("{user}:{password}")
+        format!("{user}:{}", encode_userinfo_component(password))
     }
+}
+
+/// Percent-encode one userinfo component (a username or a password) for
+/// splicing into a connection URL.
+///
+/// Passes through exactly RFC 3986's `unreserved` (`ALPHA DIGIT - . _ ~`) and
+/// `sub-delims` (`! $ & ' ( ) * + , ; =`) sets; every other byte becomes `%XX`,
+/// including `:`, `/`, `?`, `#`, `[`, `]`, `@`, `%`, space, control bytes, and
+/// each byte of a non-ASCII UTF-8 sequence. A credential built only from the
+/// pass-through sets is returned byte-for-byte unchanged, so the URLs this
+/// server has always produced for ordinary credentials do not move.
+///
+/// `:` is encoded even in the *username*, where RFC 3986's userinfo grammar
+/// permits it: [`userinfo`] overloads `:` as its own username/password
+/// separator, so an unencoded one there mis-splits the credential exactly as an
+/// unencoded `/` mis-splits the authority.
+///
+/// Encoding is safe against double-encoding because it is applied at the single
+/// point of construction and the value arrives raw from the `.env` file: `%` is
+/// itself encoded to `%25`, so `sec%3Dret` round-trips to the literal
+/// `sec%3Dret` rather than decoding to `sec=ret`. sqlx percent-decodes both
+/// components on the way back out (`sqlx-mysql/src/options/parse.rs`,
+/// `sqlx-postgres/src/options/parse.rs`), so the driver receives the original
+/// bytes.
+fn encode_userinfo_component(raw: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut out = String::with_capacity(raw.len());
+    for byte in raw.bytes() {
+        match byte {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'.'
+            | b'_'
+            | b'~'
+            | b'!'
+            | b'$'
+            | b'&'
+            | b'\''
+            | b'('
+            | b')'
+            | b'*'
+            | b'+'
+            | b','
+            | b';'
+            | b'=' => out.push(byte as char),
+            _ => {
+                out.push('%');
+                out.push(HEX[(byte >> 4) as usize] as char);
+                out.push(HEX[(byte & 0x0f) as usize] as char);
+            }
+        }
+    }
+    out
 }
 
 /// Render a `.env`-sourced value for a log line, through both redaction gates.

--- a/laravel-lsp/src/database/tests.rs
+++ b/laravel-lsp/src/database/tests.rs
@@ -286,6 +286,34 @@ fn postgres_candidates_socket_uses_libpq_style_url() {
     );
 }
 
+#[test]
+fn postgres_socket_candidate_url_actually_parses() {
+    use sqlx::postgres::PgConnectOptions;
+    use std::str::FromStr;
+
+    // `postgres_candidates_socket_uses_libpq_style_url` above pins the `?host=`
+    // shape by string match, which a URL the driver cannot parse satisfies just
+    // as well — and the authority this branch emitted did exactly that. Hand the
+    // candidate to the parser sqlx will actually use.
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let mut cfg = make_config_with(None, Some("/tmp/.s.PGSQL.5432"), "localhost");
+    cfg.driver = "pgsql".to_string();
+    cfg.port = 5432;
+    let socket = provider
+        .build_postgres_candidates(&cfg)
+        .into_iter()
+        .find(|c| c.label.starts_with("unix_socket"))
+        .expect("socket candidate");
+    let opts = PgConnectOptions::from_str(&socket.url)
+        .unwrap_or_else(|e| panic!("`{}` should parse: {e}", socket.url));
+    assert_eq!(
+        opts.get_socket().map(|p| p.to_string_lossy().into_owned()),
+        Some("/tmp/.s.PGSQL.5432".to_string()),
+        "the `host=` parameter must still reach sqlx as the socket path"
+    );
+    assert_eq!(opts.get_username(), "u");
+}
+
 // ---- classify_mysql_error: actionable per-error-code toasts (Phase 5.8b) ---
 
 #[test]

--- a/laravel-lsp/src/database/tests.rs
+++ b/laravel-lsp/src/database/tests.rs
@@ -484,6 +484,261 @@ fn mysql_candidates_non_empty_password_keeps_colon() {
     );
 }
 
+// ---- userinfo percent-encoding (issue #362) ------------------------------
+//
+// Every assertion below is settled by the real driver's own connection-string
+// parser rather than by string comparison against a hand-written expectation:
+// the defect these tests pin is that `Url::parse` reads a raw delimiter as
+// structure, so only a parse can prove the credential survives.
+
+/// Parse `url` with the driver sqlx will actually use, and assert it yields
+/// exactly `user` and `password`.
+///
+/// `MySqlConnectOptions` exposes `get_username()` but no password accessor, so
+/// the password is pinned differentially: `to_url_lossy()` of the parsed
+/// options against `to_url_lossy()` of the *same* options with the expected
+/// password set. Every other field is identical by construction (it is a clone
+/// of the parsed value), so the two URLs are equal exactly when the parsed
+/// password is the expected one.
+fn assert_mysql_credentials(url: &str, user: &str, password: &str) {
+    use sqlx::mysql::MySqlConnectOptions;
+    use sqlx::ConnectOptions;
+    use std::str::FromStr;
+
+    let parsed = MySqlConnectOptions::from_str(url)
+        .unwrap_or_else(|e| panic!("`{url}` should parse as a MySQL connection string: {e}"));
+    assert_eq!(parsed.get_username(), user, "username parsed from `{url}`");
+    assert_eq!(
+        parsed.to_url_lossy(),
+        parsed.clone().password(password).to_url_lossy(),
+        "password parsed from `{url}` is not `{password}`"
+    );
+}
+
+/// Postgres twin of [`assert_mysql_credentials`], same differential technique.
+fn assert_postgres_credentials(url: &str, user: &str, password: &str) {
+    use sqlx::postgres::PgConnectOptions;
+    use sqlx::ConnectOptions;
+    use std::str::FromStr;
+
+    let parsed = PgConnectOptions::from_str(url)
+        .unwrap_or_else(|e| panic!("`{url}` should parse as a Postgres connection string: {e}"));
+    assert_eq!(parsed.get_username(), user, "username parsed from `{url}`");
+    assert_eq!(
+        parsed.to_url_lossy(),
+        parsed.clone().password(password).to_url_lossy(),
+        "password parsed from `{url}` is not `{password}`"
+    );
+}
+
+/// A config carrying the given credentials, on the loopback host. Defaults to
+/// MySQL; the Postgres cases override `driver` and `port`.
+fn creds_config(username: &str, password: &str) -> super::DatabaseConfig {
+    let mut cfg = make_config_with(None, None, "127.0.0.1");
+    cfg.username = username.to_string();
+    cfg.password = password.to_string();
+    cfg
+}
+
+fn mysql_tcp_url(username: &str, password: &str) -> String {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    provider
+        .build_mysql_candidates(&creds_config(username, password))
+        .into_iter()
+        .find(|c| c.label.starts_with("tcp "))
+        .expect("tcp candidate")
+        .url
+}
+
+#[test]
+fn userinfo_encodes_reserved_delimiters_in_password() {
+    use super::userinfo;
+    // The four delimiters issue #362 names: each one ends the authority (or
+    // begins the credential) when `Url::parse` meets it unencoded.
+    assert_eq!(userinfo("u", "p/ss"), "u:p%2Fss");
+    assert_eq!(userinfo("u", "p?ss"), "u:p%3Fss");
+    assert_eq!(userinfo("u", "p#ss"), "u:p%23ss");
+    assert_eq!(userinfo("u", "p@ss"), "u:p%40ss");
+}
+
+#[test]
+fn userinfo_encodes_username_symmetrically() {
+    use super::userinfo;
+    // A username is spliced into the same slot and needs the same treatment.
+    // `:` is encoded there too: `userinfo` uses it as its own separator, so a
+    // raw one would mis-split the credential.
+    assert_eq!(userinfo("foo@bar", "pw"), "foo%40bar:pw");
+    assert_eq!(userinfo("a:b", "pw"), "a%3Ab:pw");
+    assert_eq!(userinfo("a/b", "pw"), "a%2Fb:pw");
+}
+
+#[test]
+fn userinfo_leaves_legal_characters_byte_for_byte() {
+    use super::userinfo;
+    // RFC 3986 `unreserved` + `sub-delims` pass through untouched, so the URLs
+    // this server has always built for ordinary credentials do not move.
+    let legal = "aZ09-._~!$&'()*+,;=";
+    assert_eq!(userinfo(legal, legal), format!("{legal}:{legal}"));
+    assert_eq!(userinfo("sail", "password"), "sail:password");
+    // …and the assembled URL is byte-for-byte what this server built before.
+    assert_eq!(
+        mysql_tcp_url("sail", "password"),
+        "mysql://sail:password@127.0.0.1:3306/testdb"
+    );
+    assert_eq!(
+        mysql_tcp_url(legal, legal),
+        format!("mysql://{legal}:{legal}@127.0.0.1:3306/testdb")
+    );
+}
+
+#[test]
+fn userinfo_encodes_space_control_and_non_ascii_bytes() {
+    use super::userinfo;
+    assert_eq!(userinfo("u", "a b"), "u:a%20b");
+    assert_eq!(userinfo("u", "a\tb"), "u:a%09b");
+    assert_eq!(userinfo("u", "a\nb"), "u:a%0Ab");
+    assert_eq!(userinfo("u", "[::1]"), "u:%5B%3A%3A1%5D");
+    // Each byte of a multi-byte UTF-8 sequence is encoded on its own; sqlx
+    // percent-decodes back to the original string.
+    assert_eq!(userinfo("u", "pä"), "u:p%C3%A4");
+}
+
+#[test]
+fn userinfo_encodes_percent_so_hex_pairs_do_not_decode() {
+    use super::userinfo;
+    // A literal `%` must become `%25`, otherwise `sec%3Dret` would round-trip
+    // through sqlx's percent-decode as `sec=ret` — a different password.
+    assert_eq!(userinfo("u", "sec%3Dret"), "u:sec%253Dret");
+    assert_eq!(userinfo("u", "100%"), "u:100%25");
+    assert_mysql_credentials(&mysql_tcp_url("u", "sec%3Dret"), "u", "sec%3Dret");
+}
+
+#[test]
+fn userinfo_empty_password_still_omits_the_colon() {
+    use super::userinfo;
+    // Encoding must not disturb the "no password" shape: `root:` tells sqlx an
+    // empty password *was* supplied and MySQL answers `using password: YES`.
+    assert_eq!(userinfo("root", ""), "root");
+    assert_eq!(userinfo("ro@ot", ""), "ro%40ot");
+}
+
+#[test]
+fn mysql_url_round_trips_reserved_password_characters() {
+    for password in ["p/ss", "p?ss", "p#ss", "p@ss", "pa:ss", "p ss", "p%ss"] {
+        assert_mysql_credentials(&mysql_tcp_url("sail", password), "sail", password);
+    }
+}
+
+#[test]
+fn mysql_url_round_trips_digit_run_before_a_delimiter() {
+    // The silent class from issue #362. The leading run before the delimiter is
+    // all digits and fits a `u16`, so the authority parses instead of erroring:
+    // every shape below resolved to host `sail`, the digits as the port, and
+    // the default `root` user, with no password at all. Nothing surfaces — the
+    // connection just goes somewhere else, and a redactor that locates the
+    // credential by parsing the URL is told there is nothing to mask.
+    for password in [
+        "12/34",
+        "1234/56",
+        "012345/aG9zdG5hbWU=",
+        "12?34",
+        "1234?56",
+        "12#34",
+        "1234#56",
+    ] {
+        assert_mysql_credentials(&mysql_tcp_url("sail", password), "sail", password);
+    }
+}
+
+#[test]
+fn mysql_url_round_trips_reserved_username_characters() {
+    for username in ["foo@bar", "a:b", "a/b", "a?b", "a#b"] {
+        assert_mysql_credentials(&mysql_tcp_url(username, "pw"), username, "pw");
+    }
+}
+
+#[test]
+fn mysql_socket_candidate_round_trips_credentials_and_socket() {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let mut cfg = make_config_with(None, Some("/tmp/mysql.sock"), "localhost");
+    cfg.username = "sa/il".to_string();
+    cfg.password = "012345/aG9zdG5hbWU=".to_string();
+    let socket = provider
+        .build_mysql_candidates(&cfg)
+        .into_iter()
+        .find(|c| c.label.starts_with("unix_socket"))
+        .expect("socket candidate");
+    assert_mysql_credentials(&socket.url, "sa/il", "012345/aG9zdG5hbWU=");
+    // The encoded credential must not disturb the trailing `socket=` param.
+    let opts = <sqlx::mysql::MySqlConnectOptions as std::str::FromStr>::from_str(&socket.url)
+        .expect("socket URL should parse");
+    assert_eq!(
+        opts.get_socket().map(|p| p.to_string_lossy().into_owned()),
+        Some("/tmp/mysql.sock".to_string())
+    );
+}
+
+#[test]
+fn postgres_tcp_candidate_round_trips_credentials() {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let mut cfg = creds_config("fo@o", "012345/aG9zdG5hbWU=");
+    cfg.driver = "pgsql".to_string();
+    cfg.port = 5432;
+    let tcp = provider
+        .build_postgres_candidates(&cfg)
+        .into_iter()
+        .find(|c| c.label.starts_with("tcp "))
+        .expect("tcp candidate");
+    assert_postgres_credentials(&tcp.url, "fo@o", "012345/aG9zdG5hbWU=");
+}
+
+#[test]
+fn postgres_socket_candidate_round_trips_credentials_and_socket() {
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let mut cfg = make_config_with(None, Some("/tmp/.s.PGSQL.5432"), "localhost");
+    cfg.driver = "pgsql".to_string();
+    cfg.port = 5432;
+    cfg.username = "fo@o".to_string();
+    cfg.password = "12/34".to_string();
+    let socket = provider
+        .build_postgres_candidates(&cfg)
+        .into_iter()
+        .find(|c| c.label.starts_with("unix_socket"))
+        .expect("socket candidate");
+    assert_postgres_credentials(&socket.url, "fo@o", "12/34");
+    // The encoded credential must not disturb the trailing `host=` param.
+    let opts = <sqlx::postgres::PgConnectOptions as std::str::FromStr>::from_str(&socket.url)
+        .expect("socket URL should parse");
+    assert_eq!(
+        opts.get_socket().map(|p| p.to_string_lossy().into_owned()),
+        Some("/tmp/.s.PGSQL.5432".to_string())
+    );
+}
+
+#[test]
+fn db_url_passthrough_is_never_re_encoded() {
+    // `config.url` is a full connection string the user supplied verbatim. It
+    // never goes through `userinfo`, and encoding it would corrupt credentials
+    // the user already encoded themselves.
+    let provider = DatabaseSchemaProvider::new(std::path::PathBuf::from("/tmp"));
+    let raw = "mysql://heroku:ab%2Fc@db.heroku.com/x";
+    let mut cfg = make_config_with(Some(raw), None, "mysql");
+    cfg.username = "ignored@me".to_string();
+    cfg.password = "ignored/me".to_string();
+    let mysql = provider.build_mysql_candidates(&cfg);
+    assert_eq!(mysql[0].label, "DB_URL");
+    assert_eq!(mysql[0].url, raw);
+
+    let pg_raw = "postgres://heroku:ab%2Fc@db.heroku.com/x";
+    let mut pg_cfg = make_config_with(Some(pg_raw), None, "postgres");
+    pg_cfg.driver = "pgsql".to_string();
+    pg_cfg.username = "ignored@me".to_string();
+    pg_cfg.password = "ignored/me".to_string();
+    let pg = provider.build_postgres_candidates(&pg_cfg);
+    assert_eq!(pg[0].label, "DB_URL");
+    assert_eq!(pg[0].url, pg_raw);
+}
+
 // ---- resolve_env: empty value should NOT swallow next line (Phase 5.5) ----
 
 #[test]


### PR DESCRIPTION
## Summary

Implements #362. `database::userinfo` spliced the `.env` username and password into a `driver://…` connection URL raw. sqlx parses every connection string with `Url::parse`, which ends the authority at the first `/`, `?` or `#` whether or not that character was meant as a delimiter, so a credential holding one escaped its own slot.

Both failure modes were reproduced against sqlx 0.9 before the fix:

| password | result today |
|---|---|
| `p/ss` | `Err(Configuration(InvalidPort))` — connection fails, no useful diagnostic |
| `12/34` | `Ok(host "sail", port 12, user "root", no password)` |
| `1234/56`, `012345/aG9zdG5hbWU=`, `12?34`, `1234?56`, `12#34`, `1234#56` | same silent misparse |

The second row is the dangerous one: nothing errors. The connection goes to a host and port assembled out of the password, the username falls back to `root`, and any redactor that locates the credential span by parsing the URL is told there is no password to mask. `openssl rand -base64` output mixes digits and `/` routinely, so this is an ordinary password shape.

## Changes

- **`encode_userinfo_component`** (new, `database.rs`) — percent-encodes one userinfo component. Passes through exactly RFC 3986 `unreserved` (`ALPHA DIGIT - . _ ~`) and `sub-delims` (`! $ & ' ( ) * + , ; =`); every other byte becomes `%XX`, including `:`, `/`, `?`, `#`, `[`, `]`, `@`, `%`, space, control bytes, and each byte of a non-ASCII UTF-8 sequence. No new dependency: the crate set needed is not any `percent-encoding` preset (`NON_ALPHANUMERIC` would encode the sub-delims and move URLs that work today), so a custom set was required either way.
- **`userinfo`** now routes both components through it. The username is encoded symmetrically with the password, `:` included — `userinfo` overloads `:` as its own separator, so an unencoded one there mis-splits exactly as an unencoded `/` mis-splits the authority.
- **Its docblock**, which said escaping "is the caller's concern … would risk double-encoding", now records why encoding is correct here: it is applied once at the single point of construction, on a value that arrives raw from `.env`, and `%` self-encodes.
- **Postgres unix-socket authority** (separate commit `99ce9ac`) — see below.
- **20 tests**, every one settled through the driver's own parser.

All four call sites that build a URL through `userinfo` — `build_mysql_candidates`' socket and TCP branches, `build_postgres_candidates`' socket and TCP branches — route through the one function; there is no fifth credential splice in the tree (`sqlite:` carries no credentials, and SQL Server goes through `tiberius::AuthMethod::sql_server`, which takes the fields structurally). `DB_URL` is passed through verbatim and never re-encoded.

## The extra commit: the Postgres socket candidate never connected

Writing the AC's per-call-site test surfaced a defect independent of this one. `build_postgres_candidates` emitted `postgres://user@/db?host=/path`, and the WHATWG URL rules sqlx's `Url::parse` implements reject an empty host that follows a userinfo component:

```
postgres://u:p@/testdb?host=/tmp/.s.PGSQL.5432  => Err(Configuration(EmptyHost))
postgres://u@/testdb?host=/tmp/.s.PGSQL.5432    => Err(Configuration(EmptyHost))
postgres://u:p@localhost/testdb?host=/tmp/...   => Ok(host "localhost", socket "/tmp/...", user "u")
```

That candidate could never connect, for any username, credential-independent. The existing coverage matched `?host=` in the URL *string*, which an unparseable URL satisfies just as well. The AC requires this branch to parse back correctly, so the fix ships here: splice the same inert `localhost` placeholder the MySQL socket branch already uses. It is committed separately (`99ce9ac`) so it can be read on its own.

**Deliberately out of scope:** `config.database` and the socket path are still spliced raw. Neither is a credential, both are a different class from the one this issue names, and encoding them would move URLs for every user. Flagging rather than folding in.

## Acceptance Criteria

- [x] `database::userinfo()` percent-encodes every byte outside `unreserved`/`sub-delims`, identically for username and password, `:` in the username included.
- [x] All four call sites receive the encoded value. No caller splices a raw credential.
- [x] A password containing `/`, `?`, `#` or `@` now parses via `MySqlConnectOptions`/`PgConnectOptions::from_str`, yielding the intended username and password — no parse error, no misread host/port.
- [x] Credentials built only from legal characters produce a byte-for-byte identical URL (`userinfo_leaves_legal_characters_byte_for_byte` pins both the component and the assembled URL). The empty-password no-trailing-colon behavior is preserved.
- [x] A literal `%` always encodes to `%25`; `sec%3Dret` round-trips to the literal `sec%3Dret`, never `sec=ret`.
- [x] The `DB_URL` passthrough is untouched, both drivers (`db_url_passthrough_is_never_re_encoded`).
- [x] Tests cover (a) `/`, `?`, `#`, `@` in a password; (b) all three issue digit-run shapes plus the `?` and `#` equivalents; (c) reserved characters in the username; (d) one test per production call site building a real `ConnCandidate`, asserting the credential and the trailing `socket=`/`host=` value both parse back.

## Test Plan

- [x] `cargo test` — 3,491 pass, 0 fail.
- [x] `cargo clippy --all-targets` — no warnings.
- [x] `cargo fmt --check` — clean.
- [x] Password assertions use a differential technique, since neither options type exposes a password accessor: `to_url_lossy()` of the parsed options against `to_url_lossy()` of the *same* options (a clone, so every other field is identical) with the expected password set. Equality holds exactly when the parsed password is the expected one.
- [x] **Mutation-verified.** Each of these reddens at least one new test, and the source was restored and re-run green after every round:

| mutation | killed by |
|---|---|
| revert `userinfo` to the raw splice | 11 tests |
| encode the password only, username raw | 4 tests |
| let `%` through the pass-through set | `userinfo_encodes_percent_so_hex_pairs_do_not_decode` |
| let `:` through | 3 tests |
| let `/` through | 8 tests |
| over-encode the legal sub-delim `+` | `userinfo_leaves_legal_characters_byte_for_byte` |
| revert the Postgres socket authority | `postgres_socket_candidate_round_trips_credentials_and_socket` |
| emit a trailing colon for an empty password | 4 tests |
| substitute a wrong expected password in both helpers | all 7 helper-using tests |

Fixes #362