### PR TITLE
Route the external-PHP disk loader through the path_within_root containment guard

### DIFF
--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -39,6 +39,10 @@ use crate::route_discovery::normalize_path;
 // The lexical (non-fail-closed) entry point of the shared containment guard —
 // admits speculative candidates that don't exist on disk yet (issue #156).
 use crate::path_containment::path_within_root_lexical;
+// The two guards `ensure_external_php_source_loaded` splits across its
+// branches (issue #364): the emit-safe one for the client-owned path it
+// returns without reading, the registration one for the path it reads.
+use crate::path_containment::{canonical_within_root_registration, path_within_root_emit_safe};
 
 // ============================================================================
 // Database Definition
@@ -10027,13 +10031,48 @@ impl SalsaActor {
     /// is unreadable — which is also how a non-existent path and a directory
     /// (a Livewire v4 MFC's component dir) are dropped from backing-class
     /// resolution.
+    ///
+    /// **Containment (issue #364).** Every path reaching here is contained by
+    /// construction today — render-index candidates come from the project's
+    /// own directory walk, Livewire candidates from a resolver that gates each
+    /// segment through `naming::is_safe_path_segment` — but this function is a
+    /// read primitive whose result is *emitted* as a goto-definition target
+    /// (`handle_blade_backing_class_resolution` maps it into
+    /// `BladeBackingResolutionData::files`). A guard that lives only in the
+    /// callers is a guard a future caller can forget, which is how #294 and
+    /// both rounds of #348 happened. The guard therefore lives at the
+    /// primitive, and it is split across the two branches because they ask
+    /// different questions — see the comments on each.
     fn ensure_external_php_source_loaded(&mut self, path: &PathBuf) -> Option<SourceFile> {
+        // Root unknown: refuse before any state is read, mutated, or stat'd.
+        // Containment cannot be decided without a root, and this function's
+        // failure mode must be closed.
+        let root = self.config_root.clone()?;
+
         // Ownership is checked BEFORE the filesystem, so a client-pushed path
         // is served from Salsa whether or not it can be stat'd at this instant.
         // Ordering the stat first would drop an unsaved buffer out of
         // backing-class resolution whenever its file is momentarily absent —
         // a branch switch, a stash, an `artisan make:*` regeneration.
         if self.external_php_text.get(path) == Some(&ExternalPhpText::PushedByClient) {
+            // This branch reads no disk — but the path it hands back is emitted
+            // to the client as a location to open, so containment still has to
+            // hold. `path_within_root_emit_safe` is the guard shaped for that:
+            // its lexical pre-gate refuses an out-of-root candidate with no
+            // `stat` probe (#145), and its `None` arm admits a *genuinely
+            // absent* in-root path — precisely the unsaved-buffer case this
+            // branch exists to protect (#361) — while refusing a dangling
+            // under-root symlink and every non-`NotFound` lstat error.
+            //
+            // The fail-closed read guard below cannot serve this branch: it
+            // refuses anything it cannot canonicalize, which is exactly the
+            // momentarily-absent buffer, so using it here would reintroduce
+            // #361. The read branch keeps the full fail-closed guard; this is
+            // an addition to a branch that guard never covered, not a
+            // substitution for it.
+            if !path_within_root_emit_safe(path, &root) {
+                return None;
+            }
             if let Some(file) = self.files.get(path).copied() {
                 return Some(file);
             }
@@ -10043,7 +10082,21 @@ impl SalsaActor {
             // belt-and-braces arm, not a reachable steady state.
         }
 
-        let current_mtime = std::fs::metadata(path).ok()?.modified().ok()?;
+        // The disk branch reads real bytes, so containment must be PROVEN.
+        // `canonical_within_root_registration` is documented for exactly this
+        // shape — a path minted from discovered source data and then read: it
+        // keeps the lexical pre-gate (no out-of-root existence oracle, #145)
+        // and fails closed on anything it cannot canonicalize, including a
+        // dangling under-root symlink (#134/#155).
+        //
+        // Both filesystem calls below go through `real`, the VERIFIED canonical
+        // path the guard returns. Re-deriving it from `path` would let a
+        // symlink swapped between guard and read hand back a target the guard
+        // never approved. `path` stays the key for `self.files` and
+        // `external_php_text`, so the callers' own lookups still resolve.
+        let real = canonical_within_root_registration(path, &root)?;
+
+        let current_mtime = std::fs::metadata(&real).ok()?.modified().ok()?;
 
         let needs_reload = match self.external_php_text.get(path) {
             Some(ExternalPhpText::LoadedFromDisk(prev_mtime)) => {
@@ -10054,7 +10107,7 @@ impl SalsaActor {
         };
 
         if needs_reload {
-            let text = std::fs::read_to_string(path).ok()?;
+            let text = std::fs::read_to_string(&real).ok()?;
             self.bump_text_revision(path);
             // This write replaces the text every per-file cache was populated
             // from. `pattern_cache` compares nothing on lookup — a hit is
@@ -11282,6 +11335,24 @@ impl SalsaActor {
     }
 
     /// Ensure a file is registered with Salsa (read from disk if needed)
+    ///
+    /// **No containment guard here, deliberately** (#364 sibling-site audit),
+    /// and the reason differs from [`Self::ensure_external_php_source_loaded`]
+    /// next door. Every call site passes the *request's own*
+    /// `textDocument.uri` — the document the client already has open and is
+    /// asking about (`handle_get_patterns`,
+    /// `handle_find_magic_member_references`, `hover_for_magic_member`,
+    /// `handle_resolve_facade_receiver_at`, `handle_magic_member_rename_data`).
+    /// That is not a path minted by joining project-derived text onto a
+    /// directory, so there is no traversal to fence: the client supplied the
+    /// path, holds the file open, and `did_open`/`did_change` already register
+    /// arbitrary client paths through `handle_update_file`. The text read here
+    /// is parsed for the answer and the path itself is never emitted as a new
+    /// navigation target.
+    ///
+    /// Gating it on the project root would also be a behaviour change, not a
+    /// hardening: a file legitimately open outside the workspace root would
+    /// stop answering hover and goto entirely.
     fn ensure_file_registered(&mut self, path: &PathBuf) {
         use std::collections::hash_map::Entry;
         // Use entry API to avoid double lookup

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -8963,67 +8963,7 @@ impl SalsaActor {
         let documents_for_actor = documents.clone();
 
         std::thread::spawn(move || {
-            let mut actor = SalsaActor {
-                db: LaravelDatabase::new(),
-                receiver: rx,
-                // Pre-allocate with reasonable capacity to avoid early reallocations
-                files: HashMap::with_capacity(64),
-                // Bootstrap table, big enough for the handful of `didOpen`
-                // buffers an editor may send before registration finishes.
-                // Replaced with a correctly-sized one — carrying those
-                // entries over — by `size_and_publish_pattern_cache`.
-                pattern_cache: Arc::new(dashmap::DashMap::with_capacity(
-                    PATTERN_CACHE_INITIAL_CAPACITY,
-                )),
-                pattern_cache_slot: pattern_cache_slot_for_actor,
-                documents: documents_for_actor,
-                loop_blocks_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
-                php_assignments_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
-                document_symbols_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
-                external_php_text: HashMap::with_capacity(64),
-                text_revision: 0,
-                file_text_revisions: HashMap::with_capacity(64),
-                // Config management
-                config_root: None,
-                config_files: HashMap::with_capacity(4),
-                config_version: 0,
-                config_cache: None,
-                registration_baselines: HashMap::new(),
-                // Reference finding
-                render_index: None,
-                render_index_version: 0,
-                render_index_generation: 0,
-                project_files: None,
-                project_files_version: 0,
-                controller_files: Vec::new(),
-                view_files: Vec::new(),
-                livewire_files: Vec::new(),
-                route_files: Vec::new(),
-                vendor_files: Vec::new(),
-                source_files: Vec::new(),
-                project_root_paths: ProjectRootPaths::default(),
-                symbol_index: crate::symbol_index::SymbolIndex::default(),
-                component_usage_index: crate::component_usage_index::ComponentUsageIndex::default(),
-                class_hierarchy_index: crate::class_hierarchy_index::ClassHierarchyIndex::default(),
-                class_files_snapshot: None,
-                // Service provider registry
-                sp_middleware_aliases: HashMap::new(),
-                sp_bindings: HashMap::new(),
-                sp_singletons: HashMap::new(),
-                sp_view_namespaces: HashMap::new(),
-                sp_blade_components: HashMap::new(),
-                sp_component_namespaces: HashMap::new(),
-                // Salsa-based env tracking
-                salsa_env_files: HashMap::with_capacity(4),
-                salsa_env_version: 0,
-                // Salsa-based translation tracking (issue #293)
-                translations: TranslationCache::default(),
-                // Salsa-based service provider tracking
-                salsa_sp_files: HashMap::with_capacity(32),
-                module_dirs: Vec::new(),
-                salsa_sp_version: 0,
-                salsa_sp_root: None,
-            };
+            let mut actor = SalsaActor::new(rx, pattern_cache_slot_for_actor, documents_for_actor);
 
             // Pre-warm query cache on actor thread (background)
             // This runs before any file parsing requests arrive,
@@ -9037,6 +8977,83 @@ impl SalsaActor {
             sender: tx,
             pattern_cache: pattern_cache_slot,
             documents,
+        }
+    }
+
+    /// Build the actor's initial state.
+    ///
+    /// Extracted from [`Self::spawn`] so the struct literal has exactly one
+    /// home and the in-crate test module can construct an actor to drive
+    /// `&mut self` methods directly — the only way to assert on `files` and
+    /// `external_php_text`, which no `SalsaHandle` message exposes (#364).
+    /// `spawn` still owns the threading; this owns the fields.
+    fn new(
+        receiver: mpsc::Receiver<SalsaRequest>,
+        pattern_cache_slot: Arc<
+            std::sync::OnceLock<Arc<dashmap::DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>>,
+        >,
+        documents: Arc<OnceLock<Arc<RwLock<HashMap<Url, (String, i32)>>>>>,
+    ) -> Self {
+        SalsaActor {
+            db: LaravelDatabase::new(),
+            receiver,
+            // Pre-allocate with reasonable capacity to avoid early reallocations
+            files: HashMap::with_capacity(64),
+            // Bootstrap table, big enough for the handful of `didOpen`
+            // buffers an editor may send before registration finishes.
+            // Replaced with a correctly-sized one — carrying those
+            // entries over — by `size_and_publish_pattern_cache`.
+            pattern_cache: Arc::new(dashmap::DashMap::with_capacity(
+                PATTERN_CACHE_INITIAL_CAPACITY,
+            )),
+            pattern_cache_slot,
+            documents,
+            loop_blocks_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
+            php_assignments_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
+            document_symbols_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
+            external_php_text: HashMap::with_capacity(64),
+            text_revision: 0,
+            file_text_revisions: HashMap::with_capacity(64),
+            // Config management
+            config_root: None,
+            config_files: HashMap::with_capacity(4),
+            config_version: 0,
+            config_cache: None,
+            registration_baselines: HashMap::new(),
+            // Reference finding
+            render_index: None,
+            render_index_version: 0,
+            render_index_generation: 0,
+            project_files: None,
+            project_files_version: 0,
+            controller_files: Vec::new(),
+            view_files: Vec::new(),
+            livewire_files: Vec::new(),
+            route_files: Vec::new(),
+            vendor_files: Vec::new(),
+            source_files: Vec::new(),
+            project_root_paths: ProjectRootPaths::default(),
+            symbol_index: crate::symbol_index::SymbolIndex::default(),
+            component_usage_index: crate::component_usage_index::ComponentUsageIndex::default(),
+            class_hierarchy_index: crate::class_hierarchy_index::ClassHierarchyIndex::default(),
+            class_files_snapshot: None,
+            // Service provider registry
+            sp_middleware_aliases: HashMap::new(),
+            sp_bindings: HashMap::new(),
+            sp_singletons: HashMap::new(),
+            sp_view_namespaces: HashMap::new(),
+            sp_blade_components: HashMap::new(),
+            sp_component_namespaces: HashMap::new(),
+            // Salsa-based env tracking
+            salsa_env_files: HashMap::with_capacity(4),
+            salsa_env_version: 0,
+            // Salsa-based translation tracking (issue #293)
+            translations: TranslationCache::default(),
+            // Salsa-based service provider tracking
+            salsa_sp_files: HashMap::with_capacity(32),
+            module_dirs: Vec::new(),
+            salsa_sp_version: 0,
+            salsa_sp_root: None,
         }
     }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -10042,12 +10042,38 @@ impl SalsaActor {
     /// callers is a guard a future caller can forget, which is how #294 and
     /// both rounds of #348 happened. The guard therefore lives at the
     /// primitive, and it is split across the two branches because they ask
-    /// different questions — see the comments on each.
+    /// different questions — see the comments on each. Both branches gate
+    /// against the candidate's owning module where it has one, so a module
+    /// symlinked in from a composer path repository keeps resolving.
     fn ensure_external_php_source_loaded(&mut self, path: &PathBuf) -> Option<SourceFile> {
         // Root unknown: refuse before any state is read, mutated, or stat'd.
         // Containment cannot be decided without a root, and this function's
         // failure mode must be closed.
         let root = self.config_root.clone()?;
+
+        // Gate against the candidate's OWNING MODULE where it has one, falling
+        // back to the project root — the same choice
+        // `livewire_namespaces::contained_class_path` makes for the
+        // registrations that MINT these paths, and the same
+        // `config::owning_module` lookup this file already uses for provider
+        // rank.
+        //
+        // `config::expand_module_dirs` admits a module directory whose real
+        // target sits outside the project ON PURPOSE: that is the composer
+        // path-repository layout. Gating this read against the root alone
+        // dropped every backing class inside such a module — silently, since
+        // there is no "component not found" diagnostic and the only symptom is
+        // goto and hover quietly doing nothing.
+        //
+        // The swap does not loosen the guard, and for a module path it
+        // TIGHTENS it: a candidate lexically under a module must canonicalize
+        // inside that module, so one reaching into a sibling module or into
+        // bare `app/` is refused even though it is inside the root.
+        // `owning_module` collapses `..` before its prefix test, so a
+        // traversing path cannot elect itself a laxer gate.
+        let gate = crate::config::owning_module(&self.module_dirs, path)
+            .map(|(_, dir)| dir.to_path_buf())
+            .unwrap_or(root);
 
         // Ownership is checked BEFORE the filesystem, so a client-pushed path
         // is served from Salsa whether or not it can be stat'd at this instant.
@@ -10070,7 +10096,7 @@ impl SalsaActor {
             // #361. The read branch keeps the full fail-closed guard; this is
             // an addition to a branch that guard never covered, not a
             // substitution for it.
-            if !path_within_root_emit_safe(path, &root) {
+            if !path_within_root_emit_safe(path, &gate) {
                 return None;
             }
             if let Some(file) = self.files.get(path).copied() {
@@ -10094,7 +10120,7 @@ impl SalsaActor {
         // symlink swapped between guard and read hand back a target the guard
         // never approved. `path` stays the key for `self.files` and
         // `external_php_text`, so the callers' own lookups still resolve.
-        let real = canonical_within_root_registration(path, &root)?;
+        let real = canonical_within_root_registration(path, &gate)?;
 
         let current_mtime = std::fs::metadata(&real).ok()?.modified().ok()?;
 

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -5817,3 +5817,227 @@ fn is_plain_php_path_separates_classes_from_templates() {
     )));
     assert!(!is_plain_php_path(Path::new("/proj/composer.json")));
 }
+
+// ─── External-PHP loader containment (#364) ────────────────────────────
+//
+// `ensure_external_php_source_loaded` is a read primitive whose result is
+// emitted as a goto-definition target, so it carries its own containment
+// guard rather than trusting each caller to have sanitised the path. The
+// criteria for #364 ask for assertions on the actor's own `files` and
+// `external_php_text` maps — "returned `None`" alone does not prove the
+// rejected path left no cached entry behind for the ~8 other
+// `self.files.get(path)` sites in this module to serve. No `SalsaHandle`
+// message exposes those maps, so these tests build a `SalsaActor` directly
+// (see `SalsaActor::new`) and call the loader as `&mut self`.
+
+/// An actor with no thread behind it. The receiver is live but never polled —
+/// these tests call `&mut self` methods directly instead of sending requests.
+fn loader_test_actor(config_root: Option<PathBuf>) -> SalsaActor {
+    let (_tx, rx) = mpsc::channel(1);
+    let mut actor = SalsaActor::new(rx, Arc::new(OnceLock::new()), Arc::new(OnceLock::new()));
+    actor.config_root = config_root;
+    actor
+}
+
+/// A project root and a sibling directory outside it, under one tempdir.
+/// Returned alongside the `TempDir` so the caller keeps it alive.
+fn root_and_outside() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path().join("project");
+    let outside = dir.path().join("outside");
+    std::fs::create_dir_all(root.join("app/Livewire")).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    (dir, root, outside)
+}
+
+/// Precondition for every rejection test below: assert the path really does
+/// resolve outside the root, so a mis-built fixture can't pass vacuously.
+fn assert_outside_root(path: &Path, root: &Path) {
+    let real = path
+        .canonicalize()
+        .expect("the fixture target must exist on disk");
+    let real_root = root.canonicalize().expect("the project root must exist");
+    assert!(
+        !real.starts_with(&real_root),
+        "fixture is not actually out of root: {real:?} is under {real_root:?}"
+    );
+}
+
+#[test]
+fn loader_refuses_an_out_of_root_candidate_and_caches_nothing() {
+    let (_dir, root, outside) = root_and_outside();
+    let escapee = outside.join("Secret.php");
+    std::fs::write(&escapee, "<?php\nclass Secret { public $token = 'x'; }\n").unwrap();
+    assert_outside_root(&escapee, &root);
+
+    let mut actor = loader_test_actor(Some(root.clone()));
+
+    assert!(
+        actor.ensure_external_php_source_loaded(&escapee).is_none(),
+        "an out-of-root candidate must not load, even though it reads fine",
+    );
+    assert!(
+        !actor.files.contains_key(&escapee),
+        "a rejected path must not be left as a Salsa input for other sites to read",
+    );
+    assert!(
+        !actor.external_php_text.contains_key(&escapee),
+        "a rejected path must not be recorded as loaded",
+    );
+}
+
+#[test]
+fn loader_refuses_a_candidate_when_the_root_is_unknown() {
+    let (_dir, root, _outside) = root_and_outside();
+    let class = root.join("app/Livewire/Counter.php");
+    let source = "<?php\nclass Counter { public $count = 0; }\n";
+    std::fs::write(&class, source).unwrap();
+
+    // Root unknown: the short-circuit fires before anything is touched.
+    let mut actor = loader_test_actor(None);
+    assert!(
+        actor.ensure_external_php_source_loaded(&class).is_none(),
+        "with no project root there is nothing to contain against — fail closed",
+    );
+    assert!(actor.files.is_empty(), "no Salsa input may be created");
+    assert!(
+        actor.external_php_text.is_empty(),
+        "nothing may be recorded as loaded",
+    );
+
+    // The same path, same actor state, with the root known: it loads. That is
+    // what proves the `None` above came from the short-circuit and not from a
+    // coincidental read failure.
+    actor.config_root = Some(root);
+    let file = actor
+        .ensure_external_php_source_loaded(&class)
+        .expect("the very same path loads once the root is known");
+    assert_eq!(*file.text(&actor.db), source);
+}
+
+#[cfg(unix)]
+#[test]
+fn loader_refuses_an_under_root_symlink_that_escapes() {
+    let (_dir, root, outside) = root_and_outside();
+
+    // Distinguishable content, so a rejection can't be confused with an empty
+    // or unreadable target.
+    let secret_src = "<?php\nclass Counter { public $secret = 'escaped'; }\n";
+    let target = outside.join("Secret.php");
+    std::fs::write(&target, secret_src).unwrap();
+
+    let link = root.join("app/Livewire/Counter.php");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    assert_outside_root(&link, &root);
+
+    let mut actor = loader_test_actor(Some(root.clone()));
+    assert!(
+        actor.ensure_external_php_source_loaded(&link).is_none(),
+        "a path lexically under the root that resolves outside it must be refused",
+    );
+    assert!(!actor.files.contains_key(&link));
+    assert!(!actor.external_php_text.contains_key(&link));
+
+    // The contrast: the SAME bytes at a genuine in-root path load normally, so
+    // the rejection tracks containment, not a read that happened to fail.
+    let genuine = root.join("app/Livewire/Real.php");
+    std::fs::write(&genuine, secret_src).unwrap();
+    let file = actor
+        .ensure_external_php_source_loaded(&genuine)
+        .expect("an in-root file with identical content loads");
+    assert_eq!(*file.text(&actor.db), secret_src);
+}
+
+#[cfg(unix)]
+#[test]
+fn retargeting_a_symlink_out_of_root_cannot_disturb_the_cached_load() {
+    let (_dir, root, outside) = root_and_outside();
+
+    let good_src = "<?php\nclass Counter { public $from = 'in-root'; }\n";
+    let good = root.join("app/Livewire/Real.php");
+    std::fs::write(&good, good_src).unwrap();
+
+    let bad_src = "<?php\nclass Counter { public $from = 'escaped'; }\n";
+    let bad = outside.join("Secret.php");
+    std::fs::write(&bad, bad_src).unwrap();
+
+    let link = root.join("app/Livewire/Counter.php");
+    std::os::unix::fs::symlink(&good, &link).unwrap();
+
+    let mut actor = loader_test_actor(Some(root.clone()));
+    let file = actor
+        .ensure_external_php_source_loaded(&link)
+        .expect("an in-root symlink to an in-root target loads");
+    assert_eq!(*file.text(&actor.db), good_src);
+    let recorded = *actor
+        .external_php_text
+        .get(&link)
+        .expect("the load is recorded");
+
+    // Swap the link out from under the cached entry.
+    std::fs::remove_file(&link).unwrap();
+    std::os::unix::fs::symlink(&bad, &link).unwrap();
+    assert_outside_root(&link, &root);
+
+    assert!(
+        actor.ensure_external_php_source_loaded(&link).is_none(),
+        "the retargeted link now escapes the root and must be refused",
+    );
+    assert_eq!(
+        *file.text(&actor.db),
+        good_src,
+        "the previously-cached text must survive the refused reload",
+    );
+    assert_eq!(
+        actor.external_php_text.get(&link),
+        Some(&recorded),
+        "the recorded mtime must survive the refused reload",
+    );
+}
+
+#[test]
+fn a_client_pushed_out_of_root_path_is_refused_even_when_cached() {
+    let (_dir, root, outside) = root_and_outside();
+    let escapee = outside.join("Secret.php");
+    std::fs::write(&escapee, "<?php\nclass Secret {}\n").unwrap();
+    assert_outside_root(&escapee, &root);
+
+    let mut actor = loader_test_actor(Some(root.clone()));
+
+    // Install it the way a client push does — this is the branch that returns
+    // without touching disk, and whose return value becomes a goto target.
+    let buffer = "<?php\nclass Secret { public $unsaved = true; }\n";
+    actor
+        .ensure_blade_source_registered(&escapee, Some(buffer.to_string()))
+        .expect("the push installs a Salsa input");
+    assert_eq!(
+        actor.external_php_text.get(&escapee),
+        Some(&ExternalPhpText::PushedByClient),
+        "precondition: the ownership fast path is what answers next",
+    );
+
+    assert!(
+        actor.ensure_external_php_source_loaded(&escapee).is_none(),
+        "client ownership is not a containment exemption — the path is emitted",
+    );
+}
+
+#[test]
+fn a_client_pushed_in_root_buffer_still_answers_while_its_file_is_absent() {
+    let (_dir, root, _outside) = root_and_outside();
+    // Never written to disk: this is the #361 case the emit-safe guard has to
+    // keep admitting.
+    let class = root.join("app/Livewire/Counter.php");
+    assert!(!class.exists(), "precondition: the file is absent on disk");
+
+    let mut actor = loader_test_actor(Some(root.clone()));
+    let buffer = "<?php\nclass Counter { public function unsaved() {} }\n";
+    actor
+        .ensure_blade_source_registered(&class, Some(buffer.to_string()))
+        .expect("the push installs a Salsa input");
+
+    let file = actor
+        .ensure_external_php_source_loaded(&class)
+        .expect("a genuinely-absent in-root buffer must still resolve");
+    assert_eq!(*file.text(&actor.db), buffer);
+}

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -6041,3 +6041,168 @@ fn a_client_pushed_in_root_buffer_still_answers_while_its_file_is_absent() {
         .expect("a genuinely-absent in-root buffer must still resolve");
     assert_eq!(*file.text(&actor.db), buffer);
 }
+
+// ─── Module-gated containment (#364, review round 1) ───────────────────
+//
+// Gating this read against the project root alone dropped every backing
+// class inside a module symlinked in from a composer path repository — the
+// layout `config::expand_module_dirs` admits on purpose and
+// `livewire_namespaces::contained_class_path` gates against the owning
+// module precisely to keep working. The loader now makes the same choice.
+// These three tests pin the widening AND its limits: a module's own subtree
+// is reachable, everything else is still refused.
+
+/// A project with `Modules/Blog` symlinked to a package directory that lives
+/// outside the project root. Returns the tempdir, the root, the module dir,
+/// and the external package dir.
+#[cfg(unix)]
+fn symlinked_module_project() -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path().join("project");
+    let package = dir.path().join("packages/blog");
+    std::fs::create_dir_all(root.join("Modules")).unwrap();
+    std::fs::create_dir_all(root.join("app")).unwrap();
+    std::fs::create_dir_all(package.join("src/Livewire")).unwrap();
+
+    let module = root.join("Modules/Blog");
+    std::os::unix::fs::symlink(&package, &module).unwrap();
+    (dir, root, module, package)
+}
+
+#[cfg(unix)]
+#[test]
+fn a_backing_class_inside_a_symlinked_module_still_loads() {
+    let (_dir, root, module, package) = symlinked_module_project();
+
+    let source = "<?php\nclass Post { public $title = 'x'; }\n";
+    std::fs::write(package.join("src/Livewire/Post.php"), source).unwrap();
+    let class = module.join("src/Livewire/Post.php");
+
+    // Precondition: this really is out of root — the case a root-only gate
+    // refused, and the reason this test exists.
+    let real = class.canonicalize().unwrap();
+    assert!(
+        !real.starts_with(root.canonicalize().unwrap()),
+        "fixture must resolve outside the project root, got {real:?}",
+    );
+
+    let mut actor = loader_test_actor(Some(root));
+    actor.module_dirs = vec![module];
+
+    let file = actor
+        .ensure_external_php_source_loaded(&class)
+        .expect("a class inside a symlinked path-repository module must load");
+    assert_eq!(*file.text(&actor.db), source);
+}
+
+#[cfg(unix)]
+#[test]
+fn a_path_escaping_its_own_module_is_still_refused() {
+    let (dir, root, module, _package) = symlinked_module_project();
+
+    // Neither in the module nor in the project: the escape the widened gate
+    // must still catch.
+    let elsewhere = dir.path().join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+    let secret = elsewhere.join("Secret.php");
+    std::fs::write(&secret, "<?php\nclass Secret { public $token = 'x'; }\n").unwrap();
+
+    // A path that LOOKS like it belongs to the module, so `owning_module`
+    // elects the module as its gate — and the gate then refuses it.
+    let link = module.join("src/Livewire/Escape.php");
+    std::os::unix::fs::symlink(&secret, &link).unwrap();
+
+    let mut actor = loader_test_actor(Some(root));
+    actor.module_dirs = vec![module];
+
+    assert!(
+        actor.ensure_external_php_source_loaded(&link).is_none(),
+        "electing a module gate must not become a way out of it",
+    );
+    assert!(!actor.files.contains_key(&link));
+    assert!(!actor.external_php_text.contains_key(&link));
+}
+
+#[cfg(unix)]
+#[test]
+fn a_module_path_reaching_back_into_the_app_is_refused() {
+    let (_dir, root, module, _package) = symlinked_module_project();
+
+    // Inside the project root, but outside the module that owns the candidate.
+    let app_file = root.join("app/Shared.php");
+    std::fs::write(&app_file, "<?php\nclass Shared {}\n").unwrap();
+
+    let link = module.join("src/Livewire/Shared.php");
+    std::os::unix::fs::symlink(&app_file, &link).unwrap();
+
+    let mut actor = loader_test_actor(Some(root));
+    actor.module_dirs = vec![module];
+
+    // Deliberately STRICTER than a root-only gate, matching the rule
+    // `livewire_namespaces::contained_class_path` already applies to the
+    // registrations that mint these paths: a module reaching into bare `app/`
+    // is inside the root and still outside its own module.
+    assert!(
+        actor.ensure_external_php_source_loaded(&link).is_none(),
+        "a module candidate must resolve inside its own module, not merely in-root",
+    );
+}
+
+#[test]
+fn a_traversing_path_cannot_elect_a_module_as_its_gate() {
+    // A REAL module directory, not a symlinked one: an interior `..` after a
+    // symlink is resolved by the OS against the link's target, which would
+    // send this path nowhere and let the test pass with no guard at all. On a
+    // real directory the escape lands on a real, readable file, so the
+    // assertion can only hold because the gate refused it.
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path().join("project");
+    let module = root.join("Modules/Blog");
+    std::fs::create_dir_all(module.join("src/Livewire")).unwrap();
+
+    let outside = dir.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    let secret = outside.join("Secret.php");
+    std::fs::write(&secret, "<?php\nclass Secret { public $token = 'x'; }\n").unwrap();
+
+    // Textually prefixed by the module dir, and it resolves to a real file.
+    let traversing = module.join("../../../outside/Secret.php");
+    assert!(
+        traversing.canonicalize().is_ok(),
+        "precondition: the escape target must be readable, or the test is vacuous",
+    );
+
+    let mut actor = loader_test_actor(Some(root));
+    actor.module_dirs = vec![module];
+
+    // `owning_module` collapses `..` before its prefix test, so this never
+    // elects the module gate — and the root gate it falls back to refuses it.
+    assert!(
+        actor
+            .ensure_external_php_source_loaded(&traversing)
+            .is_none(),
+        "an interior-`..` escape must not borrow the module's gate",
+    );
+}
+
+#[test]
+fn without_modules_the_gate_is_the_project_root() {
+    // The common case: no `modules.paths`, so `owning_module` never matches
+    // and the gate is exactly the root. Pins that the widening costs nothing
+    // for a project without modules.
+    let (_dir, root, outside) = root_and_outside();
+    let escapee = outside.join("Secret.php");
+    std::fs::write(&escapee, "<?php\nclass Secret {}\n").unwrap();
+
+    let mut actor = loader_test_actor(Some(root.clone()));
+    assert!(actor.module_dirs.is_empty(), "precondition: no modules");
+    assert!(actor.ensure_external_php_source_loaded(&escapee).is_none());
+
+    let inside = root.join("app/Livewire/Counter.php");
+    let source = "<?php\nclass Counter {}\n";
+    std::fs::write(&inside, source).unwrap();
+    let file = actor
+        .ensure_external_php_source_loaded(&inside)
+        .expect("an in-root class still loads with no modules configured");
+    assert_eq!(*file.text(&actor.db), source);
+}

--- a/laravel-lsp/src/tests/component_ancestor_navigation.rs
+++ b/laravel-lsp/src/tests/component_ancestor_navigation.rs
@@ -75,6 +75,14 @@ async fn backend_for(root: &Path) -> LaravelLanguageServer {
     let backend = service.inner().clone();
     *backend.root_path.write().await = Some(root.to_path_buf());
     *backend.cached_config.write().await = Some(Arc::new(config_for(root)));
+    // The actor's own `config_root`, which the backing-class loader's
+    // containment guard reads (#364). Production registers it before the
+    // project walk; caching the config on the backend alone does not.
+    backend
+        .salsa
+        .register_config_files(root.to_path_buf(), None, None, None)
+        .await
+        .expect("actor registers the tempdir project root");
     backend
         .salsa
         .register_project_files(

--- a/laravel-lsp/src/tests/component_member_navigation.rs
+++ b/laravel-lsp/src/tests/component_member_navigation.rs
@@ -19,6 +19,15 @@ async fn backend_with_root(root: &Path) -> LaravelLanguageServer {
     let (service, _socket) = LspService::new(LaravelLanguageServer::new);
     let backend = service.inner().clone();
     *backend.root_path.write().await = Some(root.to_path_buf());
+    // The actor keeps its OWN root, and the backing-class loader's containment
+    // guard reads it (#364). Production always sets the two together — via
+    // `register_config_with_salsa` or the cached-config request — so a fixture
+    // that sets only `root_path` is under-registering.
+    backend
+        .salsa
+        .register_config_files(root.to_path_buf(), None, None, None)
+        .await
+        .expect("actor registers the tempdir project root");
     backend
 }
 

--- a/laravel-lsp/src/tests/external_php_loader_containment.rs
+++ b/laravel-lsp/src/tests/external_php_loader_containment.rs
@@ -1,0 +1,213 @@
+//! Containment of the external-PHP backing-class loader, driven through the
+//! real pipeline (#364).
+//!
+//! `SalsaActor::ensure_external_php_source_loaded` reads a `.php` file from
+//! disk and registers it as a Salsa input; `handle_blade_backing_class_resolution`
+//! then maps every returned handle into `BladeBackingResolutionData::files`,
+//! which is the goto-definition target list. Every candidate reaching it today
+//! is pre-vetted by its caller — the render index walks the project's own
+//! tree, and `livewire_resolver::resolve_component` gates each path segment
+//! through `naming::is_safe_path_segment` — so this is a guard on the
+//! primitive, closing the class rather than trusting the next caller to
+//! remember (the failure shape of #294 and both rounds of #348).
+//!
+//! These tests enter through `SalsaHandle::blade_backing_class_resolution`,
+//! the same entry point `main.rs` uses, so the candidate travels the real
+//! `blade_backing_class_files` path rather than being handed to the loader
+//! directly. The companion unit tests in `salsa_impl/tests.rs` assert the
+//! actor's internal maps, which no handle message exposes.
+
+use laravel_lsp::salsa_impl::SalsaHandle;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn write(path: &Path, contents: &str) -> PathBuf {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+    path.to_path_buf()
+}
+
+/// A handle whose config root and project files are both `root` — the same
+/// pairing production performs before any resolution request can arrive.
+async fn handle_for(root: &Path) -> SalsaHandle {
+    let handle = laravel_lsp::salsa_impl::SalsaActor::spawn();
+    handle
+        .register_config_files(root.to_path_buf(), None, None, None)
+        .await
+        .expect("actor registers the tempdir project root");
+    handle
+        .register_project_files(
+            root.to_path_buf(),
+            vec![PathBuf::from("app/Http/Controllers")],
+            vec![root.join("resources/views")],
+            Some(root.join("resources/views/livewire")),
+            PathBuf::from("routes"),
+        )
+        .await
+        .expect("actor registers the tempdir project");
+    handle
+}
+
+/// Assert `path` really resolves outside `root`, so a mis-built fixture can't
+/// let a rejection test pass vacuously.
+fn assert_outside_root(path: &Path, root: &Path) {
+    let real = path
+        .canonicalize()
+        .expect("the fixture target must exist on disk");
+    let real_root = root.canonicalize().expect("the project root must exist");
+    assert!(
+        !real.starts_with(&real_root),
+        "fixture is not actually out of root: {real:?} is under {real_root:?}"
+    );
+}
+
+/// The paths in a resolution result, as the client would receive them.
+fn resolved_paths(data: &laravel_lsp::salsa_impl::BladeBackingResolutionData) -> Vec<PathBuf> {
+    data.files.clone()
+}
+
+#[tokio::test]
+async fn an_out_of_root_backing_class_candidate_is_not_resolved() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path().join("project");
+    let outside = dir.path().join("outside");
+    fs::create_dir_all(&root).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+
+    // A real, readable file — the rejection must come from containment, not
+    // from a read that would have failed anyway.
+    let escapee = write(
+        &outside.join("Counter.php"),
+        "<?php\nclass Counter { public $secret = 'escaped'; }\n",
+    );
+    assert_outside_root(&escapee, &root);
+
+    let blade = write(
+        &root.join("resources/views/livewire/counter.blade.php"),
+        "<div>{{ $count }}</div>\n",
+    );
+    let handle = handle_for(&root).await;
+
+    let resolved = handle
+        .blade_backing_class_resolution(
+            blade,
+            Some("livewire.counter".to_string()),
+            vec![escapee.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        !resolved_paths(&resolved).contains(&escapee),
+        "an out-of-root candidate must never surface as a goto target: {:?}",
+        resolved.files,
+    );
+    assert!(
+        !resolved.sources.iter().any(|(path, _)| path == &escapee),
+        "and its source must not be read into the resolution either",
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn an_under_root_symlink_escaping_the_root_is_not_resolved() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path().join("project");
+    let outside = dir.path().join("outside");
+    fs::create_dir_all(root.join("app/Livewire")).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+
+    // Distinguishable, non-empty content shared by both fixtures below, so the
+    // contrast isolates containment as the only difference.
+    let source = "<?php\nclass Counter { public $marker = 'distinguishable'; }\n";
+    let target = write(&outside.join("Counter.php"), source);
+
+    let link = root.join("app/Livewire/Counter.php");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    assert_outside_root(&link, &root);
+
+    let blade = write(
+        &root.join("resources/views/livewire/counter.blade.php"),
+        "<div>{{ $count }}</div>\n",
+    );
+    let handle = handle_for(&root).await;
+
+    let escaping = handle
+        .blade_backing_class_resolution(
+            blade.clone(),
+            Some("livewire.counter".to_string()),
+            vec![link.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        !resolved_paths(&escaping).contains(&link),
+        "a path lexically under the root whose target escapes it must be refused: {:?}",
+        escaping.files,
+    );
+
+    // The contrast: identical bytes at a genuine in-root path DO resolve, so
+    // the refusal above tracks containment rather than a coincidental failure
+    // to read a symlinked file.
+    let genuine = write(&root.join("app/Livewire/Real.php"), source);
+    let contained = handle
+        .blade_backing_class_resolution(
+            blade,
+            Some("livewire.counter".to_string()),
+            vec![genuine.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        resolved_paths(&contained).contains(&genuine),
+        "the same content at an in-root path must still resolve: {:?}",
+        contained.files,
+    );
+}
+
+#[tokio::test]
+async fn an_in_root_backing_class_resolves_to_its_exact_disk_content() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let root = dir.path();
+
+    let source = "<?php\nclass Counter\n{\n    public function saved(): void {}\n}\n";
+    let class = write(&root.join("app/Livewire/Counter.php"), source);
+    let blade = write(
+        &root.join("resources/views/livewire/counter.blade.php"),
+        "<div>{{ $count }}</div>\n",
+    );
+    let handle = handle_for(root).await;
+
+    let resolved = handle
+        .blade_backing_class_resolution(
+            blade,
+            Some("livewire.counter".to_string()),
+            vec![class.clone()],
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        resolved_paths(&resolved).contains(&class),
+        "an in-root backing class must resolve: {:?}",
+        resolved.files,
+    );
+    let text = resolved
+        .sources
+        .iter()
+        .find(|(path, _)| path == &class)
+        .map(|(_, text)| text.clone())
+        .expect("the backing class contributes its source");
+    // Compared against the bytes the test WROTE, read back off disk — not a
+    // literal duplicated on both sides of the assertion.
+    assert_eq!(
+        text,
+        fs::read_to_string(&class).unwrap(),
+        "the guard must return the file's real content, unchanged",
+    );
+    assert_eq!(text, source);
+}

--- a/laravel-lsp/src/tests/external_php_loader_containment.rs
+++ b/laravel-lsp/src/tests/external_php_loader_containment.rs
@@ -61,11 +61,6 @@ fn assert_outside_root(path: &Path, root: &Path) {
     );
 }
 
-/// The paths in a resolution result, as the client would receive them.
-fn resolved_paths(data: &laravel_lsp::salsa_impl::BladeBackingResolutionData) -> Vec<PathBuf> {
-    data.files.clone()
-}
-
 #[tokio::test]
 async fn an_out_of_root_backing_class_candidate_is_not_resolved() {
     let dir = tempfile::TempDir::new().unwrap();
@@ -99,7 +94,7 @@ async fn an_out_of_root_backing_class_candidate_is_not_resolved() {
         .unwrap();
 
     assert!(
-        !resolved_paths(&resolved).contains(&escapee),
+        !resolved.files.contains(&escapee),
         "an out-of-root candidate must never surface as a goto target: {:?}",
         resolved.files,
     );
@@ -143,7 +138,7 @@ async fn an_under_root_symlink_escaping_the_root_is_not_resolved() {
         .await
         .unwrap();
     assert!(
-        !resolved_paths(&escaping).contains(&link),
+        !escaping.files.contains(&link),
         "a path lexically under the root whose target escapes it must be refused: {:?}",
         escaping.files,
     );
@@ -162,7 +157,7 @@ async fn an_under_root_symlink_escaping_the_root_is_not_resolved() {
         .await
         .unwrap();
     assert!(
-        resolved_paths(&contained).contains(&genuine),
+        contained.files.contains(&genuine),
         "the same content at an in-root path must still resolve: {:?}",
         contained.files,
     );
@@ -192,7 +187,7 @@ async fn an_in_root_backing_class_resolves_to_its_exact_disk_content() {
         .unwrap();
 
     assert!(
-        resolved_paths(&resolved).contains(&class),
+        resolved.files.contains(&class),
         "an in-root backing class must resolve: {:?}",
         resolved.files,
     );

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod env_key_navigation;
 mod env_source_registration_gate;
 mod env_value_redaction;
 mod expected_path_diagnostic_containment;
+mod external_php_loader_containment;
 mod factory_goto_def_handler;
 mod flux_component_context;
 mod flux_component_hover;

--- a/laravel-lsp/src/tests/render_index_and_buffer_integrity.rs
+++ b/laravel-lsp/src/tests/render_index_and_buffer_integrity.rs
@@ -23,9 +23,18 @@ fn write(path: &Path, contents: &str) -> PathBuf {
 }
 
 /// A handle whose project is `root`, with `resources/views` registered as the
-/// view root so the Blade files below land in the actor's view-file list.
+/// view root so the Blade files below land in the actor's view-file list, and
+/// `root` registered as the config root.
 async fn handle_for(root: &Path) -> SalsaHandle {
     let handle = laravel_lsp::salsa_impl::SalsaActor::spawn();
+    // Registers the actor's `config_root`, which the backing-class loader's
+    // containment guard needs before it will read anything (#364). Production
+    // always sets it first — either here or via `RegisterCachedConfig` — so a
+    // fixture that skips it is under-registering, not exercising a real state.
+    handle
+        .register_config_files(root.to_path_buf(), None, None, None)
+        .await
+        .expect("actor registers the tempdir project root");
     handle
         .register_project_files(
             root.to_path_buf(),


### PR DESCRIPTION
## Summary

`SalsaActor::ensure_external_php_source_loaded` read file metadata and content straight from disk and registered the result as a Salsa `SourceFile`, which `handle_blade_backing_class_resolution` maps into `BladeBackingResolutionData::files` — the goto-definition target list. It carried no containment guard of its own.

Nothing escapes today: render-index candidates come from the project's own directory walk, and Livewire candidates come from `livewire_resolver::resolve_component`, which gates every path segment through `naming::is_safe_path_segment`. The hazard is structural — the guard lived in the callers, and *a new read site does not inherit the guard its neighbours carry*. That exact shape has already become a security fix three times in this repo (#294, #348 round 1, #348 round 2).

The guard now lives at the primitive.

Fixes #364

## The guard, split by branch

The two branches ask different questions, so they take different guards. The split is the AC bullet 2 waiver granted [in review](https://github.com/mike-bronner/zed-laravel/pull/366#issuecomment-5463921559) — the read branch keeps the full fail-closed guard, and the emit-safe guard is an *addition* to a branch the read guard never covered.

```rust
// Root unknown: refuse before any state is read, mutated, or stat'd.
let root = self.config_root.clone()?;

// Gate against the candidate's OWNING MODULE where it has one.
let gate = crate::config::owning_module(&self.module_dirs, path)
    .map(|(_, dir)| dir.to_path_buf())
    .unwrap_or(root);

if self.external_php_text.get(path) == Some(&ExternalPhpText::PushedByClient) {
    // Reads no disk — but the path IS emitted as a goto target.
    if !path_within_root_emit_safe(path, &gate) { return None; }
    if let Some(file) = self.files.get(path).copied() { return Some(file); }
}

// Reads real bytes, so containment must be proven.
let real = canonical_within_root_registration(path, &gate)?;
let current_mtime = std::fs::metadata(&real).ok()?.modified().ok()?;
// …
let text = std::fs::read_to_string(&real).ok()?;
```

- **Ownership fast path → `path_within_root_emit_safe`.** Its lexical pre-gate refuses an out-of-root candidate with no `stat` probe (#145). Its `None` arm admits a *genuinely absent* in-root path — the unsaved-buffer case #361 exists to protect — while refusing a dangling under-root symlink and every non-`NotFound` lstat error. The fail-closed read guard cannot serve this branch: it refuses exactly the momentarily-absent buffer, which would reintroduce #361. There is a test that proves this.
- **Disk branch → `canonical_within_root_registration`.** Documented for precisely this shape: a path minted from discovered source data and then read. Keeps the lexical pre-gate, fails closed on anything it cannot canonicalize.
- **The gate is the candidate's owning module, falling back to the project root.** `config::expand_module_dirs` admits a module directory whose real target sits outside the project *on purpose* — that is the composer path-repository layout — and `livewire_namespaces::contained_class_path` gates the registrations that mint these paths against the same owning module so they survive. Gating this read against the root alone dropped every backing class inside such a module, silently. The swap does not loosen the guard; for a module path it **tightens** it, because a candidate lexically under a module must canonicalize inside *that* module, so one reaching into a sibling module or into bare `app/` is refused despite being in-root. `config::owning_module` collapses `..` before its prefix test, so a traversing path cannot elect itself a laxer gate, and with no `modules.paths` configured it never matches — the gate is exactly the root and behaviour is unchanged.
- **Both filesystem calls go through `real`**, the verified canonical path the guard returns — never re-derived from `path`, so a symlink swapped between guard and read cannot hand back a target the guard never approved. `path` stays the key for `self.files` and `external_php_text` so caller lookups still resolve.

## Tests

Every rejection test below was verified to **fail** with the guards removed; both positive tests still pass without them, so they pin non-regression rather than the guard.

**`salsa_impl/tests.rs` — direct-actor, asserting the internal maps** (AC bullets 3, 6, 7). No `SalsaHandle` message exposes `files` or `external_php_text`, so `SalsaActor::new` was extracted from `spawn` (first commit, no behaviour change) to let the in-crate test module hold an actor.

| Test | Pins |
|---|---|
| `loader_refuses_an_out_of_root_candidate_and_caches_nothing` | rejection leaves no `files` / `external_php_text` entry |
| `loader_refuses_a_candidate_when_the_root_is_unknown` | the `config_root` short-circuit — proved by loading the *same path* once the root is set |
| `loader_refuses_an_under_root_symlink_that_escapes` | symlink escape, with an identical-content in-root contrast |
| `retargeting_a_symlink_out_of_root_cannot_disturb_the_cached_load` | cached text **and** recorded mtime survive a later escape attempt |
| `a_client_pushed_out_of_root_path_is_refused_even_when_cached` | client ownership is not a containment exemption |
| `a_client_pushed_in_root_buffer_still_answers_while_its_file_is_absent` | #361 stays whole under the guard |
| `a_backing_class_inside_a_symlinked_module_still_loads` | a composer path-repository module resolves |
| `a_path_escaping_its_own_module_is_still_refused` | electing a module gate is not a way out of it |
| `a_module_path_reaching_back_into_the_app_is_refused` | in-root is not enough for a module candidate |
| `a_traversing_path_cannot_elect_a_module_as_its_gate` | `..` is collapsed before the gate is chosen |
| `without_modules_the_gate_is_the_project_root` | zero change for a project without modules |

**`src/tests/external_php_loader_containment.rs` — through the real pipeline** (AC bullets 4, 5, 8). Candidates enter via `SalsaHandle::blade_backing_class_resolution`, the same entry point `main.rs` uses, and travel `blade_backing_class_files` rather than being handed to the loader directly. Each rejection test asserts the fixture's canonicalized path really is outside the root first, so it cannot pass vacuously. The positive test compares the resolved source against bytes read back off disk, not a literal duplicated on both sides.

## Fixture correction

Three test harnesses set the *backend's* `root_path` but never the *actor's* `config_root`. `handle_register_project_files` does not set it — only `handle_register_config_files` and the `RegisterCachedConfig` request do. Production always registers config first (`main.rs:8229` for the mid-session root change, `main.rs:23644` for startup, with `RegisterCachedConfig` covering the warm-cache branch), so this was fixture drift, not a behaviour change:

- `src/tests/render_index_and_buffer_integrity.rs`
- `src/tests/component_ancestor_navigation.rs`
- `src/tests/component_member_navigation.rs`

## Sibling-site audit (AC bullet 9)

Every site in `salsa_impl.rs` that reads file content/metadata from disk, or reads/writes `self.files`, with its containment status.

### Direct filesystem reads

| Line | Site | Status |
|---|---|---|
| `2057`, `2076` | `TranslationCache::ensure_file` / `ensure_dir` | **Guarded** — `path_within_root` immediately above each (#248) |
| `2120` | `TranslationCache::ensure_config` | **Contained by construction** — the only caller is `config_value`, whose only caller is `completion_locale`, which passes the two literals `"app.locale"` / `"app.fallback_locale"`. `group` is therefore always `"app"`; no project-derived text reaches `config_group_files` |
| `2537` | `TranslationCache::ensure_provider` | **Contained by construction, already documented** — paths come from walking the project's own `vendor/` and `app/Providers/`. This PR follows its doc-comment precedent |
| `10099`, `10110` | `ensure_external_php_source_loaded` | **Guarded by this PR**, and read through the guard's verified canonical path |
| `11360` | `ensure_file_registered` | **Contained by construction — rationale comment added by this PR.** See below |
| `11936` | `handle_resolve_facade_receiver_at` | **Guarded upstream** — `class_file` comes from `class_locator::find_php_class_file_in_app_or_vendor`, which applies `path_within_root` to every candidate (`class_locator.rs:405`) and revalidates cache hits with it (`:163`, `:234`) |

### `self.files` accesses

`2009`, `2014`, `2035`, `2052` are `TranslationCache::files` (a `HashMap<PathBuf, LangFile>`), a different map from `SalsaActor::files`; its read is guarded at `2057`. On the actor:

| Line | Site | Status |
|---|---|---|
| `9146` | `RemoveFile` handler | Eviction only, keyed by a path the client named |
| `9816`, `9823` | `handle_update_file` | Client push of the client's own open document |
| `9997`, `10013` | `ensure_blade_source_registered` | Client push (live editor buffer), no disk read |
| `10076`, `10103`, `10118`, `10122`, `10128` | inside the loader | **Guarded by this PR** — every one sits after the branch's guard |
| `10133`, `10154` | `handle_get_php_assignments`, `handle_get_document_symbols` | Read-only lookup of an already-registered input; no filesystem call, no registration |
| `10209`, `11594`, `11687`, `11899`, `11976` | reads immediately after `ensure_file_registered` | Same containment as that function |
| `11359` | `ensure_file_registered` | See below |

### `ensure_file_registered` — resolved as *contained*, with a comment

All five call sites (`handle_get_patterns`, `handle_find_magic_member_references`, `hover_for_magic_member`, `handle_resolve_facade_receiver_at`, `handle_magic_member_rename_data`) pass the **request's own `textDocument.uri`** — the document the client already has open and is asking about. That is not a path minted by joining project-derived text onto a directory, so there is no traversal to fence: the client supplied the path, holds the file open, and `did_open`/`did_change` already register arbitrary client paths through `handle_update_file`. The text read is parsed for the answer; the path itself is never emitted as a new navigation target.

Guarding it would also be a behaviour change rather than a hardening — a file legitimately open outside the workspace root would stop answering hover and goto entirely. The rationale is recorded as a doc comment on the function, following the `ensure_provider` precedent.

## Review round 1 — the module-gate regression

The first push gated against `config_root` alone. That silently dropped every backing class inside a module symlinked in from a composer path repository — the exact silent-failure mode `livewire_namespaces.rs:205` records having already been made and fixed one module over. Caught by adversarial review, reproduced with a failing test, fixed by the owning-module gate described above.

Every containment test was then verified against two mutations — reverting the gate to root-only, and removing both guards. That sweep also caught one new test passing under *both* mutations: the traversal case had been built on a symlinked module directory, where the OS resolves an interior `..` against the link's target, so the escape landed nowhere and `metadata()` failed regardless of any guard. Rebuilt on a real directory so the escape target is genuinely readable; it now fails when the guard is removed.

## Verification

- `cargo test` — 3609 passed, 0 failed
- `cargo clippy --all-targets` — clean
- `cargo fmt --check` — clean
