### PR TITLE
External-PHP loader ownership is acquired but never released — a discarded buffer serves phantom text after did_close

### DIFF
--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -24150,6 +24150,30 @@ impl LanguageServer for LaravelLanguageServer {
         // model buffer, dropping its `$this->status` entry). External edits to
         // a closed file are still picked up via `did_change_watched_files`,
         // and a real delete still goes through `RemoveFile`.
+        //
+        // What DOES end here is the buffer's OWNERSHIP of that text.
+        // `did_open`/`did_change` stamp `ExternalPhpText::PushedByClient` so
+        // the backing-class loader never reads disk over an unsaved edit —
+        // a promise to keep pushing that only holds while the buffer is open.
+        // Discarding changes on close writes nothing to disk, so no
+        // `did_change_watched_files` event ever arrives to correct it, and the
+        // loader would go on serving text that exists neither on disk nor in
+        // any buffer. Releasing ownership is the matching edge to that
+        // acquire: the path downgrades to unowned and the next resolution
+        // re-reads disk. It evicts NOTHING, which is what makes it compatible
+        // with the paragraph above.
+        //
+        // Unlike the acquire, this call can fail — but only by the actor
+        // being unreachable, and the loader whose read the release exists to
+        // unblock runs INSIDE that same actor. A failed release therefore
+        // cannot leave phantom text behind for anything to serve; there is no
+        // live reader left to serve it. Logging is the whole remedy, at the
+        // level `did_open` already uses for its own Salsa push.
+        if let Ok(path) = uri.to_file_path() {
+            if let Err(e) = self.salsa.release_external_php_ownership(path).await {
+                debug!("did_close: external-PHP ownership release failed: {e}");
+            }
+        }
 
         // Publish empty diagnostics to clear them from the client
         self.client.publish_diagnostics(uri, vec![], None).await;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -23935,6 +23935,22 @@ impl LanguageServer for LaravelLanguageServer {
             self.try_discover_from_file(&file_path).await;
             info!("   ⏱️  try_discover_from_file: {:?}", t1.elapsed());
 
+            // Take the buffer's claim on this path's text, which `did_close`
+            // hands back (see there). It goes BEFORE the push, not after: a
+            // `didClose` for a previous buffer of this same path can still be
+            // in flight — tower-lsp runs notification handlers concurrently —
+            // and only acquire-first leaves every landing point for it safe.
+            // Push-first leaves one window where the close lands between the
+            // push and the acquire, releasing the buffer that just installed
+            // its text.
+            if let Err(e) = self
+                .salsa
+                .acquire_external_php_ownership(file_path.clone())
+                .await
+            {
+                debug!("did_open: external-PHP ownership acquire failed: {e}");
+            }
+
             // Update Salsa database with new file content
             let t2 = std::time::Instant::now();
             if let Err(e) = self
@@ -24159,9 +24175,16 @@ impl LanguageServer for LaravelLanguageServer {
         // `did_change_watched_files` event ever arrives to correct it, and the
         // loader would go on serving text that exists neither on disk nor in
         // any buffer. Releasing ownership is the matching edge to that
-        // acquire: the path downgrades to unowned and the next resolution
-        // re-reads disk. It evicts NOTHING, which is what makes it compatible
-        // with the paragraph above.
+        // acquire: once the path's LAST buffer closes it downgrades to
+        // unowned and the next resolution re-reads disk. It evicts NOTHING,
+        // which is what makes it compatible with the paragraph above.
+        //
+        // "Last buffer" is not pedantry. This notification and the `didOpen`
+        // of a buffer that reopens the same path — a revert, an editor
+        // relaunching a tab — run concurrently under tower-lsp, so this close
+        // can reach the Salsa actor after that open. `did_open` counts its
+        // buffer in before pushing, and the release only downgrades the path
+        // when that count runs out, so a reopened buffer keeps its text.
         //
         // Unlike the acquire, this call can fail — but only by the actor
         // being unreachable, and the loader whose read the release exists to

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -24176,8 +24176,18 @@ impl LanguageServer for LaravelLanguageServer {
         // loader would go on serving text that exists neither on disk nor in
         // any buffer. Releasing ownership is the matching edge to that
         // acquire: once the path's LAST buffer closes it downgrades to
-        // unowned and the next resolution re-reads disk. It evicts NOTHING,
-        // which is what makes it compatible with the paragraph above.
+        // unowned and the next resolution re-reads disk.
+        //
+        // The release drops that path's Salsa text and its per-file caches
+        // along with the claim, because the loader is not the only reader of
+        // what a buffer installed — `handle_get_patterns` and the three
+        // per-file cache queries read `files[path]` directly, and the pattern
+        // cache is served with no version check. Dropping the input makes them
+        // all re-derive from disk on their next question, still lazily: nothing
+        // is read here. It evicts NOTHING ELSE — the symbol index, the reverse
+        // component-usage index, the class-hierarchy index and the resolved
+        // magic-member entries all stand, which is what makes this compatible
+        // with the paragraph above.
         //
         // "Last buffer" is not pedantry. This notification and the `didOpen`
         // of a buffer that reopens the same path — a revert, an editor

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -6464,6 +6464,13 @@ pub enum SalsaRequest {
         path: PathBuf,
         reply: oneshot::Sender<()>,
     },
+    /// Hand a client-pushed path's text back to the backing-class loader,
+    /// evicting nothing — see
+    /// [`SalsaActor::release_external_php_ownership`].
+    ReleaseExternalPhpOwnership {
+        path: PathBuf,
+        reply: oneshot::Sender<()>,
+    },
 
     /// Tell the actor to update its per-category file lists in
     /// response to a filesystem event from the language client. The
@@ -7240,6 +7247,24 @@ impl SalsaHandle {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
             .send(SalsaRequest::RemoveFile {
+                path,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Release a client push's ownership of `path`'s text, so the
+    /// backing-class loader re-reads disk on its next resolution. Evicts
+    /// nothing — see [`SalsaActor::release_external_php_ownership`] for why
+    /// this is not [`SalsaHandle::remove_file`].
+    pub async fn release_external_php_ownership(&self, path: PathBuf) -> Result<(), &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::ReleaseExternalPhpOwnership {
                 path,
                 reply: reply_tx,
             })
@@ -8696,6 +8721,14 @@ enum ExternalPhpText {
     /// pusher owns invalidation for this path and the loader must not read
     /// disk over it: a live buffer would lose the user's unsaved edits, and a
     /// watched file is already being kept current by the watcher.
+    ///
+    /// The promise to push again lasts exactly as long as the pusher does.
+    /// The watcher never goes away, so a watched file holds this state for the
+    /// session; an editor buffer does, so `textDocument/didClose` hands the
+    /// path back via [`SalsaActor::release_external_php_ownership`]. Closing a
+    /// buffer whose edits were DISCARDED writes nothing to disk and fires no
+    /// watcher event, so without that release this state would outlive every
+    /// source able to correct it.
     PushedByClient,
 }
 
@@ -9136,6 +9169,10 @@ impl SalsaActor {
                         self.class_hierarchy_index.remove_file(&path);
                         self.class_files_snapshot = None; // hierarchy changed
                     }
+                    let _ = reply.send(());
+                }
+                SalsaRequest::ReleaseExternalPhpOwnership { path, reply } => {
+                    self.release_external_php_ownership(&path);
                     let _ = reply.send(());
                 }
 
@@ -9842,6 +9879,42 @@ impl SalsaActor {
     fn mark_pushed_by_client(&mut self, path: &Path) {
         self.external_php_text
             .insert(path.to_path_buf(), ExternalPhpText::PushedByClient);
+    }
+
+    /// Hand `path`'s text back to the loader — the release edge matching
+    /// [`SalsaActor::mark_pushed_by_client`]'s acquire, driven by
+    /// `textDocument/didClose`.
+    ///
+    /// Dropping the entry restores the "nobody installed text here" state,
+    /// the one [`SalsaActor::ensure_external_php_source_loaded`] reads as
+    /// "read disk unconditionally". That is the whole point: a buffer can be
+    /// closed with its edits DISCARDED, which writes nothing to disk and so
+    /// fires no `did_change_watched_files`. Without a release the pusher's
+    /// promise to push again outlives the pusher, and the loader keeps
+    /// serving text that exists neither on disk nor in any open buffer.
+    ///
+    /// The drop is unconditional rather than gated on the entry actually
+    /// being `PushedByClient`. `did_open` pushes every opened path through
+    /// `update_file`, and the loader refuses to write over a pushed path, so
+    /// an open document's entry stays `PushedByClient` for as long as it is
+    /// open — a `LoadedFromDisk` guard here would be a branch no `didClose`
+    /// can reach, and therefore one no test can honestly pin. Were it
+    /// reached, the two spellings differ by one disk read and not by any
+    /// answer: the loader re-reads, re-stamps the mtime, and serves the same
+    /// text. Dropping is also the safe direction for the defect this closes —
+    /// every divergence falls toward consulting disk, never toward serving a
+    /// buffer nobody holds.
+    ///
+    /// Infallible and idempotent by the same token: `didClose` fires for every
+    /// closed document, most of which never enter this map, and removing an
+    /// absent key is a no-op.
+    ///
+    /// Deliberately NOT `RemoveFile`. The `SourceFile` input, the per-file
+    /// caches and the resolved magic-member entries all stay; only ownership
+    /// changes, and the next loader read replaces the text. See the comment in
+    /// `Backend::did_close` for why eviction on close is the wrong tool.
+    fn release_external_php_ownership(&mut self, path: &Path) {
+        self.external_php_text.remove(path);
     }
 
     /// Handle a Blade loop-blocks query. Memoized via Salsa + actor LRU.

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -10045,6 +10045,26 @@ impl SalsaActor {
         // refuses to evict, and nothing here touches them.
         self.files.remove(path);
         self.invalidate_file_caches(path);
+
+        // The three deferred indexes are readers too, and neither of the lines
+        // above reaches them: they answer `find_references` and the code lenses
+        // out of their own maps, refreshed lazily from whatever `mark_dirty`
+        // queued. A query run WHILE the buffer was open drains that queue, so
+        // the index is left holding the buffer's literals with the flag already
+        // cleared — a `view('…')` the discarded buffer introduced would keep
+        // answering find-references forever, pointing at a file that never
+        // contained it.
+        //
+        // Re-queueing is what `handle_update_file` does for any other change of
+        // a path's text, and this is one: the text just went from the buffer's
+        // back to disk's. It is NOT eviction — the drain runs
+        // `remove_literal_entries` + `insert_file`, which deliberately keeps
+        // the resolved magic-member entries that only a warm or save pass can
+        // rebuild, and which are the whole reason `did_close` refuses
+        // `RemoveFile`.
+        self.symbol_index.mark_dirty(path);
+        self.class_hierarchy_index.mark_dirty(path);
+        self.component_usage_index.mark_dirty(path);
     }
 
     /// Handle a Blade loop-blocks query. Memoized via Salsa + actor LRU.

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -10022,6 +10022,29 @@ impl SalsaActor {
             self.external_php_open_buffers.remove(path);
         }
         self.external_php_text.remove(path);
+
+        // Drop the TEXT that stamp was protecting, not merely the claim on it.
+        // Releasing ownership alone un-blocks the LOADER, and the loader is not
+        // the only reader: `handle_get_patterns`, `handle_get_document_symbols`,
+        // `handle_get_loop_blocks` and `handle_get_php_assignments` all read
+        // `files[path]` directly, and `pattern_cache` is checked with NO version
+        // comparison — so an entry derived from the discarded buffer is served
+        // forever rather than merely once. Find-references answering out of it
+        // names a symbol that exists in no file at all.
+        //
+        // Removing the input restores the same "nobody installed text here"
+        // state the line above restores for ownership, for every reader at
+        // once: `ensure_file_registered` finds the slot vacant and reads disk,
+        // and `ensure_external_php_source_loaded` reloads through its own
+        // containment guard. This stays LAZY — nothing is read at close time;
+        // the re-read lands on whichever query asks first.
+        //
+        // Deliberately NOT `RemoveFile`: the symbol index, the reverse
+        // component-usage index, the class-hierarchy index and the resolved
+        // magic-member entries are all left standing. Those are what `did_close`
+        // refuses to evict, and nothing here touches them.
+        self.files.remove(path);
+        self.invalidate_file_caches(path);
     }
 
     /// Handle a Blade loop-blocks query. Memoized via Salsa + actor LRU.

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -6464,8 +6464,16 @@ pub enum SalsaRequest {
         path: PathBuf,
         reply: oneshot::Sender<()>,
     },
-    /// Hand a client-pushed path's text back to the backing-class loader,
-    /// evicting nothing — see
+    /// Record that an editor buffer for this path is open, so a `didClose`
+    /// for an earlier buffer of the same path cannot hand the live one back
+    /// to the loader — see [`SalsaActor::acquire_external_php_ownership`].
+    AcquireExternalPhpOwnership {
+        path: PathBuf,
+        reply: oneshot::Sender<()>,
+    },
+
+    /// Hand a client-pushed path's text back to the backing-class loader once
+    /// its last buffer closes, evicting nothing — see
     /// [`SalsaActor::release_external_php_ownership`].
     ReleaseExternalPhpOwnership {
         path: PathBuf,
@@ -7257,10 +7265,29 @@ impl SalsaHandle {
             .map_err(|_| "Salsa actor dropped reply channel")
     }
 
-    /// Release a client push's ownership of `path`'s text, so the
-    /// backing-class loader re-reads disk on its next resolution. Evicts
-    /// nothing — see [`SalsaActor::release_external_php_ownership`] for why
-    /// this is not [`SalsaHandle::remove_file`].
+    /// Register an open editor buffer for `path`, the acquire half of
+    /// [`SalsaHandle::release_external_php_ownership`]. Call it BEFORE the
+    /// buffer's [`SalsaHandle::update_file`] push — see
+    /// [`SalsaActor::acquire_external_php_ownership`] for what that ordering
+    /// buys.
+    pub async fn acquire_external_php_ownership(&self, path: PathBuf) -> Result<(), &'static str> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(SalsaRequest::AcquireExternalPhpOwnership {
+                path,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| "Salsa actor disconnected")?;
+        reply_rx
+            .await
+            .map_err(|_| "Salsa actor dropped reply channel")
+    }
+
+    /// Release one open buffer's claim on `path`'s text. Once the last claim
+    /// goes, the backing-class loader re-reads disk on its next resolution.
+    /// Evicts nothing — see [`SalsaActor::release_external_php_ownership`] for
+    /// why this is not [`SalsaHandle::remove_file`].
     pub async fn release_external_php_ownership(&self, path: PathBuf) -> Result<(), &'static str> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
@@ -8725,10 +8752,10 @@ enum ExternalPhpText {
     /// The promise to push again lasts exactly as long as the pusher does.
     /// The watcher never goes away, so a watched file holds this state for the
     /// session; an editor buffer does, so `textDocument/didClose` hands the
-    /// path back via [`SalsaActor::release_external_php_ownership`]. Closing a
-    /// buffer whose edits were DISCARDED writes nothing to disk and fires no
-    /// watcher event, so without that release this state would outlive every
-    /// source able to correct it.
+    /// path back via [`SalsaActor::release_external_php_ownership`] once the
+    /// path's last open buffer goes. Closing a buffer whose edits were
+    /// DISCARDED writes nothing to disk and fires no watcher event, so without
+    /// that release this state would outlive every source able to correct it.
     PushedByClient,
 }
 
@@ -8808,6 +8835,24 @@ pub struct SalsaActor {
     /// installed text for that path", which is the only state that permits an
     /// unconditional read.
     external_php_text: HashMap<PathBuf, ExternalPhpText>,
+    /// How many open editor buffers currently claim each path. Incremented by
+    /// `textDocument/didOpen` and decremented by `didClose`; the
+    /// `PushedByClient` stamp above is handed back only when the count reaches
+    /// zero. Absent means zero.
+    ///
+    /// Counting — rather than one flag per path — is what makes the release
+    /// safe against out-of-order handlers. tower-lsp drives up to four
+    /// notification handlers concurrently, so the `didOpen` of a REOPENED
+    /// buffer can reach this actor before the `didClose` that preceded it at
+    /// the client. Increments and decrements commute, so the pair settles at
+    /// one whichever order it arrives in, and the live buffer keeps its
+    /// ownership; a flag would read "closed" and hand a live buffer back to
+    /// the loader, which then overwrites the shared `SourceFile` text every
+    /// other query reads.
+    ///
+    /// Kept by the open/close edges alone: `RemoveFile` deliberately does not
+    /// clear it, because deleting a path on disk does not close its buffer.
+    external_php_open_buffers: HashMap<PathBuf, u32>,
     /// Monotonic version counter for external PHP SourceFiles (incremented per disk re-read).
     /// Monotonic stamp for the text currently installed in `files[path]`,
     /// bumped by EVERY writer, and the key the three per-file LRU caches
@@ -9014,6 +9059,7 @@ impl SalsaActor {
                 php_assignments_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 document_symbols_cache: LruCache::new(NonZeroUsize::new(256).unwrap()),
                 external_php_text: HashMap::with_capacity(64),
+                external_php_open_buffers: HashMap::with_capacity(64),
                 text_revision: 0,
                 file_text_revisions: HashMap::with_capacity(64),
                 // Config management
@@ -9169,6 +9215,10 @@ impl SalsaActor {
                         self.class_hierarchy_index.remove_file(&path);
                         self.class_files_snapshot = None; // hierarchy changed
                     }
+                    let _ = reply.send(());
+                }
+                SalsaRequest::AcquireExternalPhpOwnership { path, reply } => {
+                    self.acquire_external_php_ownership(&path);
                     let _ = reply.send(());
                 }
                 SalsaRequest::ReleaseExternalPhpOwnership { path, reply } => {
@@ -9881,9 +9931,32 @@ impl SalsaActor {
             .insert(path.to_path_buf(), ExternalPhpText::PushedByClient);
     }
 
-    /// Hand `path`'s text back to the loader — the release edge matching
-    /// [`SalsaActor::mark_pushed_by_client`]'s acquire, driven by
-    /// `textDocument/didClose`.
+    /// Count one more open editor buffer for `path`, driven by
+    /// `textDocument/didOpen`. Nothing else: the text and its
+    /// `PushedByClient` stamp arrive with the buffer's own `update_file`
+    /// push, and this only records that a buffer is holding the path so
+    /// [`SalsaActor::release_external_php_ownership`] knows when the last one
+    /// lets go.
+    ///
+    /// **`did_open` must enqueue this BEFORE its `update_file` push.** A
+    /// `didClose` for a previous buffer of the same path can be in flight
+    /// concurrently and lands somewhere in this sequence. Acquire-first leaves
+    /// every landing point safe: before the acquire it releases the earlier
+    /// buffer's stamp, which the push then re-installs; between or after, it
+    /// decrements to a non-zero count and drops nothing. Push-first opens one
+    /// window where the release lands after the stamp with the count still at
+    /// zero — a live buffer left unowned, which is the defect the release
+    /// exists to prevent, reached from the other side.
+    fn acquire_external_php_ownership(&mut self, path: &Path) {
+        *self
+            .external_php_open_buffers
+            .entry(path.to_path_buf())
+            .or_insert(0) += 1;
+    }
+
+    /// Hand `path`'s text back to the loader once its LAST open buffer goes —
+    /// the release edge matching [`SalsaActor::mark_pushed_by_client`]'s
+    /// acquire, driven by `textDocument/didClose`.
     ///
     /// Dropping the entry restores the "nobody installed text here" state,
     /// the one [`SalsaActor::ensure_external_php_source_loaded`] reads as
@@ -9893,27 +9966,40 @@ impl SalsaActor {
     /// promise to push again outlives the pusher, and the loader keeps
     /// serving text that exists neither on disk nor in any open buffer.
     ///
-    /// The drop is unconditional rather than gated on the entry actually
-    /// being `PushedByClient`. `did_open` pushes every opened path through
-    /// `update_file`, and the loader refuses to write over a pushed path, so
-    /// an open document's entry stays `PushedByClient` for as long as it is
-    /// open — a `LoadedFromDisk` guard here would be a branch no `didClose`
-    /// can reach, and therefore one no test can honestly pin. Were it
-    /// reached, the two spellings differ by one disk read and not by any
-    /// answer: the loader re-reads, re-stamps the mtime, and serves the same
-    /// text. Dropping is also the safe direction for the defect this closes —
-    /// every divergence falls toward consulting disk, never toward serving a
-    /// buffer nobody holds.
+    /// A path with buffers left is NOT handed back. tower-lsp runs
+    /// notification handlers concurrently, so this close can arrive after the
+    /// `didOpen` of a buffer that reopened the same path — a revert, or Zed's
+    /// multibuffer lifecycle. The count is what distinguishes the two: it
+    /// still reads one, so the reopened buffer keeps its stamp. Releasing
+    /// there would leave a live buffer unowned, and the loader's next read
+    /// does not merely answer from disk — it writes disk text into the shared
+    /// `SourceFile` every per-file query reads, so a hover in one file would
+    /// silently revert another file's buffer text.
     ///
-    /// Infallible and idempotent by the same token: `didClose` fires for every
-    /// closed document, most of which never enter this map, and removing an
-    /// absent key is a no-op.
+    /// With no count at all the stamp goes. That is the state a
+    /// `didChangeWatchedFiles` push leaves behind — ownership with no buffer
+    /// to close it — and the safe direction besides: every divergence falls
+    /// toward consulting disk, never toward serving a buffer nobody holds.
+    ///
+    /// Infallible and idempotent: `didClose` fires for every closed document,
+    /// most of which never enter either map, and removing an absent key is a
+    /// no-op.
     ///
     /// Deliberately NOT `RemoveFile`. The `SourceFile` input, the per-file
     /// caches and the resolved magic-member entries all stay; only ownership
     /// changes, and the next loader read replaces the text. See the comment in
     /// `Backend::did_close` for why eviction on close is the wrong tool.
     fn release_external_php_ownership(&mut self, path: &Path) {
+        if let Some(open_buffers) = self.external_php_open_buffers.get_mut(path) {
+            // A present key is always at least one: the acquire inserts at
+            // one, and the branch below removes the key rather than leaving a
+            // zero behind. So this cannot underflow.
+            *open_buffers -= 1;
+            if *open_buffers > 0 {
+                return;
+            }
+            self.external_php_open_buffers.remove(path);
+        }
         self.external_php_text.remove(path);
     }
 

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -6206,3 +6206,89 @@ fn without_modules_the_gate_is_the_project_root() {
         .expect("an in-root class still loads with no modules configured");
     assert_eq!(*file.text(&actor.db), source);
 }
+
+// ─── Ownership release, at the actor's own state (#365) ────────────────
+//
+// The release does two things — hands the `PushedByClient` stamp back, and
+// drops the text that stamp was protecting — and the second MASKS the first
+// from every behavioural test. With the input gone, the loader's
+// "marked as pushed, yet the input is gone" arm falls through to the disk
+// read anyway, so a release that dropped the text and kept the stamp answers
+// identically through every handle-driven assertion. It is not identical:
+// a stamp left behind re-arms the original defect the moment anything
+// re-registers `files[path]` without clearing it — `ensure_file_registered`
+// does exactly that on the next hover of the closed file, and the loader then
+// treats the path as client-owned again and never re-reads disk.
+//
+// So the stamp gets its own assertion, against the actor's own map.
+
+#[test]
+fn releasing_the_last_buffer_hands_the_stamp_back_and_drops_the_text() {
+    let (_dir, root, _outside) = root_and_outside();
+    let class = root.join("app/Livewire/Counter.php");
+    std::fs::write(&class, "<?php\nclass Counter {}\n").unwrap();
+
+    let mut actor = loader_test_actor(Some(root));
+
+    // The acquire-then-push pair `did_open` performs, in that order.
+    actor.acquire_external_php_ownership(&class);
+    actor.handle_update_file(
+        class.clone(),
+        1,
+        "<?php\nclass Counter { public $unsaved = true; }\n".to_string(),
+    );
+    assert_eq!(
+        actor.external_php_text.get(&class),
+        Some(&ExternalPhpText::PushedByClient),
+        "precondition: the push claims ownership",
+    );
+    assert!(actor.files.contains_key(&class));
+
+    actor.release_external_php_ownership(&class);
+
+    assert!(
+        !actor.external_php_text.contains_key(&class),
+        "the stamp must be handed back, not merely rendered inert by the \
+         text going away — a stamp left behind re-arms the defect as soon as \
+         anything re-registers this path",
+    );
+    assert!(
+        !actor.external_php_open_buffers.contains_key(&class),
+        "the last buffer's count must go with it",
+    );
+    assert!(
+        !actor.files.contains_key(&class),
+        "and the text it installed must go, so every reader re-derives",
+    );
+}
+
+#[test]
+fn a_release_below_the_last_buffer_keeps_both_the_stamp_and_the_text() {
+    let (_dir, root, _outside) = root_and_outside();
+    let class = root.join("app/Livewire/Counter.php");
+    std::fs::write(&class, "<?php\nclass Counter {}\n").unwrap();
+
+    let mut actor = loader_test_actor(Some(root));
+
+    // Two buffers on one path — a split view, or a reopen that overtook its
+    // own close.
+    actor.acquire_external_php_ownership(&class);
+    actor.acquire_external_php_ownership(&class);
+    let buffer = "<?php\nclass Counter { public $unsaved = true; }\n";
+    actor.handle_update_file(class.clone(), 1, buffer.to_string());
+
+    actor.release_external_php_ownership(&class);
+
+    assert_eq!(
+        actor.external_php_text.get(&class),
+        Some(&ExternalPhpText::PushedByClient),
+        "one buffer is still open, so the path is still owned",
+    );
+    let file = actor
+        .files
+        .get(&class)
+        .copied()
+        .expect("the surviving buffer's text must not be dropped");
+    assert_eq!(*file.text(&actor.db), buffer);
+    assert_eq!(actor.external_php_open_buffers.get(&class), Some(&1));
+}

--- a/laravel-lsp/src/tests/external_php_ownership_release.rs
+++ b/laravel-lsp/src/tests/external_php_ownership_release.rs
@@ -17,17 +17,28 @@
 //! the eviction question have to stay separate. Both halves of that claim are
 //! pinned here — the downgrade happens, and nothing else does.
 //!
-//! These drive the **real** `did_close` notification handler on the
-//! `LspService::new` harness (the seam `watched_files_magic.rs` uses), not the
-//! `SalsaHandle` method underneath it: a unit test of the release would prove
-//! nothing about whether close calls it.
+//! The release is also counted, not flagged. tower-lsp runs notification
+//! handlers concurrently, so a reopened buffer's `didOpen` can reach the Salsa
+//! actor before the `didClose` it followed at the client — and a release that
+//! fired there would strip a LIVE buffer's ownership, which is the same defect
+//! reached from the other side. `did_open` counts its buffer in and `did_close`
+//! counts it out, so the pair settles the same way whichever order it arrives
+//! in.
+//!
+//! These drive the **real** `did_open` and `did_close` notification handlers on
+//! the `LspService::new` harness (the seam `watched_files_magic.rs` uses), not
+//! the `SalsaHandle` methods underneath them: a unit test of either edge would
+//! prove nothing about whether the handlers call it.
 
 use crate::LaravelLanguageServer;
 use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
-use tower_lsp::lsp_types::{DidCloseTextDocumentParams, TextDocumentIdentifier, Url};
+use tower_lsp::lsp_types::{
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, TextDocumentIdentifier,
+    TextDocumentItem, Url,
+};
 use tower_lsp::{LanguageServer, LspService};
 
 const COMPOSER: &str = r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#;
@@ -46,22 +57,37 @@ fn write_file(root: &Path, rel: &str, src: &str) -> PathBuf {
     path
 }
 
-/// Install `content` as the live editor buffer for `path` — `self.documents`
-/// plus the Salsa input, which is both halves of what `did_open` does with a
-/// buffer, and the pair `did_close` has to undo.
+/// Drive the real `textDocument/didOpen` handler for `path` with `content` as
+/// the buffer — the acquire `did_close` has to undo.
+///
+/// Driving the handler rather than re-spelling its Salsa calls here is the
+/// point: a helper that pushed the buffer itself would keep passing after
+/// `did_open` stopped counting its buffer in, and the ownership count is half
+/// of what these tests exist to pin.
 async fn open_buffer(backend: &LaravelLanguageServer, path: &Path, content: &str) -> Url {
     let uri = Url::from_file_path(path).unwrap();
     backend
-        .documents
-        .write()
-        .await
-        .insert(uri.clone(), (content.to_string(), 1));
+        .did_open(DidOpenTextDocumentParams {
+            text_document: TextDocumentItem {
+                uri: uri.clone(),
+                language_id: "php".to_string(),
+                version: 1,
+                text: content.to_string(),
+            },
+        })
+        .await;
+    uri
+}
+
+/// Install `content` as `path`'s Salsa text with NO open document — what a
+/// `didChangeWatchedFiles` push does. It takes the same `PushedByClient`
+/// stamp any client push does, but no buffer is counted in behind it.
+async fn push_without_open(backend: &LaravelLanguageServer, path: &Path, content: &str) {
     backend
         .salsa
         .update_file(path.to_path_buf(), 1, content.to_string())
         .await
-        .expect("the buffer reaches Salsa, exactly as did_open pushes it");
-    uri
+        .expect("the watcher's own read reaches Salsa");
 }
 
 /// Drive the real `textDocument/didClose` handler for `uri`.
@@ -82,6 +108,13 @@ const SAVED_CLASS: &str = "<?php\n\nnamespace App\\Livewire;\n\nuse Livewire\\Co
 /// the whole test: with disk and buffer agreeing, both a released and an
 /// unreleased path answer identically and the assertions below prove nothing.
 const DISCARDED_BUFFER: &str = "<?php\n\nnamespace App\\Livewire;\n\nuse Livewire\\Component;\n\nclass Counter extends Component\n{\n    public int $count = 0;\n\n    public function decrement(): void\n    {\n        $this->count--;\n    }\n}\n";
+
+/// A third spelling of the same class, for the reopen in the race tests. Three
+/// distinct method names keep the three states apart: `increment` is on disk,
+/// `decrement` was the buffer that closed, `multiply` is the buffer that is
+/// open now. Reusing one buffer constant for both opens could not tell "the
+/// reopened buffer answers" from "the first push's text was never replaced".
+const REOPENED_BUFFER: &str = "<?php\n\nnamespace App\\Livewire;\n\nuse Livewire\\Component;\n\nclass Counter extends Component\n{\n    public int $count = 0;\n\n    public function multiply(): void\n    {\n        $this->count *= 2;\n    }\n}\n";
 
 /// Write the v3 component pair and return `(class, blade)`.
 fn write_v3_component(root: &Path) -> (PathBuf, PathBuf) {
@@ -172,6 +205,124 @@ async fn closing_one_document_leaves_another_buffers_ownership_intact() {
             .await
             .is_none(),
         "and disk must not be read back over it",
+    );
+}
+
+// ---- the release must not outrun a reopen -------------------------------
+
+/// A close must not release a path that a LATER open has already claimed.
+///
+/// tower-lsp drives up to four notification handlers concurrently, so the
+/// `didOpen` of a reopened buffer — a revert, a tab restored, Zed's
+/// multibuffer lifecycle — can reach the Salsa actor before the `didClose`
+/// that preceded it at the client. Calling the handlers in that order IS that
+/// interleaving: the actor sees the reopen's messages first and the close
+/// last.
+///
+/// Releasing there is not a stale answer, it is a write: an unowned path sends
+/// the loader's next read into `set_text` on the shared `SourceFile` every
+/// per-file query reads, so a `$this->member` hover in the Blade view would
+/// revert the PHP buffer's text to disk.
+#[tokio::test]
+async fn a_reopen_that_overtakes_its_close_keeps_the_buffers_ownership() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    let (class, blade) = write_v3_component(dir.path());
+
+    let closing = open_buffer(&backend, &class, DISCARDED_BUFFER).await;
+    // The reopen's didOpen wins the race to the actor...
+    open_buffer(&backend, &class, REOPENED_BUFFER).await;
+    // ...and the close it should have followed arrives late.
+    close_document(&backend, closing).await;
+
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "multiply")
+            .await
+            .is_some(),
+        "the reopened buffer is live and still owns the path — the late close \
+         belongs to a buffer that no longer exists",
+    );
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "increment")
+            .await
+            .is_none(),
+        "disk must not be read back over the live buffer",
+    );
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "decrement")
+            .await
+            .is_none(),
+        "and the closed buffer's own text is gone — the reopen replaced it",
+    );
+}
+
+/// The count must not strand ownership: the reopened buffer's own close still
+/// hands the path back. Without this, refusing the late close above could be
+/// spelled as never releasing at all.
+#[tokio::test]
+async fn the_reopened_buffer_releases_when_it_closes_in_turn() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    let (class, blade) = write_v3_component(dir.path());
+
+    let closing = open_buffer(&backend, &class, DISCARDED_BUFFER).await;
+    let reopened = open_buffer(&backend, &class, REOPENED_BUFFER).await;
+    close_document(&backend, closing).await;
+
+    close_document(&backend, reopened).await;
+
+    let (path, loc) = backend
+        .locate_in_backing_class_files(&blade, "increment")
+        .await
+        .expect("with the last buffer gone, the SAVED method must resolve again");
+    assert_eq!(path, class, "resolution reaches the standalone class");
+    assert_eq!(loc.line, 10, "the saved declaration's line");
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "multiply")
+            .await
+            .is_none(),
+        "the reopened buffer's method must stop resolving once it closes too",
+    );
+}
+
+/// A `didChangeWatchedFiles` push stamps ownership with no open buffer behind
+/// it, so a close for that path finds nothing counted in. It must still hand
+/// the path back: an absent count is zero, and the original defect — text
+/// nothing holds, served forever — is what zero has to fall toward.
+#[tokio::test]
+async fn a_close_releases_a_path_no_open_ever_counted() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    let (class, blade) = write_v3_component(dir.path());
+
+    push_without_open(&backend, &class, DISCARDED_BUFFER).await;
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "decrement")
+            .await
+            .is_some(),
+        "seed: the push owns the path, exactly as a buffer's would",
+    );
+
+    close_document(&backend, Url::from_file_path(&class).unwrap()).await;
+
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "increment")
+            .await
+            .is_some(),
+        "the uncounted push is still handed back on close — disk answers again",
+    );
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "decrement")
+            .await
+            .is_none(),
+        "and its text stops answering",
     );
 }
 

--- a/laravel-lsp/src/tests/external_php_ownership_release.rs
+++ b/laravel-lsp/src/tests/external_php_ownership_release.rs
@@ -506,3 +506,106 @@ async fn closing_a_document_stops_every_reader_serving_the_discarded_text() {
         "the discarded buffer's text must not survive its document, got {names:?}",
     );
 }
+
+// ---- the inverted index is a reader too ----------------------------------
+
+/// The files the inverted symbol index reports as referencing view `name`.
+async fn view_reference_files(backend: &LaravelLanguageServer, name: &str) -> HashSet<PathBuf> {
+    backend
+        .salsa
+        .find_references(
+            laravel_lsp::salsa_impl::SymbolRefData::View(name.to_string()),
+            false,
+        )
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|loc| loc.file_path)
+        .collect()
+}
+
+/// `find_references` does not read `files[path]`; it answers from
+/// `symbol_index`, refreshed lazily from the paths `mark_dirty` queued. A
+/// query run while the buffer is open DRAINS that queue, so the index ends up
+/// holding the buffer's literals with the dirty flag cleared — and dropping
+/// the Salsa input on close cannot reach it. The view name the discarded
+/// buffer introduced then keeps answering find-references and code lenses
+/// forever, pointing at a file that never contained it.
+///
+/// The release therefore re-queues the path on the three deferred indexes,
+/// exactly as `handle_update_file` does for any other text change. Queueing is
+/// not eviction: the drain runs `remove_literal_entries` + `insert_file`, which
+/// deliberately preserves the resolved magic-member entries `did_close` exists
+/// to protect.
+#[tokio::test]
+async fn closing_a_document_stops_the_index_reporting_the_discarded_views() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    let class = write_file(
+        dir.path(),
+        "app/Livewire/Counter.php",
+        SAVED_CLASS_RENDERING,
+    );
+
+    let uri = open_buffer(&backend, &class, DISCARDED_BUFFER_RENDERING).await;
+
+    // Drain the dirty queue WHILE the buffer is open — a find-references or a
+    // code lens during the edit session. Without this the release would look
+    // correct for the wrong reason: the still-queued path would be refreshed
+    // on the first post-close query whether or not the release re-queued it.
+    assert!(
+        view_reference_files(&backend, "livewire.from-buffer")
+            .await
+            .contains(&class),
+        "precondition: a query during the edit indexes the buffer's literals",
+    );
+
+    close_document(&backend, uri).await;
+
+    let phantom = view_reference_files(&backend, "livewire.from-buffer").await;
+    assert!(
+        phantom.is_empty(),
+        "the discarded buffer's view reference must stop answering, got {phantom:?}",
+    );
+    assert!(
+        view_reference_files(&backend, "livewire.from-disk")
+            .await
+            .contains(&class),
+        "and the file on disk must answer in its place",
+    );
+}
+
+/// The other half of the same edge: re-queueing must not cost the resolved
+/// magic-member entries, which no re-parse can restore. The drain runs
+/// `remove_literal_entries` + `insert_file`, never `remove_file`, so the two
+/// requirements coexist — but only a test that actually FORCES the drain after
+/// the close can say so.
+#[tokio::test]
+async fn the_index_requeue_on_close_keeps_resolved_magic_members() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    let post = write_file(root, "app/Models/Post.php", POST);
+    seed(&backend, &post, POST).await;
+    let before = member_names(&backend, &post).await;
+    assert!(
+        before.contains("headline"),
+        "precondition: Post has resolved magic-member entries",
+    );
+
+    let uri = open_buffer(&backend, &post, POST).await;
+    close_document(&backend, uri).await;
+
+    // Force the deferred drain the release just queued. A destructive refresh
+    // would zero the entries here, where the sibling test above would still
+    // pass — it never makes the drain run.
+    let _ = view_reference_files(&backend, "no.such.view").await;
+
+    assert_eq!(
+        member_names(&backend, &post).await,
+        before,
+        "re-queueing the path must not zero what only warm/save can rebuild",
+    );
+}

--- a/laravel-lsp/src/tests/external_php_ownership_release.rs
+++ b/laravel-lsp/src/tests/external_php_ownership_release.rs
@@ -437,3 +437,72 @@ async fn closing_a_document_keeps_its_resolved_magic_members() {
         "the closed file's magic-dependency contribution must survive too",
     );
 }
+
+// ---- the text the release leaves behind ----------------------------------
+
+/// The same class again, distinguished by the view name its `render()` returns
+/// rather than by a method name: `handle_get_patterns` reports `view(...)`
+/// call sites, so a view name is what makes the two texts tell apart through
+/// the pattern path rather than the backing-class path.
+const SAVED_CLASS_RENDERING: &str = "<?php\n\nnamespace App\\Livewire;\n\nuse Livewire\\Component;\n\nclass Counter extends Component\n{\n    public function render()\n    {\n        return view('livewire.from-disk');\n    }\n}\n";
+
+const DISCARDED_BUFFER_RENDERING: &str = "<?php\n\nnamespace App\\Livewire;\n\nuse Livewire\\Component;\n\nclass Counter extends Component\n{\n    public function render()\n    {\n        return view('livewire.from-buffer');\n    }\n}\n";
+
+/// The view names `get_patterns` currently reports for `path`.
+async fn pattern_view_names(backend: &LaravelLanguageServer, path: &Path) -> HashSet<String> {
+    backend
+        .salsa
+        .get_patterns(path.to_path_buf())
+        .await
+        .unwrap()
+        .map(|data| data.views.iter().map(|v| v.name.clone()).collect())
+        .unwrap_or_default()
+}
+
+/// Releasing ownership un-blocks the LOADER, but the loader is not the only
+/// reader of the text a discarded buffer installed. `handle_get_patterns`,
+/// `handle_get_document_symbols`, `handle_get_loop_blocks` and
+/// `handle_get_php_assignments` all read `files[path]` directly, and the
+/// pattern cache is checked with no version comparison at all — so a
+/// buffer-derived entry there is served until something else evicts it.
+/// Find-references answering out of that entry names a symbol that exists in
+/// no file at all.
+///
+/// The release therefore drops the text it hands back, not merely the claim
+/// on it: every reader re-derives from disk on its next question. Still lazy —
+/// nothing is read at close time.
+#[tokio::test]
+async fn closing_a_document_stops_every_reader_serving_the_discarded_text() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    let class = write_file(
+        dir.path(),
+        "app/Livewire/Counter.php",
+        SAVED_CLASS_RENDERING,
+    );
+
+    let uri = open_buffer(&backend, &class, DISCARDED_BUFFER_RENDERING).await;
+
+    // Populate the pattern cache from the buffer, exactly as a diagnostics or
+    // find-references pass would while the document is open.
+    assert!(
+        pattern_view_names(&backend, &class)
+            .await
+            .contains("livewire.from-buffer"),
+        "precondition: the open buffer's text is what the pattern path reports",
+    );
+
+    // Changes discarded, document closed. Nothing is written to disk, so no
+    // `didChangeWatchedFiles` arrives to correct anything.
+    close_document(&backend, uri).await;
+
+    let names = pattern_view_names(&backend, &class).await;
+    assert!(
+        names.contains("livewire.from-disk"),
+        "after the close every reader must see the file on disk, got {names:?}",
+    );
+    assert!(
+        !names.contains("livewire.from-buffer"),
+        "the discarded buffer's text must not survive its document, got {names:?}",
+    );
+}

--- a/laravel-lsp/src/tests/external_php_ownership_release.rs
+++ b/laravel-lsp/src/tests/external_php_ownership_release.rs
@@ -1,0 +1,277 @@
+//! Regression: `textDocument/didClose` must relinquish the external-PHP
+//! loader ownership that `didOpen`/`didChange` acquired — without evicting
+//! anything.
+//!
+//! `handle_update_file` stamps `ExternalPhpText::PushedByClient` on every push
+//! so `ensure_external_php_source_loaded` never reads disk over an unsaved
+//! edit. That acquire had no matching release. Close a backing component class
+//! with its changes DISCARDED and the editor reverts its buffer in memory: no
+//! filesystem write happens, so no `didChangeWatchedFiles` event fires either —
+//! and the stamp, which is unconditional authority, went on serving text that
+//! existed neither on disk nor in any open buffer, until the file happened to
+//! be reopened.
+//!
+//! The release is deliberately NOT a `RemoveFile`. Eviction on close would
+//! zero the resolved magic-member entries only warm/save passes rebuild, which
+//! is exactly why `did_close` refuses to call it; the ownership downgrade and
+//! the eviction question have to stay separate. Both halves of that claim are
+//! pinned here — the downgrade happens, and nothing else does.
+//!
+//! These drive the **real** `did_close` notification handler on the
+//! `LspService::new` harness (the seam `watched_files_magic.rs` uses), not the
+//! `SalsaHandle` method underneath it: a unit test of the release would prove
+//! nothing about whether close calls it.
+
+use crate::LaravelLanguageServer;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use tower_lsp::lsp_types::{DidCloseTextDocumentParams, TextDocumentIdentifier, Url};
+use tower_lsp::{LanguageServer, LspService};
+
+const COMPOSER: &str = r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#;
+
+async fn backend_for(root: &Path) -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    let backend = service.inner().clone();
+    *backend.root_path.write().await = Some(root.to_path_buf());
+    backend
+}
+
+fn write_file(root: &Path, rel: &str, src: &str) -> PathBuf {
+    let path = root.join(rel);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(&path, src).unwrap();
+    path
+}
+
+/// Install `content` as the live editor buffer for `path` — `self.documents`
+/// plus the Salsa input, which is both halves of what `did_open` does with a
+/// buffer, and the pair `did_close` has to undo.
+async fn open_buffer(backend: &LaravelLanguageServer, path: &Path, content: &str) -> Url {
+    let uri = Url::from_file_path(path).unwrap();
+    backend
+        .documents
+        .write()
+        .await
+        .insert(uri.clone(), (content.to_string(), 1));
+    backend
+        .salsa
+        .update_file(path.to_path_buf(), 1, content.to_string())
+        .await
+        .expect("the buffer reaches Salsa, exactly as did_open pushes it");
+    uri
+}
+
+/// Drive the real `textDocument/didClose` handler for `uri`.
+async fn close_document(backend: &LaravelLanguageServer, uri: Url) {
+    backend
+        .did_close(DidCloseTextDocumentParams {
+            text_document: TextDocumentIdentifier { uri },
+        })
+        .await;
+}
+
+// ---- the release edge ----------------------------------------------------
+
+/// A Livewire v3 component whose class declares `increment()` on line 10.
+const SAVED_CLASS: &str = "<?php\n\nnamespace App\\Livewire;\n\nuse Livewire\\Component;\n\nclass Counter extends Component\n{\n    public int $count = 0;\n\n    public function increment(): void\n    {\n        $this->count++;\n    }\n}\n";
+
+/// The same class as an UNSAVED buffer that renamed the method. The rename is
+/// the whole test: with disk and buffer agreeing, both a released and an
+/// unreleased path answer identically and the assertions below prove nothing.
+const DISCARDED_BUFFER: &str = "<?php\n\nnamespace App\\Livewire;\n\nuse Livewire\\Component;\n\nclass Counter extends Component\n{\n    public int $count = 0;\n\n    public function decrement(): void\n    {\n        $this->count--;\n    }\n}\n";
+
+/// Write the v3 component pair and return `(class, blade)`.
+fn write_v3_component(root: &Path) -> (PathBuf, PathBuf) {
+    let class = write_file(root, "app/Livewire/Counter.php", SAVED_CLASS);
+    let blade = write_file(
+        root,
+        "resources/views/livewire/counter.blade.php",
+        "<div><button wire:click=\"increment\">+</button></div>\n",
+    );
+    (class, blade)
+}
+
+#[tokio::test]
+async fn a_discarded_buffer_stops_answering_once_its_document_closes() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    let (class, blade) = write_v3_component(dir.path());
+
+    // The rename exists only in the editor. Nothing is written to disk here,
+    // and nothing is written to disk anywhere in this test after this point —
+    // which is the sequence with no `didChangeWatchedFiles` to fall back on.
+    let uri = open_buffer(&backend, &class, DISCARDED_BUFFER).await;
+
+    // Seed. The buffer OWNS the path while it is open, so resolution must
+    // answer out of it — `decrement` resolves and the saved `increment` does
+    // not. Without this pair the closing assertions cannot tell a released
+    // stamp from a buffer that was never installed.
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "decrement")
+            .await
+            .is_some(),
+        "seed: the open buffer's method must resolve — the push took ownership",
+    );
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "increment")
+            .await
+            .is_none(),
+        "seed: the saved method must NOT resolve while the buffer owns the path",
+    );
+
+    // The user discards the changes and closes the tab. No disk write.
+    close_document(&backend, uri).await;
+
+    let (path, loc) = backend
+        .locate_in_backing_class_files(&blade, "increment")
+        .await
+        .expect("with the buffer gone, the SAVED method must resolve again");
+    assert_eq!(path, class, "resolution reaches the standalone class");
+    assert_eq!(loc.line, 10, "the saved declaration's line");
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "decrement")
+            .await
+            .is_none(),
+        "the discarded buffer's method must stop resolving — it exists neither \
+         on disk nor in any open buffer",
+    );
+}
+
+/// The release is keyed on the closed path alone, so a SECOND file's live
+/// buffer must survive its neighbour's close. Without this, a release that
+/// cleared the whole map would pass the test above.
+#[tokio::test]
+async fn closing_one_document_leaves_another_buffers_ownership_intact() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+    let (class, blade) = write_v3_component(dir.path());
+    let bystander = write_file(dir.path(), "app/Livewire/Other.php", SAVED_CLASS);
+
+    let closed = open_buffer(&backend, &bystander, DISCARDED_BUFFER).await;
+    open_buffer(&backend, &class, DISCARDED_BUFFER).await;
+
+    close_document(&backend, closed).await;
+
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "decrement")
+            .await
+            .is_some(),
+        "the still-open buffer keeps its ownership — only the closed path is \
+         handed back",
+    );
+    assert!(
+        backend
+            .locate_in_backing_class_files(&blade, "increment")
+            .await
+            .is_none(),
+        "and disk must not be read back over it",
+    );
+}
+
+/// `didClose` arrives for every closed document, including ones with no file
+/// path at all (an unsaved scratch buffer). The release must not assume one.
+#[tokio::test]
+async fn closing_a_document_with_no_file_path_is_a_no_op() {
+    let dir = TempDir::new().unwrap();
+    let backend = backend_for(dir.path()).await;
+
+    close_document(&backend, Url::parse("untitled:Untitled-1").unwrap()).await;
+}
+
+// ---- what the release must NOT do ----------------------------------------
+
+/// `Post` both declares an accessor and reads it via `$this->headline`, so it
+/// carries magic-member entries and a magic-dependency contribution OF ITS
+/// OWN — the state `RemoveFile` purges and `did_close` must not.
+const POST: &str = "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Post extends Model {\n    public function getHeadlineAttribute(): string { return ''; }\n    public function describe(): string { return $this->headline; }\n}\n";
+
+/// A controller reading `$post->headline` off a typed `Post` param — resolvable
+/// only while `Post` declares the accessor, which makes it a dependent.
+const CONSUMER: &str = "<?php\nnamespace App\\Http\\Controllers;\nuse App\\Models\\Post;\nclass PostController {\n    public function show(Post $post) {\n        return [$post->headline];\n    }\n}\n";
+
+/// Register a file in Salsa and run the per-file magic refresh — what the save
+/// path does, so entries + receiver deps land in the live indexes.
+async fn seed(backend: &LaravelLanguageServer, path: &Path, src: &str) {
+    backend
+        .salsa
+        .update_file(path.to_path_buf(), 1, src.to_string())
+        .await
+        .unwrap();
+    backend.refresh_file_magic(path, src).await;
+}
+
+/// The resolved magic-member *member names* the index holds for `path`.
+async fn member_names(backend: &LaravelLanguageServer, path: &Path) -> HashSet<String> {
+    backend
+        .salsa
+        .export_magic_members()
+        .await
+        .unwrap()
+        .get(path)
+        .map(|entries| entries.iter().map(|e| e.member.clone()).collect())
+        .unwrap_or_default()
+}
+
+/// Does the magic-dependency index still hold a `by_file` entry for `path`?
+fn magic_deps_has(backend: &LaravelLanguageServer, path: &Path) -> bool {
+    backend
+        .magic_deps
+        .read()
+        .unwrap()
+        .export()
+        .iter()
+        .any(|(p, _)| p == path)
+}
+
+#[tokio::test]
+async fn closing_a_document_keeps_its_resolved_magic_members() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    let post = write_file(root, "app/Models/Post.php", POST);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    seed(&backend, &post, POST).await;
+    seed(&backend, &consumer, CONSUMER).await;
+
+    assert!(
+        member_names(&backend, &post).await.contains("headline"),
+        "seed: Post resolves its own `$this->headline`",
+    );
+    assert!(
+        member_names(&backend, &consumer).await.contains("headline"),
+        "seed: the dependent resolves `$post->headline`",
+    );
+    assert!(
+        magic_deps_has(&backend, &post),
+        "seed: Post has a magic-dependency contribution",
+    );
+
+    // The model buffer closes — what happens when the references multibuffer
+    // opens over it. `RemoveFile` here would zero every assertion below, and
+    // only a warm or a save would ever rebuild them.
+    let uri = open_buffer(&backend, &post, POST).await;
+    close_document(&backend, uri).await;
+
+    assert!(
+        member_names(&backend, &post).await.contains("headline"),
+        "the closed file's own resolved entries must survive — close is not \
+         a delete",
+    );
+    assert!(
+        member_names(&backend, &consumer).await.contains("headline"),
+        "and the dependent must still resolve through it",
+    );
+    assert!(
+        magic_deps_has(&backend, &post),
+        "the closed file's magic-dependency contribution must survive too",
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod env_key_navigation;
 mod env_source_registration_gate;
 mod env_value_redaction;
 mod expected_path_diagnostic_containment;
+mod external_php_ownership_release;
 mod factory_goto_def_handler;
 mod flux_component_context;
 mod flux_component_hover;


### PR DESCRIPTION
## Summary

Implements #365.

`did_open`/`did_change` stamp `ExternalPhpText::PushedByClient` so the backing-class loader never reads disk over an unsaved edit. Nothing ever handed that ownership back. Close a buffer with its changes **discarded** and the editor reverts in memory without writing to disk, so no `did_change_watched_files` event fires either. The stamp survived both, and the loader went on serving text that existed neither on disk nor in any open buffer — until the file happened to be reopened.

`did_close` now releases the closed path, and the release is **counted**: `did_open` counts its buffer in, `did_close` counts it out, and ownership goes back to the loader only when the last buffer for that path is gone. The next resolution then re-reads disk.

The release evicts nothing. `RemoveFile` is not called: the `SourceFile` input, the per-file caches, and the resolved magic-member entries all survive. That keeps the ownership edge separate from the eviction question `did_close` deliberately declines to reopen.

## Changes

- `salsa_impl.rs` — `SalsaRequest::ReleaseExternalPhpOwnership` and its `AcquireExternalPhpOwnership` counterpart, both `SalsaHandle` methods, and the two actor arms. `SalsaActor::release_external_php_ownership` drops the path from `external_php_text` once its buffer count runs out; `acquire_external_php_ownership` is the count going up. Nothing else is touched.
- `salsa_impl.rs` — `external_php_open_buffers`, the per-path count of open editor buffers. Absent means zero.
- `main.rs` — `did_open` acquires before its `update_file` push; `did_close` releases, and its comment now states the ownership-release rule beside the existing eviction rationale.
- `salsa_impl.rs` — the `ExternalPhpText::PushedByClient` doc said the pusher owns invalidation, without saying how long. It now names the release edge and the discarded-buffer case that needs one.
- `tests/external_php_ownership_release.rs` — seven tests, driving the real `did_open` and `did_close` handlers.

## Round 2 — the close/reopen race

Round 1's release was path-keyed and unconditional, and [that could strip a live buffer's ownership](https://github.com/mike-bronner/zed-laravel/pull/367#pullrequestreview-3299694097). tower-lsp does not serialize notification handlers (`DEFAULT_MAX_CONCURRENCY = 4` in 0.20.0; this server takes the default), so the `didOpen` of a **reopened** buffer can reach the Salsa actor before the `didClose` that preceded it at the client. The actor stamps `PushedByClient` for the new buffer and the late release removes it — the very state the release exists to prevent, reached from the other side. It is a write, not a stale read: the loader's next pass takes the reload arm and `set_text`s the shared `SourceFile` every per-file query reads, so a `$this->member` hover in a Blade view could silently revert the reopened PHP buffer's text to disk.

**The property established:** the release cannot drop an ownership stamp installed by a later open of the same path.

**Counting is what establishes it.** Increments and decrements commute, so a close/reopen pair settles at one buffer whichever order it reaches the actor in. A flag, or any "is this the buffer I closed?" test, has to answer a question about ordering; a count does not.

**Both of the expressions suggested in review were tried first, and both leave the property unproven:**

- *Gate on the closed document's text or version.* A reopen that carries the same unsaved text — Zed's multibuffer lifecycle, a tab restored with its edits — pushes bytes identical to the closed buffer's, and the version can match too if the client keeps its buffer's counter across the close. The guard then passes in exactly the case that matters: a dirty live buffer, clobbered with disk.
- *Gate on the path's absence from `self.documents` at actor time.* `did_close` removes the URI from `documents` before it sends the release, so when the reopen's insert lands first, that removal erases the live entry and the check answers "not open" for a buffer that is. It closes one interleaving and not the other.

**The acquire goes before the push, not after.** A concurrent `didClose` can land anywhere in `did_open`'s sequence. Acquire-first is safe at every landing point: before the acquire it releases the earlier buffer's stamp, which the push then re-installs; between or after, it decrements to a non-zero count and drops nothing. Push-first opens one window — the close landing between the stamp and the count — where a live buffer is left unowned.

**Honest limit:** the mutation table below pins *what* the count decides, and a sequential handler test cannot pin the *ordering* of two sends inside `did_open`. Moving the acquire after the push leaves every test green. That ordering rests on the argument above and on the comment at the call site, not on coverage.

## Other decisions worth naming

**A path with no count still releases.** That is the state a `didChangeWatchedFiles` push leaves behind — ownership with no buffer to close it — and it is the safe direction for the original defect: every divergence falls toward consulting disk, never toward serving a buffer nobody holds. Pinned by `a_close_releases_a_path_no_open_ever_counted`.

**`RemoveFile` deliberately does not clear the count.** Deleting a path on disk does not close its buffer, so the buffer's claim outlives the file — and its own `didClose` still balances the books.

**The release is fallible where `mark_pushed_by_client` is not**, which is the shape #361 was bounced for. It differs here. The call fails only if the Salsa actor is unreachable, and `ensure_external_php_source_loaded` — the reader the release exists to unblock — runs inside that same actor. A failed release cannot leave phantom text for anything to serve, because no live reader is left to serve it. The acquire logs the same way, at the level `did_open` already uses for its own Salsa push.

## Sweep

The defect class is an acquire with no matching release. `mark_pushed_by_client` has three call sites: `handle_update_file`, and two in `ensure_blade_source_registered`. All three acquire on behalf of a client push, and `did_close` is the release edge for every one — it fires for the closed path whether that path is a `.php` backing class or a `.blade.php` template.

The round-2 fix adds its own pair, so the same question applies to it: `did_open` is the only handler that opens a buffer, `did_close` the only one that closes one (it holds the sole `documents.remove` in the server), and both are guarded by the same `to_file_path()` check. One acquire site, one release site, no third.

One acquirer holds ownership permanently and correctly: `did_change_watched_files` pushes the watcher's own fresh read for files that are not open. The watcher never goes away and pushes again on every change, so that ownership needs no release. The enum doc says so explicitly.

`external_php_text` has exactly one reader (`ensure_external_php_source_loaded`), and it is unchanged by this PR.

## Acceptance Criteria

- [x] `did_close` relinquishes `ExternalPhpText::PushedByClient` for the closed path, so the next `ensure_external_php_source_loaded` re-reads disk.
- [x] `RemoveFile` is **not** called on close — the magic-member entries `did_close`'s existing comment protects survive, with a test asserting they do (`closing_a_document_keeps_its_resolved_magic_members`).
- [x] A regression test drives the real sequence (`a_discarded_buffer_stops_answering_once_its_document_closes`): disk declares `increment()`, an unsaved buffer renames it to `decrement()`, `did_close` arrives with no disk write, and the **disk** method resolves again while the buffer's does not.
- [x] The `did_close` comment states the ownership-release rule alongside the existing eviction rationale.

## Test Plan

- [x] Full suite green — 3602 tests, 0 failures.
- [x] `cargo clippy --all-targets` clean; `cargo fmt --check` clean.
- [x] Every new test mutation-verified — each reddens for a different defect, and no test is redundant:

| Mutation | Test that reddens |
|---|---|
| Remove the release call from `did_close` | `a_discarded_buffer_stops_answering_once_its_document_closes` |
| Release clears the whole map instead of one path | `closing_one_document_leaves_another_buffers_ownership_intact` |
| `did_close` calls `remove_file` instead of releasing | `closing_a_document_keeps_its_resolved_magic_members` |
| `did_close` unwraps `to_file_path()` | `closing_a_document_with_no_file_path_is_a_no_op` |
| Release ignores the count (round 1's unconditional drop) | `a_reopen_that_overtakes_its_close_keeps_the_buffers_ownership` |
| `did_open` stops acquiring | `a_reopen_that_overtakes_its_close_keeps_the_buffers_ownership` |
| Release never drops a counted path | `the_reopened_buffer_releases_when_it_closes_in_turn` (and the round-1 regression) |
| Release requires a count before dropping | `a_close_releases_a_path_no_open_ever_counted` |

The regression tests carry seed assertions before the close — the buffer's method resolves and the saved one does not. Without that pair, the post-close assertions could not tell a released stamp from a buffer that was never installed. The race tests use three distinct method names (`increment` on disk, `decrement` in the closed buffer, `multiply` in the reopened one) so "the reopened buffer answers" cannot pass as "the first push's text was never replaced".

Fixes #365
