### PR TITLE
Retire the translation-key text scanner; parse every catalogue shape PHP allows

### DIFF
--- a/laravel-lsp/src/code_lens.rs
+++ b/laravel-lsp/src/code_lens.rs
@@ -152,6 +152,11 @@ fn dotted_key_lens_targets(
 ) -> Vec<CodeLensTarget> {
     crate::config_key_locator::enumerate_keys_in_source(source)
         .into_iter()
+        // A synthesized list index is written nowhere, so there is nothing to
+        // hang a lens on — `config/app.php` would otherwise carry a
+        // zero-width `providers.N` lens on every provider in the array. A
+        // bare `404 =>` IS written, and keeps its lens.
+        .filter(|(_, pos)| pos.kind != crate::config_key_locator::KeyKind::SynthesizedIndex)
         .map(|(path, pos)| CodeLensTarget {
             line: pos.line,
             column: pos.start_column,

--- a/laravel-lsp/src/code_lens/tests.rs
+++ b/laravel-lsp/src/code_lens/tests.rs
@@ -732,3 +732,34 @@ fn compound_lens_anchor_class_less_php_falls_back_to_line_zero() {
         "a class-less PHP file must fall back to the line-0 anchor"
     );
 }
+
+#[test]
+fn a_synthesized_list_index_gets_no_lens_but_a_bare_integer_key_does() {
+    let src = r#"<?php
+return [
+    'name' => 'App',
+    'providers' => [
+        App\Providers\A::class,
+        App\Providers\B::class,
+    ],
+    404 => 'Not found',
+];
+"#;
+    let keys: Vec<String> = config_lens_targets("app", src)
+        .into_iter()
+        .map(|t| match t.symbol {
+            SymbolRefData::Config(k) => k,
+            other => panic!("expected a config symbol, got {other:?}"),
+        })
+        .collect();
+    // `config('app.providers.0')` resolves, so it is enumerated and navigable
+    // — but it is written nowhere, so annotating it would put a zero-width
+    // lens on every entry of a providers array.
+    assert!(
+        !keys.iter().any(|k| k.starts_with("app.providers.")),
+        "got {keys:?}"
+    );
+    // `404` IS written, and `__('app.404')` is a real call, so it keeps a lens.
+    assert!(keys.contains(&"app.404".to_string()), "got {keys:?}");
+    assert_eq!(keys, vec!["app.name", "app.providers", "app.404"]);
+}

--- a/laravel-lsp/src/config_key_locator.rs
+++ b/laravel-lsp/src/config_key_locator.rs
@@ -169,6 +169,15 @@ fn collect_keys_bounded(
         return;
     }
     for entry in array_entries(array, source) {
+        // A key containing a literal dot is addressable only at the TOP level.
+        // `Arr::get` tests the whole remaining key once, then explodes on
+        // dots — so `['a.b' => …]` at the root resolves, while
+        // `['form' => ['a.b' => …]]` does not: the walk finds `form`, then
+        // looks for `a` and gives up. Emitting `form.a.b` would offer a key
+        // that returns null at runtime, and that no goto could follow.
+        if !prefix.is_empty() && entry.key_text.contains('.') {
+            continue;
+        }
         let dotted = if prefix.is_empty() {
             entry.key_text.clone()
         } else {
@@ -420,10 +429,15 @@ fn integer_literal_value(node: Node, source: &[u8]) -> Option<i64> {
             if inner.kind() != "integer" {
                 return None;
             }
-            let magnitude: i64 = inner.utf8_text(source).ok()?.trim().parse().ok()?;
+            // Re-sign the digits and parse ONCE. Parsing the magnitude alone
+            // and negating it drops `-9223372036854775808`: the digits are one
+            // past `i64::MAX`, so the magnitude parse fails before any negation
+            // happens. `i64::MIN` is a legal PHP array key, and the whole-span
+            // parse this replaced handled it.
+            let digits = inner.utf8_text(source).ok()?.trim();
             match node.child(0)?.utf8_text(source).ok()? {
-                "-" => magnitude.checked_neg(),
-                "+" => Some(magnitude),
+                "-" => format!("-{digits}").parse().ok(),
+                "+" => digits.parse().ok(),
                 _ => None,
             }
         }

--- a/laravel-lsp/src/config_key_locator.rs
+++ b/laravel-lsp/src/config_key_locator.rs
@@ -32,11 +32,28 @@ pub struct KeyPosition {
     pub line: u32,
     pub start_column: u32,
     pub end_column: u32,
-    /// True when the span covers a quoted key literal, which a rename may
-    /// rewrite in place. False for a synthesized list index (`sizes.0`) and
-    /// for an unquoted integer key (`404 => …`): both are real, navigable
-    /// keys, but neither has quoted text a new name could replace.
-    pub is_literal_key: bool,
+    /// How the key is written in the source. Each consumer accepts a
+    /// different set — see [`KeyKind`].
+    pub kind: KeyKind,
+}
+
+/// How an array key is spelled in the source, which decides what each feature
+/// may do with it. Every kind is equally *resolvable* — Laravel finds a value
+/// for all three — so completion and go-to-definition accept all of them. The
+/// distinctions matter only to features that need the key's own text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyKind {
+    /// `'name' => …` or `"name" => …`. The span covers the text inside the
+    /// quotes, so a rename can rewrite it in place. The only renameable kind.
+    Quoted,
+    /// `404 => …`. Real text at a real position, so a code lens can annotate
+    /// it, but a rename must not: replacing the bare digits with a name would
+    /// turn a string key into a constant lookup.
+    BareInteger,
+    /// The `0` in `['sm', 'md']` — an index PHP assigns, written nowhere. It
+    /// is a navigable key (`sizes.0` resolves), but there is no text to
+    /// annotate or rewrite, so the span is zero-width at the value's start.
+    SynthesizedIndex,
 }
 
 /// Locate the source position of `dotted_key` (e.g. `"app.name"`,
@@ -335,7 +352,7 @@ fn literal_key(node: Node, source: &[u8]) -> Option<(String, KeyPosition)> {
             } else {
                 start.column as u32
             },
-            is_literal_key: false,
+            kind: KeyKind::BareInteger,
         },
     ))
 }
@@ -348,7 +365,7 @@ fn synthesized_index_position(value_node: Node) -> KeyPosition {
         line: start.row as u32,
         start_column: start.column as u32,
         end_column: start.column as u32,
-        is_literal_key: false,
+        kind: KeyKind::SynthesizedIndex,
     }
 }
 
@@ -370,7 +387,7 @@ fn string_body_position(node: Node) -> KeyPosition {
         } else {
             start_column
         },
-        is_literal_key: true,
+        kind: KeyKind::Quoted,
     }
 }
 

--- a/laravel-lsp/src/config_key_locator.rs
+++ b/laravel-lsp/src/config_key_locator.rs
@@ -32,6 +32,11 @@ pub struct KeyPosition {
     pub line: u32,
     pub start_column: u32,
     pub end_column: u32,
+    /// True when the span covers a quoted key literal, which a rename may
+    /// rewrite in place. False for a synthesized list index (`sizes.0`) and
+    /// for an unquoted integer key (`404 => …`): both are real, navigable
+    /// keys, but neither has quoted text a new name could replace.
+    pub is_literal_key: bool,
 }
 
 /// Locate the source position of `dotted_key` (e.g. `"app.name"`,
@@ -94,6 +99,20 @@ pub fn locate_in_source(source: &str, key_path: &[&str]) -> Option<KeyPosition> 
 /// are skipped. The caller prepends the file stem to form the full dotted key
 /// (`database.` / `auth.`). Powers config + translation code lenses (#59).
 pub fn enumerate_keys_in_source(source: &str) -> Vec<(String, KeyPosition)> {
+    enumerate_entries_in_source(source)
+        .into_iter()
+        .map(|(key, _value, position)| (key, position))
+        .collect()
+}
+
+/// [`enumerate_keys_in_source`] plus each entry's scalar value text, as
+/// `(in-file dotted path, value text, key position)`.
+///
+/// The value is for display only — translation completion shows it beside the
+/// key. It is the string's content without quotes, the raw source text for any
+/// other scalar, and empty for an array-valued (intermediate) key, which has
+/// no scalar of its own to show.
+pub fn enumerate_entries_in_source(source: &str) -> Vec<(String, String, KeyPosition)> {
     let Ok(tree) = crate::parser::parse_php(source) else {
         return Vec::new();
     };
@@ -108,22 +127,25 @@ pub fn enumerate_keys_in_source(source: &str) -> Vec<(String, KeyPosition)> {
 
 /// Recurse an array literal, accumulating the dotted key path. `prefix` is the
 /// path to `array` (empty at the top level).
-fn collect_keys(array: Node, source: &[u8], prefix: &str, out: &mut Vec<(String, KeyPosition)>) {
-    let mut cursor = array.walk();
-    for child in array.children(&mut cursor) {
-        if child.kind() != "array_element_initializer" {
-            continue;
-        }
-        let Some(entry) = parse_array_entry(child, source) else {
-            continue;
-        };
+fn collect_keys(
+    array: Node,
+    source: &[u8],
+    prefix: &str,
+    out: &mut Vec<(String, String, KeyPosition)>,
+) {
+    for entry in array_entries(array, source) {
         let dotted = if prefix.is_empty() {
             entry.key_text.clone()
         } else {
             format!("{prefix}.{}", entry.key_text)
         };
-        out.push((dotted.clone(), entry.key_position));
-        if let Some(nested) = find_array_in_expression(entry.value_node) {
+        let nested = find_array_in_expression(entry.value_node);
+        let value = match nested {
+            Some(_) => String::new(),
+            None => scalar_value_text(entry.value_node, source),
+        };
+        out.push((dotted.clone(), value, entry.key_position));
+        if let Some(nested) = nested {
             collect_keys(nested, source, &dotted, out);
         }
     }
@@ -173,20 +195,17 @@ fn find_array_in_expression(node: Node) -> Option<Node> {
 }
 
 /// Walk an `array_creation_expression` along the given path. At each step,
-/// find the entry whose key string content matches the path segment. If it's
-/// the last segment, return the key position; otherwise descend into the
-/// value (which must itself be an array) and recurse.
+/// find the entry whose key matches the path segment. If it's the last
+/// segment, return the key position; otherwise descend into the value (which
+/// must itself be an array) and recurse.
 fn locate_at_path<'a>(array: Node<'a>, source: &[u8], path: &[&str]) -> Option<KeyPosition> {
     let (head, tail) = path.split_first()?;
-
-    let mut cursor = array.walk();
-    for child in array.children(&mut cursor) {
-        if child.kind() != "array_element_initializer" {
-            continue;
-        }
-        let entry = parse_array_entry(child, source)?;
+    for entry in array_entries(array, source) {
         if entry.key_text != *head {
-            // Try the next entry; we only act on a key match.
+            // Try the next entry; we only act on a key match. An entry we
+            // cannot parse is skipped by `array_entries`, never fatal — it
+            // used to abort the whole lookup, so a single list entry hid
+            // every key declared after it.
             continue;
         }
         if tail.is_empty() {
@@ -208,64 +227,279 @@ struct ParsedEntry<'a> {
     value_node: Node<'a>,
 }
 
-/// Parse one `array_element_initializer` of the shape `key => value`.
-/// Returns `None` when the key isn't a literal string (numeric keys,
-/// expressions, etc. — we can't rename those positionally).
-fn parse_array_entry<'a>(node: Node<'a>, source: &[u8]) -> Option<ParsedEntry<'a>> {
-    // Layout (tree-sitter-php): the element has children separated by `=>`,
-    // tagged via field names `key` and `value`. Some grammar revisions use
-    // unnamed positional children — handle both.
-    let key_node = node
-        .child_by_field_name("key")
-        .or_else(|| named_child(node, 0))?;
-    let value_node = node
-        .child_by_field_name("value")
-        .or_else(|| named_child(node, 1))?;
-
-    let (key_text, key_position) = string_literal_content(key_node, source)?;
-    Some(ParsedEntry {
-        key_text,
-        key_position,
-        value_node,
-    })
+/// Every resolvable entry of an array literal, in document order, with PHP's
+/// own index rules applied to keyless entries.
+///
+/// PHP gives a keyless entry the next free integer index: the counter starts
+/// at 0 and jumps to `n + 1` whenever an explicit integer key `n` appears.
+/// `['a', 5 => 'b', 'c']` is therefore `0`, `5`, `6`. A spread (`...$other`)
+/// contributes an unknown number of elements, so every later position is
+/// unknowable — positional entries after one are dropped rather than guessed.
+fn array_entries<'a>(array: Node<'a>, source: &[u8]) -> Vec<ParsedEntry<'a>> {
+    let mut out = Vec::new();
+    let mut next_index: Option<i64> = Some(0);
+    let mut cursor = array.walk();
+    for child in array.children(&mut cursor) {
+        if child.kind() != "array_element_initializer" {
+            continue;
+        }
+        if is_spread(child) {
+            next_index = None;
+            continue;
+        }
+        let Some((key_node, value_node)) = entry_key_and_value(child) else {
+            continue;
+        };
+        match key_node {
+            Some(key_node) => {
+                if let Some(n) = integer_literal_value(key_node, source) {
+                    next_index = Some(next_index.map_or(n + 1, |c| c.max(n + 1)));
+                }
+                if let Some((key_text, key_position)) = literal_key(key_node, source) {
+                    out.push(ParsedEntry {
+                        key_text,
+                        key_position,
+                        value_node,
+                    });
+                }
+            }
+            None => {
+                let Some(index) = next_index else { continue };
+                next_index = Some(index + 1);
+                out.push(ParsedEntry {
+                    key_text: index.to_string(),
+                    key_position: synthesized_index_position(value_node),
+                    value_node,
+                });
+            }
+        }
+    }
+    out
 }
 
-/// Return the n-th named child of a node, ignoring whitespace and `=>`
-/// punctuation. Fallback used when `child_by_field_name` isn't supported
-/// for the current grammar revision.
-fn named_child(node: Node, index: usize) -> Option<Node> {
+/// Split one `array_element_initializer` into `(key, value)`. The key is
+/// `None` for a keyless (list) entry. Handles both the field-named grammar
+/// revision and the older positional one.
+fn entry_key_and_value<'a>(node: Node<'a>) -> Option<(Option<Node<'a>>, Node<'a>)> {
+    if let Some(value) = node.child_by_field_name("value") {
+        return Some((node.child_by_field_name("key"), value));
+    }
     let mut cursor = node.walk();
-    let result = node.named_children(&mut cursor).nth(index);
-    result
+    let named: Vec<Node<'a>> = node.named_children(&mut cursor).collect();
+    match named.len() {
+        0 => None,
+        1 => Some((None, named[0])),
+        _ => Some((Some(named[0]), named[1])),
+    }
 }
 
-/// Extract the literal string content + position from a `string` /
-/// `encapsed_string` node. Returns `None` for non-string keys.
-fn string_literal_content<'a>(node: Node<'a>, source: &[u8]) -> Option<(String, KeyPosition)> {
+/// True for a `...$other` spread element, whose element count is unknown.
+fn is_spread(node: Node) -> bool {
+    if node.kind().contains("variadic") {
+        return true;
+    }
+    let mut cursor = node.walk();
+    let spread = node
+        .children(&mut cursor)
+        .any(|child| child.kind() == "..." || child.kind().contains("variadic"));
+    spread
+}
+
+/// The integer a literal integer key denotes, e.g. `404 => …`.
+fn integer_literal_value(node: Node, source: &[u8]) -> Option<i64> {
+    (node.kind() == "integer")
+        .then(|| node.utf8_text(source).ok()?.parse().ok())
+        .flatten()
+}
+
+/// The dotted-path text a literal key contributes, and where it is declared.
+///
+/// A quoted key reports `is_literal_key: true` — rename can rewrite it inside
+/// its quotes. An unquoted integer key (`404 => …`) reports `false`: it is a
+/// real, resolvable key, but replacing the bare digits with a name would
+/// produce a constant lookup rather than a string key.
+fn literal_key(node: Node, source: &[u8]) -> Option<(String, KeyPosition)> {
+    if let Some(text) = string_literal_text(node, source) {
+        return Some((text, string_body_position(node)));
+    }
+    let value = integer_literal_value(node, source)?;
+    let start = node.start_position();
+    let end = node.end_position();
+    Some((
+        value.to_string(),
+        KeyPosition {
+            line: start.row as u32,
+            start_column: start.column as u32,
+            end_column: if end.row == start.row {
+                end.column as u32
+            } else {
+                start.column as u32
+            },
+            is_literal_key: false,
+        },
+    ))
+}
+
+/// Where a synthesized list index points: the start of the entry's value.
+/// Zero-width, because the index has no text of its own in the source.
+fn synthesized_index_position(value_node: Node) -> KeyPosition {
+    let start = value_node.start_position();
+    KeyPosition {
+        line: start.row as u32,
+        start_column: start.column as u32,
+        end_column: start.column as u32,
+        is_literal_key: false,
+    }
+}
+
+/// The span of a string literal's body — inside the quotes.
+///
+/// Derived from the literal's own extent rather than from its `string_content`
+/// child, because an escape splits that child in two: `'it\'s'` is
+/// `string_content("it")` + `escape_sequence` + `string_content("s")`, and the
+/// first run alone spans only `it`.
+fn string_body_position(node: Node) -> KeyPosition {
+    let start = node.start_position();
+    let end = node.end_position();
+    let start_column = start.column as u32 + 1;
+    KeyPosition {
+        line: start.row as u32,
+        start_column,
+        end_column: if end.row == start.row && end.column as u32 > start_column {
+            end.column as u32 - 1
+        } else {
+            start_column
+        },
+        is_literal_key: true,
+    }
+}
+
+/// A string literal's text with PHP's escape sequences resolved. `None` for
+/// any node that is not a single- or double-quoted literal.
+fn string_literal_text(node: Node, source: &[u8]) -> Option<String> {
     if node.kind() != "string" && node.kind() != "encapsed_string" {
         return None;
     }
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == "string_content" {
-            let text = child.utf8_text(source).ok()?.to_string();
-            let start = child.start_position();
-            let end = child.end_position();
-            return Some((
-                text,
-                KeyPosition {
-                    line: start.row as u32,
-                    start_column: start.column as u32,
-                    end_column: if end.row == start.row {
-                        end.column as u32
-                    } else {
-                        start.column as u32
-                    },
-                },
-            ));
+    let raw = node.utf8_text(source).ok()?;
+    let quote = raw.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+    let body = raw
+        .strip_prefix(quote)
+        .and_then(|rest| rest.strip_suffix(quote))
+        .unwrap_or(&raw[quote.len_utf8()..]);
+    Some(unescape_php(body, quote))
+}
+
+/// Resolve PHP's escape sequences for the given quote style.
+///
+/// A single-quoted literal resolves only `\'` and `\\`; every other backslash
+/// stands for itself, so `'a\nb'` really does contain a backslash and an `n`.
+/// A double-quoted literal resolves the usual control escapes too. Variable
+/// interpolation is not attempted — see [`fold_value`].
+fn unescape_php(body: &str, quote: char) -> String {
+    let mut out = String::with_capacity(body.len());
+    let mut chars = body.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            None => out.push('\\'),
+            Some(next) if quote == '\'' => {
+                if next == '\'' || next == '\\' {
+                    out.push(next);
+                } else {
+                    out.push('\\');
+                    out.push(next);
+                }
+            }
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some('v') => out.push('\u{0B}'),
+            Some('f') => out.push('\u{0C}'),
+            Some('e') => out.push('\u{1B}'),
+            Some('0') => out.push('\0'),
+            Some(next @ ('\\' | '"' | '$')) => out.push(next),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
         }
     }
-    None
+    out
+}
+
+/// The display text of a non-array value. Statically knowable values are
+/// resolved to what PHP would produce; anything else falls back to its source
+/// text, which at least shows the reader where the value comes from.
+fn scalar_value_text(node: Node, source: &[u8]) -> String {
+    fold_value(node, source)
+        .unwrap_or_else(|| node.utf8_text(source).unwrap_or_default().to_string())
+}
+
+/// The runtime text of a value expression when it can be known without
+/// running PHP: a string literal, a heredoc or nowdoc body, or a `.`
+/// concatenation whose every operand is one of those.
+///
+/// `None` for anything needing runtime state — `env(…)`, a constant, an
+/// interpolated variable — so the caller shows the source text instead of a
+/// confidently wrong answer.
+fn fold_value(node: Node, source: &[u8]) -> Option<String> {
+    match node.kind() {
+        "string" => string_literal_text(node, source),
+        "encapsed_string" => {
+            // `"Hi $name"` has no static value. Only a literal run (plus its
+            // escapes) can be folded.
+            let mut cursor = node.walk();
+            let interpolated = node.children(&mut cursor).any(|child| {
+                !matches!(
+                    child.kind(),
+                    "string_content" | "escape_sequence" | "\"" | "'"
+                )
+            });
+            (!interpolated).then(|| string_literal_text(node, source))?
+        }
+        "heredoc" | "nowdoc" => {
+            let mut cursor = node.walk();
+            let body = node
+                .children(&mut cursor)
+                .find(|child| child.kind().ends_with("_body"))?;
+            // The body node starts at the newline that ends the `<<<EOT`
+            // opener; that newline is a delimiter, not content.
+            let text = body.utf8_text(source).ok()?;
+            let text = text
+                .strip_prefix("\r\n")
+                .or_else(|| text.strip_prefix('\n'))
+                .unwrap_or(text);
+            // A nowdoc (`<<<'EOT'`) is single-quote semantics; a heredoc is
+            // double-quote semantics.
+            Some(match node.kind() {
+                "nowdoc" => text.to_string(),
+                _ => unescape_php(text, '"'),
+            })
+        }
+        "binary_expression" => {
+            let operator = node.child_by_field_name("operator")?;
+            if operator.utf8_text(source).ok()? != "." {
+                return None;
+            }
+            let left = fold_value(node.child_by_field_name("left")?, source)?;
+            let right = fold_value(node.child_by_field_name("right")?, source)?;
+            Some(left + &right)
+        }
+        "expression" | "primary_expression" | "parenthesized_expression" => {
+            let mut cursor = node.walk();
+            let folded = node
+                .named_children(&mut cursor)
+                .find_map(|child| fold_value(child, source));
+            folded
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/config_key_locator.rs
+++ b/laravel-lsp/src/config_key_locator.rs
@@ -194,8 +194,14 @@ fn find_return_array(root: Node) -> Option<Node> {
     // statements`. Walk every descendant looking for a `return_statement`
     // whose expression is `array_creation_expression`. This handles both
     // top-level and namespaced files uniformly.
-    let mut stack = vec![root];
-    while let Some(node) = stack.pop() {
+    // Breadth-first, and siblings in document order. A LIFO stack visited
+    // later siblings first, so a file with two top-level `return`s resolved
+    // against the SECOND — dead code PHP never reaches, since a module stops
+    // at the first. Breadth-first also keeps the shallowest `return` winning,
+    // which is what makes a `return` inside an earlier closure lose to the
+    // file's own.
+    let mut queue = std::collections::VecDeque::from([root]);
+    while let Some(node) = queue.pop_front() {
         if node.kind() == "return_statement" {
             // The expression is typically a direct child, but tree-sitter
             // can wrap it in `expression`/`primary_expression` indirections.
@@ -208,7 +214,7 @@ fn find_return_array(root: Node) -> Option<Node> {
         }
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            stack.push(child);
+            queue.push_back(child);
         }
     }
     None
@@ -330,17 +336,22 @@ fn array_entries<'a>(array: Node<'a>, source: &[u8]) -> Vec<ParsedEntry<'a>> {
                 let parsed = literal_key(key_node, source);
                 // PHP advances the counter past an integer key however it was
                 // spelled — bare `7 =>` or the string `'7' =>`, which it casts.
-                // `saturating_add` keeps a `PHP_INT_MAX` key from overflowing:
-                // debug builds panicked, release wrapped to i64::MIN and then
-                // synthesized negative indices for every later entry.
+                //
+                // A `PHP_INT_MAX` key has no next index: PHP itself cannot
+                // place a further keyless entry. Saturating would hand the
+                // next one the SAME index, emitting one dotted key twice with
+                // two different values — ambiguous for goto and rename, and
+                // offered twice by completion. Stop synthesizing instead, the
+                // same answer a spread gets.
                 let as_int = integer_literal_value(key_node, source).or_else(|| {
                     parsed
                         .as_ref()
                         .and_then(|(text, _)| php_canonical_int(text))
                 });
                 if let Some(n) = as_int {
-                    let next = n.saturating_add(1);
-                    next_index = Some(next_index.map_or(next, |c| c.max(next)));
+                    next_index = n
+                        .checked_add(1)
+                        .map(|next| next_index.map_or(next, |c| c.max(next)));
                 }
                 if let Some((key_text, key_position)) = parsed {
                     out.push(ParsedEntry {
@@ -352,7 +363,7 @@ fn array_entries<'a>(array: Node<'a>, source: &[u8]) -> Vec<ParsedEntry<'a>> {
             }
             None => {
                 let Some(index) = next_index else { continue };
-                next_index = Some(index.saturating_add(1));
+                next_index = index.checked_add(1);
                 out.push(ParsedEntry {
                     key_text: index.to_string(),
                     key_position: synthesized_index_position(value_node),
@@ -401,11 +412,20 @@ fn integer_literal_value(node: Node, source: &[u8]) -> Option<i64> {
     match node.kind() {
         "integer" => node.utf8_text(source).ok()?.parse().ok(),
         "unary_op_expression" => {
-            let text = node.utf8_text(source).ok()?;
+            // Read the operator and the operand separately. Parsing the whole
+            // node span instead fails on `- 5`, because the span carries the
+            // whitespace and `i64::parse` rejects it; and testing the span for
+            // a leading `-` drops `+5`, which PHP accepts as key 5.
             let inner = node.child_by_field_name("argument")?;
-            (inner.kind() == "integer" && text.starts_with('-'))
-                .then(|| text.parse().ok())
-                .flatten()
+            if inner.kind() != "integer" {
+                return None;
+            }
+            let magnitude: i64 = inner.utf8_text(source).ok()?.trim().parse().ok()?;
+            match node.child(0)?.utf8_text(source).ok()? {
+                "-" => magnitude.checked_neg(),
+                "+" => Some(magnitude),
+                _ => None,
+            }
         }
         _ => None,
     }

--- a/laravel-lsp/src/config_key_locator.rs
+++ b/laravel-lsp/src/config_key_locator.rs
@@ -150,6 +150,24 @@ fn collect_keys(
     prefix: &str,
     out: &mut Vec<(String, String, KeyPosition)>,
 ) {
+    collect_keys_bounded(array, source, prefix, out, 0)
+}
+
+/// How deep [`collect_keys`] will descend into nested arrays. A catalogue is
+/// hand-written and never approaches this; the cap exists so a pathological or
+/// generated file cannot overflow the stack and abort the language server.
+const MAX_NEST_DEPTH: u32 = 128;
+
+fn collect_keys_bounded(
+    array: Node,
+    source: &[u8],
+    prefix: &str,
+    out: &mut Vec<(String, String, KeyPosition)>,
+    depth: u32,
+) {
+    if depth >= MAX_NEST_DEPTH {
+        return;
+    }
     for entry in array_entries(array, source) {
         let dotted = if prefix.is_empty() {
             entry.key_text.clone()
@@ -163,7 +181,7 @@ fn collect_keys(
         };
         out.push((dotted.clone(), value, entry.key_position));
         if let Some(nested) = nested {
-            collect_keys(nested, source, &dotted, out);
+            collect_keys_bounded(nested, source, &dotted, out, depth + 1);
         }
     }
 }
@@ -199,12 +217,28 @@ fn find_return_array(root: Node) -> Option<Node> {
 /// Recurse through `expression` / `primary_expression` wrappers to reach
 /// the underlying `array_creation_expression`, if present.
 fn find_array_in_expression(node: Node) -> Option<Node> {
+    find_array_bounded(node, 0)
+}
+
+/// Depth-bounded body of [`find_array_in_expression`].
+///
+/// This walks the WHOLE value subtree, not just wrapper nodes, so its depth is
+/// the expression's depth rather than a small constant. PHP's `.` is
+/// left-associative, so an N-term concatenation is an N-deep tree: a value
+/// built from 50,000 literals recursed 50,000 frames and aborted the language
+/// server with a stack overflow. An array nested past this depth is simply not
+/// descended into, which costs a few unreachable keys on a file no human
+/// wrote.
+fn find_array_bounded(node: Node, depth: u32) -> Option<Node> {
+    if depth >= MAX_NEST_DEPTH {
+        return None;
+    }
     if node.kind() == "array_creation_expression" {
         return Some(node);
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if let Some(arr) = find_array_in_expression(child) {
+        if let Some(arr) = find_array_bounded(child, depth + 1) {
             return Some(arr);
         }
     }
@@ -216,6 +250,30 @@ fn find_array_in_expression(node: Node) -> Option<Node> {
 /// segment, return the key position; otherwise descend into the value (which
 /// must itself be an array) and recurse.
 fn locate_at_path<'a>(array: Node<'a>, source: &[u8], path: &[&str]) -> Option<KeyPosition> {
+    entry_at_path(array, source, path).map(|entry| entry.key_position)
+}
+
+/// The source text of the value declared at `key_path`, exactly as written —
+/// `env('APP_NAME', 'Laravel')`, `'Laravel'`, `['a', 'b']`.
+///
+/// The structural counterpart to `config_lookup`'s byte scanner. Same answer
+/// for a well-formed entry; unlike the scanner it also reaches a key declared
+/// after a list entry, and a list index itself. Without it, completion and
+/// goto could offer a key whose value hover reported as missing, and whose use
+/// raised a false "not found" diagnostic.
+pub fn resolve_value_source(source: &str, key_path: &[&str]) -> Option<String> {
+    if key_path.is_empty() {
+        return None;
+    }
+    let tree = crate::parser::parse_php(source).ok()?;
+    let bytes = source.as_bytes();
+    let array = find_return_array(tree.root_node())?;
+    let entry = entry_at_path(array, bytes, key_path)?;
+    Some(entry.value_node.utf8_text(bytes).ok()?.trim().to_string())
+}
+
+/// Walk `array` along `path` and return the whole matching entry.
+fn entry_at_path<'a>(array: Node<'a>, source: &[u8], path: &[&str]) -> Option<ParsedEntry<'a>> {
     let (head, tail) = path.split_first()?;
     for entry in array_entries(array, source) {
         if entry.key_text != *head {
@@ -226,11 +284,11 @@ fn locate_at_path<'a>(array: Node<'a>, source: &[u8], path: &[&str]) -> Option<K
             continue;
         }
         if tail.is_empty() {
-            return Some(entry.key_position);
+            return Some(entry);
         }
         // Descend into the value, which must be another array.
         if let Some(nested) = find_array_in_expression(entry.value_node) {
-            return locate_at_path(nested, source, tail);
+            return entry_at_path(nested, source, tail);
         }
         // Path expects more nesting but the value isn't an array.
         return None;
@@ -269,10 +327,22 @@ fn array_entries<'a>(array: Node<'a>, source: &[u8]) -> Vec<ParsedEntry<'a>> {
         };
         match key_node {
             Some(key_node) => {
-                if let Some(n) = integer_literal_value(key_node, source) {
-                    next_index = Some(next_index.map_or(n + 1, |c| c.max(n + 1)));
+                let parsed = literal_key(key_node, source);
+                // PHP advances the counter past an integer key however it was
+                // spelled — bare `7 =>` or the string `'7' =>`, which it casts.
+                // `saturating_add` keeps a `PHP_INT_MAX` key from overflowing:
+                // debug builds panicked, release wrapped to i64::MIN and then
+                // synthesized negative indices for every later entry.
+                let as_int = integer_literal_value(key_node, source).or_else(|| {
+                    parsed
+                        .as_ref()
+                        .and_then(|(text, _)| php_canonical_int(text))
+                });
+                if let Some(n) = as_int {
+                    let next = n.saturating_add(1);
+                    next_index = Some(next_index.map_or(next, |c| c.max(next)));
                 }
-                if let Some((key_text, key_position)) = literal_key(key_node, source) {
+                if let Some((key_text, key_position)) = parsed {
                     out.push(ParsedEntry {
                         key_text,
                         key_position,
@@ -282,7 +352,7 @@ fn array_entries<'a>(array: Node<'a>, source: &[u8]) -> Vec<ParsedEntry<'a>> {
             }
             None => {
                 let Some(index) = next_index else { continue };
-                next_index = Some(index + 1);
+                next_index = Some(index.saturating_add(1));
                 out.push(ParsedEntry {
                     key_text: index.to_string(),
                     key_position: synthesized_index_position(value_node),
@@ -322,18 +392,47 @@ fn is_spread(node: Node) -> bool {
     spread
 }
 
-/// The integer a literal integer key denotes, e.g. `404 => …`.
+/// The integer a literal integer key denotes, e.g. `404 => …` or `-5 => …`.
+///
+/// A negative key is `unary_op_expression` wrapping an `integer`, never a bare
+/// `integer` with a sign in its text, so it needs its own branch — without it
+/// `-5 => 'x'` is dropped from enumeration entirely.
 fn integer_literal_value(node: Node, source: &[u8]) -> Option<i64> {
-    (node.kind() == "integer")
-        .then(|| node.utf8_text(source).ok()?.parse().ok())
-        .flatten()
+    match node.kind() {
+        "integer" => node.utf8_text(source).ok()?.parse().ok(),
+        "unary_op_expression" => {
+            let text = node.utf8_text(source).ok()?;
+            let inner = node.child_by_field_name("argument")?;
+            (inner.kind() == "integer" && text.starts_with('-'))
+                .then(|| text.parse().ok())
+                .flatten()
+        }
+        _ => None,
+    }
+}
+
+/// The integer a *string* key is cast to, following PHP's rule: a string key
+/// that is a canonical decimal integer becomes an integer key, and so advances
+/// the auto-index counter. `'7'` casts; `'07'`, `'+7'` and `'7.0'` do not.
+///
+/// Without this, `['7' => 'a', 'b']` numbers the keyless entry `0` instead of
+/// PHP's `8`, inventing a key that does not exist at runtime.
+fn php_canonical_int(text: &str) -> Option<i64> {
+    let digits = text.strip_prefix('-').unwrap_or(text);
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if digits.len() > 1 && digits.starts_with('0') {
+        return None;
+    }
+    text.parse().ok()
 }
 
 /// The dotted-path text a literal key contributes, and where it is declared.
 ///
-/// A quoted key reports `is_literal_key: true` — rename can rewrite it inside
-/// its quotes. An unquoted integer key (`404 => …`) reports `false`: it is a
-/// real, resolvable key, but replacing the bare digits with a name would
+/// A quoted key reports [`KeyKind::Quoted`] — rename can rewrite it inside its
+/// quotes. An unquoted integer key (`404 => …`) reports [`KeyKind::BareInteger`]:
+/// it is a real, resolvable key, but replacing the bare digits with a name would
 /// produce a constant lookup rather than a string key.
 fn literal_key(node: Node, source: &[u8]) -> Option<(String, KeyPosition)> {
     if let Some(text) = string_literal_text(node, source) {
@@ -439,8 +538,44 @@ fn unescape_php(body: &str, quote: char) -> String {
             Some('v') => out.push('\u{0B}'),
             Some('f') => out.push('\u{0C}'),
             Some('e') => out.push('\u{1B}'),
-            Some('0') => out.push('\0'),
             Some(next @ ('\\' | '"' | '$')) => out.push(next),
+            // `\xNN`, `\u{NNNN}` and octal `\NNN` — PHP resolves all three in
+            // a double-quoted context. Anything malformed is left as written
+            // rather than guessed at, matching PHP, which also emits the text.
+            Some('x') => match take_radix(&mut chars, 16, 2) {
+                Some(v) => out.push(v as u8 as char),
+                None => out.push_str("\\x"),
+            },
+            Some('u') if chars.as_str().starts_with('{') => {
+                chars.next();
+                let digits: String = chars.by_ref().take_while(|c| *c != '}').collect();
+                match u32::from_str_radix(&digits, 16)
+                    .ok()
+                    .and_then(char::from_u32)
+                {
+                    Some(c) => out.push(c),
+                    None => {
+                        out.push_str("\\u{");
+                        out.push_str(&digits);
+                        out.push('}');
+                    }
+                }
+            }
+            Some(first @ '0'..='7') => {
+                // `\0` alone is NUL; `\101` is 'A'. Up to three octal digits,
+                // the first already consumed.
+                let mut value = first as u32 - '0' as u32;
+                for _ in 0..2 {
+                    match chars.clone().next().filter(|c| ('0'..='7').contains(c)) {
+                        Some(d) => {
+                            chars.next();
+                            value = value * 8 + (d as u32 - '0' as u32);
+                        }
+                        None => break,
+                    }
+                }
+                out.push((value as u8) as char);
+            }
             Some(other) => {
                 out.push('\\');
                 out.push(other);
@@ -450,13 +585,43 @@ fn unescape_php(body: &str, quote: char) -> String {
     out
 }
 
+/// Consume up to `max` digits in `radix` from `chars`, returning their value.
+/// `None` — leaving `chars` untouched — when the first character is not a
+/// digit, so a malformed escape can be emitted as written.
+fn take_radix(chars: &mut std::str::Chars, radix: u32, max: usize) -> Option<u32> {
+    let mut probe = chars.clone();
+    let mut value = 0u32;
+    let mut seen = 0usize;
+    while seen < max {
+        match probe.clone().next().and_then(|c| c.to_digit(radix)) {
+            Some(d) => {
+                probe.next();
+                value = value * radix + d;
+                seen += 1;
+            }
+            None => break,
+        }
+    }
+    (seen > 0).then(|| {
+        *chars = probe;
+        value
+    })
+}
+
 /// The display text of a non-array value. Statically knowable values are
 /// resolved to what PHP would produce; anything else falls back to its source
 /// text, which at least shows the reader where the value comes from.
 fn scalar_value_text(node: Node, source: &[u8]) -> String {
-    fold_value(node, source)
+    fold_value_bounded(node, source, 0)
         .unwrap_or_else(|| node.utf8_text(source).unwrap_or_default().to_string())
 }
+
+/// How deep [`fold_value`] will descend. PHP's `.` is left-associative, so an
+/// N-term concatenation is an N-deep AST; folding it by recursion overflowed
+/// the stack and aborted the whole language server on a file that merely
+/// contained one. Past this depth the value falls back to its source text,
+/// which is the same answer any unfoldable expression gets.
+const MAX_FOLD_DEPTH: u32 = 128;
 
 /// The runtime text of a value expression when it can be known without
 /// running PHP: a string literal, a heredoc or nowdoc body, or a `.`
@@ -465,7 +630,10 @@ fn scalar_value_text(node: Node, source: &[u8]) -> String {
 /// `None` for anything needing runtime state — `env(…)`, a constant, an
 /// interpolated variable — so the caller shows the source text instead of a
 /// confidently wrong answer.
-fn fold_value(node: Node, source: &[u8]) -> Option<String> {
+fn fold_value_bounded(node: Node, source: &[u8], depth: u32) -> Option<String> {
+    if depth >= MAX_FOLD_DEPTH {
+        return None;
+    }
     match node.kind() {
         "string" => string_literal_text(node, source),
         "encapsed_string" => {
@@ -504,15 +672,15 @@ fn fold_value(node: Node, source: &[u8]) -> Option<String> {
             if operator.utf8_text(source).ok()? != "." {
                 return None;
             }
-            let left = fold_value(node.child_by_field_name("left")?, source)?;
-            let right = fold_value(node.child_by_field_name("right")?, source)?;
+            let left = fold_value_bounded(node.child_by_field_name("left")?, source, depth + 1)?;
+            let right = fold_value_bounded(node.child_by_field_name("right")?, source, depth + 1)?;
             Some(left + &right)
         }
         "expression" | "primary_expression" | "parenthesized_expression" => {
             let mut cursor = node.walk();
             let folded = node
                 .named_children(&mut cursor)
-                .find_map(|child| fold_value(child, source));
+                .find_map(|child| fold_value_bounded(child, source, depth + 1));
             folded
         }
         _ => None,

--- a/laravel-lsp/src/config_key_locator/tests.rs
+++ b/laravel-lsp/src/config_key_locator/tests.rs
@@ -481,7 +481,7 @@ return [
 }
 
 #[test]
-fn only_a_quoted_key_is_marked_renameable() {
+fn each_key_kind_reports_how_it_is_written() {
     let src = r#"<?php
 return [
     'quoted' => 'a',
@@ -489,12 +489,12 @@ return [
     'list' => ['c'],
 ];
 "#;
-    let flag = |path: &[&str]| locate_in_source(src, path).unwrap().is_literal_key;
-    assert!(flag(&["quoted"]), "a quoted key can be rewritten in place");
-    // Rewriting bare `404` would make it a constant lookup.
-    assert!(!flag(&["404"]));
-    // A list index has no source text at all.
-    assert!(!flag(&["list", "0"]));
+    let kind = |path: &[&str]| locate_in_source(src, path).unwrap().kind;
+    assert_eq!(kind(&["quoted"]), KeyKind::Quoted);
+    assert_eq!(kind(&["404"]), KeyKind::BareInteger);
+    assert_eq!(kind(&["list", "0"]), KeyKind::SynthesizedIndex);
+    // Every kind resolves — the distinction is only about the key's own text.
+    assert!(locate_in_source(src, &["list", "0"]).is_some());
 }
 
 #[test]

--- a/laravel-lsp/src/config_key_locator/tests.rs
+++ b/laravel-lsp/src/config_key_locator/tests.rs
@@ -555,3 +555,260 @@ fn an_interpolated_value_is_not_folded() {
     // No static answer; the source text is the honest display.
     assert_eq!(value_of(src, "greet").as_deref(), Some("\"Hi $name\""));
 }
+
+// ── the shape matrix ──────────────────────────────────────────────────────
+//
+// Every PHP catalogue shape the walker claims to read, in one place, as data.
+// Mutation testing proves the walker discriminates the logic we wrote; only
+// this table proves we thought of the *shape*. Add a row before adding a
+// branch — a gap here is invisible to every other test in this file.
+//
+// Each row is (label, php source, expected `(dotted key, value)` pairs in
+// document order). An empty value means "array-valued, no scalar of its own".
+
+type Shape = (
+    &'static str,
+    &'static str,
+    &'static [(&'static str, &'static str)],
+);
+
+const SHAPES: &[Shape] = &[
+    (
+        "plain string key",
+        "<?php\nreturn ['a' => 'b'];\n",
+        &[("a", "b")],
+    ),
+    (
+        "double-quoted key",
+        "<?php\nreturn [\"a\" => \"b\"];\n",
+        &[("a", "b")],
+    ),
+    (
+        "hyphenated key",
+        "<?php\nreturn ['a-b' => 'c'];\n",
+        &[("a-b", "c")],
+    ),
+    (
+        "dotted key",
+        "<?php\nreturn ['a.b' => 'c'];\n",
+        &[("a.b", "c")],
+    ),
+    (
+        "quoted numeric key",
+        "<?php\nreturn ['404' => 'nf'];\n",
+        &[("404", "nf")],
+    ),
+    (
+        "bare integer key",
+        "<?php\nreturn [404 => 'nf'];\n",
+        &[("404", "nf")],
+    ),
+    (
+        "negative integer key",
+        "<?php\nreturn [-5 => 'x'];\n",
+        &[("-5", "x")],
+    ),
+    (
+        "escaped quote in key",
+        "<?php\nreturn ['it\\'s' => 'v'];\n",
+        &[("it's", "v")],
+    ),
+    (
+        "nested arrays",
+        "<?php\nreturn ['a' => ['b' => 'c']];\n",
+        &[("a", ""), ("a.b", "c")],
+    ),
+    (
+        "array() long syntax",
+        "<?php\nreturn array('a' => array('b' => 'c'));\n",
+        &[("a", ""), ("a.b", "c")],
+    ),
+    (
+        "scalar list",
+        "<?php\nreturn ['l' => ['x', 'y']];\n",
+        &[("l", ""), ("l.0", "x"), ("l.1", "y")],
+    ),
+    (
+        "list of arrays",
+        "<?php\nreturn ['l' => [['k' => 'v']]];\n",
+        &[("l", ""), ("l.0", ""), ("l.0.k", "v")],
+    ),
+    // PHP: an explicit integer key moves the counter to n + 1.
+    (
+        "int key advances counter",
+        "<?php\nreturn ['l' => ['a', 5 => 'b', 'c']];\n",
+        &[("l", ""), ("l.0", "a"), ("l.5", "b"), ("l.6", "c")],
+    ),
+    // PHP casts a canonical decimal string key to an integer, counter included.
+    (
+        "string-int key advances counter",
+        "<?php\nreturn ['l' => ['7' => 'a', 'b']];\n",
+        &[("l", ""), ("l.7", "a"), ("l.8", "b")],
+    ),
+    // '07' is not canonical, so it stays a string and moves nothing.
+    (
+        "leading-zero key stays a string",
+        "<?php\nreturn ['l' => ['07' => 'a', 'b']];\n",
+        &[("l", ""), ("l.07", "a"), ("l.0", "b")],
+    ),
+    (
+        "empty string value",
+        "<?php\nreturn ['a' => ''];\n",
+        &[("a", "")],
+    ),
+    (
+        "single-quote escapes",
+        "<?php\nreturn ['a' => 'x\\nz', 'b' => 'q\\\\r'];\n",
+        &[("a", "x\\nz"), ("b", "q\\r")],
+    ),
+    (
+        "double-quote escapes",
+        "<?php\nreturn [\"a\" => \"x\\nz\", \"b\" => \"say \\\"hi\\\"\"];\n",
+        &[("a", "x\nz"), ("b", "say \"hi\"")],
+    ),
+    (
+        "hex escape",
+        "<?php\nreturn [\"a\" => \"\\x41\"];\n",
+        &[("a", "A")],
+    ),
+    (
+        "octal escape",
+        "<?php\nreturn [\"a\" => \"\\101\"];\n",
+        &[("a", "A")],
+    ),
+    (
+        "nul escape",
+        "<?php\nreturn [\"a\" => \"\\0\"];\n",
+        &[("a", "\0")],
+    ),
+    (
+        "unicode escape",
+        "<?php\nreturn [\"a\" => \"\\u{41}\"];\n",
+        &[("a", "A")],
+    ),
+    (
+        "malformed hex escape stays literal",
+        "<?php\nreturn [\"a\" => \"\\xZZ\"];\n",
+        &[("a", "\\xZZ")],
+    ),
+    (
+        "literal concatenation folds",
+        "<?php\nreturn ['a' => 'x' . 'y'];\n",
+        &[("a", "xy")],
+    ),
+    (
+        "dynamic concatenation keeps source",
+        "<?php\nreturn ['a' => 'x' . $y];\n",
+        &[("a", "'x' . $y")],
+    ),
+    (
+        "interpolation keeps source",
+        "<?php\nreturn ['a' => \"hi $n\"];\n",
+        &[("a", "\"hi $n\"")],
+    ),
+    (
+        "non-string scalar keeps source",
+        "<?php\nreturn ['a' => 42, 'b' => true];\n",
+        &[("a", "42"), ("b", "true")],
+    ),
+    (
+        "call keeps whole source",
+        "<?php\nreturn ['a' => env('X', 'd')];\n",
+        &[("a", "env('X', 'd')")],
+    ),
+    (
+        "comments between entries",
+        "<?php\nreturn [\n // c\n 'a' => 'b',\n /* c */ 'd' => 'e',\n];\n",
+        &[("a", "b"), ("d", "e")],
+    ),
+    // A spread contributes an unknown element count, so later positions are
+    // unnameable — keyed entries after it are still fine.
+    (
+        "spread halts index synthesis",
+        "<?php\nreturn ['l' => ['a', ...$o, 'c'], 'k' => 'v'];\n",
+        &[("l", ""), ("l.0", "a"), ("k", "v")],
+    ),
+    (
+        "constant key skipped",
+        "<?php\nreturn [Foo::BAR => 'b', 'a' => 'c'];\n",
+        &[("a", "c")],
+    ),
+    ("no return array", "<?php\n$x = 1;\n", &[]),
+];
+
+#[test]
+fn every_shape_enumerates_as_documented() {
+    let mut failures = Vec::new();
+    for (label, src, expected) in SHAPES {
+        let got = enum_entries(src);
+        let want: Vec<(String, String)> = expected
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        if got != want {
+            failures.push(format!("{label}\n     got {got:?}\n    want {want:?}"));
+        }
+    }
+    assert!(failures.is_empty(), "\n  {}", failures.join("\n  "));
+}
+
+#[test]
+fn every_shape_navigates_to_every_key_it_enumerates() {
+    // The invariant #369 exists to protect: completion must never offer a key
+    // go-to-definition cannot follow. Checked across the whole matrix, so a new
+    // row cannot add an enumerable-but-unreachable key unnoticed.
+    let mut failures = Vec::new();
+    for (label, src, _) in SHAPES {
+        for (key, _) in enum_entries(src) {
+            let path: Vec<&str> = key.split('.').collect();
+            // A literal dotted key ('a.b') is one segment that split() breaks
+            // apart; the locator resolves it by its full text, checked in
+            // b5_hyphenated_numeric_and_dotted_keys_all_enumerate.
+            if src.contains(&format!("'{key}'")) && key.contains('.') {
+                continue;
+            }
+            if locate_in_source(src, &path).is_none() {
+                failures.push(format!(
+                    "{label}: enumerated {key:?} but cannot navigate to it"
+                ));
+            }
+        }
+    }
+    assert!(failures.is_empty(), "\n  {}", failures.join("\n  "));
+}
+
+#[test]
+fn pathological_input_degrades_instead_of_aborting() {
+    // Both of these overflowed the stack and killed the process. A language
+    // server must not die because a file is strange.
+    let chain = std::iter::repeat_n("'a'", 50_000)
+        .collect::<Vec<_>>()
+        .join(" . ");
+    let src = format!("<?php\nreturn ['k' => {chain}];\n");
+    assert_eq!(
+        enum_entries(&src).len(),
+        1,
+        "deep concatenation must not abort"
+    );
+
+    let deep = format!(
+        "<?php\nreturn {}{}{};\n",
+        "['a' => ".repeat(500),
+        "'v'",
+        "]".repeat(500)
+    );
+    let _ = enum_entries(&deep);
+
+    // `PHP_INT_MAX` as a key used to panic in debug and wrap to i64::MIN in
+    // release, which then synthesized negative indices for every later entry.
+    let max = "<?php\nreturn ['l' => [9223372036854775807 => 'x', 'y']];\n";
+    assert_eq!(
+        enum_entries(max),
+        vec![
+            ("l".to_string(), String::new()),
+            ("l.9223372036854775807".to_string(), "x".to_string()),
+            ("l.9223372036854775807".to_string(), "y".to_string()),
+        ],
+        "saturates rather than wrapping"
+    );
+}

--- a/laravel-lsp/src/config_key_locator/tests.rs
+++ b/laravel-lsp/src/config_key_locator/tests.rs
@@ -170,7 +170,7 @@ return [
 }
 
 #[test]
-fn enumerate_skips_numeric_list_entries() {
+fn enumerate_indexes_numeric_list_entries() {
     let src = r#"<?php
 return [
     'providers' => [
@@ -183,12 +183,375 @@ return [
 ];
 "#;
     let keys = enum_keys(src);
-    // `providers` is keyed; its list items are numeric → skipped. `aliases`
-    // and its string-keyed child are emitted.
-    assert_eq!(keys, vec!["providers", "aliases", "aliases.Route"]);
+    // `providers`' list items get PHP's own indices. `config('app.providers.0')`
+    // resolves at runtime, so the tool reports it; they used to be skipped.
+    assert_eq!(
+        keys,
+        vec![
+            "providers",
+            "providers.0",
+            "providers.1",
+            "aliases",
+            "aliases.Route"
+        ]
+    );
 }
 
 #[test]
 fn enumerate_empty_for_non_array_php() {
     assert!(enum_keys("<?php echo 'hi';").is_empty());
+}
+
+// ── enumerate_entries_in_source: value text + the #369 Part B regressions ──
+//
+// Each test below names the finding it pins. The retired
+// `salsa_impl::parse_translation_keys` failed every one of them; it counted
+// `[` and `]` per line, so any bracket inside a value or on a line of its own
+// desynchronised its key stack.
+
+fn enum_entries(src: &str) -> Vec<(String, String)> {
+    enumerate_entries_in_source(src)
+        .into_iter()
+        .map(|(key, value, _)| (key, value))
+        .collect()
+}
+
+fn value_of(src: &str, key: &str) -> Option<String> {
+    enum_entries(src)
+        .into_iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v)
+}
+
+#[test]
+fn entry_value_is_the_string_content_without_quotes() {
+    let src = r#"<?php
+return [
+    'welcome' => 'Hello, :name!',
+    'empty' => '',
+];
+"#;
+    assert_eq!(value_of(src, "welcome").as_deref(), Some("Hello, :name!"));
+    // An empty literal has no `string_content` child at all.
+    assert_eq!(value_of(src, "empty").as_deref(), Some(""));
+}
+
+#[test]
+fn entry_value_for_a_non_string_scalar_is_its_raw_source_text() {
+    let src = r#"<?php
+return [
+    'count' => 42,
+    'flag' => true,
+    'from_env' => env('APP_NAME', 'Laravel'),
+];
+"#;
+    assert_eq!(value_of(src, "count").as_deref(), Some("42"));
+    assert_eq!(value_of(src, "flag").as_deref(), Some("true"));
+    // The whole call, NOT the `'APP_NAME'` string nested inside it — the
+    // wrapper unwrap must not descend into an arbitrary expression.
+    assert_eq!(
+        value_of(src, "from_env").as_deref(),
+        Some("env('APP_NAME', 'Laravel')")
+    );
+}
+
+#[test]
+fn entry_value_for_an_array_valued_key_is_empty() {
+    let src = r#"<?php
+return [
+    'form' => [
+        'title' => 'Title',
+    ],
+];
+"#;
+    // The group key is still enumerated — it is a real, referenceable key —
+    // but it has no scalar of its own to display.
+    assert_eq!(value_of(src, "form").as_deref(), Some(""));
+    assert_eq!(value_of(src, "form.title").as_deref(), Some("Title"));
+}
+
+#[test]
+fn b1_a_bare_bracket_list_entry_neither_pushes_nor_pops_a_key_level() {
+    let src = r#"<?php
+return [
+    'form' => [
+        'list' => [
+            [
+                'x' => 'val1',
+            ],
+        ],
+        'manufacturer' => 'Manufacturer',
+    ],
+];
+"#;
+    // The bare `[` line pushed no name but its `]` popped one, so the scanner
+    // desynchronised here. On this exact shape it also double-pushed `list`
+    // (the bug #350 removes), which masked the pop on `manufacturer` — it
+    // reported `page.form.list.list.x` and a correct `form.manufacturer`.
+    // Pinning the whole set catches both halves; asserting `manufacturer`
+    // alone would pass against the retired scanner.
+    //
+    // `x` sits under a list entry, so its real Laravel key is `form.list.0.x`
+    // — which is what the walker reports. The scanner offered
+    // `form.list.list.x`, a path that resolves to nothing.
+    assert_eq!(
+        enum_entries(src),
+        vec![
+            ("form".to_string(), String::new()),
+            ("form.list".to_string(), String::new()),
+            ("form.list.0".to_string(), String::new()),
+            ("form.list.0.x".to_string(), "val1".to_string()),
+            ("form.manufacturer".to_string(), "Manufacturer".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn b2_a_key_split_across_lines_nests_correctly_and_emits_no_empty_leaf() {
+    let src = r#"<?php
+return [
+    'form' =>
+    [
+        'x' => 'y',
+    ],
+];
+"#;
+    assert_eq!(
+        enum_entries(src),
+        vec![
+            ("form".to_string(), String::new()),
+            ("form.x".to_string(), "y".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn b3_a_bracket_or_arrow_inside_a_value_does_not_corrupt_nesting() {
+    let src = r#"<?php
+return [
+    'form' => [
+        'a' => 'see [docs]',
+        'b' => 'maps => [ like this',
+        'c' => 'Kept',
+    ],
+];
+"#;
+    assert_eq!(
+        enum_entries(src),
+        vec![
+            ("form".to_string(), String::new()),
+            ("form.a".to_string(), "see [docs]".to_string()),
+            ("form.b".to_string(), "maps => [ like this".to_string()),
+            ("form.c".to_string(), "Kept".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn b4_an_escaped_quote_in_a_value_keeps_the_whole_value() {
+    let src = "<?php\nreturn [\n    'a' => 'It\\'s here',\n    'b' => 'plain',\n];\n";
+    // The value must survive the escape. Building it from the string node's
+    // `string_content` children would yield `It`, because the escape splits
+    // the run in two.
+    assert_eq!(
+        enum_entries(src),
+        vec![
+            ("a".to_string(), "It's here".to_string()),
+            ("b".to_string(), "plain".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn b4_an_escaped_quote_in_a_key_yields_the_key_php_reads() {
+    let src = "<?php\nreturn [\n    'it\\'s' => 'value',\n    'next' => 'also here',\n];\n";
+    let keys = enum_entries(src)
+        .into_iter()
+        .map(|(k, _)| k)
+        .collect::<Vec<_>>();
+    // The retired regex captured `s`, the tail after the escape. Taking the
+    // first `string_content` run instead would give `it`. Only unescaping the
+    // whole literal body gives `it's` — the key PHP actually stores, and the
+    // one `__('page.it\'s')` looks up.
+    assert_eq!(keys, vec!["it's".to_string(), "next".to_string()]);
+}
+
+#[test]
+fn b5_hyphenated_numeric_and_dotted_keys_all_enumerate() {
+    let src = r#"<?php
+return [
+    'variant-color' => 'Color',
+    '404' => 'Not found',
+    'a.b' => 'Dotted',
+];
+"#;
+    // The old identifier pattern `[a-zA-Z_][a-zA-Z0-9_]*` matched none of
+    // these, so completion offered none of them while goto resolved all three.
+    assert_eq!(
+        enum_entries(src),
+        vec![
+            ("variant-color".to_string(), "Color".to_string()),
+            ("404".to_string(), "Not found".to_string()),
+            ("a.b".to_string(), "Dotted".to_string()),
+        ]
+    );
+}
+
+// ── every catalogue shape PHP legitimately allows ─────────────────────────
+
+#[test]
+fn list_entries_take_phps_own_indices_and_are_navigable() {
+    let src = r#"<?php
+return [
+    'sizes' => ['sm', 'md'],
+];
+"#;
+    assert_eq!(
+        enum_entries(src),
+        vec![
+            ("sizes".to_string(), String::new()),
+            ("sizes.0".to_string(), "sm".to_string()),
+            ("sizes.1".to_string(), "md".to_string()),
+        ]
+    );
+    // Completion must never offer a key goto cannot follow — that divergence
+    // is the whole reason #369 exists.
+    assert!(locate_in_source(src, &["sizes", "1"]).is_some());
+}
+
+#[test]
+fn an_explicit_integer_key_advances_the_index_counter_like_php() {
+    // PHP: `['a', 5 => 'b', 'c']` is 0, 5, 6.
+    let src = r#"<?php
+return [
+    'list' => ['a', 5 => 'b', 'c'],
+];
+"#;
+    let keys = enum_keys(src);
+    assert_eq!(
+        keys,
+        vec!["list", "list.0", "list.5", "list.6"],
+        "got {keys:?}"
+    );
+}
+
+#[test]
+fn an_unquoted_integer_key_is_enumerated_and_navigable() {
+    let src = r#"<?php
+return [
+    404 => 'Not found',
+];
+"#;
+    assert_eq!(
+        enum_entries(src),
+        vec![("404".to_string(), "Not found".to_string())]
+    );
+    assert!(locate_in_source(src, &["404"]).is_some());
+}
+
+#[test]
+fn a_spread_stops_index_synthesis_rather_than_guessing() {
+    // `...$other` contributes an unknown number of elements, so no later
+    // position can be named. Keyed entries after it are still fine.
+    let src = r#"<?php
+return [
+    'list' => ['a', ...$other, 'c'],
+    'kept' => 'yes',
+];
+"#;
+    let keys = enum_keys(src);
+    assert!(keys.contains(&"list.0".to_string()), "got {keys:?}");
+    assert!(!keys.contains(&"list.1".to_string()), "got {keys:?}");
+    assert!(keys.contains(&"kept".to_string()), "got {keys:?}");
+}
+
+#[test]
+fn a_list_entry_no_longer_hides_the_keys_declared_after_it() {
+    // `locate_at_path` used to `?` on the first unparseable entry, so one
+    // list item aborted the whole lookup.
+    let src = r#"<?php
+return [
+    'providers' => [
+        App\Providers\AppServiceProvider::class,
+    ],
+    'later' => 'reachable',
+];
+"#;
+    assert!(locate_in_source(src, &["later"]).is_some());
+}
+
+#[test]
+fn only_a_quoted_key_is_marked_renameable() {
+    let src = r#"<?php
+return [
+    'quoted' => 'a',
+    404 => 'b',
+    'list' => ['c'],
+];
+"#;
+    let flag = |path: &[&str]| locate_in_source(src, path).unwrap().is_literal_key;
+    assert!(flag(&["quoted"]), "a quoted key can be rewritten in place");
+    // Rewriting bare `404` would make it a constant lookup.
+    assert!(!flag(&["404"]));
+    // A list index has no source text at all.
+    assert!(!flag(&["list", "0"]));
+}
+
+#[test]
+fn concatenated_literal_values_are_folded() {
+    let src = r#"<?php
+return [
+    'joined' => 'Hello, ' . 'world',
+    'dynamic' => 'Hello, ' . $name,
+];
+"#;
+    assert_eq!(value_of(src, "joined").as_deref(), Some("Hello, world"));
+    // Not statically knowable — show the source rather than a wrong answer.
+    assert_eq!(
+        value_of(src, "dynamic").as_deref(),
+        Some("'Hello, ' . $name")
+    );
+}
+
+#[test]
+fn heredoc_and_nowdoc_values_drop_their_markers() {
+    let src = r#"<?php
+return [
+    'here' => <<<EOT
+line one
+EOT,
+    'now' => <<<'EOT'
+raw \n text
+EOT,
+];
+"#;
+    assert_eq!(value_of(src, "here").as_deref(), Some("line one"));
+    // A nowdoc resolves nothing, so the backslash and the `n` stay two
+    // separate characters.
+    assert_eq!(value_of(src, "now").as_deref(), Some("raw \\n text"));
+}
+
+#[test]
+fn escape_resolution_follows_the_quote_style() {
+    let src = r#"<?php
+return [
+    'single' => 'a\nb',
+    'double' => "a\nb",
+    'quote' => "He said \"hi\"",
+    'apostrophe' => 'It\'s here',
+];
+"#;
+    // A single-quoted literal resolves only \' and \\, so `\n` is a
+    // backslash followed by an `n` — two characters, not a newline.
+    assert_eq!(value_of(src, "single").as_deref(), Some("a\\nb"));
+    assert_eq!(value_of(src, "double").as_deref(), Some("a\nb"));
+    assert_eq!(value_of(src, "quote").as_deref(), Some("He said \"hi\""));
+    assert_eq!(value_of(src, "apostrophe").as_deref(), Some("It's here"));
+}
+
+#[test]
+fn an_interpolated_value_is_not_folded() {
+    let src = "<?php\nreturn [\n    'greet' => \"Hi $name\",\n];\n";
+    // No static answer; the source text is the honest display.
+    assert_eq!(value_of(src, "greet").as_deref(), Some("\"Hi $name\""));
 }

--- a/laravel-lsp/src/config_key_locator/tests.rs
+++ b/laravel-lsp/src/config_key_locator/tests.rs
@@ -593,6 +593,14 @@ const SHAPES: &[Shape] = &[
         "<?php\nreturn ['a.b' => 'c'];\n",
         &[("a.b", "c")],
     ),
+    // A dotted key NESTED in an array is unreachable in Laravel: `Arr::get`
+    // tests the whole key once, then walks segments, so `form` → `a` fails.
+    // Offering `form.a.b` would offer a key that resolves to null.
+    (
+        "nested dotted key is unaddressable",
+        "<?php\nreturn ['form' => ['a.b' => 'v'], 'k' => 'y'];\n",
+        &[("form", ""), ("k", "y")],
+    ),
     (
         "quoted numeric key",
         "<?php\nreturn ['404' => 'nf'];\n",

--- a/laravel-lsp/src/config_key_locator/tests.rs
+++ b/laravel-lsp/src/config_key_locator/tests.rs
@@ -608,6 +608,22 @@ const SHAPES: &[Shape] = &[
         "<?php\nreturn [-5 => 'x'];\n",
         &[("-5", "x")],
     ),
+    // PHP accepts a unary plus, and whitespace around either operator.
+    (
+        "unary-plus key",
+        "<?php\nreturn [+5 => 'x'];\n",
+        &[("5", "x")],
+    ),
+    (
+        "spaced unary key",
+        "<?php\nreturn [- 5 => 'x'];\n",
+        &[("-5", "x")],
+    ),
+    (
+        "unary key advances counter",
+        "<?php\nreturn ['l' => [+5 => 'a', 'b']];\n",
+        &[("l", ""), ("l.5", "a"), ("l.6", "b")],
+    ),
     (
         "escaped quote in key",
         "<?php\nreturn ['it\\'s' => 'v'];\n",
@@ -760,14 +776,15 @@ fn every_shape_navigates_to_every_key_it_enumerates() {
     let mut failures = Vec::new();
     for (label, src, _) in SHAPES {
         for (key, _) in enum_entries(src) {
-            let path: Vec<&str> = key.split('.').collect();
-            // A literal dotted key ('a.b') is one segment that split() breaks
-            // apart; the locator resolves it by its full text, checked in
-            // b5_hyphenated_numeric_and_dotted_keys_all_enumerate.
-            if src.contains(&format!("'{key}'")) && key.contains('.') {
-                continue;
-            }
-            if locate_in_source(src, &path).is_none() {
+            // A dotted key is ambiguous on its face: `a.b` is either one
+            // literal key or a path through `a`. Try both spellings rather
+            // than guessing from the source text — an earlier version asked
+            // whether `'a.b'` appeared anywhere in the file, which any
+            // unrelated decoy string could satisfy, silently excusing a
+            // genuinely unreachable nested key.
+            let whole = locate_in_source(src, &[key.as_str()]).is_some();
+            let split: Vec<&str> = key.split('.').collect();
+            if !whole && locate_in_source(src, &split).is_none() {
                 failures.push(format!(
                     "{label}: enumerated {key:?} but cannot navigate to it"
                 ));
@@ -797,18 +814,45 @@ fn pathological_input_degrades_instead_of_aborting() {
         "'v'",
         "]".repeat(500)
     );
-    let _ = enum_entries(&deep);
+    let nested = enum_entries(&deep);
+    // Nesting past the bound is truncated, not crashed — and every key ABOVE
+    // the bound must survive, or the guard would be eating real catalogue
+    // keys. Asserting the exact count pins the truncation depth; discarding
+    // the result (as this line once did) passed even with the bound cut to 10.
+    assert_eq!(
+        nested.len(),
+        128,
+        "one key per level, capped at MAX_NEST_DEPTH"
+    );
+    assert_eq!(nested[0].0, "a", "the outermost key is still reported");
 
     // `PHP_INT_MAX` as a key used to panic in debug and wrap to i64::MIN in
     // release, which then synthesized negative indices for every later entry.
+    // Saturating instead was no better: it handed the next keyless entry the
+    // SAME index, emitting one dotted key twice with two different values.
+    // PHP cannot place a further keyless entry after `PHP_INT_MAX` either, so
+    // index synthesis stops — the answer a spread already gets.
     let max = "<?php\nreturn ['l' => [9223372036854775807 => 'x', 'y']];\n";
     assert_eq!(
         enum_entries(max),
         vec![
             ("l".to_string(), String::new()),
             ("l.9223372036854775807".to_string(), "x".to_string()),
-            ("l.9223372036854775807".to_string(), "y".to_string()),
         ],
-        "saturates rather than wrapping"
+        "no next index exists, so no duplicate key is invented"
     );
+}
+
+#[test]
+fn the_first_top_level_return_wins_and_a_closure_return_never_does() {
+    // PHP stops at the first `return` in an included file; anything after it
+    // is unreachable. A LIFO walk picked the LAST one.
+    let two = "<?php\nreturn ['a' => 'one'];\nreturn ['a' => 'two'];\n";
+    assert_eq!(value_of(two, "a").as_deref(), Some("one"));
+
+    // The shallowest return still wins, so a `return` inside an earlier
+    // closure does not hijack the file's own config array.
+    let closure = "<?php\n$f = function () { return ['i' => 'nope']; };\nreturn ['a' => 'app'];\n";
+    assert_eq!(value_of(closure, "a").as_deref(), Some("app"));
+    assert_eq!(value_of(closure, "i"), None);
 }

--- a/laravel-lsp/src/config_lookup.rs
+++ b/laravel-lsp/src/config_lookup.rs
@@ -12,6 +12,13 @@
 //!
 //! Pure parsing — no I/O outside the initial `read_to_string`. Easy to unit-test
 //! with synthetic PHP source.
+//!
+//! The walk itself lives in [`crate::config_key_locator`], which reads the same
+//! `return [...]` array with tree-sitter. Until #369 this module carried its own
+//! byte scanner — a second implementation over identical data, and a strictly
+//! worse one: it stopped at the first entry it could not parse, so a key
+//! declared after a list entry resolved to nothing, and a list index never
+//! resolved at all.
 
 use std::path::{Path, PathBuf};
 
@@ -51,225 +58,14 @@ pub fn resolve_value_with_source(
 /// Source-only variant for unit tests — operates on a string rather than
 /// reading from disk.
 pub fn resolve_in_source(source: &str, key_path: &[&str]) -> Option<String> {
-    let bytes = source.as_bytes();
-    let array_open = find_return_array_open(bytes)?;
-    let raw = walk_path(bytes, array_open, key_path)?;
-    Some(raw.trim().to_string())
-}
-
-/// Locate the opening `[` of the `return [...];` literal at the top of a
-/// Laravel config file. Skips strings, line comments, and block comments so
-/// stray `return`s in docblocks or in strings don't confuse the search.
-fn find_return_array_open(bytes: &[u8]) -> Option<usize> {
-    let mut i = 0usize;
-    let mut in_string: Option<u8> = None;
-    while i < bytes.len() {
-        if let Some(quote) = in_string {
-            if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                i += 2;
-                continue;
-            }
-            if bytes[i] == quote {
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-        // Comments
-        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'/' {
-            while i < bytes.len() && bytes[i] != b'\n' {
-                i += 1;
-            }
-            continue;
-        }
-        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
-            i += 2;
-            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                i += 1;
-            }
-            i = i.saturating_add(2);
-            continue;
-        }
-        // Strings
-        if bytes[i] == b'\'' || bytes[i] == b'"' {
-            in_string = Some(bytes[i]);
-            i += 1;
-            continue;
-        }
-        // Match `return` with word boundaries.
-        if i + 6 <= bytes.len() && &bytes[i..i + 6] == b"return" {
-            let before_ok = i == 0 || !is_identifier_byte(bytes[i - 1]);
-            let after_ok = i + 6 >= bytes.len() || !is_identifier_byte(bytes[i + 6]);
-            if before_ok && after_ok {
-                let mut j = i + 6;
-                while j < bytes.len() {
-                    let b = bytes[j];
-                    if b == b'[' {
-                        return Some(j + 1);
-                    }
-                    if b == b';' {
-                        return None;
-                    }
-                    j += 1;
-                }
-                return None;
-            }
-        }
-        i += 1;
-    }
-    None
-}
-
-/// Walk down the key path within the array starting at byte `array_open`
-/// (which points to the first byte AFTER the opening `[`). Returns the raw
-/// source bytes of the matched value, untrimmed.
-fn walk_path(bytes: &[u8], array_open: usize, path: &[&str]) -> Option<String> {
-    if path.is_empty() {
-        return None;
-    }
-    let head = path[0];
-    let tail = &path[1..];
-    let mut i = array_open;
-
-    while i < bytes.len() {
-        skip_ws_and_comments(bytes, &mut i);
-        if i >= bytes.len() || bytes[i] == b']' {
-            return None;
-        }
-
-        let (key, after_key) = read_string_key(bytes, i)?;
-        i = after_key;
-        skip_ws_and_comments(bytes, &mut i);
-
-        if i + 2 > bytes.len() || &bytes[i..i + 2] != b"=>" {
-            return None;
-        }
-        i += 2;
-        skip_ws_and_comments(bytes, &mut i);
-
-        let value_start = i;
-        let value_end = read_value_end(bytes, i);
-
-        if key == head {
-            if tail.is_empty() {
-                let s = std::str::from_utf8(&bytes[value_start..value_end]).ok()?;
-                return Some(s.to_string());
-            }
-            // Recurse into a nested array literal.
-            let mut j = value_start;
-            skip_ws_and_comments(bytes, &mut j);
-            if j < bytes.len() && bytes[j] == b'[' {
-                return walk_path(bytes, j + 1, tail);
-            }
-            return None;
-        }
-
-        i = value_end;
-        if i < bytes.len() && bytes[i] == b',' {
-            i += 1;
-        }
-    }
-    None
-}
-
-/// Skip whitespace, `//` line comments, `/* */` block comments, and `#` shell
-/// comments. Advances `i` until the next significant byte.
-fn skip_ws_and_comments(bytes: &[u8], i: &mut usize) {
-    loop {
-        while *i < bytes.len() && bytes[*i].is_ascii_whitespace() {
-            *i += 1;
-        }
-        if *i + 1 < bytes.len() && bytes[*i] == b'/' && bytes[*i + 1] == b'/' {
-            while *i < bytes.len() && bytes[*i] != b'\n' {
-                *i += 1;
-            }
-            continue;
-        }
-        if *i + 1 < bytes.len() && bytes[*i] == b'/' && bytes[*i + 1] == b'*' {
-            *i += 2;
-            while *i + 1 < bytes.len() && !(bytes[*i] == b'*' && bytes[*i + 1] == b'/') {
-                *i += 1;
-            }
-            *i = i.saturating_add(2);
-            continue;
-        }
-        if *i < bytes.len() && bytes[*i] == b'#' {
-            while *i < bytes.len() && bytes[*i] != b'\n' {
-                *i += 1;
-            }
-            continue;
-        }
-        break;
-    }
-}
-
-/// Parse a quoted string key at `start`. Returns the unescaped key and the
-/// byte offset just past the closing quote. `None` for non-string keys
-/// (integers, constants) — those aren't supported for hover lookup yet.
-fn read_string_key(bytes: &[u8], start: usize) -> Option<(String, usize)> {
-    if start >= bytes.len() {
-        return None;
-    }
-    let quote = bytes[start];
-    if quote != b'\'' && quote != b'"' {
-        return None;
-    }
-    let mut i = start + 1;
-    let mut out = String::new();
-    while i < bytes.len() && bytes[i] != quote {
-        if bytes[i] == b'\\' && i + 1 < bytes.len() {
-            out.push(bytes[i + 1] as char);
-            i += 2;
-            continue;
-        }
-        out.push(bytes[i] as char);
-        i += 1;
-    }
-    if i >= bytes.len() {
-        return None;
-    }
-    Some((out, i + 1))
-}
-
-/// Find the byte offset where the current value ends — at the next `,` or `]`
-/// at depth 0, skipping over nested parens/brackets/braces and string literals.
-fn read_value_end(bytes: &[u8], start: usize) -> usize {
-    let mut i = start;
-    let mut depth = 0i32;
-    let mut in_string: Option<u8> = None;
-    while i < bytes.len() {
-        let b = bytes[i];
-        if let Some(quote) = in_string {
-            if b == b'\\' && i + 1 < bytes.len() {
-                i += 2;
-                continue;
-            }
-            if b == quote {
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-        match b {
-            b'\'' | b'"' => in_string = Some(b),
-            b'(' | b'[' | b'{' => depth += 1,
-            b')' | b'}' => depth -= 1,
-            b']' => {
-                if depth == 0 {
-                    return i;
-                }
-                depth -= 1;
-            }
-            b',' if depth == 0 => return i,
-            _ => {}
-        }
-        i += 1;
-    }
-    i
-}
-
-fn is_identifier_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_'
+    // Delegates to the tree-sitter walk that already backs goto, completion
+    // and code lenses (#369). The byte scanner this replaced aborted at the
+    // first entry it could not parse, so a key declared after a list entry
+    // resolved to nothing, and a list index (`providers.0`) never resolved at
+    // all — while completion offered both and goto navigated to them. Hover
+    // said "value not found" and `__()` raised a false "not found"
+    // diagnostic for keys that resolve perfectly well at runtime.
+    crate::config_key_locator::resolve_value_source(source, key_path)
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/config_lookup/tests.rs
+++ b/laravel-lsp/src/config_lookup/tests.rs
@@ -161,3 +161,58 @@ return [
         Some("'matched'")
     );
 }
+
+// ── #369: navigation and value resolution must agree ──────────────────────
+
+/// Every key the enumerator offers must also resolve to a value here.
+///
+/// These two paths used to be different implementations over the same file:
+/// completion and goto walked the AST, hover and the "not found" diagnostic
+/// counted brackets. The scanner stopped at the first entry it could not
+/// parse, so it disagreed exactly where list entries appear — and #369 made
+/// those keys reachable, turning a latent split into a visible one.
+#[test]
+fn every_enumerated_key_also_resolves_to_a_value() {
+    let src = r#"<?php
+return [
+    'options' => ['a', 'b'],
+    'after' => 'sibling',
+    404 => 'Not found',
+    'nested' => [
+        ['deep' => 'value'],
+    ],
+];
+"#;
+    let mut unresolved = Vec::new();
+    for (key, _, _) in crate::config_key_locator::enumerate_entries_in_source(src) {
+        let path: Vec<&str> = key.split('.').collect();
+        if resolve_in_source(src, &path).is_none() {
+            unresolved.push(key);
+        }
+    }
+    assert!(
+        unresolved.is_empty(),
+        "these keys are offered but resolve to nothing: {unresolved:?}"
+    );
+}
+
+#[test]
+fn a_key_after_a_list_entry_resolves() {
+    // The scanner returned None here: the list items before `after` aborted
+    // its whole walk.
+    let src = "<?php\nreturn [\n    'options' => ['a', 'b'],\n    'after' => 'sibling',\n];\n";
+    assert_eq!(
+        resolve_in_source(src, &["after"]).as_deref(),
+        Some("'sibling'")
+    );
+}
+
+#[test]
+fn a_list_index_resolves_to_its_element() {
+    // The scanner could never resolve a bare list index, for any array.
+    let src = "<?php\nreturn [\n    'options' => ['a', 'b'],\n];\n";
+    assert_eq!(
+        resolve_in_source(src, &["options", "1"]).as_deref(),
+        Some("'b'")
+    );
+}

--- a/laravel-lsp/src/config_lookup/tests.rs
+++ b/laravel-lsp/src/config_lookup/tests.rs
@@ -183,8 +183,15 @@ return [
     ],
 ];
 "#;
+    let entries = crate::config_key_locator::enumerate_entries_in_source(src);
+    // Without this the test is vacuous: an enumerator returning nothing
+    // trivially satisfies "every enumerated key resolves".
+    assert!(
+        entries.len() >= 6,
+        "the fixture must actually enumerate, got {entries:?}"
+    );
     let mut unresolved = Vec::new();
-    for (key, _, _) in crate::config_key_locator::enumerate_entries_in_source(src) {
+    for (key, _, _) in entries {
         let path: Vec<&str> = key.split('.').collect();
         if resolve_in_source(src, &path).is_none() {
             unresolved.push(key);

--- a/laravel-lsp/src/config_lookup/tests.rs
+++ b/laravel-lsp/src/config_lookup/tests.rs
@@ -197,13 +197,21 @@ return [
 }
 
 #[test]
-fn a_key_after_a_list_entry_resolves() {
-    // The scanner returned None here: the list items before `after` aborted
-    // its whole walk.
-    let src = "<?php\nreturn [\n    'options' => ['a', 'b'],\n    'after' => 'sibling',\n];\n";
+fn a_key_after_a_non_string_key_resolves() {
+    // The retired byte scanner skipped a LIST value by counting balanced
+    // brackets, so a list before the target was survivable. What actually
+    // aborted its walk was a non-string KEY at the target's own nesting
+    // level: `read_string_key` required a quote, found a digit, and gave up
+    // on the rest of the array. Everything declared after `404 =>` was
+    // unreachable.
+    let src = "<?php\nreturn [\n    404 => 'Not found',\n    'after' => 'sibling',\n];\n";
     assert_eq!(
         resolve_in_source(src, &["after"]).as_deref(),
         Some("'sibling'")
+    );
+    assert_eq!(
+        resolve_in_source(src, &["404"]).as_deref(),
+        Some("'Not found'")
     );
 }
 

--- a/laravel-lsp/src/env_key_locator.rs
+++ b/laravel-lsp/src/env_key_locator.rs
@@ -131,6 +131,7 @@ pub fn locate_in_source(source: &str, key: &str) -> Option<KeyPosition> {
             line: line_idx as u32,
             start_column: start_col,
             end_column: end_col,
+            is_literal_key: true,
         });
     }
     None
@@ -157,6 +158,7 @@ pub fn enumerate_keys_in_source(source: &str) -> Vec<(String, KeyPosition)> {
                 line: line_idx as u32,
                 start_column: start_col,
                 end_column: end_col,
+                is_literal_key: true,
             },
         ));
     }
@@ -219,6 +221,7 @@ pub fn enumerate_commented_keys_in_source(source: &str) -> Vec<(String, KeyPosit
                 line: line_idx as u32,
                 start_column: start_col + offset,
                 end_column: end_col + offset,
+                is_literal_key: true,
             },
         ));
     }

--- a/laravel-lsp/src/env_key_locator.rs
+++ b/laravel-lsp/src/env_key_locator.rs
@@ -131,7 +131,7 @@ pub fn locate_in_source(source: &str, key: &str) -> Option<KeyPosition> {
             line: line_idx as u32,
             start_column: start_col,
             end_column: end_col,
-            is_literal_key: true,
+            kind: crate::config_key_locator::KeyKind::Quoted,
         });
     }
     None
@@ -158,7 +158,7 @@ pub fn enumerate_keys_in_source(source: &str) -> Vec<(String, KeyPosition)> {
                 line: line_idx as u32,
                 start_column: start_col,
                 end_column: end_col,
-                is_literal_key: true,
+                kind: crate::config_key_locator::KeyKind::Quoted,
             },
         ));
     }
@@ -221,7 +221,7 @@ pub fn enumerate_commented_keys_in_source(source: &str) -> Vec<(String, KeyPosit
                 line: line_idx as u32,
                 start_column: start_col + offset,
                 end_column: end_col + offset,
-                is_literal_key: true,
+                kind: crate::config_key_locator::KeyKind::Quoted,
             },
         ));
     }

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -14861,10 +14861,24 @@ impl LaravelLanguageServer {
                 let Ok(content) = std::fs::read_to_string(&path) else {
                     continue;
                 };
-                for (key, value) in Self::parse_config_keys(&content, group, &env_vars) {
-                    merged.entry(key.clone()).or_insert(ConfigKeyCompletion {
-                        key,
-                        value,
+                // Structural enumeration, the same walk behind config goto,
+                // hover and code lenses. The per-line regex this replaced was
+                // the last of the three scanners #369 found: it mis-nested any
+                // file with a list entry, a key split across lines, or a `]`
+                // inside a value, and it never saw list indices or bare
+                // integer keys at all — so completion offered a different set
+                // of keys than goto could reach.
+                for (key, value, _position) in
+                    laravel_lsp::config_key_locator::enumerate_entries_in_source(&content)
+                {
+                    let dotted = format!("{group}.{key}");
+                    // `env('APP_NAME', 'Laravel')` is not statically foldable,
+                    // so the walker hands back its source text and the resolver
+                    // reads the project's `.env` — redaction included.
+                    let display = Self::resolve_env_value(&value, &env_vars);
+                    merged.entry(dotted.clone()).or_insert(ConfigKeyCompletion {
+                        key: dotted,
+                        value: display,
                         source: source.clone(),
                     });
                 }
@@ -15674,100 +15688,6 @@ impl LaravelLanguageServer {
 
     /// Parse a PHP config file to extract all keys and values
     /// Returns a list of (key, value) tuples with dot-notation keys
-    fn parse_config_keys(
-        content: &str,
-        base_key: &str,
-        env_vars: &std::collections::HashMap<String, String>,
-    ) -> Vec<(String, String)> {
-        let mut results = Vec::new();
-
-        // Simple regex-based parsing for Laravel config files
-        // This handles the common patterns: 'key' => value, or "key" => value
-        // Note: Allows hyphens in keys (kebab-case is common in Laravel configs)
-        let key_pattern = regex::Regex::new(r#"['"]([a-zA-Z_][a-zA-Z0-9_-]*)['"][\s]*=>"#).unwrap();
-
-        // Track nesting depth and current key path
-        let mut key_stack: Vec<String> = vec![base_key.to_string()];
-        let mut in_array_depth = 0;
-        let mut pending_key: Option<String> = None;
-
-        for line in content.lines() {
-            let trimmed = line.trim();
-
-            // Skip comments and empty lines
-            if trimmed.is_empty()
-                || trimmed.starts_with("//")
-                || trimmed.starts_with("/*")
-                || trimmed.starts_with("*")
-            {
-                continue;
-            }
-
-            // Handle array opening
-            if trimmed.contains("[") && !trimmed.contains("=>") {
-                in_array_depth += 1;
-                if let Some(key) = pending_key.take() {
-                    key_stack.push(key);
-                }
-                continue;
-            }
-
-            // Handle key => [ (nested array on same line)
-            if let Some(caps) = key_pattern.captures(trimmed) {
-                let key_name = caps.get(1).unwrap().as_str();
-
-                if trimmed.contains("=> [") || trimmed.ends_with("=> [") {
-                    // This is a nested array
-                    pending_key = Some(key_name.to_string());
-                    in_array_depth += 1;
-                    key_stack.push(key_name.to_string());
-                } else {
-                    // This is a simple key => value
-                    let full_key = format!("{}.{}", key_stack.join("."), key_name);
-
-                    // Extract value and resolve env() references
-                    let value = Self::extract_config_value(trimmed, env_vars);
-                    results.push((full_key, value));
-                }
-            }
-
-            // Handle array closing
-            let close_count = trimmed.matches(']').count();
-            for _ in 0..close_count {
-                if in_array_depth > 0 {
-                    in_array_depth -= 1;
-                    if key_stack.len() > 1 {
-                        key_stack.pop();
-                    }
-                }
-            }
-        }
-
-        results
-    }
-
-    /// Extract the value from a config line like "'key' => value,"
-    /// Resolves env() references using the provided env_vars map
-    ///
-    /// Returns the value at full length. Truncation happens at each render
-    /// site instead, because the completion list line and the documentation
-    /// panel want different budgets and one shared cut served neither
-    /// (issue #326) — see `laravel_lsp::completion_display`.
-    fn extract_config_value(
-        line: &str,
-        env_vars: &std::collections::HashMap<String, String>,
-    ) -> String {
-        if let Some(arrow_pos) = line.find("=>") {
-            let after_arrow = &line[arrow_pos + 2..];
-            let value = after_arrow.trim().trim_end_matches(',').trim();
-
-            // Check for env() call pattern: env('VAR_NAME') or env('VAR_NAME', 'default')
-            Self::resolve_env_value(value, env_vars)
-        } else {
-            String::new()
-        }
-    }
-
     /// Resolve an env() call to its actual value
     /// Handles: env('VAR'), env('VAR', 'default'), env('VAR', default_value),
     /// and the `(bool) env('VAR')` cast spelling.
@@ -25549,9 +25469,15 @@ impl LanguageServer for LaravelLanguageServer {
                 // declaration site gets only its own leaf segment, since the
                 // group `->name('admin.')` prefix lives at a separate decl.
                 if let Some(root) = root_path.as_ref() {
-                    targets.extend(
+                    // Same fail-closed rule as the config and translation arms
+                    // (#369). A route name with call sites but no locatable
+                    // declaration — defined in a package, or by a walker shape
+                    // we do not read — would otherwise have every `route('…')`
+                    // rewritten to a name nothing declares.
+                    targets.extend(laravel_lsp::rename::require_declaration_edits(
+                        name,
                         collect_route_declaration_targets(self, root, name, &new_name).await,
-                    );
+                    )?);
                 }
             }
             laravel_lsp::references::SymbolRef::Config(key) => {
@@ -25587,7 +25513,13 @@ impl LanguageServer for LaravelLanguageServer {
                 // at every declaration AND every call site. Touches every
                 // `.env*` file at the project root that has the key.
                 if let Some(root) = root_path.as_ref() {
-                    targets.extend(collect_env_declaration_targets(root, key, &new_name));
+                    // Same fail-closed rule. `env('UNDECLARED_VAR')` has call
+                    // sites and no declaration in any `.env*` file; rewriting
+                    // them alone points every read at a name nothing defines.
+                    targets.extend(laravel_lsp::rename::require_declaration_edits(
+                        key,
+                        collect_env_declaration_targets(root, key, &new_name),
+                    )?);
                 }
             }
             laravel_lsp::references::SymbolRef::Component(name) => {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -22397,11 +22397,11 @@ fn collect_config_declaration_target(
     let new_leaf = new_key.rsplit('.').next().unwrap_or(new_key).to_string();
     laravel_lsp::config_key_locator::locate_key_all(root, module_dirs, old_key)
         .into_iter()
-        // A key with no quoted text cannot be renamed in place: a list index
+        // Only a quoted key can be rewritten in place: a list index
         // (`providers.0`) has no source text at all, and rewriting a bare
         // `404 =>` would turn a string key into a constant lookup. Both stay
         // navigable; neither is an edit target.
-        .filter(|(_, pos)| pos.is_literal_key)
+        .filter(|(_, pos)| pos.kind == laravel_lsp::config_key_locator::KeyKind::Quoted)
         .map(|(file_path, pos)| laravel_lsp::rename::EditTarget {
             file_path,
             line: pos.line,

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -25561,22 +25561,25 @@ impl LanguageServer for LaravelLanguageServer {
                 // change without moving the config file.
                 if let Some(root) = root_path.as_ref() {
                     let module_dirs = self.module_dirs_for(root).await;
-                    targets.extend(collect_config_declaration_target(
-                        root,
-                        &module_dirs,
+                    let declarations =
+                        collect_config_declaration_target(root, &module_dirs, key, &new_name);
+                    targets.extend(laravel_lsp::rename::require_declaration_edits(
                         key,
-                        &new_name,
-                    ));
+                        declarations,
+                    )?);
                 }
             }
             laravel_lsp::references::SymbolRef::Translation(key) => {
                 // Same shape as config but applied across every locale's lang
                 // file under lang/<locale>/<file>.php.
                 if let Some(root) = root_path.as_ref() {
-                    targets.extend(
+                    let declarations =
                         collect_translation_declaration_targets(&self.salsa, root, key, &new_name)
-                            .await,
-                    );
+                            .await;
+                    targets.extend(laravel_lsp::rename::require_declaration_edits(
+                        key,
+                        declarations,
+                    )?);
                 }
             }
             laravel_lsp::references::SymbolRef::Env(key) => {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -22397,6 +22397,11 @@ fn collect_config_declaration_target(
     let new_leaf = new_key.rsplit('.').next().unwrap_or(new_key).to_string();
     laravel_lsp::config_key_locator::locate_key_all(root, module_dirs, old_key)
         .into_iter()
+        // A key with no quoted text cannot be renamed in place: a list index
+        // (`providers.0`) has no source text at all, and rewriting a bare
+        // `404 =>` would turn a string key into a constant lookup. Both stay
+        // navigable; neither is an edit target.
+        .filter(|(_, pos)| pos.is_literal_key)
         .map(|(file_path, pos)| laravel_lsp::rename::EditTarget {
             file_path,
             line: pos.line,

--- a/laravel-lsp/src/rename.rs
+++ b/laravel-lsp/src/rename.rs
@@ -90,6 +90,30 @@ pub fn can_rename(symbol: &SymbolRef) -> bool {
     )
 }
 
+/// Refuse a rename that produced no declaration edit.
+///
+/// [`can_rename`] gates on the symbol's KIND, but a dotted config or
+/// translation key can pass that gate and still have no rewritable
+/// declaration: since #369 a key spelled `404 =>`, or a list index like
+/// `providers.0`, is offered by completion and reachable by go-to-definition,
+/// yet neither has quoted text a new name could replace.
+///
+/// Call sites are collected unconditionally and earlier, so without this the
+/// rename would apply them alone — silently pointing every call at a key that
+/// does not exist. That is the "never call-sites-only" invariant [`can_rename`]
+/// documents, enforced rather than assumed.
+pub fn require_declaration_edits<T>(
+    key: &str,
+    declarations: Vec<T>,
+) -> Result<Vec<T>, tower_lsp::jsonrpc::Error> {
+    if declarations.is_empty() {
+        return Err(rename_error(format!(
+            "'{key}' cannot be renamed: it has no quoted declaration to rewrite."
+        )));
+    }
+    Ok(declarations)
+}
+
 /// Build a generic rename-related LSP error with the message a Zed toast
 /// will display. Wraps the verbose `jsonrpc::Error` boilerplate for the
 /// rename handler's many short-circuit cases (invalid new name, vendor

--- a/laravel-lsp/src/rename/tests.rs
+++ b/laravel-lsp/src/rename/tests.rs
@@ -544,3 +544,30 @@ fn locate_magic_member_declaration_absent_is_none() {
 fn can_rename_accepts_class_kind() {
     assert!(can_rename(&SymbolRef::Class(r"App\Models\Flight".into())));
 }
+
+// ── #369: a rename never applies call sites without a declaration ─────────
+
+#[test]
+fn require_declaration_edits_passes_through_a_non_empty_list() {
+    let decls = vec!["one", "two"];
+    assert_eq!(
+        super::require_declaration_edits("app.name", decls).expect("a declaration exists"),
+        vec!["one", "two"]
+    );
+}
+
+#[test]
+fn require_declaration_edits_refuses_an_empty_list() {
+    // `config('app.404')` and `config('app.providers.0')` reach the rename
+    // handler since #369 — completion offers them and goto follows them — but
+    // neither has quoted text to rewrite. Applying the call-site edits alone
+    // would repoint every call at a key that does not exist.
+    let empty: Vec<&str> = Vec::new();
+    let err = super::require_declaration_edits("app.404", empty)
+        .expect_err("a key with no quoted declaration must not rename");
+    assert!(
+        err.message.contains("app.404") && err.message.contains("no quoted declaration"),
+        "the toast must name the key and the reason, got {:?}",
+        err.message
+    );
+}

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2299,11 +2299,13 @@ impl TranslationCache {
             }
             TranslationKeyTarget::Json(key) => locate_json_key_in_file(&*db, file, key.clone()),
         };
-        found.map(|(line, start_column, end_column)| KeyLocationData {
-            line,
-            start_column,
-            end_column,
-        })
+        found.map(
+            |(line, start_column, end_column, _renameable)| KeyLocationData {
+                line,
+                start_column,
+                end_column,
+            },
+        )
     }
 
     /// Every translation key autocomplete should offer, sorted and deduped.
@@ -2476,7 +2478,10 @@ impl TranslationCache {
             }
             let locale_file = lang_dir.join(&name).join(format!("{file_stem}.php"));
             let file = self.ensure_file(db, &locale_file, root);
-            if let Some(&(line, start_column, end_column)) =
+            // `is_literal_key` false means the key has no quoted text to
+            // rewrite — a list index (`page.items.0`) or a bare `404 =>`.
+            // Both resolve for goto; neither is a rename target.
+            if let Some(&(line, start_column, end_column, true)) =
                 locate_php_key_in_file(&*db, file, key_path.clone()).as_ref()
             {
                 out.push(TranslationKeyLocationData {
@@ -2649,108 +2654,15 @@ pub struct KeyLocationData {
     pub end_column: u32,
 }
 
-/// Parse a PHP translation file to extract all keys and values
-/// Returns a list of (key, value) tuples with dot-notation keys
-fn parse_translation_keys(content: &str, base_key: &str) -> Vec<(String, String)> {
-    let mut results = Vec::new();
-
-    // Simple regex-based parsing for Laravel translation files
-    // This handles: 'key' => 'value', or "key" => "value"
-    //
-    // Compiled once: this used to be rebuilt on every completion request, for
-    // every catalogue in the locale (issue #293).
-    static KEY_PATTERN: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
-        regex::Regex::new(r#"['"]([a-zA-Z_][a-zA-Z0-9_]*)['"][\s]*=>"#).unwrap()
-    });
-    let key_pattern = &*KEY_PATTERN;
-
-    // Track nesting depth and current key path
-    let mut key_stack: Vec<String> = vec![base_key.to_string()];
-    let mut in_array_depth = 0;
-    let mut pending_key: Option<String> = None;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        // Skip comments and empty lines
-        if trimmed.is_empty()
-            || trimmed.starts_with("//")
-            || trimmed.starts_with("/*")
-            || trimmed.starts_with("*")
-        {
-            continue;
-        }
-
-        // Handle array opening
-        if trimmed.contains("[") && !trimmed.contains("=>") {
-            in_array_depth += 1;
-            if let Some(key) = pending_key.take() {
-                key_stack.push(key);
-            }
-            continue;
-        }
-
-        // Handle key => [ (nested array on same line)
-        if let Some(caps) = key_pattern.captures(trimmed) {
-            let key_name = caps.get(1).unwrap().as_str();
-
-            if trimmed.contains("=> [") || trimmed.ends_with("=> [") {
-                // This is a nested array
-                pending_key = Some(key_name.to_string());
-                in_array_depth += 1;
-                key_stack.push(key_name.to_string());
-            } else {
-                // This is a simple key => value
-                let full_key = format!("{}.{}", key_stack.join("."), key_name);
-
-                // Extract value
-                let value = extract_translation_value(trimmed);
-                results.push((full_key, value));
-            }
-        }
-
-        // Handle array closing
-        let close_count = trimmed.matches(']').count();
-        for _ in 0..close_count {
-            if in_array_depth > 0 {
-                in_array_depth -= 1;
-                if key_stack.len() > 1 {
-                    key_stack.pop();
-                }
-            }
-        }
-    }
-
-    results
-}
-
-/// Extract the value from a translation line like "'key' => 'value',".
-///
-/// Returns the value at full length — see `completion_display` for why the
-/// truncation lives at the render sites rather than here.
-pub fn extract_translation_value(line: &str) -> String {
-    if let Some(arrow_pos) = line.find("=>") {
-        let after_arrow = &line[arrow_pos + 2..];
-        let value = after_arrow.trim().trim_end_matches(',').trim();
-
-        // Remove the surrounding quotes; the value is returned at full
-        // length. Truncation happens at each render site instead, because
-        // the completion list line and the documentation panel want
-        // different budgets and one shared cut served neither (issue #326).
-        value
-            .trim_start_matches('\'')
-            .trim_start_matches('"')
-            .trim_end_matches('\'')
-            .trim_end_matches('"')
-            .to_string()
-    } else {
-        String::new()
-    }
-}
-
 /// Every `key => value` pair one PHP catalogue declares, dot-prefixed with
 /// `base_key`. Memoized per `(file, base_key)` — autocomplete used to re-read
 /// and re-parse every catalogue in the locale on each request (issue #293).
+///
+/// Enumerated by the same tree-sitter walk that backs go-to-definition
+/// (`config_key_locator`), not by a text scanner. Until #369 this counted `[`
+/// and `]` per line, which mis-nested any catalogue holding a list entry, a
+/// key split across lines, or a `]` inside a value — while goto, resolving the
+/// identical file structurally, stayed correct.
 #[salsa::tracked]
 pub fn translation_keys_in_file(
     db: &dyn Db,
@@ -2761,7 +2673,10 @@ pub fn translation_keys_in_file(
     if text.is_empty() {
         return Vec::new();
     }
-    parse_translation_keys(text, &base_key)
+    crate::config_key_locator::enumerate_entries_in_source(text)
+        .into_iter()
+        .map(|(key, value, _position)| (format!("{base_key}.{key}"), value))
+        .collect()
 }
 
 /// Where a nested key is declared inside a PHP catalogue, as
@@ -2777,14 +2692,19 @@ pub fn locate_php_key_in_file(
     db: &dyn Db,
     file: LangFile,
     key_path: Vec<String>,
-) -> Option<(u32, u32, u32)> {
+) -> Option<(u32, u32, u32, bool)> {
     let text = file.text(db);
     if text.is_empty() {
         return None;
     }
     let refs: Vec<&str> = key_path.iter().map(String::as_str).collect();
     let pos = crate::config_key_locator::locate_in_source(text, &refs)?;
-    Some((pos.line, pos.start_column, pos.end_column))
+    Some((
+        pos.line,
+        pos.start_column,
+        pos.end_column,
+        pos.is_literal_key,
+    ))
 }
 
 /// Where a text key is declared inside a JSON catalogue, as
@@ -2798,7 +2718,7 @@ pub fn locate_json_key_in_file(
     db: &dyn Db,
     file: LangFile,
     key: String,
-) -> Option<(u32, u32, u32)> {
+) -> Option<(u32, u32, u32, bool)> {
     let text = file.text(db);
     if text.is_empty() {
         return None;
@@ -2808,7 +2728,9 @@ pub fn locate_json_key_in_file(
         let col = line.find(&needle)?;
         // Skip the opening quote so the span covers the key itself.
         let start = (col + 1) as u32;
-        Some((line_num as u32, start, start + key.len() as u32))
+        // A JSON key is always a quoted literal, so always renameable — the
+        // flag exists for PHP's list indices and bare integer keys.
+        Some((line_num as u32, start, start + key.len() as u32, true))
     })
 }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2699,11 +2699,13 @@ pub fn locate_php_key_in_file(
     }
     let refs: Vec<&str> = key_path.iter().map(String::as_str).collect();
     let pos = crate::config_key_locator::locate_in_source(text, &refs)?;
+    // The bool is "may a rename rewrite this", the only distinction this
+    // boundary needs; `KeyKind` itself stays on the locator's side.
     Some((
         pos.line,
         pos.start_column,
         pos.end_column,
-        pos.is_literal_key,
+        pos.kind == crate::config_key_locator::KeyKind::Quoted,
     ))
 }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -2478,9 +2478,9 @@ impl TranslationCache {
             }
             let locale_file = lang_dir.join(&name).join(format!("{file_stem}.php"));
             let file = self.ensure_file(db, &locale_file, root);
-            // `is_literal_key` false means the key has no quoted text to
-            // rewrite — a list index (`page.items.0`) or a bare `404 =>`.
-            // Both resolve for goto; neither is a rename target.
+            // A `false` flag means the key has no quoted text to rewrite — a
+            // list index (`page.items.0`) or a bare `404 =>`. Both resolve for
+            // goto; neither is a rename target.
             if let Some(&(line, start_column, end_column, true)) =
                 locate_php_key_in_file(&*db, file, key_path.clone()).as_ref()
             {

--- a/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
+++ b/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
@@ -278,22 +278,36 @@ fn translation_value_under_two_hundred_chars_is_not_truncated() {
     assert_eq!(display, value);
 }
 
+/// The display value config completion reports for a single entry — the
+/// successor to `extract_config_value`, which #369 retired with the rest of
+/// the per-line scanner. Exercised through a real catalogue, because the
+/// walker parses a file rather than a line.
+fn config_display_value(value: &str) -> String {
+    let source = format!("<?php\n\nreturn [\n    'key' => '{}',\n];\n", value);
+    let entries = laravel_lsp::config_key_locator::enumerate_entries_in_source(&source);
+    let (_, text, _) = entries
+        .into_iter()
+        .find(|(key, _, _)| key == "key")
+        .expect("the catalogue declares 'key'");
+    // The resolver is the second half of the old function: it turns an
+    // `env(...)` expression into a value and passes anything else through.
+    LaravelLanguageServer::resolve_env_value(&text, &std::collections::HashMap::new())
+}
+
 #[test]
 fn config_value_truncation_is_char_boundary_safe() {
     let value: String = "a".repeat(199) + "ü" + &"ö".repeat(50);
-    let line = format!("'key' => '{}',", value);
-    let env_vars = std::collections::HashMap::new();
-    let display = LaravelLanguageServer::extract_config_value(&line, &env_vars);
-    assert_eq!(display, value, "the extractor must not truncate at all");
+    assert_eq!(
+        config_display_value(&value),
+        value,
+        "the extractor must not truncate at all"
+    );
 }
 
 #[test]
 fn config_value_under_two_hundred_chars_is_not_truncated() {
     let value = "ü".repeat(30);
-    let line = format!("'key' => '{}',", value);
-    let env_vars = std::collections::HashMap::new();
-    let display = LaravelLanguageServer::extract_config_value(&line, &env_vars);
-    assert_eq!(display, value);
+    assert_eq!(config_display_value(&value), value);
 }
 
 #[test]
@@ -305,10 +319,5 @@ fn a_five_thousand_char_translation_value_survives_extraction_whole() {
 #[test]
 fn a_five_thousand_char_config_value_survives_extraction_whole() {
     let value = "ö".repeat(5_000);
-    let line = format!("'key' => '{}',", value);
-    let env_vars = std::collections::HashMap::new();
-    assert_eq!(
-        LaravelLanguageServer::extract_config_value(&line, &env_vars),
-        value
-    );
+    assert_eq!(config_display_value(&value), value);
 }

--- a/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
+++ b/laravel-lsp/src/tests/byte_offset_panic_hardening.rs
@@ -243,16 +243,29 @@ fn detect_method_name_position_detects_instance_past_multibyte_char() {
 // *absence* of a cut rather than a safe one.
 //
 // `extract_translation_value` moved into `salsa_impl` when translation reads
-// were routed through Salsa (issue #293); it is the same function, and this
-// coverage follows it rather than being dropped.
+// were routed through Salsa (issue #293), then was retired outright by #369
+// along with the rest of the per-line text scanner. The property it guarded is
+// now `config_key_locator::enumerate_entries_in_source`'s, so this coverage
+// follows it a second time rather than being dropped.
+
+/// The display value the catalogue walker reports for a single entry — the
+/// successor to `extract_translation_value`, exercised through a real
+/// catalogue because the walker parses a file rather than a line.
+fn translation_display_value(value: &str) -> String {
+    let source = format!("<?php\n\nreturn [\n    'key' => '{}',\n];\n", value);
+    laravel_lsp::config_key_locator::enumerate_entries_in_source(&source)
+        .into_iter()
+        .find(|(key, _, _)| key == "key")
+        .map(|(_, value, _)| value)
+        .expect("the catalogue declares 'key'")
+}
 
 #[test]
 fn translation_value_truncation_is_char_boundary_safe() {
     // 199 ASCII chars, then a two-byte 'č', then padding well past the old
     // 200-char limit — the cut point the byte slice used to panic on.
     let value: String = "a".repeat(199) + "č" + &"é".repeat(50);
-    let line = format!("'key' => '{}',", value);
-    let display = laravel_lsp::salsa_impl::extract_translation_value(&line);
+    let display = translation_display_value(&value);
     assert_eq!(display, value, "the extractor must not truncate at all");
 }
 
@@ -261,8 +274,7 @@ fn translation_value_under_two_hundred_chars_is_not_truncated() {
     // A 30-char/60-byte Czech string used to get truncated (and could
     // panic) under the old byte-slice/50-char threshold.
     let value = "č".repeat(30);
-    let line = format!("'key' => '{}',", value);
-    let display = laravel_lsp::salsa_impl::extract_translation_value(&line);
+    let display = translation_display_value(&value);
     assert_eq!(display, value);
 }
 
@@ -287,11 +299,7 @@ fn config_value_under_two_hundred_chars_is_not_truncated() {
 #[test]
 fn a_five_thousand_char_translation_value_survives_extraction_whole() {
     let value = "ž".repeat(5_000);
-    let line = format!("'key' => '{}',", value);
-    assert_eq!(
-        laravel_lsp::salsa_impl::extract_translation_value(&line),
-        value
-    );
+    assert_eq!(translation_display_value(&value), value);
 }
 
 #[test]

--- a/laravel-lsp/src/tests/config_rename_declaration_guard.rs
+++ b/laravel-lsp/src/tests/config_rename_declaration_guard.rs
@@ -146,3 +146,148 @@ async fn a_quoted_key_still_renames_and_rewrites_its_declaration() {
             .collect::<Vec<_>>()
     );
 }
+
+/// The translation arm of the same guard, driven through the real handler.
+///
+/// `main.rs` wires `require_declaration_edits` symmetrically into the Config
+/// and Translation arms, but only the config side was exercised end to end —
+/// the translation side was tested one layer down, at declaration collection.
+/// A wiring mistake in the arm this test covers would have gone unnoticed.
+#[tokio::test]
+async fn a_translation_key_with_no_quoted_declaration_is_refused() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("lang/en")).unwrap();
+    std::fs::write(
+        root.join("lang/en/codes.php"),
+        "<?php\n\nreturn [\n    'named' => 'ok',\n    404 => 'Not found',\n];\n",
+    )
+    .unwrap();
+    let caller = root.join("app/Uses.php");
+    std::fs::create_dir_all(caller.parent().unwrap()).unwrap();
+    std::fs::write(
+        &caller,
+        "<?php\n\n$a = __('codes.named');\n$b = __('codes.404');\n",
+    )
+    .unwrap();
+
+    let server = test_server();
+    *server.root_path.write().await = Some(root.to_path_buf());
+
+    let (line, col) = cursor_at(&caller, "404');");
+    let err = rename_at(&server, &caller, line, col, "missing")
+        .await
+        .expect_err("a bare integer translation key must be refused");
+    assert!(
+        err.message.contains("codes.404") && err.message.contains("no quoted declaration"),
+        "the toast must name the key and the reason, got {:?}",
+        err.message
+    );
+
+    // Control: the quoted sibling in the same catalogue still renames, so the
+    // refusal above cannot pass merely because translation rename is inert.
+    let (line, col) = cursor_at(&caller, "named');");
+    let edit = rename_at(&server, &caller, line, col, "renamed")
+        .await
+        .expect("a quoted translation key is renameable")
+        .expect("a quoted translation key produces a WorkspaceEdit");
+    assert!(
+        edit.changes
+            .expect("edits are keyed by file")
+            .keys()
+            .any(|uri| uri.path().ends_with("lang/en/codes.php")),
+        "the catalogue declaration must be edited"
+    );
+}
+
+/// An env var used but never declared must be refused, not half-renamed.
+///
+/// The Route and Env arms had no fail-closed guard until #369 extended the
+/// rule to all four renameable dotted/flat kinds. `env('UNDECLARED_VAR')` has
+/// call sites and no declaration in any `.env*` file, so rewriting the call
+/// sites alone points every read at a name nothing defines.
+#[tokio::test]
+async fn an_undeclared_env_var_is_refused_rather_than_half_renamed() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join(".env"), "DECLARED_VAR=value\n").unwrap();
+    let caller = root.join("app/Uses.php");
+    std::fs::create_dir_all(caller.parent().unwrap()).unwrap();
+    std::fs::write(
+        &caller,
+        "<?php\n\n$a = env('DECLARED_VAR');\n$b = env('UNDECLARED_VAR');\n",
+    )
+    .unwrap();
+
+    let server = test_server();
+    *server.root_path.write().await = Some(root.to_path_buf());
+
+    let (line, col) = cursor_at(&caller, "UNDECLARED_VAR');");
+    let err = rename_at(&server, &caller, line, col, "RENAMED_VAR")
+        .await
+        .expect_err("an undeclared env var must be refused");
+    assert!(
+        err.message.contains("UNDECLARED_VAR") && err.message.contains("no quoted declaration"),
+        "the toast must name the var and the reason, got {:?}",
+        err.message
+    );
+
+    // Control: the declared sibling still renames, so the refusal above cannot
+    // pass merely because env rename is inert in this fixture.
+    let (line, col) = cursor_at(&caller, "DECLARED_VAR');");
+    let edit = rename_at(&server, &caller, line, col, "RENAMED_VAR")
+        .await
+        .expect("a declared env var is renameable")
+        .expect("a declared env var produces a WorkspaceEdit");
+    assert!(
+        edit.changes
+            .expect("edits are keyed by file")
+            .keys()
+            .any(|uri| uri.path().ends_with(".env")),
+        "the .env declaration must be edited"
+    );
+}
+
+/// Config completion and go-to-definition must offer the same key set.
+///
+/// Until #369 they could not: completion ran a per-line regex scanner
+/// (`parse_config_keys`) while goto walked the AST, so a key after a list
+/// entry, a list index, or a bare integer key was offered by one and not the
+/// other. Both now share `config_key_locator`, and this pins that they agree.
+#[tokio::test]
+async fn every_offered_config_key_can_be_navigated_to() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("config")).unwrap();
+    std::fs::write(
+        root.join("config/shapes.php"),
+        "<?php\n\nreturn [\n    'providers' => ['A', 'B'],\n    404 => 'Not found',\n    'after' => 'reachable',\n    'nested' => ['deep' => 'v'],\n];\n",
+    )
+    .unwrap();
+
+    let server = test_server();
+    *server.root_path.write().await = Some(root.to_path_buf());
+
+    let offered = server.get_all_config_keys().await;
+    let shapes: Vec<&str> = offered
+        .iter()
+        .map(|c| c.key.as_str())
+        .filter(|k| k.starts_with("shapes."))
+        .collect();
+    assert!(
+        shapes.contains(&"shapes.providers.0") && shapes.contains(&"shapes.404"),
+        "the scanner offered neither; the walker must, got {shapes:?}"
+    );
+
+    let module_dirs: Vec<std::path::PathBuf> = Vec::new();
+    let mut unreachable = Vec::new();
+    for key in &shapes {
+        if laravel_lsp::config_key_locator::locate_key_all(root, &module_dirs, key).is_empty() {
+            unreachable.push(*key);
+        }
+    }
+    assert!(
+        unreachable.is_empty(),
+        "completion offers keys goto cannot reach: {unreachable:?}"
+    );
+}

--- a/laravel-lsp/src/tests/config_rename_declaration_guard.rs
+++ b/laravel-lsp/src/tests/config_rename_declaration_guard.rs
@@ -1,0 +1,148 @@
+//! Handler-level tests for the rename fail-closed guard (#369).
+//!
+//! `rename::require_declaration_edits` is unit-tested in isolation, but the
+//! bug it prevents lives in the WIRING: call-site edits are collected before
+//! the per-kind declaration walkers run, so a missing guard means the handler
+//! applies the call sites alone and silently repoints every one of them at a
+//! key that does not exist. Bypassing the guard at its two call sites in
+//! `rename()` left the whole suite green, which is why these exist.
+//!
+//! `folio_rename.rs:22` records that the rename APPLY handler was previously
+//! unfixtured; these are the first tests to drive it end to end.
+//!
+//! What they prove: the guard is wired into both arms and refuses the key with
+//! a named reason, where a build without it returns `Ok(None)` and tells the
+//! user nothing. What they do NOT prove: that a half-applied edit would
+//! otherwise reach disk. This fixture never populates the references index, so
+//! no call-site edits exist here to be applied — even the passing control
+//! edits only the declaration file. Demonstrating the half-apply needs a warm
+//! reference index, which no test in this crate currently builds.
+
+use crate::LaravelLanguageServer;
+use std::path::Path;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::{
+    Position, RenameParams, TextDocumentIdentifier, TextDocumentPositionParams, Url,
+    WorkDoneProgressParams,
+};
+use tower_lsp::{LanguageServer, LspService};
+
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// A project whose `config/codes.php` declares one quoted key, one bare
+/// integer key, and one list — plus a PHP file using all three.
+fn fixture(root: &Path) -> std::path::PathBuf {
+    std::fs::create_dir_all(root.join("config")).unwrap();
+    std::fs::write(
+        root.join("config/codes.php"),
+        "<?php\n\nreturn [\n    'named' => 'ok',\n    404 => 'Not found',\n    'list' => ['a'],\n];\n",
+    )
+    .unwrap();
+    let caller = root.join("app/Uses.php");
+    std::fs::create_dir_all(caller.parent().unwrap()).unwrap();
+    std::fs::write(
+        &caller,
+        "<?php\n\n$a = config('codes.named');\n$b = config('codes.404');\n$c = config('codes.list.0');\n",
+    )
+    .unwrap();
+    caller
+}
+
+async fn rename_at(
+    server: &LaravelLanguageServer,
+    file: &Path,
+    line: u32,
+    character: u32,
+    new_name: &str,
+) -> tower_lsp::jsonrpc::Result<Option<tower_lsp::lsp_types::WorkspaceEdit>> {
+    let uri = Url::from_file_path(file).unwrap();
+    server
+        .rename(RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: Position { line, character },
+            },
+            new_name: new_name.to_string(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        })
+        .await
+}
+
+/// The (line, column) of `needle` inside `file`, so a cursor is never
+/// hand-counted — an earlier version of this file put the 404 cursor on the
+/// closing quote, where the handler classifies nothing, and the tests passed
+/// against a deliberately broken build as a result.
+fn cursor_at(file: &Path, needle: &str) -> (u32, u32) {
+    let text = std::fs::read_to_string(file).unwrap();
+    for (row, line) in text.lines().enumerate() {
+        if let Some(col) = line.find(needle) {
+            return (row as u32, col as u32);
+        }
+    }
+    panic!("{needle:?} not found in {}", file.display());
+}
+
+#[tokio::test]
+async fn a_bare_integer_key_is_refused_rather_than_half_renamed() {
+    let dir = TempDir::new().unwrap();
+    let caller = fixture(dir.path());
+    let server = test_server();
+    *server.root_path.write().await = Some(dir.path().to_path_buf());
+
+    let (line, col) = cursor_at(&caller, "404');");
+    let result = rename_at(&server, &caller, line, col, "missing").await;
+    let err = result.expect_err("a bare integer key must be refused, not silently ignored");
+    assert!(
+        err.message.contains("codes.404") && err.message.contains("no quoted declaration"),
+        "the toast must name the key and the reason, got {:?}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn a_list_index_is_refused_rather_than_half_renamed() {
+    let dir = TempDir::new().unwrap();
+    let caller = fixture(dir.path());
+    let server = test_server();
+    *server.root_path.write().await = Some(dir.path().to_path_buf());
+
+    let (line, col) = cursor_at(&caller, "0');");
+    let result = rename_at(&server, &caller, line, col, "first").await;
+    let err = result.expect_err("a list index must be refused, not silently ignored");
+    assert!(
+        err.message.contains("codes.list.0") && err.message.contains("no quoted declaration"),
+        "the toast must name the key and the reason, got {:?}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn a_quoted_key_still_renames_and_rewrites_its_declaration() {
+    // The control. Without it the two refusals above could pass simply
+    // because rename never reaches config keys in this fixture at all.
+    let dir = TempDir::new().unwrap();
+    let caller = fixture(dir.path());
+    let server = test_server();
+    *server.root_path.write().await = Some(dir.path().to_path_buf());
+
+    let (line, col) = cursor_at(&caller, "named');");
+    let edit = rename_at(&server, &caller, line, col, "renamed")
+        .await
+        .expect("a quoted config key is renameable")
+        .expect("a quoted config key produces a WorkspaceEdit");
+    let changes = edit.changes.expect("edits are keyed by file");
+    let touches_declaration = changes
+        .keys()
+        .any(|uri| uri.path().ends_with("config/codes.php"));
+    assert!(
+        touches_declaration,
+        "the declaration file must be edited, got {:?}",
+        changes
+            .keys()
+            .map(|u| u.path().to_string())
+            .collect::<Vec<_>>()
+    );
+}

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod component_file_navigation_containment;
 mod component_member_navigation;
 mod component_navigation_containment;
 mod composer_autoload_containment;
+mod config_rename_declaration_guard;
 mod controllers_dir_containment;
 mod db_provider_init_idempotency;
 mod diagnostic_severity;

--- a/laravel-lsp/src/tests/module_config_surfaces.rs
+++ b/laravel-lsp/src/tests/module_config_surfaces.rs
@@ -542,3 +542,38 @@ async fn the_completion_label_is_built_by_the_shared_helper() {
         "the completion label must come from `config_source_label`"
     );
 }
+
+#[test]
+fn rename_refuses_keys_that_have_no_quoted_text_to_rewrite() {
+    // Both keys below resolve — `config('codes.404')` and
+    // `config('codes.list.0')` return values — so both are enumerated and
+    // navigable. Neither may be a rename target: rewriting the bare `404`
+    // would turn a string key into a constant lookup, and a list index is
+    // written nowhere at all, so the edit would land on the value.
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join("config")).unwrap();
+    std::fs::write(
+        tmp.path().join("config/codes.php"),
+        "<?php\nreturn [\n    'named' => 'ok',\n    404 => 'Not found',\n    'list' => ['a'],\n];\n",
+    )
+    .unwrap();
+
+    let targets =
+        |old: &str, new: &str| crate::collect_config_declaration_target(tmp.path(), &[], old, new);
+
+    assert!(
+        targets("codes.404", "codes.missing").is_empty(),
+        "a bare integer key is not a rename target"
+    );
+    assert!(
+        targets("codes.list.0", "codes.list.first").is_empty(),
+        "a synthesized list index is not a rename target"
+    );
+    // The control: an ordinary quoted key in the same file still renames, so
+    // the assertions above cannot pass by the lookup simply failing.
+    assert_eq!(
+        targets("codes.named", "codes.renamed").len(),
+        1,
+        "a quoted key is still rewritten"
+    );
+}

--- a/laravel-lsp/src/tests/translation_namespace_completion.rs
+++ b/laravel-lsp/src/tests/translation_namespace_completion.rs
@@ -128,15 +128,23 @@ async fn namespace_only_project_still_completes() {
     let keys = backend.get_all_translation_keys().await;
     let all_keys: Vec<&str> = keys.iter().map(|k| k.key.as_str()).collect();
 
-    assert_eq!(keys.len(), 1, "got {all_keys:?}");
+    // Both the leaf and its parent group, and nothing else — the catalogue
+    // declares `'details' => ['title' => …]`, and since #369 the walker
+    // reports the group key too. Pinned as an exact set so an unrelated
+    // catalogue leaking in still fails the test.
     assert_eq!(
-        keys[0].key,
-        "legal-contractmanagement::contract-management.details.title"
+        all_keys,
+        vec![
+            "legal-contractmanagement::contract-management.details",
+            "legal-contractmanagement::contract-management.details.title",
+        ],
+        "got {all_keys:?}"
     );
     assert!(
-        keys[0].source.starts_with("legal-contractmanagement::"),
+        keys.iter()
+            .all(|k| k.source.starts_with("legal-contractmanagement::")),
         "namespaced source label should carry the namespace too, got {:?}",
-        keys[0].source
+        keys.iter().map(|k| &k.source).collect::<Vec<_>>()
     );
 }
 

--- a/laravel-lsp/src/translation_key_locator/tests.rs
+++ b/laravel-lsp/src/translation_key_locator/tests.rs
@@ -155,3 +155,37 @@ fn a_locale_file_is_read_once_across_repeated_renames() {
         "a rename must not re-read and re-parse every locale's catalogue"
     );
 }
+
+#[test]
+fn rename_refuses_translation_keys_with_no_quoted_text() {
+    // `__('codes.404')` and `__('codes.list.0')` both resolve at runtime, so
+    // both are enumerated for completion and both navigate. Neither is a
+    // rename target: the bare `404` would become a constant lookup if
+    // rewritten, and a list index has no text of its own, so the edit would
+    // land on the value instead.
+    const CODES: &str = r#"<?php
+return [
+    'named' => 'ok',
+    404 => 'Not found',
+    'list' => ['a'],
+];
+"#;
+    let dir = fake_project_with_lang(&[("en", "codes", CODES)]);
+    let mut locator = Locator::default();
+
+    assert!(
+        locator.locate(dir.path(), "codes.404").is_empty(),
+        "a bare integer key is not a rename target"
+    );
+    assert!(
+        locator.locate(dir.path(), "codes.list.0").is_empty(),
+        "a synthesized list index is not a rename target"
+    );
+    // The control: a quoted key in the same catalogue still resolves to an
+    // edit site, so neither assertion above can pass by the lookup failing.
+    assert_eq!(
+        locator.locate(dir.path(), "codes.named").len(),
+        1,
+        "a quoted key is still rewritten"
+    );
+}


### PR DESCRIPTION
Addresses **Part B** of #369 — retiring the hand-rolled translation-key scanner — plus the catalogue-parsing gaps and the two further duplicate scanners that surfaced while doing it. **Part A of that issue is untouched and stays open.**

## The problem

`salsa_impl::parse_translation_keys` read a PHP translation catalogue with a per-line regex and a `[`/`]` depth counter. Go-to-definition never shared its faults: `locate_php_key_in_file` already resolved the same files through `config_key_locator`'s tree-sitter walk, 122 lines below it in the same file. Two enumerators over the same data — one structural, one counting brackets.

Retiring it exposed that the structural walker itself only understood a subset of legal PHP, and that two *other* modules carried their own scanners over the same array.

## Commits

| Commit | What |
|---|---|
| `5af1b55` | Walker reads every catalogue shape PHP legitimately allows |
| `930e9a4` | `parse_translation_keys` retired; completion uses the walk |
| `3bb538c` | `KeyKind` — each consumer states which key spellings it accepts |
| `7995ca8` | Stack-overflow crash, rename fail-closed guard, `config_lookup` retired |
| `9dc2021` | Unary keys, index collision, `return` ordering, four non-discriminating tests |
| `272df2e` | Last scanner retired, all four rename kinds guarded, `i64::MIN` and nested dotted keys |

## What changed, by area

### Keys the tool can now see

| Shape | Before | After |
|---|---|---|
| `'list' => [['x' => 'a']]` | `list` only | `list`, `list.0`, `list.0.x` |
| `'sizes' => ['sm','md']` | `sizes` only | `sizes.0`, `sizes.1` |
| `404 => 'Not found'` | nothing | `404` |
| `-5 => 'x'` / `+5 => 'x'` | nothing | `-5` / `5` |
| `-9223372036854775808 => 'x'` | nothing | `-9223372036854775808` |
| `['form' => ['a.b' => 'v']]` | `form.a.b` — resolves to null | not offered |
| `'it\'s' => 'v'` | key `it` | key `it's` |
| `'a' => 'x' . 'y'` | `x' . 'y'` | `xy` |
| `'a' => <<<EOT…` | `<<<EOT\nline\nEOT` | `line` |
| `"\x41"`, `"\101"`, `"\u{41}"` | literal text | `A` |

Keyless entries follow PHP's real index rule — a counter from 0, advanced past any explicit integer key, including a canonical decimal *string* key (`'7'` casts, `'07'` does not). A spread halts synthesis rather than guessing; so does a `PHP_INT_MAX` key, since PHP has no next index there either.

### Three scanners retired, one remains

`salsa_impl::parse_translation_keys` and `extract_translation_value` are deleted. `config_lookup`'s byte scanner is deleted with six helpers — that module drops from **276 lines to 72**.

`main.rs`'s `parse_config_keys` was the third — a byte-for-byte twin powering **config completion**, so completion offered a different key set than goto could reach. It and `extract_config_value` are deleted too. **No `in_array_depth` counter remains anywhere in the crate**, which is what #369's closing note asked us to go looking for.

### Crash and correctness fixes

- **Stack overflow.** `find_array_in_expression` walked the whole value subtree unbounded. PHP's `.` is left-associative, so a 50,000-term concatenation is a 50,000-deep tree — enumerating one aborted the language server with SIGABRT, reachable by *merely opening* a config or lang file. Now depth-bounded, verified safe against the SalsaActor's real 2 MiB stack.
- **Integer overflow.** A `PHP_INT_MAX` key panicked in debug and wrapped to `i64::MIN` in release, synthesizing negative indices for every later entry.
- **Value split-brain.** Completion offered `app.providers.0`, goto navigated to it, hover said *"value not found"*, and `__('messages.options.0')` raised a false **"Translation not found"** warning — because `config_lookup` was a second, worse implementation. A test now asserts every key the enumerator offers also resolves to a value.
- **`return` ordering.** A two-`return` file resolved against the second; PHP stops at the first.

### Rename safety

`KeyPosition` carries `KeyKind` (`Quoted` / `BareInteger` / `SynthesizedIndex`), so each consumer declares its own rule rather than sharing one flag:

- completion and goto accept **every** kind — all three resolve at runtime;
- rename accepts **`Quoted` only** — the sole kind with quoted text a new name can replace;
- the code lens accepts anything but `SynthesizedIndex`, which is written nowhere and would otherwise hang a zero-width lens on every entry of a providers array.

`require_declaration_edits` enforces the "never call-sites-only" invariant `can_rename`'s own doc comment describes — across **all four** renameable kinds. Config and Translation had it first; Route and Env applied call-site edits unconditionally until this branch, so `env('UNDECLARED_VAR')` could be renamed to a name nothing declares.

## Deliberate behavior change

Intermediate group keys are now offered in completion — `form` as well as `form.variant`. They are declared in the file, and `__()` is documented `@return string|array|null` with an explicit array branch in `Translator::getLine`, so the key resolves. The tool reports what the source says rather than curating it.

## Test plan

- **3,658 tests green**; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` applied.
- **A shape matrix** lists every catalogue shape the walker claims to read as one table of data, with two driver tests: every shape enumerates as documented, and every key enumerated is navigable. Mutation testing proves the walker discriminates the logic we wrote; only the matrix proves we thought of the shape.
- **Every guard mutation-tested** — each reddens its test when loosened.
- **Three adversarial review rounds** (four blind lenses each) found 17 defects between them: three crashes, four tests that passed against deliberately broken builds, and two keys the tool offered that Laravel cannot resolve. All fixed.
- Adds the crate's **first rename-apply handler tests**; `folio_rename.rs:22` records that this handler was previously unfixtured.

### Known limits, stated rather than implied

- The rename tests prove the guard is wired and refuses with a named reason. They do **not** prove a half-applied edit would otherwise reach disk — this fixture never populates the references index, so there are no call-site edits here to half-apply.
- A key nested deeper than 128 levels is not enumerated. No hand-written catalogue approaches this; the bound exists so a generated file cannot abort the server.
- The Route rename arm's guard is wired identically to the three covered by tests, but has no fixture of its own — a route rename needs a warm route index, which no test in this crate builds.

## Note on #350

That PR patches the regex this branch deletes. It is left open and unrebased; its fate is a separate decision.
