### PR TITLE
perf: stop re-walking vendor on every request, and fix Livewire detection

### DIFF
--- a/laravel-lsp/src/class_hierarchy_index.rs
+++ b/laravel-lsp/src/class_hierarchy_index.rs
@@ -15,9 +15,16 @@
 //! ## Shape
 //!
 //! Mirrors `symbol_index`: a forward map (`fqcn → ClassNode`) plus reverse
-//! adjacency maps, a `by_file` reverse index for cheap eviction, and a lazy
-//! `dirty` set. Owned by the SalsaActor; all access is single-threaded
-//! through the actor queue, so no internal locking.
+//! adjacency maps and a `by_file` reverse index for cheap eviction. Owned by
+//! the SalsaActor; all access is single-threaded through the actor queue, so
+//! no internal locking.
+//!
+//! Unlike `symbol_index` there is **no lazy `dirty` set**. This index is
+//! refreshed eagerly, in `handle_get_patterns`: every parse of a PHP file
+//! runs `remove_file` + `insert_file` for that path, which is the only
+//! populator for files warming skipped. A deferred-refresh queue alongside
+//! that would be a second mechanism for a job already done — see the removal
+//! note in issue #371.
 //!
 //! ## FQCN resolution
 //!
@@ -35,7 +42,6 @@
 //!    extends/implements/trait_uses.
 //! 2. `remove_file(p)` evicts only nodes whose `file_path == p`, so a
 //!    duplicate FQCN declared elsewhere survives.
-//! 3. `take_dirty()` is idempotent: a second call returns an empty Vec.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -183,8 +189,6 @@ pub struct ClassHierarchyIndex {
     subclasses: HashMap<String, Vec<String>>,
     /// path → FQCNs that file contributed, for eviction.
     by_file: HashMap<PathBuf, Vec<String>>,
-    /// Files whose nodes may have drifted; refreshed lazily by the caller.
-    dirty: HashSet<PathBuf>,
 }
 
 impl ClassHierarchyIndex {
@@ -254,16 +258,6 @@ impl ClassHierarchyIndex {
         }
     }
 
-    /// Mark a path as needing refresh (cheap; work deferred to `take_dirty`).
-    pub fn mark_dirty(&mut self, path: &Path) {
-        self.dirty.insert(path.to_path_buf());
-    }
-
-    /// Drain and return the dirty set so the caller can re-index each path.
-    pub fn take_dirty(&mut self) -> Vec<PathBuf> {
-        self.dirty.drain().collect()
-    }
-
     /// Drop everything — used to rebuild from scratch after warming.
     pub fn clear(&mut self) {
         self.classes.clear();
@@ -271,7 +265,6 @@ impl ClassHierarchyIndex {
         self.trait_users.clear();
         self.subclasses.clear();
         self.by_file.clear();
-        self.dirty.clear();
     }
 
     /// The declaration node for a class FQCN, if indexed.

--- a/laravel-lsp/src/class_hierarchy_index/tests.rs
+++ b/laravel-lsp/src/class_hierarchy_index/tests.rs
@@ -120,15 +120,6 @@ fn remove_file_evicts_node_and_reverse_edges() {
 }
 
 #[test]
-fn take_dirty_drains_and_is_idempotent() {
-    let mut idx = ClassHierarchyIndex::default();
-    idx.mark_dirty(&PathBuf::from("/p/A.php"));
-    idx.mark_dirty(&PathBuf::from("/p/A.php"));
-    assert_eq!(idx.take_dirty().len(), 1);
-    assert!(idx.take_dirty().is_empty());
-}
-
-#[test]
 fn fqcn_file_map_maps_each_class_to_its_file() {
     let mut idx = ClassHierarchyIndex::default();
     let user_path = PathBuf::from("/proj/app/Models/User.php");

--- a/laravel-lsp/src/command_disk_cache.rs
+++ b/laravel-lsp/src/command_disk_cache.rs
@@ -52,8 +52,15 @@ use crate::command_index::{CommandEntry, CommandIndex};
 /// matches.
 ///
 /// History:
-///   v1 — initial command index cache.
-const SCHEMA_VERSION: u32 = 1;
+///   v1 — initial command index cache (command declarations only).
+///   v2 — records EVERY scanned `*.php` file with its mtime, not just the ones
+///        that declared a command. A cache of declarations alone can say
+///        "this command is unchanged", but it cannot say "this file declares
+///        nothing and still declares nothing" — so it could never authorise
+///        skipping the read. Recording the negative verdicts is what turns the
+///        cache from a cold-start display accelerator into a real skip
+///        (issue #371).
+const SCHEMA_VERSION: u32 = 2;
 
 const CACHE_FILENAME: &str = "command_cache.bin";
 
@@ -63,18 +70,30 @@ const CACHE_FILENAME: &str = "command_cache.bin";
 #[derive(Serialize, Deserialize)]
 struct CacheFile {
     schema_version: u32,
-    entries: Vec<CachedEntry>,
+    /// Every `*.php` file the last scan looked at, **in walk order**. Order is
+    /// load-bearing: `CommandIndex::insert_entry` keeps the first file walked
+    /// on a same-tier duplicate, so replaying these in a different order could
+    /// resolve a colliding command name to a different file.
+    files: Vec<ScannedFile>,
 }
 
-/// One resolved command declaration plus the mtime we observed for its
-/// declaring file when it was indexed. Both `secs` and `nanos` are stored
-/// independently for byte-exact comparison — a `touch` that preserves the
-/// second but bumps the nanos must still count as "changed."
-#[derive(Serialize, Deserialize)]
-struct CachedEntry {
-    mtime_secs: u64,
-    mtime_nanos: u32,
-    entry: CommandEntry,
+/// One file the scan looked at, the mtime observed then, and the command it
+/// declared — `None` when it declared none.
+///
+/// Both `secs` and `nanos` are stored independently for byte-exact comparison:
+/// a `touch` that preserves the second but bumps the nanos must still count as
+/// "changed".
+///
+/// The `None` case is the whole point of schema v2. A cache holding only
+/// declarations can tell you a known command is unchanged, but it cannot tell
+/// you that the other 16,000 files still declare nothing — so every one of them
+/// had to be read and regex-scanned again on every startup.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ScannedFile {
+    pub mtime_secs: u64,
+    pub mtime_nanos: u32,
+    pub path: PathBuf,
+    pub entry: Option<CommandEntry>,
 }
 
 /// Where the cache file for `project_root` lives on disk. Returns `None` only
@@ -110,17 +129,52 @@ fn read_mtime(path: &Path) -> Option<(u64, u32)> {
         .and_then(split_mtime)
 }
 
-/// Restore the cached command index for `project_root`, validating every entry
-/// against its declaring file's current mtime. Returns the rebuilt index, or
-/// `None` when there's no cache, it's unreadable, or the schema doesn't match —
-/// in every case the caller falls back to a full
-/// [`crate::command_index::build_command_index`].
+/// A previous scan's per-file verdicts, keyed by path.
 ///
-/// Stale entries (changed, moved, or deleted files) are silently skipped; the
-/// returned index contains only the entries that still match disk, with the
-/// App > Package > Framework priority merge re-applied via
-/// [`CommandIndex::insert_entry`].
-pub fn load_index(project_root: &Path) -> Option<CommandIndex> {
+/// Consulted by [`crate::command_index::scan_commands`] to skip reading a file
+/// whose mtime is unchanged — the same per-file staleness model
+/// [`crate::pattern_disk_cache`] uses.
+#[derive(Default)]
+pub struct CommandScanCache {
+    by_path: std::collections::HashMap<PathBuf, ScannedFile>,
+}
+
+impl CommandScanCache {
+    /// The verdict recorded for `path`, **only if** the file's current mtime
+    /// still matches what the scan observed.
+    ///
+    /// `Some(None)` means "known to declare nothing" — a real answer, and the
+    /// one that saves nearly all the work. `None` means unknown or stale, so
+    /// the caller must read the file.
+    ///
+    /// `current` is passed in rather than stat'd here so the caller can reuse
+    /// the `metadata` its directory walk already produced.
+    pub fn verdict(&self, path: &Path, current: (u64, u32)) -> Option<Option<&CommandEntry>> {
+        let cached = self.by_path.get(path)?;
+        (cached.mtime_secs == current.0 && cached.mtime_nanos == current.1)
+            .then_some(cached.entry.as_ref())
+    }
+
+    /// How many files the cache holds verdicts for.
+    pub fn len(&self) -> usize {
+        self.by_path.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_path.is_empty()
+    }
+}
+
+/// Load the previous scan's verdicts for `project_root`.
+///
+/// `None` when there is no cache, it is unreadable, or the schema does not
+/// match — the caller then does a full scan, which is exactly the pre-cache
+/// behaviour.
+///
+/// Entries are NOT mtime-validated here. Validation happens per file in
+/// [`CommandScanCache::verdict`], against the mtime the caller's walk already
+/// read, so this load performs no I/O beyond the single cache-file read.
+pub fn load_scan(project_root: &Path) -> Option<CommandScanCache> {
     let path = cache_file_path(project_root)?;
     let bytes = std::fs::read(&path).ok()?;
 
@@ -142,13 +196,46 @@ pub fn load_index(project_root: &Path) -> Option<CommandIndex> {
         return None;
     }
 
+    let mut by_path = std::collections::HashMap::with_capacity(cache.files.len());
+    for file in cache.files {
+        by_path.insert(file.path.clone(), file);
+    }
+    Some(CommandScanCache { by_path })
+}
+
+/// Restore a command index from the cache for `project_root`, validating every
+/// entry against its declaring file's current mtime.
+///
+/// The cold-start accelerator: goto-definition and hover on command strings
+/// work off this while the full scan runs. Returns `None` when there is no
+/// usable cache.
+///
+/// Files are replayed in the recorded walk order so the App > Package >
+/// Framework merge — and its first-walked-wins tie-break on same-tier
+/// duplicates — reproduces the scan that wrote the cache.
+pub fn load_index(project_root: &Path) -> Option<CommandIndex> {
+    let path = cache_file_path(project_root)?;
+    let bytes = std::fs::read(&path).ok()?;
+
+    let cache: CacheFile =
+        match bincode::serde::decode_from_slice(&bytes, bincode::config::standard()) {
+            Ok((c, _)) => c,
+            Err(e) => {
+                tracing::debug!("command_disk_cache: decode failed, ignoring: {}", e);
+                return None;
+            }
+        };
+    if cache.schema_version != SCHEMA_VERSION {
+        return None;
+    }
+
     let mut index = CommandIndex::default();
-    for cached in cache.entries {
-        // Only restore the entry if its declaring file is still present and
-        // unchanged. Anything else falls through to the full rebuild.
-        match read_mtime(&cached.entry.file) {
-            Some((s, n)) if s == cached.mtime_secs && n == cached.mtime_nanos => {
-                index.insert_entry(cached.entry);
+    for file in cache.files {
+        let Some(entry) = file.entry else { continue };
+        // Only restore a declaration whose file is still present and unchanged.
+        match read_mtime(&entry.file) {
+            Some((s, n)) if s == file.mtime_secs && n == file.mtime_nanos => {
+                index.insert_entry(entry);
             }
             _ => {}
         }
@@ -156,38 +243,26 @@ pub fn load_index(project_root: &Path) -> Option<CommandIndex> {
     Some(index)
 }
 
-/// Persist `index` to disk, stamping each command with its declaring file's
-/// CURRENT mtime. Called after every successful build/rebuild. Safe to run on
-/// the blocking pool — it's sync I/O.
+/// Persist a completed scan. Called after every successful build/rebuild.
+/// Safe to run on the blocking pool — it is sync I/O.
 ///
-/// Returns the number of entries written, or an error if the cache directory
-/// or file couldn't be written. Errors are advisory — failing to persist
-/// doesn't affect the live in-memory index.
-pub fn save_index(index: &CommandIndex, project_root: &Path) -> Result<usize> {
+/// Returns the number of file verdicts written. Errors are advisory: failing
+/// to persist does not affect the live in-memory index, it only costs the next
+/// startup its shortcut.
+///
+/// Unlike the v1 `save_index` this replaces, the mtimes are NOT re-stat'd here.
+/// They are the ones the scan observed when it read each file, which is the
+/// only value that makes the verdict sound: re-stat'ing at save time would
+/// stamp a file modified DURING the scan as clean, and the next run would trust
+/// a verdict derived from the pre-edit contents.
+pub fn save_scan(files: &[ScannedFile], project_root: &Path) -> Result<usize> {
     let cache_path =
         cache_file_path(project_root).context("could not resolve cache directory for project")?;
 
-    let mut entries: Vec<CachedEntry> = Vec::with_capacity(index.len());
-    for entry in index.entries() {
-        // Stat the declaring file at save time so the stamped mtime reflects
-        // what's on disk RIGHT NOW. A file modified since indexing simply
-        // fails the next load's mtime check and gets re-parsed.
-        let Some((secs, nanos)) = read_mtime(&entry.file) else {
-            // File vanished between build and save — skip it; load_index would
-            // drop a dangling entry anyway.
-            continue;
-        };
-        entries.push(CachedEntry {
-            mtime_secs: secs,
-            mtime_nanos: nanos,
-            entry: entry.clone(),
-        });
-    }
-
-    let total = entries.len();
+    let total = files.len();
     let cache = CacheFile {
         schema_version: SCHEMA_VERSION,
-        entries,
+        files: files.to_vec(),
     };
 
     let encoded = bincode::serde::encode_to_vec(&cache, bincode::config::standard())

--- a/laravel-lsp/src/command_disk_cache/tests.rs
+++ b/laravel-lsp/src/command_disk_cache/tests.rs
@@ -32,6 +32,29 @@ fn entry(name: &str, class: &str, file: PathBuf, priority: CommandPriority) -> C
     }
 }
 
+/// Save an index the way the pre-#371 `save_index` did: stat each declaring
+/// file now and write one verdict per declaration.
+///
+/// Kept as a test helper rather than as production API. Production always
+/// saves a whole scan (`save_scan`), including the "declares nothing" verdicts
+/// that make the skip possible; this shim exists only so the round-trip and
+/// mtime-invalidation properties below stay pinned exactly as they were.
+fn save_index_for_test(index: &CommandIndex, root: &Path) -> anyhow::Result<usize> {
+    let mut files = Vec::new();
+    for entry in index.entries() {
+        let Some((secs, nanos)) = read_mtime(&entry.file) else {
+            continue;
+        };
+        files.push(ScannedFile {
+            mtime_secs: secs,
+            mtime_nanos: nanos,
+            path: entry.file.clone(),
+            entry: Some(entry.clone()),
+        });
+    }
+    save_scan(&files, root)
+}
+
 #[test]
 fn save_then_load_restores_entries() {
     let project = tempfile::TempDir::new().unwrap();
@@ -49,7 +72,7 @@ fn save_then_load_restores_entries() {
         CommandPriority::App,
     ));
 
-    let saved = save_index(&index, project.path()).unwrap();
+    let saved = save_index_for_test(&index, project.path()).unwrap();
     assert_eq!(saved, 1, "save should report one entry written");
 
     let restored = load_index(project.path()).expect("cache should load");
@@ -76,7 +99,7 @@ fn load_drops_entry_whose_file_was_deleted() {
 
     let mut index = CommandIndex::default();
     index.insert_entry(entry("a:gone", "Gone", file.clone(), CommandPriority::App));
-    save_index(&index, project.path()).unwrap();
+    save_index_for_test(&index, project.path()).unwrap();
 
     std::fs::remove_file(&file).unwrap();
 
@@ -100,7 +123,7 @@ fn load_drops_entry_whose_file_changed() {
         file.clone(),
         CommandPriority::App,
     ));
-    save_index(&index, project.path()).unwrap();
+    save_index_for_test(&index, project.path()).unwrap();
 
     // Sleep just long enough that the OS records a different mtime, then
     // rewrite the file. 50ms is enough for APFS / ext4 / NTFS (matches the
@@ -139,7 +162,7 @@ fn load_reapplies_priority_merge() {
     // Sanity: the in-memory merge already kept the App entry.
     assert_eq!(index.resolve("queue:work").unwrap().class_name, "AppQueue");
 
-    save_index(&index, project.path()).unwrap();
+    save_index_for_test(&index, project.path()).unwrap();
     let restored = load_index(project.path()).expect("cache should load");
     assert_eq!(restored.len(), 1, "same name collapses to one entry");
     assert_eq!(
@@ -149,8 +172,14 @@ fn load_reapplies_priority_merge() {
     );
 }
 
+/// The invariant this guards moved (issue #371): `save_scan` no longer
+/// re-stats at save time, because doing so would stamp a file modified DURING
+/// the scan as clean and let the next run trust a verdict derived from its
+/// pre-edit contents. A dangling entry is instead dropped on load, where the
+/// mtime read fails. The user-visible property — a command whose file is gone
+/// never resolves — is unchanged, so it is asserted here at its new location.
 #[test]
-fn save_skips_entry_whose_file_vanished() {
+fn an_entry_whose_file_vanished_never_resolves() {
     let project = tempfile::TempDir::new().unwrap();
     let present = touch(project.path(), "Here.php", "<?php class Here {}");
 
@@ -163,8 +192,11 @@ fn save_skips_entry_whose_file_vanished() {
         CommandPriority::App,
     ));
 
-    let saved = save_index(&index, project.path()).unwrap();
-    assert_eq!(saved, 1, "the entry with no file on disk is skipped");
+    let saved = save_index_for_test(&index, project.path()).unwrap();
+    assert_eq!(
+        saved, 1,
+        "only the present file has a stattable mtime to record"
+    );
 
     let restored = load_index(project.path()).unwrap();
     assert!(restored.resolve("a:here").is_some());

--- a/laravel-lsp/src/command_index.rs
+++ b/laravel-lsp/src/command_index.rs
@@ -48,6 +48,7 @@ use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
 use crate::command_signature::{extends_console_command, extract_command_signature};
+use crate::vendor_index::{has_pruned_ancestor, VendorFile, VendorIndex};
 
 /// Source tier of a command declaration. Higher wins when two classes declare
 /// the same command name (`App` overrides a `Package` which overrides the
@@ -156,32 +157,79 @@ pub fn class_name_from_content(content: &str) -> Option<String> {
 
 /// Directory names never worth descending into when hunting for command
 /// classes — build output and VCS metadata, none of which hold PHP source.
-const SKIP_DIRS: &[&str] = &["node_modules", ".git", "storage", "public"];
+pub const SKIP_DIRS: &[&str] = &["node_modules", ".git", "storage", "public"];
+
+/// True when the command index wants this vendor file's text.
+///
+/// The former walk pruned [`SKIP_DIRS`] with `WalkDir::filter_entry`; the
+/// shared vendor walk prunes nothing (other consumers descend into those
+/// directories), so the same exclusion is re-applied here per file.
+pub fn vendor_command_needs_source(vendor_root: &Path, file: &VendorFile) -> bool {
+    !has_pruned_ancestor(&file.path, vendor_root, SKIP_DIRS)
+}
 
 /// Build the index by walking every `*.php` under `<root>` (project + vendor),
 /// keeping the highest-priority declaration per command name. Non-PHP files,
 /// build/VCS directories, and files that don't `extends ...Command` are skipped
 /// cheaply so a large `vendor/` tree doesn't dominate the walk.
 pub fn build_command_index(root: &Path) -> CommandIndex {
+    build_command_index_with_vendor(root, &VendorIndex::build(root))
+}
+
+/// [`build_command_index`] driven by an already-built shared vendor walk
+/// (issue #371), so warm start reads each vendor file once for this *and* the
+/// route index instead of twice.
+///
+/// Output is identical to the single walk this replaces. The former traversal
+/// visited project and vendor files interleaved in `root` order, and
+/// `insert_entry` keeps the first file walked on a *same-tier* duplicate — but
+/// [`classify_priority`] derives the tier from the path, and `App` means
+/// exactly "not under `vendor/`". So a same-tier collision can never straddle
+/// the project/vendor split, and preserving order *within* each leg (the
+/// project walk below, and [`VendorIndex`]'s retained walk order) preserves
+/// every winner.
+pub fn build_command_index_with_vendor(root: &Path, vendor: &VendorIndex) -> CommandIndex {
     let mut index = CommandIndex::default();
+    index_project_commands(root, &mut index);
+    let vendor_root = vendor.vendor_root().to_path_buf();
+    vendor.for_each_source(
+        |file| vendor_command_needs_source(&vendor_root, file),
+        |file, content| index_command_file(&mut index, &file.path, content),
+    );
+    index
+}
+
+/// The non-vendor leg: walk `<root>` for command declarations, skipping the
+/// build/VCS directories and the top-level `vendor/` that the shared index
+/// already covers.
+///
+/// Only `<root>/vendor` is skipped, not every directory named `vendor`. A
+/// nested `app/vendor/` was walked by the former single pass and is not part of
+/// the shared index, so pruning it by name would silently drop its commands.
+pub fn index_project_commands(root: &Path, index: &mut CommandIndex) {
     for entry in WalkDir::new(root)
         .into_iter()
         .filter_entry(|e| {
-            !(e.file_type().is_dir()
-                && e.file_name()
-                    .to_str()
-                    .is_some_and(|n| SKIP_DIRS.contains(&n)))
+            if !e.file_type().is_dir() {
+                return true;
+            }
+            let Some(name) = e.file_name().to_str() else {
+                return true;
+            };
+            if e.depth() == 1 && name == "vendor" {
+                return false;
+            }
+            !SKIP_DIRS.contains(&name)
         })
         .filter_map(|e| e.ok())
     {
         let path = entry.path();
         if path.is_file() && path.extension().is_some_and(|ext| ext == "php") {
             if let Ok(content) = std::fs::read_to_string(path) {
-                index_command_file(&mut index, path, &content);
+                index_command_file(index, path, &content);
             }
         }
     }
-    index
 }
 
 /// Index a single PHP file's command declaration, if it has one. Exposed for

--- a/laravel-lsp/src/command_index.rs
+++ b/laravel-lsp/src/command_index.rs
@@ -47,6 +47,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
+use crate::command_disk_cache::{CommandScanCache, ScannedFile};
 use crate::command_signature::{extends_console_command, extract_command_signature};
 use crate::vendor_index::{has_pruned_ancestor, VendorFile, VendorIndex};
 
@@ -172,6 +173,11 @@ pub fn vendor_command_needs_source(vendor_root: &Path, file: &VendorFile) -> boo
 /// keeping the highest-priority declaration per command name. Non-PHP files,
 /// build/VCS directories, and files that don't `extends ...Command` are skipped
 /// cheaply so a large `vendor/` tree doesn't dominate the walk.
+/// The uncached whole-project scan.
+///
+/// Production drives [`scan_commands`] directly so it can pass the disk cache
+/// and keep the resulting verdicts; this wrapper is the plain
+/// "index everything, trust nothing" form the tests compare against.
 pub fn build_command_index(root: &Path) -> CommandIndex {
     build_command_index_with_vendor(root, &VendorIndex::build(root))
 }
@@ -189,25 +195,96 @@ pub fn build_command_index(root: &Path) -> CommandIndex {
 /// project walk below, and [`VendorIndex`]'s retained walk order) preserves
 /// every winner.
 pub fn build_command_index_with_vendor(root: &Path, vendor: &VendorIndex) -> CommandIndex {
-    let mut index = CommandIndex::default();
-    index_project_commands(root, &mut index);
-    let vendor_root = vendor.vendor_root().to_path_buf();
-    vendor.for_each_source(
-        |file| vendor_command_needs_source(&vendor_root, file),
-        |file, content| index_command_file(&mut index, &file.path, content),
-    );
-    index
+    scan_commands(root, vendor, None).index
 }
 
-/// The non-vendor leg: walk `<root>` for command declarations, skipping the
-/// build/VCS directories and the top-level `vendor/` that the shared index
-/// already covers.
+/// A completed command scan: the resolved index, plus the per-file verdict for
+/// every `*.php` file looked at, in walk order.
+///
+/// The verdicts are what [`crate::command_disk_cache`] persists so the next
+/// scan can skip unchanged files. Walk order is preserved because
+/// [`CommandIndex::insert_entry`] keeps the first file walked on a same-tier
+/// duplicate.
+#[derive(Default)]
+pub struct CommandScan {
+    pub index: CommandIndex,
+    pub files: Vec<ScannedFile>,
+}
+
+/// Scan the project and `vendor/` for Artisan commands, reusing `cache` for
+/// any file whose mtime is unchanged (issue #371).
+///
+/// Without a cache this reads and regex-scans every `*.php` file in the
+/// project — 16,202 of them on this repo's `test-project/` — on every startup
+/// AND on every watched change under a `Commands/` directory. The disk cache
+/// existed but only accelerated the cold-start *display*: the full walk ran
+/// afterwards unconditionally, because a cache of declarations alone cannot
+/// say "these 16,000 other files still declare nothing".
+///
+/// With a cache, an unchanged file costs one `metadata` call (which the walk
+/// already needed) and a hash lookup. Only new or modified files are read.
+///
+/// A file the cache has no fresh verdict for is read, exactly as before — so a
+/// missing, stale or schema-mismatched cache degrades to the old behaviour
+/// rather than to a wrong index.
+pub fn scan_commands(
+    root: &Path,
+    vendor: &VendorIndex,
+    cache: Option<&CommandScanCache>,
+) -> CommandScan {
+    let mut scan = CommandScan::default();
+    consider_project_commands(root, cache, &mut scan);
+
+    let vendor_root = vendor.vendor_root().to_path_buf();
+    for file in vendor.files() {
+        if vendor_command_needs_source(&vendor_root, file) {
+            consider_file(&mut scan, cache, &file.path);
+        }
+    }
+
+    scan
+}
+
+/// Run the non-vendor leg of the scan into `scan`, honouring `cache`.
+pub fn consider_project_commands(
+    root: &Path,
+    cache: Option<&CommandScanCache>,
+    scan: &mut CommandScan,
+) {
+    for path in project_command_paths(root) {
+        consider_file(scan, cache, &path);
+    }
+}
+
+/// Index one file, reusing the cached verdict when its mtime is unchanged.
+fn consider_file(scan: &mut CommandScan, cache: Option<&CommandScanCache>, path: &Path) {
+    if try_cached(scan, cache, path) {
+        return;
+    }
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return;
+    };
+    record_source(scan, path, &content);
+}
+
+/// A file's mtime as `(secs, nanos)`, matching the disk cache's representation.
+fn file_mtime(path: &Path) -> Option<(u64, u32)> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    let d = modified
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .ok()?;
+    Some((d.as_secs(), d.subsec_nanos()))
+}
+
+/// Every `*.php` path in the project leg, in walk order — the non-vendor half
+/// of the scan. Skips the build/VCS directories and the top-level `vendor/`
+/// that the shared index already covers.
 ///
 /// Only `<root>/vendor` is skipped, not every directory named `vendor`. A
 /// nested `app/vendor/` was walked by the former single pass and is not part of
 /// the shared index, so pruning it by name would silently drop its commands.
-pub fn index_project_commands(root: &Path, index: &mut CommandIndex) {
-    for entry in WalkDir::new(root)
+fn project_command_paths(root: &Path) -> Vec<PathBuf> {
+    WalkDir::new(root)
         .into_iter()
         .filter_entry(|e| {
             if !e.file_type().is_dir() {
@@ -222,14 +299,10 @@ pub fn index_project_commands(root: &Path, index: &mut CommandIndex) {
             !SKIP_DIRS.contains(&name)
         })
         .filter_map(|e| e.ok())
-    {
-        let path = entry.path();
-        if path.is_file() && path.extension().is_some_and(|ext| ext == "php") {
-            if let Ok(content) = std::fs::read_to_string(path) {
-                index_command_file(index, path, &content);
-            }
-        }
-    }
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "php"))
+        .map(|e| e.path().to_path_buf())
+        .collect()
 }
 
 /// Index a single PHP file's command declaration, if it has one. Exposed for
@@ -240,20 +313,23 @@ pub fn index_project_commands(root: &Path, index: &mut CommandIndex) {
 /// wins over a package/framework command of the same name, and a same-tier
 /// duplicate leaves the first-walked winner in place.
 pub fn index_command_file(index: &mut CommandIndex, path: &Path, content: &str) {
+    if let Some(entry) = command_entry_for(path, content) {
+        index.insert_entry(entry);
+    }
+}
+
+/// The command declaration `content` holds, if any. The verdict the scan cache
+/// persists — `None` is a real answer, not an absence of one.
+pub fn command_entry_for(path: &Path, content: &str) -> Option<CommandEntry> {
     // Cheap gate: skip anything that isn't a Command subclass before the
     // heavier signature/class-name extraction runs.
     if !extends_console_command(content) {
-        return;
+        return None;
     }
-    let Some(sig) = extract_command_signature(content) else {
-        return;
-    };
-    let Some(class_name) = class_name_from_content(content) else {
-        return;
-    };
+    let sig = extract_command_signature(content)?;
+    let class_name = class_name_from_content(content)?;
 
-    let priority = classify_priority(path);
-    index.insert_entry(CommandEntry {
+    Some(CommandEntry {
         name: sig.name,
         class_name,
         raw_signature: sig.raw_signature,
@@ -261,7 +337,52 @@ pub fn index_command_file(index: &mut CommandIndex, path: &Path, content: &str) 
         line: sig.line,
         start_column: sig.start_column,
         end_column: sig.end_column,
-        priority,
+        priority: classify_priority(path),
+    })
+}
+
+/// Try to satisfy `path` from the scan cache, recording its verdict when the
+/// mtime is unchanged. Returns `true` when the file needs no read.
+///
+/// Public so the combined warm-start pass in [`crate::vendor_scan`] can decide
+/// whether a vendor file still has to be read for the command index before it
+/// reads it for the route index.
+pub fn try_cached(scan: &mut CommandScan, cache: Option<&CommandScanCache>, path: &Path) -> bool {
+    let Some(mtime) = file_mtime(path) else {
+        // Unstattable: do not read it either. A verdict recorded without a
+        // usable mtime could never be validated, so it would be trusted
+        // forever.
+        return true;
+    };
+    let Some(verdict) = cache.and_then(|c| c.verdict(path, mtime)) else {
+        return false;
+    };
+    if let Some(entry) = verdict {
+        scan.index.insert_entry(entry.clone());
+    }
+    scan.files.push(ScannedFile {
+        mtime_secs: mtime.0,
+        mtime_nanos: mtime.1,
+        path: path.to_path_buf(),
+        entry: verdict.cloned(),
+    });
+    true
+}
+
+/// Record a freshly-read file's verdict into `scan`.
+pub fn record_source(scan: &mut CommandScan, path: &Path, content: &str) {
+    let Some(mtime) = file_mtime(path) else {
+        return;
+    };
+    let entry = command_entry_for(path, content);
+    if let Some(entry) = entry.clone() {
+        scan.index.insert_entry(entry);
+    }
+    scan.files.push(ScannedFile {
+        mtime_secs: mtime.0,
+        mtime_nanos: mtime.1,
+        path: path.to_path_buf(),
+        entry,
     });
 }
 

--- a/laravel-lsp/src/command_index/tests.rs
+++ b/laravel-lsp/src/command_index/tests.rs
@@ -301,3 +301,231 @@ fn shared_vendor_walk_keeps_the_same_winner_on_a_same_tier_collision() {
          or this test proves nothing about order"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Per-file mtime skip (issue #371)
+// ---------------------------------------------------------------------------
+//
+// `build_command_index` read and regex-scanned every `*.php` file in the
+// project AND `vendor/` on every startup, and on every watched change under a
+// `Commands/` directory — 16,202 files on this repo's `test-project/`. The disk
+// cache existed but only accelerated the cold-start display: the full walk ran
+// afterwards unconditionally, because a cache holding only DECLARATIONS cannot
+// say "these 16,000 other files still declare nothing".
+//
+// The observable for "was this file read?" is a file whose on-disk contents no
+// longer match the cached verdict. If the scan reads it, the new contents win;
+// if it trusts the cache, the old verdict survives. That discriminates a real
+// skip from a scan that merely produces the right answer by re-reading.
+
+use crate::command_disk_cache::{load_scan, save_scan, CommandScanCache};
+use crate::vendor_index::VendorIndex;
+
+/// Scan `root` twice: once cold, then once with the first scan's verdicts.
+fn scan_twice(root: &Path) -> (CommandScan, CommandScanCache) {
+    let vendor = VendorIndex::build(root);
+    let first = scan_commands(root, &vendor, None);
+    save_scan(&first.files, root).unwrap();
+    let cache = load_scan(root).expect("the scan we just saved must load");
+    (first, cache)
+}
+
+/// The file's mtime in the `(secs, nanos)` form the cache stores.
+fn mtime_of(path: &Path) -> (u64, u32) {
+    let d = std::fs::metadata(path)
+        .unwrap()
+        .modified()
+        .unwrap()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap();
+    (d.as_secs(), d.subsec_nanos())
+}
+
+#[test]
+fn an_unchanged_file_is_not_reread() {
+    // Discriminator: the cache is given a verdict that DISAGREES with the
+    // file's contents, stamped with the file's real current mtime. A scan that
+    // re-reads reports what is on disk; one that honours the cache reports the
+    // planted verdict. Built through the public save/load API rather than by
+    // rewinding the clock, so it needs no extra dependency.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("app/Console/Commands")).unwrap();
+    let cmd = root.join("app/Console/Commands/Send.php");
+    std::fs::write(&cmd, command_class("Send", "mail:ondisk")).unwrap();
+
+    let (secs, nanos) = mtime_of(&cmd);
+    let planted = crate::command_disk_cache::ScannedFile {
+        mtime_secs: secs,
+        mtime_nanos: nanos,
+        path: cmd.clone(),
+        entry: Some(CommandEntry {
+            name: "mail:cached".to_string(),
+            class_name: "Send".to_string(),
+            raw_signature: "mail:cached".to_string(),
+            file: cmd.clone(),
+            line: 0,
+            start_column: 0,
+            end_column: 0,
+            priority: CommandPriority::App,
+        }),
+    };
+    save_scan(&[planted], root).unwrap();
+    let cache = load_scan(root).expect("the planted scan must load");
+
+    let vendor = VendorIndex::build(root);
+    let scan = scan_commands(root, &vendor, Some(&cache));
+
+    assert!(
+        scan.index.resolve("mail:cached").is_some(),
+        "an unchanged mtime must be answered from the cache"
+    );
+    assert!(
+        scan.index.resolve("mail:ondisk").is_none(),
+        "the file was never read, so its on-disk signature cannot have been seen          — if this resolves, the scan is still reading every file"
+    );
+}
+
+#[test]
+fn a_changed_file_is_reread() {
+    // The other half: the skip must not survive a real edit, or the index goes
+    // permanently stale.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("app/Console/Commands")).unwrap();
+    let cmd = root.join("app/Console/Commands/Send.php");
+    std::fs::write(&cmd, command_class("Send", "mail:send")).unwrap();
+
+    let (_, cache) = scan_twice(root);
+
+    // A genuine edit: contents AND mtime move.
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    std::fs::write(&cmd, command_class("Send", "mail:changed")).unwrap();
+
+    let vendor = VendorIndex::build(root);
+    let second = scan_commands(root, &vendor, Some(&cache));
+
+    assert!(
+        second.index.resolve("mail:changed").is_some(),
+        "a changed mtime must force a re-read"
+    );
+    assert!(second.index.resolve("mail:send").is_none());
+}
+
+#[test]
+fn a_new_file_is_read_even_though_the_cache_is_fresh() {
+    // A cache of declarations could never authorise skipping a file it had
+    // never seen. Neither may this one.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("app/Console/Commands")).unwrap();
+    std::fs::write(
+        root.join("app/Console/Commands/Send.php"),
+        command_class("Send", "mail:send"),
+    )
+    .unwrap();
+
+    let (_, cache) = scan_twice(root);
+
+    std::fs::write(
+        root.join("app/Console/Commands/Prune.php"),
+        command_class("Prune", "db:prune"),
+    )
+    .unwrap();
+
+    let vendor = VendorIndex::build(root);
+    let second = scan_commands(root, &vendor, Some(&cache));
+
+    assert!(
+        second.index.resolve("db:prune").is_some(),
+        "a file with no cached verdict must be read"
+    );
+    assert!(
+        second.index.resolve("mail:send").is_some(),
+        "and the cached one is still served"
+    );
+}
+
+#[test]
+fn a_deleted_file_leaves_the_index() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("app/Console/Commands")).unwrap();
+    let cmd = root.join("app/Console/Commands/Send.php");
+    std::fs::write(&cmd, command_class("Send", "mail:send")).unwrap();
+
+    let (_, cache) = scan_twice(root);
+    std::fs::remove_file(&cmd).unwrap();
+
+    let vendor = VendorIndex::build(root);
+    let second = scan_commands(root, &vendor, Some(&cache));
+
+    assert!(
+        second.index.resolve("mail:send").is_none(),
+        "a deleted file is never walked, so its cached verdict is never replayed"
+    );
+}
+
+#[test]
+fn the_scan_records_a_verdict_for_every_file_including_non_commands() {
+    // The negative verdicts ARE the feature. Recording only declarations is
+    // what made the old cache unable to skip anything.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("app/Console/Commands")).unwrap();
+    std::fs::write(
+        root.join("app/Console/Commands/Send.php"),
+        command_class("Send", "mail:send"),
+    )
+    .unwrap();
+    std::fs::write(root.join("app/Plain.php"), "<?php\nclass Plain {}\n").unwrap();
+
+    let vendor = VendorIndex::build(root);
+    let scan = scan_commands(root, &vendor, None);
+
+    assert_eq!(
+        scan.files.len(),
+        2,
+        "both files get a verdict: {:?}",
+        scan.files
+            .iter()
+            .map(|f| f.path.clone())
+            .collect::<Vec<_>>()
+    );
+    let plain = scan
+        .files
+        .iter()
+        .find(|f| f.path.ends_with("Plain.php"))
+        .expect("the non-command file must be recorded");
+    assert!(
+        plain.entry.is_none(),
+        "its verdict is `declares nothing` — a real answer, not an absence"
+    );
+}
+
+#[test]
+fn an_unusable_cache_degrades_to_a_full_scan() {
+    // Missing, stale or schema-mismatched: every one must fall back to reading,
+    // never to a wrong index.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("app/Console/Commands")).unwrap();
+    std::fs::write(
+        root.join("app/Console/Commands/Send.php"),
+        command_class("Send", "mail:send"),
+    )
+    .unwrap();
+
+    let vendor = VendorIndex::build(root);
+    assert!(
+        scan_commands(root, &vendor, None)
+            .index
+            .resolve("mail:send")
+            .is_some(),
+        "no cache at all must still find the command"
+    );
+    assert!(
+        load_scan(root).is_none(),
+        "fixture check — nothing has been saved for this project yet"
+    );
+}

--- a/laravel-lsp/src/command_index/tests.rs
+++ b/laravel-lsp/src/command_index/tests.rs
@@ -161,3 +161,143 @@ fn build_index_walks_project_and_vendor() {
 
     std::fs::remove_dir_all(&dir).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Shared vendor walk equivalence (issue #371)
+// ---------------------------------------------------------------------------
+
+/// The command index as it was built before the shared vendor walk: ONE
+/// `WalkDir` over `<root>`, pruning [`SKIP_DIRS`], reading every `*.php`.
+///
+/// Kept here as an executable oracle rather than as a comment. The refactor's
+/// whole claim is that splitting this into a project leg plus a shared vendor
+/// leg changes nothing, and the only way to test a claim about the old
+/// implementation is to keep the old implementation.
+fn build_command_index_single_walk(root: &Path) -> CommandIndex {
+    let mut index = CommandIndex::default();
+    for entry in WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|e| {
+            !(e.file_type().is_dir()
+                && e.file_name()
+                    .to_str()
+                    .is_some_and(|n| SKIP_DIRS.contains(&n)))
+        })
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if path.is_file() && path.extension().is_some_and(|ext| ext == "php") {
+            if let Ok(content) = std::fs::read_to_string(path) {
+                index_command_file(&mut index, path, &content);
+            }
+        }
+    }
+    index
+}
+
+/// Compare two indexes by everything a consumer can observe.
+fn as_pairs(index: &CommandIndex) -> Vec<(String, PathBuf, CommandPriority)> {
+    let mut v: Vec<_> = index
+        .entries()
+        .map(|e| (e.name.clone(), e.file.clone(), e.priority))
+        .collect();
+    v.sort();
+    v
+}
+
+/// A project holding the collisions and exclusions the split could break:
+/// an app command shadowing a package one, two packages colliding at the same
+/// tier, a framework command, a command inside a pruned `vendor/**/public/`
+/// subtree, one in a NESTED `app/vendor/` (walked before, not in the shared
+/// index), and one very deep in vendor.
+fn seed_command_project(root: &Path) {
+    let write = |rel: &str, class: &str, sig: &str| {
+        let p = root.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, command_class(class, sig)).unwrap();
+    };
+    write("app/Console/Commands/Send.php", "AppSend", "mail:send");
+    write("app/vendor/Nested/Deep.php", "NestedCmd", "nested:run");
+    write("vendor/acme/pkg/src/Send.php", "PkgSend", "mail:send");
+    write("vendor/acme/pkg/src/Only.php", "PkgOnly", "pkg:only");
+    write("vendor/beta/pkg/src/Only.php", "BetaOnly", "pkg:only");
+    write(
+        "vendor/laravel/framework/src/Illuminate/Foundation/Console/Work.php",
+        "WorkCmd",
+        "queue:work",
+    );
+    write(
+        "vendor/acme/pkg/public/Hidden.php",
+        "HiddenCmd",
+        "hidden:cmd",
+    );
+    write(
+        "vendor/acme/pkg/a/b/c/d/e/f/g/Deep.php",
+        "DeepCmd",
+        "deep:cmd",
+    );
+}
+
+#[test]
+fn shared_vendor_walk_builds_the_same_index_as_the_single_walk() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    seed_command_project(root);
+
+    let shared = build_command_index_with_vendor(root, &VendorIndex::build(root));
+    let oracle = build_command_index_single_walk(root);
+
+    assert_eq!(
+        as_pairs(&shared),
+        as_pairs(&oracle),
+        "splitting the walk must not change a single resolved command"
+    );
+
+    // Fixture checks — the equality above is worthless if the project is too
+    // bland to exercise the rules the split could break.
+    assert_eq!(
+        shared.resolve("mail:send").map(|e| e.priority),
+        Some(CommandPriority::App),
+        "an app command must still beat the package command of the same name, \
+         even though they are now found in two separate legs"
+    );
+    assert!(
+        shared.resolve("hidden:cmd").is_none(),
+        "a command under a pruned vendor/**/public/ subtree stays excluded"
+    );
+    assert!(
+        shared.resolve("nested:run").is_some(),
+        "a NESTED app/vendor/ is not the shared index's vendor root — it must \
+         still be walked by the project leg"
+    );
+    assert!(
+        shared.resolve("deep:cmd").is_some(),
+        "the command leg has no depth budget"
+    );
+}
+
+#[test]
+fn shared_vendor_walk_keeps_the_same_winner_on_a_same_tier_collision() {
+    // `insert_entry` keeps the FIRST file walked when two declarations share a
+    // name AND a tier, so the vendor leg has to preserve walk order. Two
+    // packages both declaring `pkg:only` is that case.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path();
+    seed_command_project(root);
+
+    let shared = build_command_index_with_vendor(root, &VendorIndex::build(root));
+    let oracle = build_command_index_single_walk(root);
+
+    let winner = |i: &CommandIndex| i.resolve("pkg:only").map(|e| e.file.clone());
+    assert_eq!(
+        winner(&shared),
+        winner(&oracle),
+        "the same-tier collision must resolve to the same file as before"
+    );
+    assert_eq!(
+        shared.resolve("pkg:only").map(|e| e.priority),
+        Some(CommandPriority::Package),
+        "fixture check — both colliding declarations must really be same-tier, \
+         or this test proves nothing about order"
+    );
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -126,6 +126,8 @@ pub mod slot_navigation;
 pub mod translation_key_locator;
 pub mod translation_lookup;
 pub mod validation_rules;
+pub mod vendor_index;
+pub mod vendor_scan;
 pub mod vendor_translations;
 pub mod view_declaration_locator;
 

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -95,6 +95,7 @@ pub mod magic_dependency_index;
 pub mod magic_disk_cache;
 pub mod markdown_safety;
 pub mod naming;
+pub mod parse_budget;
 pub mod parser;
 pub mod path_containment;
 pub mod path_join;

--- a/laravel-lsp/src/livewire_version.rs
+++ b/laravel-lsp/src/livewire_version.rs
@@ -46,6 +46,24 @@ pub fn detect_from_composer_lock(json: &str) -> LivewireVersion {
     }
 }
 
+/// Is `livewire/livewire` present in this `composer.lock`?
+///
+/// The installation test that `has_livewire` needs. It searches the whole lock
+/// document, so it matches whether the package sits in `packages` or in
+/// `packages-dev`. That is deliberate: the question is "does this project have
+/// Livewire on disk", and `composer install` writes both sets into `vendor/`.
+/// A dev-only Livewire still puts components under `app/Livewire` and still
+/// wants completion and navigation.
+///
+/// It also matches regardless of WHY the package is there — a direct
+/// requirement or a transitive one pulled in by Flux, Volt, Filament or MaryUI.
+/// That is the whole point: `composer.json` names only direct requirements, so
+/// testing it misses every project that acquires Livewire through a starter kit
+/// or a UI package.
+pub fn is_installed(composer_lock_json: &str) -> bool {
+    find_livewire_name(composer_lock_json).is_some()
+}
+
 const LOOKAHEAD_BYTES: usize = 500;
 
 fn find_livewire_name(json: &str) -> Option<usize> {

--- a/laravel-lsp/src/livewire_version/tests.rs
+++ b/laravel-lsp/src/livewire_version/tests.rs
@@ -87,3 +87,57 @@ fn unknown_for_v2_or_unrecognized_major() {
 fn unknown_for_empty_input() {
     assert_eq!(detect_from_composer_lock(""), LivewireVersion::Unknown);
 }
+
+// === Installation detection (transitive-dependency defect) ==================
+
+#[test]
+fn is_installed_finds_livewire_in_packages() {
+    let lock = r#"{ "packages": [
+        { "name": "livewire/flux", "version": "v2.9.1" },
+        { "name": "livewire/livewire", "version": "v3.6.4" }
+    ], "packages-dev": [] }"#;
+    assert!(
+        is_installed(lock),
+        "a transitively-installed Livewire is still installed"
+    );
+}
+
+#[test]
+fn is_installed_finds_livewire_in_packages_dev() {
+    // The claim made in `is_installed`'s docs: the whole lock is searched, so
+    // `packages-dev` counts. A dev-only Livewire still writes to `vendor/` and
+    // still has components under `app/Livewire` worth completing.
+    let lock = r#"{ "packages": [
+        { "name": "laravel/framework", "version": "v12.0.1" }
+    ], "packages-dev": [
+        { "name": "livewire/livewire", "version": "v3.6.4" }
+    ] }"#;
+    assert!(is_installed(lock), "a dev-only Livewire is still installed");
+}
+
+#[test]
+fn is_installed_is_false_without_livewire() {
+    let lock = r#"{ "packages": [
+        { "name": "laravel/framework", "version": "v12.0.1" },
+        { "name": "livewire/flux", "version": "v2.9.1" }
+    ], "packages-dev": [] }"#;
+    assert!(
+        !is_installed(lock),
+        "livewire/flux is not livewire/livewire — a prefix match here would \
+         report Livewire installed for any package under the livewire/ vendor"
+    );
+}
+
+#[test]
+fn is_installed_is_false_for_an_empty_lock() {
+    assert!(!is_installed(""));
+    assert!(!is_installed("{}"));
+}
+
+#[test]
+fn is_installed_tolerates_compact_json() {
+    // `composer.lock` is pretty-printed by Composer, but a lock that has been
+    // through a formatter or a tool must not silently read as "not installed".
+    let lock = r#"{"packages":[{"name":"livewire/livewire","version":"v3.6.4"}]}"#;
+    assert!(is_installed(lock));
+}

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -4980,6 +4980,11 @@ impl LaravelLanguageServer {
         // Read config/livewire.php
         let livewire_config = fs::read_to_string(root_path.join("config/livewire.php")).ok();
 
+        // Read composer.lock — the authority on whether Livewire is installed,
+        // because `composer.json` names only direct requirements and Livewire
+        // usually arrives transitively (Flux, Volt, Filament, MaryUI).
+        let composer_lock = fs::read_to_string(root_path.join("composer.lock")).ok();
+
         // Register with Salsa
         if let Err(e) = self
             .salsa
@@ -4988,6 +4993,7 @@ impl LaravelLanguageServer {
                 composer_json,
                 view_config,
                 livewire_config,
+                composer_lock,
             )
             .await
         {

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -21,7 +21,7 @@ use walkdir::WalkDir;
 use laravel_lsp::cache_manager::{
     BindingEntry, CacheManager, CachedLaravelConfig, MiddlewareEntry, RescanType, ScanResult,
 };
-use laravel_lsp::command_index::{build_command_index, CommandIndex};
+use laravel_lsp::command_index::CommandIndex;
 use laravel_lsp::completion_format::CompletionDoc;
 use laravel_lsp::config::{find_project_root, is_same_git_repo};
 use laravel_lsp::middleware_parser::{middleware_base_alias, resolve_class_to_file};
@@ -17641,9 +17641,16 @@ return [
         self.restore_command_index_from_disk(root).await;
 
         let root_buf = root.to_path_buf();
-        let index = tokio::task::spawn_blocking(move || build_command_index(&root_buf)).await;
-        match index {
-            Ok(index) => self.publish_command_index(root, index).await,
+        let vendor = self.vendor_index(root).await;
+        let scan = tokio::task::spawn_blocking(move || {
+            // Per-file mtime skip (issue #371): an unchanged file costs a
+            // `metadata` call and a hash lookup instead of a read plus regex.
+            let cache = laravel_lsp::command_disk_cache::load_scan(&root_buf);
+            laravel_lsp::command_index::scan_commands(&root_buf, &vendor, cache.as_ref())
+        })
+        .await;
+        match scan {
+            Ok(scan) => self.publish_command_scan(root, scan).await,
             Err(e) => {
                 tracing::warn!("Failed to build command index: {}", e);
             }
@@ -17678,26 +17685,33 @@ return [
     ///
     /// The save is advisory — a failure doesn't affect the live in-memory
     /// index, it only costs the next cold start its shortcut.
-    async fn publish_command_index(
+    async fn publish_command_scan(
         &self,
         root: &Path,
-        index: laravel_lsp::command_index::CommandIndex,
+        scan: laravel_lsp::command_index::CommandScan,
     ) {
-        info!("🎛️  Command index built: {} commands", index.len());
+        info!(
+            "🎛️  Command index built: {} commands from {} files",
+            scan.index.len(),
+            scan.files.len()
+        );
 
-        let to_save = index.clone();
+        // Persist every file's verdict, not just the declarations — the
+        // "declares nothing" answers are what let the next scan skip the read
+        // (issue #371).
+        let files = scan.files;
         let root_for_save = root.to_path_buf();
         let saved = tokio::task::spawn_blocking(move || {
-            laravel_lsp::command_disk_cache::save_index(&to_save, &root_for_save)
+            laravel_lsp::command_disk_cache::save_scan(&files, &root_for_save)
         })
         .await;
         match saved {
-            Ok(Ok(n)) => info!("🗄️  Command disk cache: saved {} commands", n),
+            Ok(Ok(n)) => info!("🗄️  Command disk cache: saved {} file verdicts", n),
             Ok(Err(e)) => debug!("Command disk cache save failed: {}", e),
             Err(e) => debug!("Command disk cache save task panicked: {}", e),
         }
 
-        *self.command_index.write().await = Some(index);
+        *self.command_index.write().await = Some(scan.index);
     }
 
     /// Rebuild the route index and the command index together, from ONE pass
@@ -17718,8 +17732,12 @@ return [
         let vendor = self.vendor_index(root).await;
         let root_buf = root.to_path_buf();
         let built = tokio::task::spawn_blocking(move || {
-            let (files, commands) =
-                laravel_lsp::vendor_scan::build_route_files_and_command_index(&root_buf, &vendor);
+            let cache = laravel_lsp::command_disk_cache::load_scan(&root_buf);
+            let (files, commands) = laravel_lsp::vendor_scan::build_route_files_and_command_index(
+                &root_buf,
+                &vendor,
+                cache.as_ref(),
+            );
             let file_count = files.len();
             let routes = build_route_index(&root_buf, &files);
             (file_count, routes, commands)
@@ -17734,7 +17752,7 @@ return [
                     file_count
                 );
                 *self.route_index.write().await = Some(routes);
-                self.publish_command_index(root, commands).await;
+                self.publish_command_scan(root, commands).await;
             }
             Err(e) => {
                 tracing::warn!("Failed to build vendor-derived indexes: {}", e);

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -2080,6 +2080,16 @@ struct LaravelLanguageServer {
     /// already drives the vendor provider rescan.
     vendor_index: Arc<RwLock<Option<(PathBuf, Arc<VendorIndex>)>>>,
 
+    /// Cached `<x-` / `<flux:` / `<livewire:` completion enumerations
+    /// (issue #371). See [`ComponentCompletionCache`].
+    component_completions: Arc<RwLock<ComponentCompletionCache>>,
+
+    /// TTL backstop for [`Self::component_completions`], normally
+    /// [`COMPONENT_COMPLETION_TTL`]. A field rather than a constant so tests
+    /// can disable it and prove the watcher hook works on its own — see
+    /// [`CachedEnumeration::fresh`].
+    component_completion_ttl: std::time::Duration,
+
     /// `true` once first-load warming has built the reference indexes. The
     /// unused-symbol diagnostic gates on this — running it mid-warm (empty
     /// index) would flag every lensed symbol with a false "no references"
@@ -4701,6 +4711,8 @@ impl LaravelLanguageServer {
             db_provider_task: Arc::new(tokio::sync::Mutex::new(None)),
             route_index: Arc::new(RwLock::new(None)),
             vendor_index: Arc::new(RwLock::new(None)),
+            component_completions: Arc::new(RwLock::new(ComponentCompletionCache::default())),
+            component_completion_ttl: COMPONENT_COMPLETION_TTL,
             warm_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             indexing_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             migration_index: Arc::new(RwLock::new(None)),
@@ -6088,6 +6100,114 @@ impl LaravelLanguageServer {
             }
         }
         registered
+    }
+
+    /// Drop every cached component enumeration.
+    ///
+    /// The primary freshness mechanism for [`ComponentCompletionCache`], called
+    /// from `did_change_watched_files` on any watched `.php`/`.blade.php`
+    /// change and from `invalidate_config_cache` — the scanned directory set is
+    /// itself config-derived, so a config change can move it.
+    async fn invalidate_component_completions(&self) {
+        *self.component_completions.write().await = ComponentCompletionCache::default();
+    }
+
+    /// The project root, or `None` when none has been discovered yet.
+    async fn completion_root(&self) -> Option<PathBuf> {
+        self.root_path.read().await.clone()
+    }
+
+    /// Blade `<x-…>` candidates, cached. Rebuilds on a miss.
+    async fn cached_blade_components(
+        &self,
+    ) -> Arc<Vec<laravel_lsp::component_completion::ComponentCandidate>> {
+        let Some(root) = self.completion_root().await else {
+            return Arc::new(Vec::new());
+        };
+        {
+            let cache = self.component_completions.read().await;
+            if cache.matches(&root) {
+                if let Some(hit) = cache
+                    .blade
+                    .as_ref()
+                    .and_then(|e| e.fresh(std::time::Instant::now(), self.component_completion_ttl))
+                {
+                    return hit;
+                }
+            }
+        }
+        let items = Arc::new(self.get_all_blade_components().await);
+        let mut cache = self.component_completions.write().await;
+        cache.retain_only(&root);
+        cache.blade = Some(CachedEnumeration {
+            built_at: std::time::Instant::now(),
+            items: items.clone(),
+        });
+        items
+    }
+
+    /// Flux `<flux:…>` candidates, cached. Rebuilds on a miss.
+    async fn cached_flux_components(
+        &self,
+    ) -> Arc<Vec<laravel_lsp::component_completion::ComponentCandidate>> {
+        let Some(root) = self.completion_root().await else {
+            return Arc::new(Vec::new());
+        };
+        {
+            let cache = self.component_completions.read().await;
+            if cache.matches(&root) {
+                if let Some(hit) = cache
+                    .flux
+                    .as_ref()
+                    .and_then(|e| e.fresh(std::time::Instant::now(), self.component_completion_ttl))
+                {
+                    return hit;
+                }
+            }
+        }
+        // Blocking: three `WalkDir`s plus a `canonicalize` per emitted entry.
+        let scan_root = root.clone();
+        let items = Arc::new(
+            tokio::task::spawn_blocking(move || {
+                laravel_lsp::component_completion::collect_flux_components(&scan_root)
+            })
+            .await
+            .unwrap_or_default(),
+        );
+        let mut cache = self.component_completions.write().await;
+        cache.retain_only(&root);
+        cache.flux = Some(CachedEnumeration {
+            built_at: std::time::Instant::now(),
+            items: items.clone(),
+        });
+        items
+    }
+
+    /// Livewire `<livewire:…>` candidates, cached. Rebuilds on a miss.
+    async fn cached_livewire_components(&self) -> Arc<Vec<LivewireComponentCompletion>> {
+        let Some(root) = self.completion_root().await else {
+            return Arc::new(Vec::new());
+        };
+        {
+            let cache = self.component_completions.read().await;
+            if cache.matches(&root) {
+                if let Some(hit) = cache
+                    .livewire
+                    .as_ref()
+                    .and_then(|e| e.fresh(std::time::Instant::now(), self.component_completion_ttl))
+                {
+                    return hit;
+                }
+            }
+        }
+        let items = Arc::new(self.get_all_livewire_components().await);
+        let mut cache = self.component_completions.write().await;
+        cache.retain_only(&root);
+        cache.livewire = Some(CachedEnumeration {
+            built_at: std::time::Instant::now(),
+            items: items.clone(),
+        });
+        items
     }
 
     /// Drop the cached vendor walk so the next consumer rebuilds it.
@@ -9213,6 +9333,12 @@ impl LaravelLanguageServer {
         // Module directories are derived from the filesystem too (a module
         // may appear or disappear alongside its composer.json/config).
         *self.cached_module_dirs.write().await = None;
+        // The component-completion scans read their directory set FROM that
+        // config — view paths, anonymous component paths/namespaces, class
+        // component namespaces, the Livewire path, module registrars. A config
+        // change can move the directories, not just their contents, so the
+        // cached enumerations have to go with it (issue #371).
+        self.invalidate_component_completions().await;
     }
 
     /// Get middleware from cache first, then Salsa
@@ -18417,6 +18543,8 @@ return [
             db_provider_task: self.db_provider_task.clone(),
             route_index: self.route_index.clone(),
             vendor_index: self.vendor_index.clone(),
+            component_completions: self.component_completions.clone(),
+            component_completion_ttl: self.component_completion_ttl,
             warm_complete: self.warm_complete.clone(),
             indexing_in_flight: self.indexing_in_flight.clone(),
             migration_index: self.migration_index.clone(),
@@ -22315,6 +22443,89 @@ fn collect_vendor_provider_sources(
     out
 }
 
+/// How long a cached component enumeration may still be served, as a
+/// **backstop only**.
+///
+/// The watcher hook is the mechanism: `did_change_watched_files` drops this
+/// cache on any watched `.php`/`.blade.php` create/change/delete, and
+/// `invalidate_config_cache` drops it when the config that *defines* the
+/// scanned directory set changes. Between them they cover every conventional
+/// project layout, which is the same way `route_index`, `command_index`,
+/// `migration_index` and the config cache are all kept fresh.
+///
+/// This timeout exists only for the directories those globs cannot see:
+/// `Blade::anonymousComponentPath`, `Blade::anonymousComponentNamespace`,
+/// `Blade::componentNamespace` (resolved through PSR-4) and
+/// `Livewire::addNamespace` / module registrars can each point at a directory
+/// the watcher was never registered for. Without a backstop a component
+/// created there would be missing from completion for the rest of the session.
+/// Because the watcher carries the common case, the exact value here is not
+/// load-bearing and is deliberately not tuned.
+///
+/// Completion is the right surface to accept bounded staleness on: a
+/// completion item missing for two seconds is an annoyance, whereas a stale
+/// go-to-definition target sends the reader to the wrong file. That asymmetry
+/// is what justifies a TTL here, and it does not transfer to a navigation
+/// cache.
+const COMPONENT_COMPLETION_TTL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// One cached component enumeration, with the instant it was built.
+struct CachedEnumeration<T> {
+    built_at: std::time::Instant,
+    items: Arc<Vec<T>>,
+}
+
+impl<T> CachedEnumeration<T> {
+    /// The entry, unless the TTL backstop has expired.
+    ///
+    /// `ttl` is passed in rather than read from
+    /// [`COMPONENT_COMPLETION_TTL`] so tests can hold the clock. A
+    /// two-mechanism cache fails badly when the backstop MASKS a broken
+    /// primary: if the watcher hook ever stops firing, a live TTL turns that
+    /// into "completions feel intermittently stale" — self-correcting, never
+    /// reported, and able to survive for years. Tests therefore raise the TTL
+    /// beyond reach and assert the watcher and config hooks each clear the
+    /// cache on their own.
+    fn fresh(&self, now: std::time::Instant, ttl: std::time::Duration) -> Option<Arc<Vec<T>>> {
+        (now.duration_since(self.built_at) < ttl).then(|| self.items.clone())
+    }
+}
+
+/// The three tag-context completion enumerations, cached per project root.
+///
+/// Each is filled on first use and dropped as a group by
+/// [`LaravelLanguageServer::invalidate_component_completions`]. Before this
+/// cache existed, every keystroke in a `<x-`, `<flux:` or `<livewire:` context
+/// re-walked the component directories and paid a `canonicalize()` per emitted
+/// entry — measured at ~23 ms and ~16 ms per request on this repo's
+/// `test-project/`, with no repeat ever cheaper than the first (issue #371).
+#[derive(Default)]
+struct ComponentCompletionCache {
+    /// The project root the entries below describe. A different root discards
+    /// them rather than answering with another project's components.
+    root: Option<PathBuf>,
+    blade: Option<CachedEnumeration<laravel_lsp::component_completion::ComponentCandidate>>,
+    flux: Option<CachedEnumeration<laravel_lsp::component_completion::ComponentCandidate>>,
+    livewire: Option<CachedEnumeration<LivewireComponentCompletion>>,
+}
+
+impl ComponentCompletionCache {
+    /// Drop everything if these entries describe a different project root.
+    fn retain_only(&mut self, root: &Path) {
+        if self.root.as_deref() != Some(root) {
+            *self = Self {
+                root: Some(root.to_path_buf()),
+                ..Self::default()
+            };
+        }
+    }
+
+    /// True when the cached entries belong to `root`.
+    fn matches(&self, root: &Path) -> bool {
+        self.root.as_deref() == Some(root)
+    }
+}
+
 fn is_in_routes_dir(root: Option<&Path>, path: &Path) -> bool {
     let Some(r) = root else {
         return false;
@@ -24334,6 +24545,10 @@ impl LanguageServer for LaravelLanguageServer {
         // Did this batch record any `.php` magic change? Gates the debounced
         // incremental batch — an Inertia-only burst does no magic work.
         let mut magic_dirty = false;
+        // Did this batch touch any `.php`/`.blade.php`? Drops the cached
+        // component-completion enumerations once for the whole batch rather
+        // than per event in a burst.
+        let mut components_changed = false;
         // Did a service provider change? The vendor translation-namespace map
         // is built by scanning providers, and is cached for the whole session.
         let mut providers_changed = false;
@@ -24455,6 +24670,13 @@ impl LanguageServer for LaravelLanguageServer {
                 let is_delete = matches!(change.typ, FileChangeType::DELETED);
                 self.record_watched_change(&path, is_delete).await;
                 magic_dirty = true;
+                // A `.php`/`.blade.php` create, change or delete anywhere the
+                // watcher covers can add or remove a component tag, so the
+                // cached `<x-` / `<flux:` / `<livewire:` enumerations are stale
+                // (issue #371). This is the PRIMARY freshness mechanism for
+                // that cache — its TTL is only a backstop for directories these
+                // globs cannot see.
+                components_changed = true;
             }
             match change.typ {
                 FileChangeType::CREATED => {
@@ -24562,6 +24784,14 @@ impl LanguageServer for LaravelLanguageServer {
             // in the editor or restarted the server: a registration that
             // failed the gate at index time stayed failed forever.
             *self.cached_livewire.write().await = None;
+        }
+
+        // A component file changed on disk — drop the cached tag-completion
+        // enumerations so the next `<x-` / `<flux:` / `<livewire:` keystroke
+        // rescans. One per batch rather than per event, so a `git pull` that
+        // rewrites hundreds of views clears the cache once.
+        if components_changed {
+            self.invalidate_component_completions().await;
         }
 
         // A Command class changed on disk — rebuild the Artisan command index so
@@ -27320,14 +27550,14 @@ impl LanguageServer for LaravelLanguageServer {
                 );
 
                 // Get all Blade components
-                let components = self.get_all_blade_components().await;
+                let components = self.cached_blade_components().await;
 
                 use laravel_lsp::component_completion::CandidateKind;
 
                 // Build completion items, filtering by prefix (case-insensitive)
                 let prefix_lower = component_ctx.prefix.to_lowercase();
                 let items: Vec<CompletionItem> = components
-                    .into_iter()
+                    .iter()
                     .filter(|c| c.name.to_lowercase().starts_with(&prefix_lower))
                     .map(|c| {
                         let (item_kind, summary) = match c.kind {
@@ -27390,14 +27620,11 @@ impl LanguageServer for LaravelLanguageServer {
                     flux_ctx.prefix
                 );
 
-                let candidates = match self.root_path.read().await.clone() {
-                    Some(root) => laravel_lsp::component_completion::collect_flux_components(&root),
-                    None => Vec::new(),
-                };
+                let candidates = self.cached_flux_components().await;
 
                 let prefix_lower = flux_ctx.prefix.to_lowercase();
                 let items: Vec<CompletionItem> = candidates
-                    .into_iter()
+                    .iter()
                     .filter(|c| c.name.to_lowercase().starts_with(&prefix_lower))
                     .map(|c| CompletionItem {
                         label: c.name.clone(),
@@ -27591,12 +27818,12 @@ impl LanguageServer for LaravelLanguageServer {
                 );
 
                 // Get all Livewire components
-                let components = self.get_all_livewire_components().await;
+                let components = self.cached_livewire_components().await;
 
                 // Build completion items, filtering by prefix (case-insensitive)
                 let prefix_lower = livewire_prefix.to_lowercase();
                 let items: Vec<CompletionItem> = components
-                    .into_iter()
+                    .iter()
                     .filter(|c| c.name.to_lowercase().starts_with(&prefix_lower))
                     .map(|c| CompletionItem {
                         label: c.name.clone(),

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -34,6 +34,7 @@ use laravel_lsp::query_chain::cursor::char_col_to_byte_offset;
 use laravel_lsp::route_discovery::{
     build_route_index, discover_route_files, normalize_path, RouteIndex,
 };
+use laravel_lsp::vendor_index::VendorIndex;
 
 // Salsa 0.25 database - integrated via actor pattern for async compatibility
 use laravel_lsp::salsa_impl::{
@@ -2068,6 +2069,16 @@ struct LaravelLanguageServer {
     /// Populated at init by walking routes/, vendor/*/routes/, and content-matched
     /// vendor PHP files. Replaces the legacy hard-coded route-file scan.
     route_index: Arc<RwLock<Option<RouteIndex>>>,
+
+    /// The shared walk of `<root>/vendor`, built once and reused by every
+    /// subsystem that used to walk the Composer tree for itself (issue #371).
+    ///
+    /// Keyed by the root it describes, so a project-root change rebuilds rather
+    /// than serving another project's files. Dropped by
+    /// [`LaravelLanguageServer::invalidate_vendor_index`] whenever the tree can
+    /// have changed under us — which is the same `composer.lock` signal that
+    /// already drives the vendor provider rescan.
+    vendor_index: Arc<RwLock<Option<(PathBuf, Arc<VendorIndex>)>>>,
 
     /// `true` once first-load warming has built the reference indexes. The
     /// unused-symbol diagnostic gates on this — running it mid-warm (empty
@@ -4689,6 +4700,7 @@ impl LaravelLanguageServer {
             database_schema: Arc::new(RwLock::new(None)),
             db_provider_task: Arc::new(tokio::sync::Mutex::new(None)),
             route_index: Arc::new(RwLock::new(None)),
+            vendor_index: Arc::new(RwLock::new(None)),
             warm_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             indexing_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             migration_index: Arc::new(RwLock::new(None)),
@@ -5135,6 +5147,21 @@ impl LaravelLanguageServer {
             p.report("Discovering project files…", Some(0), true).await;
         }
 
+        // The shared vendor walk (issue #371). The actor used to run its own
+        // fifth `WalkDir` over `vendor/`; it lives on a dedicated thread and
+        // cannot reach this cache, so the list is handed in. `.git` is filtered
+        // here because that pass never descended into it.
+        let vendor = self.vendor_index(root_path).await;
+        let vendor_root = vendor.vendor_root().to_path_buf();
+        let vendor_files: Vec<PathBuf> = vendor
+            .files()
+            .iter()
+            .filter(|f| {
+                !laravel_lsp::vendor_index::has_pruned_ancestor(&f.path, &vendor_root, &[".git"])
+            })
+            .map(|f| f.path.clone())
+            .collect();
+
         // Register with Salsa
         if let Err(e) = self
             .salsa
@@ -5144,6 +5171,7 @@ impl LaravelLanguageServer {
                 view_paths,
                 livewire_path,
                 PathBuf::from("routes"),
+                vendor_files,
             )
             .await
         {
@@ -5982,6 +6010,96 @@ impl LaravelLanguageServer {
         Some(decls)
     }
 
+    /// The shared walk of `<root>/vendor`, built on first use and reused
+    /// (issue #371).
+    ///
+    /// Before this, five subsystems each ran their own `WalkDir` over the
+    /// Composer tree — 16,051 `.php` files on this repo's `test-project/`, and
+    /// a bare stat walk of that costs ~0.25 s. They now filter one shared
+    /// result, each re-applying its own former depth and pruning limits as a
+    /// path predicate, so every consumer sees exactly the file set it saw
+    /// before.
+    ///
+    /// The build runs in `spawn_blocking`: it is a synchronous filesystem walk
+    /// and must never occupy a Tokio worker. Two callers arriving together can
+    /// both build — harmless, since the walk is a pure function of the tree and
+    /// the loser's result is simply replaced — and worth far less than holding
+    /// the write lock across the whole walk.
+    async fn vendor_index(&self, root: &Path) -> Arc<VendorIndex> {
+        {
+            let guard = self.vendor_index.read().await;
+            if let Some((cached_root, index)) = guard.as_ref() {
+                if cached_root == root {
+                    return index.clone();
+                }
+            }
+        }
+        let owned = root.to_path_buf();
+        let built = Arc::new(
+            tokio::task::spawn_blocking(move || VendorIndex::build(&owned))
+                .await
+                .unwrap_or_default(),
+        );
+        *self.vendor_index.write().await = Some((root.to_path_buf(), built.clone()));
+        built
+    }
+
+    /// Register every vendor service-provider / `Http/Kernel.php` source with
+    /// Salsa, returning how many registrations succeeded.
+    ///
+    /// Shared by the init scan and the `composer.lock` rescan, which carried
+    /// byte-identical copies of these two legs before (issue #371).
+    ///
+    /// The split matters as much as the sharing: the walk-and-read half is
+    /// synchronous filesystem work and runs inside `spawn_blocking`, leaving
+    /// only the `await`-ing Salsa registrations on the async side. Both former
+    /// copies did the reads inline in an `async fn`, blocking a Tokio worker
+    /// for the whole scan.
+    ///
+    /// Only ~73 of 16,051 vendor files match on a real project, so the reads
+    /// are not worth sharing with the route/command pass — the *walk* is, and
+    /// that comes from `vendor`.
+    async fn register_vendor_provider_sources(
+        &self,
+        root: &Path,
+        vendor: &Arc<VendorIndex>,
+    ) -> usize {
+        let root_buf = root.to_path_buf();
+        let index = vendor.clone();
+        let sources =
+            tokio::task::spawn_blocking(move || collect_vendor_provider_sources(&root_buf, &index))
+                .await
+                .unwrap_or_default();
+
+        let mut registered = 0;
+        for source in sources {
+            if self
+                .salsa
+                .register_service_provider_source(
+                    source.path,
+                    source.content,
+                    source.priority,
+                    root.to_path_buf(),
+                )
+                .await
+                .is_ok()
+            {
+                registered += 1;
+            }
+        }
+        registered
+    }
+
+    /// Drop the cached vendor walk so the next consumer rebuilds it.
+    ///
+    /// Called wherever the Composer tree can have changed — the same
+    /// `composer.lock` signal that already triggers the vendor provider
+    /// rescan. Dropping rather than rebuilding keeps the cost off whichever
+    /// path noticed the change.
+    async fn invalidate_vendor_index(&self) {
+        *self.vendor_index.write().await = None;
+    }
+
     /// The inherited external-load name prefixes (issue #43) that apply to
     /// `path`, read from the warm route index. Always includes `""`.
     ///
@@ -6214,95 +6332,15 @@ impl LaravelLanguageServer {
         let documents = self.documents.read().await;
         let mut registered_count = 0;
 
-        // Priority 0: Framework providers
-        let framework_path = root.join("vendor/laravel/framework/src/Illuminate");
-        if framework_path.exists() {
-            for entry in WalkDir::new(&framework_path)
-                .max_depth(10)
-                .into_iter()
-                .filter_map(|e| e.ok())
-            {
-                let path = entry.path();
-                if path.is_file()
-                    && path.extension().is_some_and(|ext| ext == "php")
-                    && path
-                        .file_name()
-                        .is_some_and(|name| name.to_string_lossy().ends_with("ServiceProvider.php"))
-                {
-                    if let Ok(content) = std::fs::read_to_string(path) {
-                        if self
-                            .salsa
-                            .register_service_provider_source(
-                                path.to_path_buf(),
-                                content,
-                                0, // framework priority
-                                root.to_path_buf(),
-                            )
-                            .await
-                            .is_ok()
-                        {
-                            registered_count += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Priority 1: Package providers and Kernel files (for middleware definitions)
-        let vendor_path = root.join("vendor");
-        debug!(
-            "🔍 Scanning vendor path: {:?} (exists={})",
-            vendor_path,
-            vendor_path.exists()
-        );
-        if vendor_path.exists() {
-            for entry in WalkDir::new(&vendor_path)
-                .max_depth(6)
-                .into_iter()
-                .filter_map(|e| e.ok())
-            {
-                let path = entry.path();
-                // Skip framework (already done with priority 0)
-                if path.starts_with(&framework_path) {
-                    continue;
-                }
-                if path.is_file() && path.extension().is_some_and(|ext| ext == "php") {
-                    let file_name = path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    let path_str = path.to_string_lossy();
-
-                    // Scan ServiceProvider files for middleware/binding registrations
-                    // and Http/Kernel.php files for middleware alias/group definitions
-                    let is_service_provider = file_name.ends_with("ServiceProvider.php");
-                    let is_http_kernel = file_name == "Kernel.php"
-                        && (path_str.contains("/Http/") || path_str.contains("\\Http\\"));
-
-                    if is_service_provider || is_http_kernel {
-                        debug!(
-                            "📄 [init] Found vendor file: {} (SP={}, Kernel={})",
-                            path_str, is_service_provider, is_http_kernel
-                        );
-                        if let Ok(content) = std::fs::read_to_string(path) {
-                            if self
-                                .salsa
-                                .register_service_provider_source(
-                                    path.to_path_buf(),
-                                    content,
-                                    1, // package priority
-                                    root.to_path_buf(),
-                                )
-                                .await
-                                .is_ok()
-                            {
-                                registered_count += 1;
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        // Priority 0 (framework) + 1 (packages): every vendor service provider
+        // and `Http/Kernel.php`. Both legs used to run a `WalkDir` and a
+        // `std::fs::read_to_string` inline in this `async fn` — synchronous
+        // filesystem work occupying a Tokio worker thread — and the identical
+        // code appeared again in `rescan_vendor_providers`. Now: one shared
+        // walk, the reads done in `spawn_blocking`, and only the Salsa
+        // registrations left on the async side (issue #371).
+        let vendor = self.vendor_index(root).await;
+        registered_count += self.register_vendor_provider_sources(root, &vendor).await;
 
         // Priority 3: Application providers (app/Providers/)
         let app_providers_path = root.join("app/Providers");
@@ -6626,9 +6664,8 @@ impl LaravelLanguageServer {
             let route_root = root.to_path_buf();
             let server = self.clone_for_spawn();
             tokio::spawn(async move {
-                server.rebuild_route_index(&route_root).await;
+                server.rebuild_route_and_command_indexes(&route_root).await;
                 server.rebuild_migration_index(&route_root).await;
-                server.rebuild_command_index(&route_root).await;
             });
         }
 
@@ -6662,86 +6699,15 @@ impl LaravelLanguageServer {
         let mut middleware_count = 0;
         let mut bindings_count = 0;
 
-        // Priority 0: Framework providers
-        let framework_path = root.join("vendor/laravel/framework/src/Illuminate");
-        if framework_path.exists() {
-            for entry in WalkDir::new(&framework_path)
-                .max_depth(10)
-                .into_iter()
-                .filter_map(|e| e.ok())
-            {
-                let path = entry.path();
-                if path.is_file()
-                    && path.extension().is_some_and(|ext| ext == "php")
-                    && path
-                        .file_name()
-                        .is_some_and(|name| name.to_string_lossy().ends_with("ServiceProvider.php"))
-                {
-                    if let Ok(content) = std::fs::read_to_string(path) {
-                        if self
-                            .salsa
-                            .register_service_provider_source(
-                                path.to_path_buf(),
-                                content,
-                                0, // framework priority
-                                root.to_path_buf(),
-                            )
-                            .await
-                            .is_ok()
-                        {
-                            registered_count += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Priority 1: Package providers and Kernel files (for middleware definitions)
-        let vendor_path = root.join("vendor");
-        if vendor_path.exists() {
-            for entry in WalkDir::new(&vendor_path)
-                .max_depth(6)
-                .into_iter()
-                .filter_map(|e| e.ok())
-            {
-                let path = entry.path();
-                // Skip framework (already done with priority 0)
-                if path.starts_with(&framework_path) {
-                    continue;
-                }
-                if path.is_file() && path.extension().is_some_and(|ext| ext == "php") {
-                    let file_name = path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    let path_str = path.to_string_lossy();
-
-                    // Scan ServiceProvider files for middleware/binding registrations
-                    // and Http/Kernel.php files for middleware alias/group definitions
-                    let is_service_provider = file_name.ends_with("ServiceProvider.php");
-                    let is_http_kernel = file_name == "Kernel.php"
-                        && (path_str.contains("/Http/") || path_str.contains("\\Http\\"));
-
-                    if is_service_provider || is_http_kernel {
-                        if let Ok(content) = std::fs::read_to_string(path) {
-                            if self
-                                .salsa
-                                .register_service_provider_source(
-                                    path.to_path_buf(),
-                                    content,
-                                    1, // package priority
-                                    root.to_path_buf(),
-                                )
-                                .await
-                                .is_ok()
-                            {
-                                registered_count += 1;
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        // The same two vendor legs the init scan runs, through the same shared
+        // walk and the same `spawn_blocking` reads. These were byte-identical
+        // copies of the init code before (issue #371).
+        //
+        // The shared walk is invalidated first: this path exists precisely
+        // because `composer.lock` changed, so the cached file list is stale.
+        self.invalidate_vendor_index().await;
+        let vendor = self.vendor_index(root).await;
+        registered_count += self.register_vendor_provider_sources(root, &vendor).await;
 
         drop(documents);
 
@@ -7977,9 +7943,8 @@ impl LaravelLanguageServer {
 
         // Rebuild the route name index so any route definition changes (added,
         // renamed, removed) are reflected on the next goto-definition request.
-        self.rebuild_route_index(&root).await;
+        self.rebuild_route_and_command_indexes(&root).await;
         self.rebuild_migration_index(&root).await;
-        self.rebuild_command_index(&root).await;
 
         // Populate cache with ALL parsed middleware/bindings AFTER all rescans complete
         // This ensures we capture middleware from both vendor and app sources
@@ -8315,9 +8280,9 @@ impl LaravelLanguageServer {
         info!("========================================");
         info!("🛣️  Building route index from root: {:?}", discovered_root);
         info!("========================================");
-        self.rebuild_route_index(&discovered_root).await;
+        self.rebuild_route_and_command_indexes(&discovered_root)
+            .await;
         self.rebuild_migration_index(&discovered_root).await;
-        self.rebuild_command_index(&discovered_root).await;
 
         // Initialize environment variables with Salsa
         info!("========================================");
@@ -17513,52 +17478,106 @@ return [
     /// for `Command` subclasses. Mirrors `rebuild_migration_index` — the
     /// (blocking) walk runs off the async runtime, then the index is swapped in.
     async fn rebuild_command_index(&self, root: &Path) {
-        // Cold start: restore the disk-cached index immediately so
-        // goto-definition/hover on command strings work without waiting for
-        // the full project+vendor walk below. Only on a cold index (None) —
-        // file-watcher rebuilds already have a live index and skip this. The
-        // full build that follows corrects any drift (added/removed commands
-        // while the LSP was off) and re-saves the cache.
-        if self.command_index.read().await.is_none() {
-            let root_for_load = root.to_path_buf();
-            if let Ok(Some(cached)) = tokio::task::spawn_blocking(move || {
-                laravel_lsp::command_disk_cache::load_index(&root_for_load)
-            })
-            .await
-            {
-                info!(
-                    "🗄️  Command index: restored {} commands from disk cache",
-                    cached.len()
-                );
-                *self.command_index.write().await = Some(cached);
-            }
-        }
+        self.restore_command_index_from_disk(root).await;
 
         let root_buf = root.to_path_buf();
         let index = tokio::task::spawn_blocking(move || build_command_index(&root_buf)).await;
         match index {
-            Ok(index) => {
-                info!("🎛️  Command index built: {} commands", index.len());
-
-                // Persist the freshly built index so the next cold start can
-                // skip the walk. Advisory — a save failure doesn't affect the
-                // live in-memory index.
-                let to_save = index.clone();
-                let root_for_save = root.to_path_buf();
-                let saved = tokio::task::spawn_blocking(move || {
-                    laravel_lsp::command_disk_cache::save_index(&to_save, &root_for_save)
-                })
-                .await;
-                match saved {
-                    Ok(Ok(n)) => info!("🗄️  Command disk cache: saved {} commands", n),
-                    Ok(Err(e)) => debug!("Command disk cache save failed: {}", e),
-                    Err(e) => debug!("Command disk cache save task panicked: {}", e),
-                }
-
-                *self.command_index.write().await = Some(index);
-            }
+            Ok(index) => self.publish_command_index(root, index).await,
             Err(e) => {
                 tracing::warn!("Failed to build command index: {}", e);
+            }
+        }
+    }
+
+    /// Cold start: restore the disk-cached command index immediately so
+    /// goto-definition/hover on command strings work without waiting for the
+    /// full project+vendor walk. Only on a cold index (`None`) — file-watcher
+    /// rebuilds already have a live index and skip this. Whichever full build
+    /// follows corrects any drift (commands added/removed while the LSP was
+    /// off) and re-saves the cache.
+    async fn restore_command_index_from_disk(&self, root: &Path) {
+        if self.command_index.read().await.is_some() {
+            return;
+        }
+        let root_for_load = root.to_path_buf();
+        if let Ok(Some(cached)) = tokio::task::spawn_blocking(move || {
+            laravel_lsp::command_disk_cache::load_index(&root_for_load)
+        })
+        .await
+        {
+            info!(
+                "🗄️  Command index: restored {} commands from disk cache",
+                cached.len()
+            );
+            *self.command_index.write().await = Some(cached);
+        }
+    }
+
+    /// Persist a freshly built command index and swap it in.
+    ///
+    /// The save is advisory — a failure doesn't affect the live in-memory
+    /// index, it only costs the next cold start its shortcut.
+    async fn publish_command_index(
+        &self,
+        root: &Path,
+        index: laravel_lsp::command_index::CommandIndex,
+    ) {
+        info!("🎛️  Command index built: {} commands", index.len());
+
+        let to_save = index.clone();
+        let root_for_save = root.to_path_buf();
+        let saved = tokio::task::spawn_blocking(move || {
+            laravel_lsp::command_disk_cache::save_index(&to_save, &root_for_save)
+        })
+        .await;
+        match saved {
+            Ok(Ok(n)) => info!("🗄️  Command disk cache: saved {} commands", n),
+            Ok(Err(e)) => debug!("Command disk cache save failed: {}", e),
+            Err(e) => debug!("Command disk cache save task panicked: {}", e),
+        }
+
+        *self.command_index.write().await = Some(index);
+    }
+
+    /// Rebuild the route index and the command index together, from ONE pass
+    /// over the vendor tree (issue #371).
+    ///
+    /// Both are derived from the same vendor files, and every caller that
+    /// wants one wants the other immediately afterwards. Built separately they
+    /// read every vendor `.php` twice — ~31,400 reads on this repo's
+    /// `test-project/` against ~16,200 for the shared pass. The single-index
+    /// rebuilds stay for the incremental paths (a saved routes file, a changed
+    /// `Commands` file), which need only one and run rarely.
+    ///
+    /// Output is identical to calling both in sequence; see
+    /// `vendor_scan::build_route_files_and_command_index`.
+    async fn rebuild_route_and_command_indexes(&self, root: &Path) {
+        self.restore_command_index_from_disk(root).await;
+
+        let vendor = self.vendor_index(root).await;
+        let root_buf = root.to_path_buf();
+        let built = tokio::task::spawn_blocking(move || {
+            let (files, commands) =
+                laravel_lsp::vendor_scan::build_route_files_and_command_index(&root_buf, &vendor);
+            let file_count = files.len();
+            let routes = build_route_index(&root_buf, &files);
+            (file_count, routes, commands)
+        })
+        .await;
+
+        match built {
+            Ok((file_count, routes, commands)) => {
+                info!(
+                    "🛣️  Route index built: {} named routes from {} files",
+                    routes.len(),
+                    file_count
+                );
+                *self.route_index.write().await = Some(routes);
+                self.publish_command_index(root, commands).await;
+            }
+            Err(e) => {
+                tracing::warn!("Failed to build vendor-derived indexes: {}", e);
             }
         }
     }
@@ -18397,6 +18416,7 @@ return [
             database_schema: self.database_schema.clone(),
             db_provider_task: self.db_provider_task.clone(),
             route_index: self.route_index.clone(),
+            vendor_index: self.vendor_index.clone(),
             warm_complete: self.warm_complete.clone(),
             indexing_in_flight: self.indexing_in_flight.clone(),
             migration_index: self.migration_index.clone(),
@@ -22217,6 +22237,84 @@ async fn decl_range_at(
 /// file doesn't exist yet, a permission error) we fall back to comparing the
 /// uncanonicalized paths rather than guess — no panic, and the same behaviour
 /// for in-memory paths that aren't on disk.
+/// Depth budget the framework service-provider leg used, counted from
+/// `vendor/laravel/framework/src/Illuminate` (its own former `WalkDir` root).
+const FRAMEWORK_PROVIDER_MAX_DEPTH: usize = 10;
+/// Depth budget the package service-provider leg used, counted from `vendor/`.
+const PACKAGE_PROVIDER_MAX_DEPTH: usize = 6;
+
+/// One vendor file the service-provider registry wants, with the priority tier
+/// its location implies.
+struct VendorProviderSource {
+    path: PathBuf,
+    content: String,
+    priority: u8,
+}
+
+/// Which priority tier, if any, the vendor provider scan registers `file` at.
+///
+/// Reproduces the two former `WalkDir` legs exactly:
+///
+/// * **Framework (0)** — `*ServiceProvider.php` under
+///   `vendor/laravel/framework/src/Illuminate`, within 10 levels of *that*
+///   directory. Measured against the framework root rather than `vendor/`, so
+///   the budget cannot drift with where the package happens to sit.
+/// * **Package (1)** — anything else in `vendor/` within 6 levels, named
+///   `*ServiceProvider.php` or an `Http/**/Kernel.php`.
+///
+/// A framework-owned `Http/Kernel.php` belongs to neither: the framework leg
+/// admitted only providers, and the package leg skipped framework paths
+/// outright. Returning `None` for it preserves that.
+fn vendor_provider_priority(
+    framework_root: &Path,
+    file: &laravel_lsp::vendor_index::VendorFile,
+) -> Option<u8> {
+    let name = file.path.file_name()?.to_string_lossy().to_string();
+
+    if file.path.starts_with(framework_root) {
+        let depth = laravel_lsp::vendor_index::depth_below(&file.path, framework_root)?;
+        let admitted =
+            depth <= FRAMEWORK_PROVIDER_MAX_DEPTH && name.ends_with("ServiceProvider.php");
+        return admitted.then_some(0);
+    }
+
+    if file.depth > PACKAGE_PROVIDER_MAX_DEPTH {
+        return None;
+    }
+    let path_str = file.path.to_string_lossy();
+    let is_service_provider = name.ends_with("ServiceProvider.php");
+    let is_http_kernel =
+        name == "Kernel.php" && (path_str.contains("/Http/") || path_str.contains("\\Http\\"));
+    (is_service_provider || is_http_kernel).then_some(1)
+}
+
+/// Read every vendor provider / kernel source the registry needs, from the
+/// shared vendor walk.
+///
+/// Blocking: a predicate over the whole file list plus a few dozen reads. Runs
+/// inside `spawn_blocking` — see
+/// [`LaravelLanguageServer::register_vendor_provider_sources`].
+fn collect_vendor_provider_sources(
+    root: &Path,
+    vendor: &laravel_lsp::vendor_index::VendorIndex,
+) -> Vec<VendorProviderSource> {
+    let framework_root = root.join("vendor/laravel/framework/src/Illuminate");
+    let mut out = Vec::new();
+    vendor.for_each_source(
+        |file| vendor_provider_priority(&framework_root, file).is_some(),
+        |file, content| {
+            if let Some(priority) = vendor_provider_priority(&framework_root, file) {
+                out.push(VendorProviderSource {
+                    path: file.path.clone(),
+                    content: content.to_string(),
+                    priority,
+                });
+            }
+        },
+    );
+    out
+}
+
 fn is_in_routes_dir(root: Option<&Path>, path: &Path) -> bool {
     let Some(r) = root else {
         return false;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -5339,7 +5339,10 @@ impl LaravelLanguageServer {
         //   * Bulk-import in chunks so the actor's pattern_cache.put loop
         //     never holds the actor for too long on a giant project.
         const MAX_CONCURRENT_PARSES: usize = 8;
-        const MAX_FILE_SIZE_BYTES: u64 = 256 * 1024; // 256 KB
+        // The cap and the `.json.php` rule both live in `parse_budget` now, so
+        // the warm pass, the rename scan and the watched-file magic batch
+        // cannot drift apart (issue #371).
+        use laravel_lsp::parse_budget::MAX_PARSED_FILE_SIZE_BYTES;
 
         let salsa = self.salsa.clone();
         // Cloned into the warm task so it can ask the client to re-resolve code
@@ -5493,8 +5496,7 @@ impl LaravelLanguageServer {
                     // — without it, editing a service provider or a config file never
                     // re-registered with Salsa on Windows, so middleware aliases, bindings
                     // and config values silently stopped updating (issue #292).
-                    let path_str = path.to_string_lossy();
-                    if path_str.ends_with(".json.php") {
+                    if laravel_lsp::parse_budget::is_json_php(&path) {
                         return Some((
                             path,
                             Arc::new(laravel_lsp::salsa_impl::ParsedPatternsData::default()),
@@ -5506,12 +5508,12 @@ impl LaravelLanguageServer {
                     // insert empty patterns so the cache lookup
                     // succeeds and never falls through to Salsa.
                     let metadata = std::fs::metadata(&path).ok()?;
-                    if metadata.len() > MAX_FILE_SIZE_BYTES {
+                    if metadata.len() > MAX_PARSED_FILE_SIZE_BYTES {
                         info!(
                             "warming: skipping oversized file {} ({} bytes > {} cap)",
                             path.display(),
                             metadata.len(),
-                            MAX_FILE_SIZE_BYTES
+                            MAX_PARSED_FILE_SIZE_BYTES
                         );
                         return Some((
                             path,
@@ -7875,10 +7877,42 @@ impl LaravelLanguageServer {
         for (path, pending) in batch {
             let is_vendor = path.components().any(|c| c.as_os_str() == "vendor");
 
+            // Parse-budget gate (issue #371). The warm pass refuses to parse
+            // `*.json.php` blobs and anything over 256 KB — 0.4–2.2 s per file,
+            // 1,735 of them under `aws-sdk-php` alone — but this path had
+            // neither rule, and a `composer install` rewrites thousands of
+            // vendor files straight into it, drained serially through the
+            // single Salsa actor thread with no cap.
+            //
+            // Beyond the cost, parsing here would be INCONSISTENT: the warm
+            // pass deliberately left these files out of the index, so a watched
+            // change was quietly pulling in files the rest of the pipeline has
+            // agreed to ignore.
+            //
+            // An excluded file is handled exactly like a deleted one, which is
+            // the honest description of its state: it contributes nothing to
+            // the index. For the overwhelmingly common case — never indexed,
+            // because the warm pass skipped it too — `old_surfaces` is empty
+            // and the branch below is a no-op. For the rarer case of a file
+            // that was indexed while small and has since grown past the cap,
+            // withdrawing its now-unmaintainable contributions and rippling
+            // them to dependents is exactly right.
+            let excluded = laravel_lsp::parse_budget::skip_reason_on_disk(&path);
+            if let Some(reason) = excluded {
+                debug!(
+                    "magic batch: skipping {} ({})",
+                    path.display(),
+                    reason.describe()
+                );
+            }
+
             // Authoritative existence check: read the file NOW. `None` = gone,
             // whatever the advisory `deleted` flag says (a flag-race across
             // overlapping notifications can leave it present-but-missing).
-            let content = self.read_file_for_magic(&path).await;
+            let content = match excluded {
+                Some(_) => None,
+                None => self.read_file_for_magic(&path).await,
+            };
 
             let Some(content) = content else {
                 // Gone: post-change surface is empty, so every pre-change FQCN is
@@ -20836,8 +20870,8 @@ return [
         new_name: &str,
         model_decl_file: Option<&Path>,
     ) -> Vec<laravel_lsp::rename::EditTarget> {
+        use laravel_lsp::parse_budget::MAX_PARSED_FILE_SIZE_BYTES;
         use std::sync::Arc;
-        const MAX_FILE_SIZE_BYTES: u64 = 256 * 1024;
         const MAX_CONCURRENT_PARSES: usize = 8;
 
         let root_owned = root.to_path_buf();
@@ -20856,7 +20890,7 @@ return [
                 let _permit = permit_owner.acquire_owned().await.ok()?;
                 // Per-file size cap — skip oversized files (data dumps).
                 let metadata = std::fs::metadata(&path).ok()?;
-                if metadata.len() > MAX_FILE_SIZE_BYTES {
+                if metadata.len() > MAX_PARSED_FILE_SIZE_BYTES {
                     return None;
                 }
                 let path_for_task = path.clone();

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -5982,6 +5982,46 @@ impl LaravelLanguageServer {
         Some(decls)
     }
 
+    /// The inherited external-load name prefixes (issue #43) that apply to
+    /// `path`, read from the warm route index. Always includes `""`.
+    ///
+    /// `route_discovery::external_prefixes_for_file` answers the same question,
+    /// but it gets there by running `discover_route_files` — a `read_to_string`
+    /// of every `.php` file under `vendor/` (16k+ on a real project) on every
+    /// single call. `RouteIndex::external_prefixes` is the *identical* map:
+    /// `build_route_index` fills it from the same load-graph pass that produced
+    /// the routes, and `did_save` rebuilds the index whenever a contributing
+    /// file changes. So this is the same answer for free.
+    ///
+    /// Cold start (index not built yet) yields `[""]` — the same default
+    /// `RouteIndex::external_prefixes_for` gives for a file the load graph
+    /// never reached, and the answer that leaves route names unprefixed rather
+    /// than guessing a prefix.
+    async fn cached_external_prefixes(&self, path: &Path) -> Vec<String> {
+        let guard = self.route_index.read().await;
+        guard
+            .as_ref()
+            .map(|index| index.external_prefixes_for(path))
+            .unwrap_or_else(|| vec![String::new()])
+    }
+
+    /// The whole normalized-path → inherited-prefixes map from the warm route
+    /// index, for callers that need it for many files at once.
+    ///
+    /// Cloned out rather than handed back behind the `RwLock` guard: callers
+    /// iterate the map across `.await` points that take other locks, and
+    /// holding a read guard across those is how deadlocks start. The map holds
+    /// one small entry per contributing route file, so the clone is far cheaper
+    /// than the vendor walk it replaces. Cold start yields an empty map, which
+    /// every caller already reads as `[""]` per file.
+    async fn cached_external_prefix_map(&self) -> HashMap<PathBuf, Vec<String>> {
+        let guard = self.route_index.read().await;
+        guard
+            .as_ref()
+            .map(|index| index.external_prefixes.clone())
+            .unwrap_or_default()
+    }
+
     /// The fully-qualified Folio route name a `.blade.php` page declares, IF the
     /// cursor at `position` sits on the page's own `name('...')` helper call.
     ///
@@ -22080,11 +22120,14 @@ async fn classify_with_decl_fallback(
     // project-level name (`admin.x`). Anchor the symbol to that resolved name
     // so find-references / rename match every contributing site across files.
     // The raw name still matches via `find_declarations_named_with_external`'s
-    // always-present `""` prefix. `external_prefixes_for_file` runs the
-    // cross-file load graph, so it's only worth paying when `root` is known.
-    let resolved = root
-        .map(|r| laravel_lsp::route_discovery::external_prefixes_for_file(r, file_path))
-        .and_then(|prefixes| prefixes.into_iter().find(|p| !p.is_empty()))
+    // always-present `""` prefix. Read from the warm route index — the
+    // cross-file load graph already ran once at index build time, and rerunning
+    // it here would re-read the whole vendor tree per request (issue #80).
+    let resolved = server
+        .cached_external_prefixes(file_path)
+        .await
+        .into_iter()
+        .find(|p| !p.is_empty())
         .map(|primary| format!("{}{}", primary, decl.full_name))
         .unwrap_or_else(|| decl.full_name.clone());
 
@@ -22094,9 +22137,12 @@ async fn classify_with_decl_fallback(
 /// Look up the source-text range a `prepare_rename` should return when the
 /// cursor sat on a declaration-fallback site (parser saw nothing, but the
 /// locator did). Used for prepare_rename's editor-highlight range.
+///
+/// Takes no project root: the external-load prefixes it needs come from the
+/// server's warm route index, which is already keyed by absolute path (issue
+/// #80).
 async fn decl_range_at(
     server: &LaravelLanguageServer,
-    root: Option<&Path>,
     file_path: &Path,
     position: Position,
     symbol: &laravel_lsp::references::SymbolRef,
@@ -22109,9 +22155,8 @@ async fn decl_range_at(
     if let Some(decls) = server.cached_route_decls(file_path).await {
         // `name` may carry an external-file group prefix (issue #43); match a raw
         // in-file decl whose name equals `name` once that prefix is prepended.
-        let external = root
-            .map(|r| laravel_lsp::route_discovery::external_prefixes_for_file(r, file_path))
-            .unwrap_or_else(|| vec![String::new()]);
+        // Warm-index read, not a fresh load-graph walk (issue #80).
+        let external = server.cached_external_prefixes(file_path).await;
         for d in decls.iter().filter(|d| {
             external
                 .iter()
@@ -22350,10 +22395,11 @@ async fn collect_declaration_locations(
             if !routes_dir.exists() {
                 return out;
             }
-            // Inherited external-load prefixes for EVERY route file, computed
-            // once per request instead of re-running the project load graph per
-            // file inside the loop below (avoids O(files²)).
-            let external_prefix_map = laravel_lsp::route_discovery::external_prefixes_map(root);
+            // Inherited external-load prefixes for EVERY route file, read from
+            // the warm route index. `external_prefixes_map` computes the same
+            // map, but by re-walking the vendor tree on every request (issue
+            // #80); the index already holds it, refreshed on save.
+            let external_prefix_map = server.cached_external_prefix_map().await;
             for entry in WalkDir::new(&routes_dir)
                 .max_depth(6)
                 .into_iter()
@@ -22571,10 +22617,11 @@ async fn collect_route_declaration_targets(
     let mut targets = Vec::new();
     let routes_dir = root.join("routes");
     if routes_dir.exists() {
-        // Inherited external-load prefixes for EVERY route file, computed once
-        // per request instead of re-running the project load graph per file
-        // inside the loop below (avoids O(files²)).
-        let external_prefix_map = laravel_lsp::route_discovery::external_prefixes_map(root);
+        // Inherited external-load prefixes for EVERY route file, read from the
+        // warm route index. `external_prefixes_map` computes the same map, but
+        // by re-walking the vendor tree on every request (issue #80); the index
+        // already holds it, refreshed on save.
+        let external_prefix_map = server.cached_external_prefix_map().await;
         for entry in WalkDir::new(&routes_dir)
             .max_depth(6)
             .into_iter()
@@ -24972,24 +25019,28 @@ impl LanguageServer for LaravelLanguageServer {
         // externally-prefixed route file we recompute the route symbols here
         // with the prefix applied; every other file uses the cached Salsa
         // result unchanged.
-        let root_path = self.root_path.read().await.clone();
+        //
+        // Ordering matters (issue #80): the prefix lookup reads the warm route
+        // index, and nothing more expensive than that runs before the
+        // "is there actually a prefix?" test. This handler used to call
+        // `route_discovery::external_prefixes_for_file`, which re-walked the
+        // whole vendor tree *first* and then threw the result away for the
+        // overwhelmingly common unprefixed file — 510 ms per repeat request on
+        // a routes file against 0.2 ms on any other PHP file.
         if laravel_lsp::document_symbols::classify_file(&file_path)
             == laravel_lsp::document_symbols::FileKind::RouteFile
         {
-            if let Some(root) = root_path.as_ref() {
-                let external =
-                    laravel_lsp::route_discovery::external_prefixes_for_file(root, &file_path);
-                if external.iter().any(|p| !p.is_empty()) {
-                    if let Some(content) = self.document_or_disk_content(uri, &file_path).await {
-                        let entries = laravel_lsp::document_symbols::extract_symbols_with_external(
-                            &content,
-                            laravel_lsp::document_symbols::FileKind::RouteFile,
-                            &external,
-                        );
-                        let symbols: Vec<DocumentSymbol> =
-                            entries.iter().map(symbol_entry_to_lsp).collect();
-                        return Ok(Some(DocumentSymbolResponse::Nested(symbols)));
-                    }
+            let external = self.cached_external_prefixes(&file_path).await;
+            if external.iter().any(|p| !p.is_empty()) {
+                if let Some(content) = self.document_or_disk_content(uri, &file_path).await {
+                    let entries = laravel_lsp::document_symbols::extract_symbols_with_external(
+                        &content,
+                        laravel_lsp::document_symbols::FileKind::RouteFile,
+                        &external,
+                    );
+                    let symbols: Vec<DocumentSymbol> =
+                        entries.iter().map(symbol_entry_to_lsp).collect();
+                    return Ok(Some(DocumentSymbolResponse::Nested(symbols)));
                 }
             }
         }
@@ -25260,7 +25311,7 @@ impl LanguageServer for LaravelLanguageServer {
         let pattern_range = pattern_range_at(&patterns, position.line, position.character);
         let range = match pattern_range {
             Some(r) => Some(r),
-            None => decl_range_at(self, root_path.as_deref(), &file_path, position, &symbol).await,
+            None => decl_range_at(self, &file_path, position, &symbol).await,
         };
         match &range {
             Some(r) => debug!(

--- a/laravel-lsp/src/parse_budget.rs
+++ b/laravel-lsp/src/parse_budget.rs
@@ -1,0 +1,85 @@
+//! The per-file limits that keep tree-sitter away from files it cannot parse
+//! affordably, in one place.
+//!
+//! Two exclusions, both learned the hard way during warm-up tuning:
+//!
+//! * **`*.json.php`** — the Laravel/PHP convention for pre-baked JSON data
+//!   wrapped as PHP. Pure data, never user-facing Laravel patterns, and
+//!   tree-sitter-php chokes on the deeply-nested array literals: 0.4–2.2 s
+//!   *per file*. This repo's `test-project/` has 1,735 of them under
+//!   `aws-sdk-php`.
+//! * **A 256 KB size cap** — dropping it from 4 MB cut warming from 70 s to
+//!   under 10 s on a real Laravel project with vendor, Flux icons and IDE
+//!   helpers checked in. The biggest real application PHP file in the test
+//!   project is 55 KB; IDE helpers top out at 186 KB. Everything above the cap
+//!   is auto-generated metadata.
+//!
+//! The rules lived as three independent copies of `const MAX_FILE_SIZE_BYTES:
+//! u64 = 256 * 1024` plus one hand-written `.json.php` test, and the watched-
+//! file magic rebuild had neither (issue #371). Enumerations maintained by hand
+//! in several places drift; this module exists so there is one to change.
+
+use std::path::Path;
+
+/// Largest file worth handing to tree-sitter.
+pub const MAX_PARSED_FILE_SIZE_BYTES: u64 = 256 * 1024;
+
+/// True when `path` names a pre-baked JSON data file wrapped as PHP.
+///
+/// A filename-suffix test, so it needs no path normalization — a file
+/// extension contains no separators, unlike the directory tests elsewhere in
+/// this crate that had to learn about Windows `\` the hard way (issue #292).
+pub fn is_json_php(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.ends_with(".json.php"))
+}
+
+/// Why a file is excluded from parsing, if it is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipReason {
+    /// Pre-baked JSON data wrapped as PHP.
+    JsonPhp,
+    /// Larger than [`MAX_PARSED_FILE_SIZE_BYTES`]; carries the actual size.
+    TooLarge(u64),
+}
+
+impl SkipReason {
+    /// A short phrase for logs.
+    pub fn describe(&self) -> String {
+        match self {
+            SkipReason::JsonPhp => "pre-baked JSON data file".to_string(),
+            SkipReason::TooLarge(size) => {
+                format!("{size} bytes > {MAX_PARSED_FILE_SIZE_BYTES} cap")
+            }
+        }
+    }
+}
+
+/// Whether `path` of `size` bytes should be excluded from parsing.
+///
+/// The name test comes first: it is free, and a `.json.php` file under the size
+/// cap must still be excluded.
+pub fn skip_reason(path: &Path, size: u64) -> Option<SkipReason> {
+    if is_json_php(path) {
+        return Some(SkipReason::JsonPhp);
+    }
+    (size > MAX_PARSED_FILE_SIZE_BYTES).then_some(SkipReason::TooLarge(size))
+}
+
+/// [`skip_reason`] for a file on disk, sizing it with one `metadata` call.
+///
+/// A path that cannot be stat'd yields `None` — "nothing to exclude" — leaving
+/// the caller's own existence handling to decide what a missing file means.
+/// Deciding that here would let a transient stat failure masquerade as an
+/// exclusion and silently withdraw a live file from an index.
+pub fn skip_reason_on_disk(path: &Path) -> Option<SkipReason> {
+    if is_json_php(path) {
+        return Some(SkipReason::JsonPhp);
+    }
+    let size = std::fs::metadata(path).ok()?.len();
+    (size > MAX_PARSED_FILE_SIZE_BYTES).then_some(SkipReason::TooLarge(size))
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/parse_budget/tests.rs
+++ b/laravel-lsp/src/parse_budget/tests.rs
@@ -1,0 +1,120 @@
+//! Tests for the shared parse budget (issue #371).
+
+use super::*;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+#[test]
+fn json_php_is_recognised_by_its_full_suffix() {
+    assert!(is_json_php(Path::new(
+        "/p/vendor/aws/data/endpoints.json.php"
+    )));
+    assert!(
+        !is_json_php(Path::new("/p/app/Models/User.php")),
+        "an ordinary PHP file is not a data blob"
+    );
+    assert!(
+        !is_json_php(Path::new("/p/data/endpoints.json")),
+        "a bare .json file is not PHP and never reaches the PHP parser"
+    );
+    assert!(
+        !is_json_php(Path::new("/p/app/json.php")),
+        "the suffix is `.json.php`, not the filename `json.php` — this file is \
+         ordinary PHP source"
+    );
+}
+
+#[test]
+fn json_php_ignores_directory_names() {
+    // A filename-suffix test must not be satisfied by a DIRECTORY called
+    // `x.json.php`, which would exclude every real source file beneath it.
+    assert!(
+        !is_json_php(Path::new("/p/weird.json.php/Model.php")),
+        "only the file's own name decides"
+    );
+}
+
+#[test]
+fn the_size_cap_binds_at_the_documented_boundary() {
+    let p = Path::new("/p/app/Big.php");
+    assert_eq!(
+        skip_reason(p, MAX_PARSED_FILE_SIZE_BYTES),
+        None,
+        "a file exactly at the cap is still parsed — the rule is `>`, not `>=`"
+    );
+    assert_eq!(
+        skip_reason(p, MAX_PARSED_FILE_SIZE_BYTES + 1),
+        Some(SkipReason::TooLarge(MAX_PARSED_FILE_SIZE_BYTES + 1)),
+        "one byte over is excluded"
+    );
+    assert_eq!(skip_reason(p, 0), None, "an empty file is parsed");
+}
+
+#[test]
+fn the_cap_is_the_documented_256_kb() {
+    // The value is load-bearing: it was tuned from 4 MB down to this, and the
+    // module docs quote the resulting numbers. A silent change would make that
+    // prose false.
+    assert_eq!(MAX_PARSED_FILE_SIZE_BYTES, 256 * 1024);
+}
+
+#[test]
+fn a_small_json_php_is_still_excluded() {
+    // The name test must run first. A tiny `.json.php` is excluded for what it
+    // is, not for how big it is — tree-sitter's trouble is the nesting, and a
+    // size-only rule would let small ones through.
+    assert_eq!(
+        skip_reason(Path::new("/p/data/tiny.json.php"), 10),
+        Some(SkipReason::JsonPhp),
+        "a 10-byte .json.php is still a data blob"
+    );
+}
+
+#[test]
+fn on_disk_sizing_matches_the_in_memory_rule() {
+    let tmp = TempDir::new().unwrap();
+    let small = tmp.path().join("Small.php");
+    fs::write(&small, "<?php\n").unwrap();
+    let big = tmp.path().join("Big.php");
+    fs::write(&big, vec![b'x'; (MAX_PARSED_FILE_SIZE_BYTES + 1) as usize]).unwrap();
+    let data: PathBuf = tmp.path().join("blob.json.php");
+    fs::write(&data, "<?php return [];").unwrap();
+
+    assert_eq!(skip_reason_on_disk(&small), None);
+    assert_eq!(
+        skip_reason_on_disk(&big),
+        Some(SkipReason::TooLarge(MAX_PARSED_FILE_SIZE_BYTES + 1))
+    );
+    assert_eq!(skip_reason_on_disk(&data), Some(SkipReason::JsonPhp));
+}
+
+#[test]
+fn an_unstattable_path_reports_no_exclusion() {
+    // Fail-open is correct HERE and only here: the caller owns existence
+    // handling, and reporting "excluded" for a transient stat failure would let
+    // a live file be silently withdrawn from an index it belongs in.
+    let tmp = TempDir::new().unwrap();
+    assert_eq!(skip_reason_on_disk(&tmp.path().join("gone.php")), None);
+}
+
+#[test]
+fn an_unstattable_json_php_is_still_excluded() {
+    // The name rule needs no stat, so it must survive one failing. Otherwise a
+    // deleted-then-recreated data blob could slip past the exclusion on a race.
+    let tmp = TempDir::new().unwrap();
+    assert_eq!(
+        skip_reason_on_disk(&tmp.path().join("gone.json.php")),
+        Some(SkipReason::JsonPhp)
+    );
+}
+
+#[test]
+fn describe_reports_the_measured_size() {
+    // The log line is the only place an operator learns WHY a file was skipped.
+    assert!(SkipReason::TooLarge(300_000).describe().contains("300000"));
+    assert!(SkipReason::TooLarge(300_000)
+        .describe()
+        .contains(&MAX_PARSED_FILE_SIZE_BYTES.to_string()));
+    assert!(SkipReason::JsonPhp.describe().contains("JSON"));
+}

--- a/laravel-lsp/src/route_discovery.rs
+++ b/laravel-lsp/src/route_discovery.rs
@@ -19,6 +19,8 @@ use std::path::{Path, PathBuf};
 use tree_sitter::Node;
 use walkdir::WalkDir;
 
+use crate::vendor_index::{VendorFile, VendorIndex};
+
 /// A `->group(...)`/`::group(...)` callsite that loads an *external file*
 /// instead of running a closure body (issue #43). Laravel `require`s the file
 /// and applies the group's attributes — including its `->as('admin.')` name
@@ -167,6 +169,83 @@ pub fn discovery_walk_count() -> u64 {
     DISCOVERY_WALKS.with(|c| c.get())
 }
 
+/// Depth budget for the vendor leg of route discovery, in `WalkDir` terms
+/// (`vendor/` itself is depth 0). Was `WalkDir::max_depth(8)` before the shared
+/// vendor walk; it is now applied as a predicate over
+/// [`VendorIndex`](crate::vendor_index::VendorIndex), which sees the whole
+/// tree so that other consumers can apply their own, different budgets.
+pub const VENDOR_ROUTE_MAX_DEPTH: usize = 8;
+
+/// Accumulates discovered route files, keeping the highest priority seen per
+/// path. Merging by maximum rather than by arrival is what makes discovery
+/// independent of walk order.
+#[derive(Debug, Default)]
+pub struct RouteFileSet(HashMap<PathBuf, u8>);
+
+impl RouteFileSet {
+    /// Record `path` at `priority`, keeping whichever priority is higher.
+    pub fn promote(&mut self, path: PathBuf, priority: u8) {
+        promote(&mut self.0, path, priority);
+    }
+
+    pub fn into_files(self) -> Vec<RouteFile> {
+        self.0
+            .into_iter()
+            .map(|(path, priority)| RouteFile { path, priority })
+            .collect()
+    }
+}
+
+/// True when route discovery needs this vendor file's **text** to decide.
+///
+/// Two kinds of file need no read: one past the depth budget, which discovery
+/// never considered at all, and one under a package `routes/` directory, which
+/// is a route file by Laravel convention regardless of content. Everything else
+/// is decided by content match, so the shared vendor pass reads it for us.
+pub fn vendor_route_needs_source(file: &VendorFile) -> bool {
+    file.depth <= VENDOR_ROUTE_MAX_DEPTH && !is_under_routes_dir(&file.path)
+}
+
+/// Record the vendor route files that need no read — everything under a package
+/// `routes/` directory, within the depth budget.
+pub fn collect_conventional_vendor_route_files(vendor: &VendorIndex, out: &mut RouteFileSet) {
+    for file in vendor.files() {
+        if file.depth <= VENDOR_ROUTE_MAX_DEPTH && is_under_routes_dir(&file.path) {
+            out.promote(file.path.clone(), priority_for_vendor_path(&file.path));
+        }
+    }
+}
+
+/// Record an already-read vendor file if its text shows route-registration
+/// shape (a router token AND a `->name(` call).
+///
+/// This is what catches macro bodies (Laravel UI's `AuthRouteMethods`),
+/// service-provider `boot()` registrations, and Filament-style
+/// `Panel::routes(fn () => ...)` panels.
+pub fn accept_vendor_route_source(out: &mut RouteFileSet, path: &Path, content: &str) {
+    if content_registers_named_routes(content) {
+        out.promote(path.to_path_buf(), priority_for_vendor_path(path));
+    }
+}
+
+/// Record the non-vendor route files: the project's own `routes/` tree, plus
+/// app service providers and `bootstrap/app.php` that register routes in
+/// `boot()`. Those are content-matched to avoid pulling in unrelated `app/`
+/// files.
+pub fn collect_project_route_files(root: &Path, out: &mut RouteFileSet) {
+    let project_routes = root.join("routes");
+    if project_routes.exists() {
+        for path in walk_php_files(&project_routes, 6) {
+            out.promote(path, PRIORITY_APP);
+        }
+    }
+    for candidate in app_provider_candidates(root) {
+        if candidate.exists() && file_registers_named_routes(&candidate) {
+            out.promote(candidate, PRIORITY_APP);
+        }
+    }
+}
+
 /// Walk the project to discover every file likely to define named routes.
 ///
 /// The returned list is deduplicated by path. Order is not significant — the
@@ -174,73 +253,31 @@ pub fn discovery_walk_count() -> u64 {
 ///
 /// **Expensive.** Content-matching the vendor tree means a `read_to_string` of
 /// every `.php` file below `vendor/`. Call this from warm-up/rebuild paths
-/// only; request handlers read the cached [`RouteIndex`] instead.
+/// only; request handlers read the cached [`RouteIndex`] instead. Warm start
+/// shares its vendor reads with the command index — see
+/// [`discover_route_files_with_vendor`].
 pub fn discover_route_files(root: &Path) -> Vec<RouteFile> {
+    discover_route_files_with_vendor(root, &VendorIndex::build(root))
+}
+
+/// [`discover_route_files`] driven by an already-built shared vendor walk.
+///
+/// Identical output to walking `vendor/` here: `vendor` holds the whole tree
+/// and the depth budget is re-applied per file by [`vendor_route_needs_source`]
+/// and [`collect_conventional_vendor_route_files`]. Splitting it out lets warm
+/// start read each vendor file once for this *and* the command index instead of
+/// twice (issue #371).
+pub fn discover_route_files_with_vendor(root: &Path, vendor: &VendorIndex) -> Vec<RouteFile> {
     DISCOVERY_WALKS.with(|c| c.set(c.get().saturating_add(1)));
-    let mut seen: HashMap<PathBuf, u8> = HashMap::new();
+    let mut out = RouteFileSet::default();
 
-    // Project routes/ — recursive, every *.php
-    let project_routes = root.join("routes");
-    if project_routes.exists() {
-        for path in walk_php_files(&project_routes, 6) {
-            promote(&mut seen, path, PRIORITY_APP);
-        }
-    }
+    collect_project_route_files(root, &mut out);
+    collect_conventional_vendor_route_files(vendor, &mut out);
+    vendor.for_each_source(vendor_route_needs_source, |file, content| {
+        accept_vendor_route_source(&mut out, &file.path, content);
+    });
 
-    // Package routes/*.php and any vendor file whose content registers routes.
-    let vendor = root.join("vendor");
-    if vendor.exists() {
-        for entry in WalkDir::new(&vendor)
-            .max_depth(8)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            let path = entry.path();
-            if !path.is_file() {
-                continue;
-            }
-            if path.extension().is_none_or(|ext| ext != "php") {
-                continue;
-            }
-
-            // Anything under a vendor `routes/` subdirectory is a route file
-            // by Laravel package convention.
-            if is_under_routes_dir(path) {
-                promote(
-                    &mut seen,
-                    path.to_path_buf(),
-                    priority_for_vendor_path(path),
-                );
-                continue;
-            }
-
-            // Otherwise content-match: register the file only if it both
-            // contains a route-registration token AND a `->name(` call.
-            // This is what catches macro bodies (Laravel UI's
-            // AuthRouteMethods), service-provider `boot()` registrations,
-            // and Filament-style `Panel::routes(fn () => ...)` panels.
-            if file_registers_named_routes(path) {
-                promote(
-                    &mut seen,
-                    path.to_path_buf(),
-                    priority_for_vendor_path(path),
-                );
-            }
-        }
-    }
-
-    // App-level service providers and bootstrap/app.php often register routes
-    // directly in `boot()`. Scan with content match to avoid pulling in
-    // unrelated *.php files in app/.
-    for candidate in app_provider_candidates(root) {
-        if candidate.exists() && file_registers_named_routes(&candidate) {
-            promote(&mut seen, candidate, PRIORITY_APP);
-        }
-    }
-
-    seen.into_iter()
-        .map(|(path, priority)| RouteFile { path, priority })
-        .collect()
+    out.into_files()
 }
 
 /// Build a complete route name → location index from the given files.

--- a/laravel-lsp/src/route_discovery.rs
+++ b/laravel-lsp/src/route_discovery.rs
@@ -86,12 +86,18 @@ pub struct RouteIndex {
     /// routes, so consumers (e.g. the code-lens handler) resolve a file's
     /// fully-qualified route names without re-parsing every route file. Use
     /// [`RouteIndex::external_prefixes_for`], which defaults to `[""]`.
+    ///
+    /// **Ordered:** `""` first, then the inherited prefixes lexicographically.
+    /// A caller taking the first non-empty entry as the file's primary
+    /// project-level name therefore gets the same answer every run — see the
+    /// sort in `compute_effective_prefixes`.
     pub external_prefixes: HashMap<PathBuf, Vec<String>>,
 }
 
 impl RouteIndex {
     /// The inherited external-load name prefixes that apply to `path` (always
-    /// includes `""`). Reads the map cached at build time — no I/O.
+    /// includes `""` first, then the rest lexicographically). Reads the map
+    /// cached at build time — no I/O.
     pub fn external_prefixes_for(&self, path: &Path) -> Vec<String> {
         self.external_prefixes
             .get(&normalize_path(path))
@@ -135,11 +141,42 @@ pub struct RouteFile {
     pub priority: u8,
 }
 
+thread_local! {
+    /// How many [`discover_route_files`] walks this thread has started.
+    ///
+    /// The walk reads *every* `.php` file under `vendor/` — tens of thousands
+    /// on a real project — so it belongs in warm-up (`rebuild_route_index`,
+    /// which runs it inside `spawn_blocking`) and nowhere near a per-request
+    /// handler. This counter is the seam the regression tests use to prove a
+    /// handler answered from the warm [`RouteIndex::external_prefixes`] cache
+    /// instead of re-walking (issue #80).
+    ///
+    /// Thread-local rather than a global `AtomicU64` so tests running in
+    /// parallel cannot see each other's walks: a `#[tokio::test]` drives its
+    /// current-thread runtime on the test's own thread, and the one production
+    /// walk site hands the work to a `spawn_blocking` thread. `Cell<u64>` is
+    /// enough — a thread-local is never shared, so no atomics are needed.
+    static DISCOVERY_WALKS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// How many [`discover_route_files`] walks the **calling thread** has started.
+///
+/// Test instrumentation: take a reading, drive a handler, take another. An
+/// unchanged count proves the handler touched no route file on disk.
+pub fn discovery_walk_count() -> u64 {
+    DISCOVERY_WALKS.with(|c| c.get())
+}
+
 /// Walk the project to discover every file likely to define named routes.
 ///
 /// The returned list is deduplicated by path. Order is not significant — the
 /// final index resolves conflicts via priority.
+///
+/// **Expensive.** Content-matching the vendor tree means a `read_to_string` of
+/// every `.php` file below `vendor/`. Call this from warm-up/rebuild paths
+/// only; request handlers read the cached [`RouteIndex`] instead.
 pub fn discover_route_files(root: &Path) -> Vec<RouteFile> {
+    DISCOVERY_WALKS.with(|c| c.set(c.get().saturating_add(1)));
     let mut seen: HashMap<PathBuf, u8> = HashMap::new();
 
     // Project routes/ — recursive, every *.php
@@ -273,14 +310,23 @@ fn dedup_prefixes(prefixes: &[String]) -> Vec<String> {
 /// A file referenced via `Route::as('admin.')->group(base_path('that.php'))`
 /// from somewhere in the project inherits the loading group's name prefix
 /// (`"admin."`) transitively across the entire `->group(<path>)` load graph.
-/// This is exactly the set [`build_route_index`] applies when indexing the file
-/// — exposed standalone so rename / find-references / document-symbols can
-/// resolve a route's project-level name without re-running a full index build.
 ///
-/// Runs [`discover_route_files`] + the same BFS load-graph expansion and
-/// prefix propagation as [`build_route_index`], then looks up `file`'s
-/// normalized key. Returns `["".into()]` when `file` isn't reachable (it's
-/// still scanned directly, so the empty prefix always applies).
+/// **Not for request handlers.** This is the uncached reference implementation:
+/// it runs [`discover_route_files`] — a `read_to_string` of every `.php` file
+/// under `vendor/` — plus the same BFS load-graph expansion and prefix
+/// propagation as [`build_route_index`], and only then looks up `file`'s
+/// normalized key. [`build_route_index`] already stores the identical answer
+/// for every file in [`RouteIndex::external_prefixes`], so anything holding a
+/// built index must call [`RouteIndex::external_prefixes_for`] instead. Calling
+/// this per request is what made `textDocument/documentSymbol` on a routes file
+/// cost ~510 ms against ~0.2 ms elsewhere (issue #80).
+///
+/// It stays as the independent oracle the tests compare the cached map against
+/// — see `external_prefixes_for_file_agrees_with_the_built_index`, which is
+/// what licenses every handler to read the cache instead.
+///
+/// Returns `["".into()]` when `file` isn't reachable (it's still scanned
+/// directly, so the empty prefix always applies).
 pub fn external_prefixes_for_file(root: &Path, file: &Path) -> Vec<String> {
     let files = discover_route_files(root);
     let expansion = expand_load_graph(root, &files);
@@ -296,25 +342,6 @@ pub fn external_prefixes_for_file(root: &Path, file: &Path) -> Vec<String> {
         }
     }
     out
-}
-
-/// Like [`external_prefixes_for_file`] but computes the inherited external-load
-/// prefixes for EVERY route file in one pass, keyed by normalized path. Callers
-/// iterating many files (rename / find-references) build this once instead of
-/// re-running the whole project load graph per file (avoids O(files²)).
-///
-/// Each returned entry always includes `""`. A file with no inherited prefix is
-/// simply absent from the map — callers should treat a miss as `["".into()]`.
-pub fn external_prefixes_map(root: &Path) -> HashMap<PathBuf, Vec<String>> {
-    let files = discover_route_files(root);
-    let expansion = expand_load_graph(root, &files);
-    let effective = compute_effective_prefixes(&expansion.files, &expansion.loads);
-
-    let mut map: HashMap<PathBuf, Vec<String>> = HashMap::new();
-    for (key, prefixes) in effective {
-        map.insert(key, dedup_prefixes(&prefixes));
-    }
-    map
 }
 
 /// The fully-expanded working set produced by following `->group(<path>)`
@@ -459,6 +486,29 @@ fn compute_effective_prefixes(
     let mut effective: HashMap<PathBuf, Vec<String>> = HashMap::new();
     for start in &known {
         propagate(start, "", &edges, &mut effective, &mut Vec::new(), 0);
+    }
+
+    // Sort each file's prefixes. The DFS above visits `known` (a `HashSet`) and
+    // `files` (a `HashMap` drain, via `discover_route_files`) in whatever order
+    // the hasher's per-instance seed produces, so a file reachable under two
+    // different prefixes collected them in an order that changed from run to
+    // run — and from call to call inside one process.
+    //
+    // That is not cosmetic. `classify_with_decl_fallback` anchors a route
+    // declaration to the FIRST non-empty prefix, so a file loaded by both
+    // `Route::as('admin.')->group(...)` and `Route::as('blog.')->group(...)`
+    // resolved to `admin.x` or `blog.x` at random — find-references and rename
+    // would disagree with themselves between two invocations on the same
+    // unedited project.
+    //
+    // Sorting the output (rather than the traversal) is what makes the result
+    // stable: the reachable SET is already start-order independent — each DFS
+    // is bounded by its own cycle stack and its own depth budget — so only the
+    // order ever varied. Lexicographic is an arbitrary but total rule; the load
+    // graph ranks sibling loaders in no other way, and a caller taking `.first()`
+    // needs *some* defined answer.
+    for prefixes in effective.values_mut() {
+        prefixes.sort();
     }
     effective
 }

--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -777,6 +777,169 @@ fn external_prefixes_for_file_transitive_chain_accumulates() {
 }
 
 #[test]
+fn external_prefixes_for_file_agrees_with_the_built_index() {
+    // The premise the whole of issue #80 rests on: every request handler now
+    // answers external-prefix questions from `RouteIndex::external_prefixes`
+    // instead of calling `external_prefixes_for_file`. That is only sound if
+    // the two agree — so compare them directly, file by file, on a project
+    // exercising the shapes the propagation has to get right:
+    //
+    //   a.php   — loader, inherits nothing
+    //   b.php   — loaded with `admin.`, and itself a loader
+    //   c.php   — loaded transitively, inherits the accumulated `admin.blog.`
+    //   solo.php — a route file no load edge ever reaches
+    //
+    // Comparing only the prefixed files would pass for a cache that returned
+    // `[""]` for everything reachable *and* everything else, so the unprefixed
+    // files are part of the comparison too.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let routes = root.join("routes");
+    std::fs::create_dir_all(&routes).unwrap();
+    std::fs::write(
+        routes.join("a.php"),
+        "<?php\nRoute::as('admin.')->group(base_path('routes/b.php'));\n",
+    )
+    .unwrap();
+    std::fs::write(
+        routes.join("b.php"),
+        "<?php\nRoute::get('/dash', fn () => 'ok')->name('dash');\n\
+         Route::as('blog.')->group(base_path('routes/c.php'));\n",
+    )
+    .unwrap();
+    std::fs::write(
+        routes.join("c.php"),
+        "<?php\nRoute::get('/posts', fn () => 'ok')->name('posts.index');\n",
+    )
+    .unwrap();
+    std::fs::write(
+        routes.join("solo.php"),
+        "<?php\nRoute::get('/solo', fn () => 'ok')->name('solo');\n",
+    )
+    .unwrap();
+
+    let index = build_route_index(root, &discover_route_files(root));
+
+    // Compared as SEQUENCES, not as sets: `compute_effective_prefixes` sorts,
+    // so the two sides must agree element for element, in order. (Before that
+    // sort this comparison was flaky — see
+    // `external_prefixes_are_ordered_deterministically`.)
+    for leaf in ["a.php", "b.php", "c.php", "solo.php"] {
+        let file = routes.join(leaf);
+        assert_eq!(
+            index.external_prefixes_for(&file),
+            external_prefixes_for_file(root, &file),
+            "the cached index and the uncached walk must agree for {leaf}"
+        );
+    }
+
+    // Pin what "agree" is worth here: the comparison above would be vacuously
+    // true if both sides answered `[""]` everywhere, so assert the fixture
+    // really does carry an accumulated prefix through the index.
+    assert!(
+        index
+            .external_prefixes_for(&routes.join("c.php"))
+            .contains(&"admin.blog.".to_string()),
+        "fixture check — the index must carry the transitive `admin.blog.` \
+         prefix, otherwise the equality above proves nothing: {:?}",
+        index.external_prefixes_for(&routes.join("c.php"))
+    );
+}
+
+/// `admin.php` and `blog.php` both load `shared.php`, under different name
+/// prefixes. That is the shape whose prefix order used to vary run to run.
+fn seed_two_loader_project(root: &Path) -> PathBuf {
+    let routes = root.join("routes");
+    std::fs::create_dir_all(&routes).unwrap();
+    std::fs::write(
+        routes.join("admin.php"),
+        "<?php\nRoute::as('admin.')->group(base_path('routes/shared.php'));\n",
+    )
+    .unwrap();
+    std::fs::write(
+        routes.join("blog.php"),
+        "<?php\nRoute::as('blog.')->group(base_path('routes/shared.php'));\n",
+    )
+    .unwrap();
+    let shared = routes.join("shared.php");
+    std::fs::write(
+        &shared,
+        "<?php\nRoute::get('/posts', fn () => 'ok')->name('posts.index');\n",
+    )
+    .unwrap();
+    shared
+}
+
+#[test]
+fn external_prefixes_are_ordered_deterministically() {
+    // Regression: `compute_effective_prefixes` DFS'd a `HashSet` of start files
+    // and pushed each reached prefix in visit order, so a file reachable under
+    // two prefixes got them in an order set by the hasher's per-instance seed.
+    // Rust seeds each `HashMap`/`HashSet` instance differently, so the order
+    // changed between two calls *inside one process* — which is exactly what
+    // `classify_with_decl_fallback` reads when it takes the first non-empty
+    // prefix as a declaration's project-level name. Find-references and rename
+    // could therefore anchor to `admin.posts.index` on one invocation and
+    // `blog.posts.index` on the next, on an unedited project.
+    //
+    // Repeating the computation is the whole point: a single call cannot
+    // observe instability, and each iteration builds fresh maps with fresh
+    // seeds. 20 rounds made the unsorted version fail every time it was run.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let shared = seed_two_loader_project(root);
+
+    let expected = vec![String::new(), "admin.".to_string(), "blog.".to_string()];
+
+    for round in 0..20 {
+        let index = build_route_index(root, &discover_route_files(root));
+        assert_eq!(
+            index.external_prefixes_for(&shared),
+            expected,
+            "round {round}: the built index must order prefixes `\"\"` first, \
+             then lexicographically — an order that never varies between runs"
+        );
+        assert_eq!(
+            external_prefixes_for_file(root, &shared),
+            expected,
+            "round {round}: the uncached walk must produce the same stable order"
+        );
+    }
+}
+
+#[test]
+fn a_route_reachable_under_two_prefixes_resolves_to_a_stable_name() {
+    // The consequence the sort exists for, stated in the terms a user sees.
+    // `classify_with_decl_fallback` builds a declaration's project-level name
+    // as `<first non-empty prefix><in-file name>`; with two loaders that first
+    // element has to be the same on every call or find-references and rename
+    // silently target different symbols on successive invocations.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let shared = seed_two_loader_project(root);
+
+    let names: std::collections::HashSet<String> = (0..20)
+        .map(|_| {
+            let index = build_route_index(root, &discover_route_files(root));
+            let primary = index
+                .external_prefixes_for(&shared)
+                .into_iter()
+                .find(|p| !p.is_empty())
+                .expect("a doubly-loaded file must inherit at least one prefix");
+            format!("{primary}posts.index")
+        })
+        .collect();
+
+    assert_eq!(
+        names,
+        std::collections::HashSet::from(["admin.posts.index".to_string()]),
+        "20 rounds must all resolve to the one lexicographically-first name; \
+         more than one entry here means rename would rewrite a different symbol \
+         depending on when it ran: {names:?}"
+    );
+}
+
+#[test]
 fn external_group_cycle_is_guarded() {
     // a.php loads b.php; b.php loads a.php. Must terminate and still index
     // both files' bare names without blowing up.

--- a/laravel-lsp/src/route_discovery/tests.rs
+++ b/laravel-lsp/src/route_discovery/tests.rs
@@ -2068,3 +2068,182 @@ $this->app->resource('photos', PhotoController::class);
         "resource() must keep its current receiver-agnostic behavior",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Shared vendor walk equivalence (issue #371)
+// ---------------------------------------------------------------------------
+
+/// Route-file discovery as it was before the shared vendor walk: the project
+/// legs, plus its OWN `WalkDir::new(vendor).max_depth(8)`.
+///
+/// An executable oracle, kept because the refactor's claim is about the old
+/// implementation and there is no other way to test such a claim.
+fn discover_route_files_own_walk(root: &Path) -> Vec<RouteFile> {
+    let mut seen: HashMap<PathBuf, u8> = HashMap::new();
+
+    let project_routes = root.join("routes");
+    if project_routes.exists() {
+        for path in walk_php_files(&project_routes, 6) {
+            promote(&mut seen, path, PRIORITY_APP);
+        }
+    }
+
+    let vendor = root.join("vendor");
+    if vendor.exists() {
+        for entry in WalkDir::new(&vendor)
+            .max_depth(8)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if !path.is_file() || path.extension().is_none_or(|ext| ext != "php") {
+                continue;
+            }
+            if is_under_routes_dir(path) {
+                promote(
+                    &mut seen,
+                    path.to_path_buf(),
+                    priority_for_vendor_path(path),
+                );
+                continue;
+            }
+            if file_registers_named_routes(path) {
+                promote(
+                    &mut seen,
+                    path.to_path_buf(),
+                    priority_for_vendor_path(path),
+                );
+            }
+        }
+    }
+
+    for candidate in app_provider_candidates(root) {
+        if candidate.exists() && file_registers_named_routes(&candidate) {
+            promote(&mut seen, candidate, PRIORITY_APP);
+        }
+    }
+
+    seen.into_iter()
+        .map(|(path, priority)| RouteFile { path, priority })
+        .collect()
+}
+
+fn as_sorted_pairs(files: &[RouteFile]) -> Vec<(PathBuf, u8)> {
+    let mut v: Vec<_> = files.iter().map(|f| (f.path.clone(), f.priority)).collect();
+    v.sort();
+    v
+}
+
+/// A project holding every shape the vendor leg's rules key on: a package
+/// `routes/` file (accepted with no read), a provider that registers routes by
+/// content, a framework-tier file (different priority), a non-registering file,
+/// a registering file just inside the depth-8 budget, one just outside it, and
+/// one inside a `node_modules/` subtree the route walk has never pruned.
+fn seed_route_project(root: &Path) {
+    let route_src = "<?php\nRoute::get('/x', fn () => 'ok')->name('x');\n";
+    let write = |rel: &str, body: &str| {
+        let p = root.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, body).unwrap();
+    };
+    write("routes/web.php", route_src);
+    write("app/Providers/RouteServiceProvider.php", route_src);
+    write(
+        "vendor/acme/pkg/routes/web.php",
+        "<?php\n// no routes here\n",
+    );
+    write("vendor/acme/pkg/src/Provider.php", route_src);
+    write("vendor/acme/pkg/src/Plain.php", "<?php\nclass Plain {}\n");
+    write(
+        "vendor/laravel/framework/src/Illuminate/Foo/Bar.php",
+        route_src,
+    );
+    // depth 8 — the last depth the vendor leg considers.
+    write("vendor/acme/pkg/a/b/c/d/e/In.php", route_src);
+    // depth 9 — past it.
+    write("vendor/acme/pkg/a/b/c/d/e/f/Out.php", route_src);
+    write("vendor/acme/pkg/node_modules/Bundled.php", route_src);
+}
+
+#[test]
+fn shared_vendor_walk_discovers_the_same_route_files_as_its_own_walk() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed_route_project(root);
+
+    let shared =
+        discover_route_files_with_vendor(root, &crate::vendor_index::VendorIndex::build(root));
+    let oracle = discover_route_files_own_walk(root);
+
+    assert_eq!(
+        as_sorted_pairs(&shared),
+        as_sorted_pairs(&oracle),
+        "sharing the vendor walk must not change which files are discovered, \
+         nor their priorities"
+    );
+
+    // Fixture checks, so the equality above cannot pass vacuously.
+    let has = |rel: &str| shared.iter().any(|f| f.path == root.join(rel));
+    assert!(
+        has("vendor/acme/pkg/routes/web.php"),
+        "a package routes/ file is accepted by convention even though its \
+         content registers nothing — proving the no-read branch still runs"
+    );
+    assert!(
+        has("vendor/acme/pkg/src/Provider.php"),
+        "a content-matched vendor file is still discovered — proving the \
+         shared read pass reaches the classifier"
+    );
+    assert!(
+        !has("vendor/acme/pkg/src/Plain.php"),
+        "a vendor file registering no routes is still rejected"
+    );
+    assert!(
+        has("vendor/acme/pkg/a/b/c/d/e/In.php"),
+        "depth 8 is inside the vendor budget"
+    );
+    assert!(
+        !has("vendor/acme/pkg/a/b/c/d/e/f/Out.php"),
+        "depth 9 is outside it — the budget must still bind now that the \
+         shared walk itself is unbounded"
+    );
+    assert!(
+        has("vendor/acme/pkg/node_modules/Bundled.php"),
+        "route discovery never pruned node_modules, and must not start now \
+         just because another consumer of the shared walk does"
+    );
+    assert_eq!(
+        shared
+            .iter()
+            .find(|f| f.path == root.join("vendor/laravel/framework/src/Illuminate/Foo/Bar.php"))
+            .map(|f| f.priority),
+        Some(PRIORITY_FRAMEWORK),
+        "framework files keep their own tier"
+    );
+}
+
+#[test]
+fn shared_vendor_walk_matches_the_old_walk_without_a_vendor_dir() {
+    // The former code guarded the whole vendor leg on `vendor.exists()`. The
+    // shared index reports `is_empty()` instead; the project legs must still
+    // produce exactly what they did.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join("routes")).unwrap();
+    std::fs::write(
+        root.join("routes/web.php"),
+        "<?php\nRoute::get('/x', fn () => 'ok')->name('x');\n",
+    )
+    .unwrap();
+
+    let shared =
+        discover_route_files_with_vendor(root, &crate::vendor_index::VendorIndex::build(root));
+    let oracle = discover_route_files_own_walk(root);
+
+    assert_eq!(as_sorted_pairs(&shared), as_sorted_pairs(&oracle));
+    assert_eq!(
+        shared.len(),
+        1,
+        "fixture check — the project leg found its file"
+    );
+}

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -9818,7 +9818,6 @@ impl SalsaActor {
         // new patterns aren't parsed until something asks for them
         // via get_patterns anyway. Lazy refresh amortizes both costs.
         self.symbol_index.mark_dirty(&path);
-        self.class_hierarchy_index.mark_dirty(&path);
         // A Blade edit can add or delete an `<x-…>` / `<livewire:…>` tag, so
         // the reverse usage index has to re-read this file before its next
         // answer (no-op for non-Blade paths).
@@ -9996,7 +9995,6 @@ impl SalsaActor {
         // rebuild, and which are the whole reason `did_close` refuses
         // `RemoveFile`.
         self.symbol_index.mark_dirty(path);
-        self.class_hierarchy_index.mark_dirty(path);
         self.component_usage_index.mark_dirty(path);
     }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -1383,6 +1383,16 @@ pub fn parse_composer_json(db: &dyn Db, file: ConfigFile) -> (bool, Vec<String>)
     (has_livewire, packages)
 }
 
+/// Is Livewire installed, according to `composer.lock`?
+///
+/// A Salsa-tracked query over the lock file, so the answer is cached and
+/// invalidated through the same config path as every other parsed config
+/// input — no separate filesystem probe and no separate invalidation story.
+#[salsa::tracked]
+pub fn parse_composer_lock(db: &dyn Db, file: ConfigFile) -> bool {
+    crate::livewire_version::is_installed(file.text(db))
+}
+
 /// Parse config/view.php to extract view paths
 #[salsa::tracked(returns(clone))]
 pub fn parse_view_config(db: &dyn Db, file: ConfigFile, root: PathBuf) -> Vec<PathBuf> {
@@ -1610,11 +1620,34 @@ pub fn build_laravel_config<'db>(
     composer: Option<ConfigFile>,
     view_config: Option<ConfigFile>,
     livewire_config: Option<ConfigFile>,
+    composer_lock: Option<ConfigFile>,
 ) -> LaravelConfigRef<'db> {
-    // Parse composer.json for Livewire detection
-    let has_livewire = composer
-        .map(|f| parse_composer_json(db, f).0)
-        .unwrap_or(false);
+    // Is Livewire installed? Read `composer.lock`, NOT `composer.json`.
+    //
+    // `composer.json` lists only DIRECT requirements, and Livewire very
+    // commonly arrives transitively — `livewire/flux`, `livewire/volt`,
+    // `filament/filament` and `robsontenorio/mary` all depend on it, and
+    // Laravel's own `livewire-starter-kit` ships exactly that shape. Testing
+    // `composer.json` therefore reported "no Livewire" for a project whose
+    // `app/Livewire` is full of components: `livewire_path` stayed `None`, so
+    // `<livewire:` completion returned nothing and the Livewire directory was
+    // never registered with the file watcher.
+    //
+    // `composer.lock` lists every installed package, direct or transitive,
+    // which is the question actually being asked. It changes exactly when
+    // packages are installed or removed, which is exactly when this answer
+    // should change.
+    //
+    // Fallback when the lock is absent (a fresh clone before `composer
+    // install`): the old `composer.json` test. It is strictly better than
+    // assuming "not installed", and it preserves today's behaviour for the
+    // projects it did serve correctly — those that require Livewire directly.
+    let has_livewire = match composer_lock {
+        Some(lock) => *parse_composer_lock(db, lock),
+        None => composer
+            .map(|f| parse_composer_json(db, f).0)
+            .unwrap_or(false),
+    };
 
     // Parse view config for view paths
     let view_paths = view_config
@@ -6445,6 +6478,8 @@ pub enum SalsaRequest {
         composer_json: Option<String>,
         view_config: Option<String>,
         livewire_config: Option<String>,
+        /// `composer.lock`, the authority on whether Livewire is installed.
+        composer_lock: Option<String>,
         reply: oneshot::Sender<()>,
     },
     /// Update a specific configuration file
@@ -7311,6 +7346,7 @@ impl SalsaHandle {
         composer_json: Option<String>,
         view_config: Option<String>,
         livewire_config: Option<String>,
+        composer_lock: Option<String>,
     ) -> Result<(), &'static str> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
@@ -7319,6 +7355,7 @@ impl SalsaHandle {
                 composer_json,
                 view_config,
                 livewire_config,
+                composer_lock,
                 reply: reply_tx,
             })
             .await
@@ -9231,6 +9268,7 @@ impl SalsaActor {
                     composer_json,
                     view_config,
                     livewire_config,
+                    composer_lock,
                     reply,
                 } => {
                     self.handle_register_config_files(
@@ -9238,6 +9276,7 @@ impl SalsaActor {
                         composer_json,
                         view_config,
                         livewire_config,
+                        composer_lock,
                     );
                     let _ = reply.send(());
                 }
@@ -10963,6 +11002,7 @@ impl SalsaActor {
         composer_json: Option<String>,
         view_config: Option<String>,
         livewire_config: Option<String>,
+        composer_lock: Option<String>,
     ) {
         self.config_root = Some(root_path.clone());
         self.config_version += 1;
@@ -10985,6 +11025,13 @@ impl SalsaActor {
         // Register config/livewire.php
         if let Some(text) = livewire_config {
             let path = root_path.join("config/livewire.php");
+            let file = ConfigFile::new(&self.db, path.clone(), self.config_version, text);
+            self.config_files.insert(path, file);
+        }
+
+        // Register composer.lock — the Livewire installation authority.
+        if let Some(text) = composer_lock {
+            let path = root_path.join("composer.lock");
             let file = ConfigFile::new(&self.db, path.clone(), self.config_version, text);
             self.config_files.insert(path, file);
         }
@@ -11027,6 +11074,7 @@ impl SalsaActor {
             .config_files
             .get(&root.join("config/livewire.php"))
             .copied();
+        let composer_lock = self.config_files.get(&root.join("composer.lock")).copied();
 
         // Use Salsa query to build config
         let config_ref = build_laravel_config(
@@ -11035,6 +11083,7 @@ impl SalsaActor {
             composer,
             view_config,
             livewire_config,
+            composer_lock,
         );
 
         // THE MERGE RULE, for all five registries below: the highest

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -6499,6 +6499,11 @@ pub enum SalsaRequest {
         view_paths: Vec<PathBuf>,
         livewire_path: Option<PathBuf>,
         routes_path: PathBuf,
+        /// Every `vendor/` PHP file, from the shared vendor walk (issue #371).
+        /// Handed in rather than re-walked here: this actor runs on its own
+        /// thread and cannot reach the server's cached
+        /// [`crate::vendor_index::VendorIndex`].
+        vendor_files: Vec<PathBuf>,
         reply: oneshot::Sender<()>,
     },
     /// Find all references to a specific view across the project
@@ -7366,6 +7371,7 @@ impl SalsaHandle {
         view_paths: Vec<PathBuf>,
         livewire_path: Option<PathBuf>,
         routes_path: PathBuf,
+        vendor_files: Vec<PathBuf>,
     ) -> Result<(), &'static str> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.sender
@@ -7375,6 +7381,7 @@ impl SalsaHandle {
                 view_paths,
                 livewire_path,
                 routes_path,
+                vendor_files,
                 reply: reply_tx,
             })
             .await
@@ -9250,6 +9257,7 @@ impl SalsaActor {
                     view_paths,
                     livewire_path,
                     routes_path,
+                    vendor_files,
                     reply,
                 } => {
                     self.handle_register_project_files(
@@ -9258,6 +9266,7 @@ impl SalsaActor {
                         view_paths,
                         livewire_path,
                         routes_path,
+                        vendor_files,
                     );
                     let _ = reply.send(());
                 }
@@ -11246,6 +11255,7 @@ impl SalsaActor {
         view_paths: Vec<PathBuf>,
         livewire_path: Option<PathBuf>,
         routes_path: PathBuf,
+        vendor_files: Vec<PathBuf>,
     ) {
         use walkdir::WalkDir;
 
@@ -11369,43 +11379,20 @@ impl SalsaActor {
             }
         }
 
-        // Scan vendor/ — Composer packages can declare Livewire,
-        // routes, controllers, views, translations. We index every
-        // `*.php` and `*.blade.php` under vendor/ and rely on the
-        // warming-stage filters (skip `*.json.php` data files, drop
-        // anything >256KB) to keep tree-sitter away from pathological
-        // auto-generated content.
+        // Vendor files come from the shared vendor walk (issue #371) instead
+        // of a fifth independent `WalkDir` over the Composer tree. The caller
+        // filters `.git` out for us — this pass never descended into it — and
+        // the set is otherwise identical: every `*.php` and `*.blade.php`,
+        // unbounded depth. `.blade.php` needs no separate test because its
+        // extension is already `php`.
         //
-        // Yes, this reads ~21k file contents on a real-world project,
-        // which adds a few seconds to first registration. Subsequent
-        // startups load most of those entries from the disk cache
-        // (see pattern_disk_cache.rs), so the cost is bounded and
-        // one-time per `composer install`.
-        let vendor_dir = root_path.join("vendor");
-        if vendor_dir.is_dir() {
-            for entry in WalkDir::new(&vendor_dir)
-                .into_iter()
-                .filter_entry(|e| e.file_name().to_str().map(|s| s != ".git").unwrap_or(true))
-                .filter_map(|e| e.ok())
-            {
-                if !entry.file_type().is_file() {
-                    continue;
-                }
-                let name = entry.file_name().to_string_lossy();
-                // Match both `*.php` and `*.blade.php` in one pass. The
-                // `.blade.php` test must come first because a file
-                // ending in `.blade.php` also satisfies `.php`.
-                let is_blade = name.ends_with(".blade.php");
-                let is_php = !is_blade && name.ends_with(".php");
-                if !(is_php || is_blade) {
-                    continue;
-                }
-                let path = entry.path().to_path_buf();
-                self.vendor_files.push(path);
-                // Salsa input deferred to first cache miss — see
-                // handle_get_patterns for the architectural why.
-            }
-        }
+        // Composer packages can declare Livewire components, routes,
+        // controllers, views and translations, so all of them are indexed; the
+        // warming-stage filters (skip `*.json.php` data files, drop anything
+        // >256KB) keep tree-sitter away from pathological auto-generated
+        // content. Salsa inputs are deferred to the first cache miss — see
+        // `handle_get_patterns` for the architectural why.
+        self.vendor_files = vendor_files;
 
         // Scan the whole project (minus vendor + noise dirs) for every
         // `*.php` / `*.blade.php`. The categorized scans above cover the

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -847,7 +847,7 @@ async fn salsa_config_indexes_anonymous_component_registrations() {
     let root = PathBuf::from("/tmp/zed-laravel-issue44");
 
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -885,7 +885,7 @@ async fn salsa_config_refreshes_when_provider_registered_after_first_build() {
     let root = PathBuf::from("/tmp/zed-laravel-issue44-late");
 
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
 
@@ -2671,7 +2671,7 @@ async fn livewire_config_namespaces_merge_into_laravel_config() {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     let config = handle
@@ -2810,7 +2810,7 @@ async fn scope_project() -> (TempDir, SalsaHandle, PathBuf) {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -2885,7 +2885,7 @@ class C {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -2941,7 +2941,7 @@ class C {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -2999,7 +2999,7 @@ class C {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -3395,7 +3395,7 @@ async fn facade_alias_snapshot_seeds_defaults() {
     let root = dir.path().to_path_buf();
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
 
@@ -3446,7 +3446,7 @@ return Application::configure(basePath: __DIR__)
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -3691,7 +3691,7 @@ class AppServiceProvider extends ServiceProvider {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -3746,7 +3746,7 @@ class AppServiceProvider extends ServiceProvider {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -3820,7 +3820,7 @@ class {n}ServiceProvider extends ServiceProvider {{
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     // Register in the REVERSE of the winning order (F→A), so an insertion-ordered
@@ -3895,7 +3895,7 @@ class AppServiceProvider extends ServiceProvider {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -4021,7 +4021,7 @@ return [
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
 
@@ -4093,7 +4093,7 @@ class Ids {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -4205,7 +4205,7 @@ class AboutController {{
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     // Registering the provider source parses the `auth → AuthManager` binding
@@ -4377,7 +4377,7 @@ class AboutController {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -4500,7 +4500,7 @@ class AboutController {{
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -4669,7 +4669,7 @@ class PageController {{
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle
@@ -4770,7 +4770,7 @@ class AppServiceProvider extends ServiceProvider {
 
     let handle = SalsaActor::spawn();
     handle
-        .register_config_files(root.clone(), None, None, None)
+        .register_config_files(root.clone(), None, None, None, None)
         .await
         .unwrap();
     handle

--- a/laravel-lsp/src/salsa_impl/tests.rs
+++ b/laravel-lsp/src/salsa_impl/tests.rs
@@ -5220,6 +5220,14 @@ async fn register_temp_project(handle: &SalsaHandle, php_files: usize) -> tempfi
             vec![dir.path().join("resources/views")],
             None,
             PathBuf::from("routes"),
+            // The shared vendor walk the production caller passes in
+            // (issue #371) — built from the same root, so the actor
+            // registers exactly what it would in production.
+            crate::vendor_index::VendorIndex::build(dir.path())
+                .files()
+                .iter()
+                .map(|f| f.path.clone())
+                .collect(),
         )
         .await
         .unwrap();

--- a/laravel-lsp/src/tests/class_hierarchy_freshness.rs
+++ b/laravel-lsp/src/tests/class_hierarchy_freshness.rs
@@ -1,0 +1,150 @@
+//! The class-hierarchy index stays current WITHOUT a deferred-refresh queue
+//! (issue #371).
+//!
+//! `ClassHierarchyIndex` carried a `mark_dirty` / `take_dirty` pair copied from
+//! `symbol_index`. `mark_dirty` ran on every `update_file` and on the
+//! `did_close` re-queue; `take_dirty` was never called anywhere in production —
+//! only from its own unit test. So the set was write-only: it accumulated one
+//! `PathBuf` per distinct path touched and was never drained for the life of
+//! the session, while doing nothing.
+//!
+//! Nothing broke, because the index is refreshed EAGERLY somewhere else:
+//! `handle_get_patterns` runs `remove_file` + `insert_file` on every PHP parse,
+//! and its own comment calls that path "the ONLY populator" for files warming
+//! skipped.
+//!
+//! Deleting a mechanism is only safe if the property it appeared to provide is
+//! actually provided elsewhere, so that property is what these tests pin: after
+//! an edit, the hierarchy reflects the file's new classes, with nothing
+//! draining a dirty set. If the eager refresh in `handle_get_patterns` is ever
+//! removed or made conditional, these go red — which is the failure the deleted
+//! queue would otherwise have masked responsibility for.
+
+use crate::LaravelLanguageServer;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+use tower_lsp::LspService;
+
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+const COMPOSER: &str = r#"{ "autoload": { "psr-4": { "App\\": "app/" } } }"#;
+
+fn model(class: &str, parent: &str) -> String {
+    format!("<?php\nnamespace App\\Models;\nclass {class} extends {parent} {{}}\n")
+}
+
+/// Register `src` for `path` and force the parse that refreshes the hierarchy.
+async fn update_and_parse(server: &LaravelLanguageServer, path: &Path, src: &str) {
+    server
+        .salsa
+        .update_file(path.to_path_buf(), 1, src.to_string())
+        .await
+        .unwrap();
+    let _ = server.salsa.get_patterns(path.to_path_buf()).await;
+}
+
+/// The FQCNs the hierarchy currently attributes to `path`.
+async fn fqcns_for(server: &LaravelLanguageServer, path: &Path) -> Vec<String> {
+    let mut names: Vec<String> = server
+        .salsa
+        .snapshot_hierarchy_nodes()
+        .await
+        .unwrap()
+        .get(path)
+        .map(|nodes| nodes.iter().map(|n| n.fqcn.clone()).collect())
+        .unwrap_or_default();
+    names.sort();
+    names
+}
+
+#[tokio::test]
+async fn a_parsed_file_enters_the_hierarchy() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("app/Models")).unwrap();
+    fs::write(root.join("composer.json"), COMPOSER).unwrap();
+    let server = test_server();
+    *server.root_path.write().await = Some(root.to_path_buf());
+
+    let path = root.join("app/Models/Post.php");
+    let src = model("Post", "Model");
+    fs::write(&path, &src).unwrap();
+    update_and_parse(&server, &path, &src).await;
+
+    assert_eq!(
+        fqcns_for(&server, &path).await,
+        vec!["App\\Models\\Post".to_string()],
+        "the eager refresh in handle_get_patterns is what populates the \
+         hierarchy — no dirty-set drain is involved"
+    );
+}
+
+#[tokio::test]
+async fn a_renamed_class_replaces_its_predecessor_without_a_dirty_drain() {
+    // The discriminating case. A stale hierarchy would keep `Post` alongside
+    // `Article`, or keep `Post` alone. Only an eager remove+insert on the parse
+    // yields exactly the new name.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("app/Models")).unwrap();
+    fs::write(root.join("composer.json"), COMPOSER).unwrap();
+    let server = test_server();
+    *server.root_path.write().await = Some(root.to_path_buf());
+
+    let path = root.join("app/Models/Post.php");
+    let before = model("Post", "Model");
+    fs::write(&path, &before).unwrap();
+    update_and_parse(&server, &path, &before).await;
+    assert_eq!(
+        fqcns_for(&server, &path).await,
+        vec!["App\\Models\\Post".to_string()],
+        "fixture check — the pre-edit state must be indexed"
+    );
+
+    let after = model("Article", "Model");
+    fs::write(&path, &after).unwrap();
+    update_and_parse(&server, &path, &after).await;
+
+    assert_eq!(
+        fqcns_for(&server, &path).await,
+        vec!["App\\Models\\Article".to_string()],
+        "the edit must both add the new class AND evict the old one; a \
+         write-only dirty set never did either"
+    );
+}
+
+#[tokio::test]
+async fn an_added_class_is_visible_after_the_edit() {
+    // A second declaration appearing in an already-indexed file — the case a
+    // deferred queue would have handled at drain time, and which the eager
+    // path must handle at parse time instead.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("app/Models")).unwrap();
+    fs::write(root.join("composer.json"), COMPOSER).unwrap();
+    let server = test_server();
+    *server.root_path.write().await = Some(root.to_path_buf());
+
+    let path = root.join("app/Models/Post.php");
+    let before = model("Post", "Model");
+    fs::write(&path, &before).unwrap();
+    update_and_parse(&server, &path, &before).await;
+
+    let after =
+        "<?php\nnamespace App\\Models;\nclass Post extends Model {}\nclass Draft extends Post {}\n";
+    fs::write(&path, after).unwrap();
+    update_and_parse(&server, &path, after).await;
+
+    assert_eq!(
+        fqcns_for(&server, &path).await,
+        vec![
+            "App\\Models\\Draft".to_string(),
+            "App\\Models\\Post".to_string()
+        ],
+        "both declarations must be present after the edit"
+    );
+}

--- a/laravel-lsp/src/tests/component_ancestor_navigation.rs
+++ b/laravel-lsp/src/tests/component_ancestor_navigation.rs
@@ -80,7 +80,7 @@ async fn backend_for(root: &Path) -> LaravelLanguageServer {
     // project walk; caching the config on the backend alone does not.
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .expect("actor registers the tempdir project root");
     backend

--- a/laravel-lsp/src/tests/component_ancestor_navigation.rs
+++ b/laravel-lsp/src/tests/component_ancestor_navigation.rs
@@ -91,6 +91,14 @@ async fn backend_for(root: &Path) -> LaravelLanguageServer {
             vec![root.join("resources/views")],
             Some(root.join("resources/views/livewire")),
             PathBuf::from("routes"),
+            // The shared vendor walk the production caller passes in
+            // (issue #371) — built from the same root, so the actor
+            // registers exactly what it would in production.
+            laravel_lsp::vendor_index::VendorIndex::build(root)
+                .files()
+                .iter()
+                .map(|f| f.path.clone())
+                .collect(),
         )
         .await
         .expect("actor registers the tempdir project");

--- a/laravel-lsp/src/tests/component_completion_cache.rs
+++ b/laravel-lsp/src/tests/component_completion_cache.rs
@@ -1,0 +1,357 @@
+//! Tests for the cached `<x-` / `<flux:` / `<livewire:` completion
+//! enumerations (issue #371).
+//!
+//! Before the cache, every keystroke in a tag context re-walked the component
+//! directories and paid a `canonicalize()` per emitted entry — ~23 ms for
+//! `<x-` and ~16 ms for `<flux:` on this repo's `test-project/`, with no repeat
+//! ever cheaper than the first.
+//!
+//! Freshness has two mechanisms, and the whole point of these tests is to keep
+//! them apart. The watcher hook is the primary; the TTL is a backstop for
+//! directories the watcher's globs cannot see. The dangerous failure is the
+//! backstop MASKING a broken primary: if the watcher hook stops firing, a live
+//! TTL turns that into "completions feel intermittently stale" — self-
+//! correcting, never reported, and able to survive indefinitely.
+//!
+//! So every test of the watcher or config hook first raises
+//! `component_completion_ttl` beyond reach (`UNREACHABLE_TTL`). If the hook
+//! under test is broken, the assertion fails outright instead of degrading into
+//! tolerable staleness. Only `ttl_backstop_*` exercises the TTL, and it does so
+//! by setting the TTL to zero rather than by sleeping — a test that waits out a
+//! real 2 s TTL is both slow and unable to tell the two mechanisms apart.
+
+use crate::LaravelLanguageServer;
+use std::fs;
+use std::path::Path;
+use std::time::Duration;
+use tempfile::TempDir;
+use tower_lsp::lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent, Url};
+use tower_lsp::{LanguageServer, LspService};
+
+/// Far longer than any test runs, so the TTL backstop can never fire and the
+/// mechanism under test is the only thing that could clear the cache.
+const UNREACHABLE_TTL: Duration = Duration::from_secs(3600);
+
+fn test_server(ttl: Duration) -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    let mut server = service.inner().clone();
+    server.component_completion_ttl = ttl;
+    server
+}
+
+/// Lay down a project with one anonymous Blade component and one Flux
+/// component, and point the server at it.
+async fn seed(server: &LaravelLanguageServer, root: &Path) {
+    write_component(root, "alpha");
+    write_flux(root, "alpha");
+    *server.root_path.write().await = Some(root.to_path_buf());
+}
+
+fn write_component(root: &Path, name: &str) {
+    let p = root
+        .join("resources/views/components")
+        .join(format!("{name}.blade.php"));
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(&p, "<div>{{ $slot }}</div>").unwrap();
+}
+
+fn write_flux(root: &Path, name: &str) {
+    let p = root
+        .join("resources/views/flux")
+        .join(format!("{name}.blade.php"));
+    fs::create_dir_all(p.parent().unwrap()).unwrap();
+    fs::write(&p, "<div>{{ $slot }}</div>").unwrap();
+}
+
+fn names(items: &[laravel_lsp::component_completion::ComponentCandidate]) -> Vec<String> {
+    let mut v: Vec<String> = items.iter().map(|c| c.name.clone()).collect();
+    v.sort();
+    v
+}
+
+/// Fire a watched-file event for `path`, the way the client would.
+async fn watched_change(server: &LaravelLanguageServer, path: &Path, typ: FileChangeType) {
+    server
+        .did_change_watched_files(DidChangeWatchedFilesParams {
+            changes: vec![FileEvent {
+                uri: Url::from_file_path(path).unwrap(),
+                typ,
+            }],
+        })
+        .await;
+}
+
+// ---------------------------------------------------------------------------
+// The cache exists at all
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn repeat_requests_are_served_without_rescanning() {
+    // Proves the result is actually cached, by changing the filesystem behind
+    // the server's back with no event: a scan would see `beta`, the cache
+    // cannot. Without this, every "the cache was cleared" test below could pass
+    // on a server that never cached anything.
+    let tmp = TempDir::new().unwrap();
+    let server = test_server(UNREACHABLE_TTL);
+    seed(&server, tmp.path()).await;
+
+    let first = server.cached_blade_components().await;
+    assert_eq!(names(&first), vec!["alpha".to_string()]);
+
+    write_component(tmp.path(), "beta");
+    let second = server.cached_blade_components().await;
+
+    assert_eq!(
+        names(&second),
+        vec!["alpha".to_string()],
+        "a second request must be served from the cache, not re-walked"
+    );
+}
+
+#[tokio::test]
+async fn flux_repeat_requests_are_served_without_rescanning() {
+    let tmp = TempDir::new().unwrap();
+    let server = test_server(UNREACHABLE_TTL);
+    seed(&server, tmp.path()).await;
+
+    assert_eq!(
+        names(&server.cached_flux_components().await),
+        vec!["alpha".to_string()]
+    );
+    write_flux(tmp.path(), "beta");
+
+    assert_eq!(
+        names(&server.cached_flux_components().await),
+        vec!["alpha".to_string()],
+        "the Flux enumeration is cached too"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The watcher hook, with the TTL held beyond reach
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_watched_blade_event_alone_clears_the_cache() {
+    // THE test this design exists for. The TTL cannot fire, so if the watcher
+    // hook is ever dropped by a refactor this goes red rather than quietly
+    // degrading to "stale for two seconds".
+    let tmp = TempDir::new().unwrap();
+    let server = test_server(UNREACHABLE_TTL);
+    seed(&server, tmp.path()).await;
+
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string()],
+        "cache warmed"
+    );
+
+    write_component(tmp.path(), "beta");
+    let created = tmp.path().join("resources/views/components/beta.blade.php");
+    watched_change(&server, &created, FileChangeType::CREATED).await;
+
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string(), "beta".to_string()],
+        "the watcher event alone must clear the cache — with the TTL unable to \
+         fire, nothing else could have"
+    );
+}
+
+#[tokio::test]
+async fn a_watched_delete_alone_clears_the_cache() {
+    // Deletes matter as much as creates: a removed component that lingers in
+    // completion inserts a tag that no longer resolves.
+    let tmp = TempDir::new().unwrap();
+    let server = test_server(UNREACHABLE_TTL);
+    seed(&server, tmp.path()).await;
+    write_component(tmp.path(), "beta");
+
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string(), "beta".to_string()]
+    );
+
+    let removed = tmp.path().join("resources/views/components/beta.blade.php");
+    fs::remove_file(&removed).unwrap();
+    watched_change(&server, &removed, FileChangeType::DELETED).await;
+
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string()],
+        "a delete event must clear the cache too"
+    );
+}
+
+#[tokio::test]
+async fn a_watched_event_clears_the_flux_and_livewire_entries_too() {
+    // The three enumerations are dropped as a group. A hook that only cleared
+    // the Blade entry would leave the other two stale forever under an
+    // unreachable TTL.
+    let tmp = TempDir::new().unwrap();
+    let server = test_server(UNREACHABLE_TTL);
+    seed(&server, tmp.path()).await;
+
+    let _ = server.cached_blade_components().await;
+    assert_eq!(
+        names(&server.cached_flux_components().await),
+        vec!["alpha".to_string()],
+        "flux cache warmed"
+    );
+
+    write_flux(tmp.path(), "beta");
+    let created = tmp.path().join("resources/views/flux/beta.blade.php");
+    watched_change(&server, &created, FileChangeType::CREATED).await;
+
+    assert_eq!(
+        names(&server.cached_flux_components().await),
+        vec!["alpha".to_string(), "beta".to_string()],
+        "the Flux entry must be cleared by the same event"
+    );
+}
+
+#[tokio::test]
+async fn a_non_php_watched_event_does_not_clear_the_cache() {
+    // Discriminates the hook from "clear on absolutely everything", which would
+    // make the cache useless. An asset change cannot add a component tag.
+    let tmp = TempDir::new().unwrap();
+    let server = test_server(UNREACHABLE_TTL);
+    seed(&server, tmp.path()).await;
+    let _ = server.cached_blade_components().await;
+
+    let asset = tmp.path().join("resources/css/app.css");
+    fs::create_dir_all(asset.parent().unwrap()).unwrap();
+    fs::write(&asset, "body{}").unwrap();
+    write_component(tmp.path(), "beta");
+    watched_change(&server, &asset, FileChangeType::CHANGED).await;
+
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string()],
+        "a non-PHP event must leave the cache intact"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The config hook, with the TTL held beyond reach
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn config_invalidation_alone_clears_the_cache() {
+    // The scanned directory SET is config-derived, so a config change can move
+    // the directories rather than just their contents. Same isolation: the TTL
+    // cannot fire, so only this hook can explain a cleared cache.
+    let tmp = TempDir::new().unwrap();
+    let server = test_server(UNREACHABLE_TTL);
+    seed(&server, tmp.path()).await;
+
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string()]
+    );
+
+    write_component(tmp.path(), "beta");
+    server.invalidate_config_cache().await;
+
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string(), "beta".to_string()],
+        "invalidate_config_cache alone must clear the component enumerations"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The TTL backstop, exercised without sleeping
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ttl_backstop_expires_the_cache_without_any_event() {
+    // The backstop's whole job: bound staleness for a directory no watcher glob
+    // covers, where no event will ever arrive. Driven by a zero TTL rather than
+    // by sleeping out the real one — a 2 s sleep would be slow AND unable to
+    // distinguish the backstop from the hooks.
+    let tmp = TempDir::new().unwrap();
+    let server = test_server(Duration::ZERO);
+    seed(&server, tmp.path()).await;
+
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string()]
+    );
+
+    write_component(tmp.path(), "beta");
+
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string(), "beta".to_string()],
+        "an expired entry must be rebuilt with no watcher or config event at all"
+    );
+}
+
+#[tokio::test]
+async fn the_shipped_ttl_is_short_enough_to_be_a_backstop() {
+    // Guards the value from drifting into something that would make staleness
+    // user-visible. Deliberately loose: the watcher carries the common case, so
+    // the exact number is not load-bearing and this is not a tuning knob.
+    let server = test_server(crate::COMPONENT_COMPLETION_TTL);
+    assert!(
+        server.component_completion_ttl <= Duration::from_secs(5),
+        "the backstop must bound staleness to something a user would not \
+         notice, got {:?}",
+        server.component_completion_ttl
+    );
+    assert!(
+        server.component_completion_ttl > Duration::ZERO,
+        "a zero TTL would disable caching entirely, which is the bug this \
+         whole change removes"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Root identity
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_different_project_root_discards_the_cache() {
+    // Cached entries are keyed by root. Answering one project's completion with
+    // another's components would be worse than a slow scan.
+    let first = TempDir::new().unwrap();
+    let second = TempDir::new().unwrap();
+    let server = test_server(UNREACHABLE_TTL);
+
+    seed(&server, first.path()).await;
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string()]
+    );
+
+    write_component(second.path(), "gamma");
+    *server.root_path.write().await = Some(second.path().to_path_buf());
+
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["gamma".to_string()],
+        "a new root must rescan, never serve the previous project's components"
+    );
+}
+
+#[tokio::test]
+async fn no_root_yields_no_components_and_caches_nothing() {
+    // Fail-closed: before a root is discovered there is nothing to scan, and
+    // that emptiness must not be cached as if it were an answer.
+    let tmp = TempDir::new().unwrap();
+    let server = test_server(UNREACHABLE_TTL);
+
+    assert!(
+        server.cached_blade_components().await.is_empty(),
+        "no root means no components"
+    );
+
+    seed(&server, tmp.path()).await;
+    assert_eq!(
+        names(&server.cached_blade_components().await),
+        vec!["alpha".to_string()],
+        "once a root arrives the scan must run — the rootless answer must not \
+         have been cached"
+    );
+}

--- a/laravel-lsp/src/tests/component_member_navigation.rs
+++ b/laravel-lsp/src/tests/component_member_navigation.rs
@@ -25,7 +25,7 @@ async fn backend_with_root(root: &Path) -> LaravelLanguageServer {
     // that sets only `root_path` is under-registering.
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .expect("actor registers the tempdir project root");
     backend

--- a/laravel-lsp/src/tests/external_php_loader_containment.rs
+++ b/laravel-lsp/src/tests/external_php_loader_containment.rs
@@ -42,6 +42,14 @@ async fn handle_for(root: &Path) -> SalsaHandle {
             vec![root.join("resources/views")],
             Some(root.join("resources/views/livewire")),
             PathBuf::from("routes"),
+            // The shared vendor walk the production caller passes in
+            // (issue #371) — built from the same root, so the actor
+            // registers exactly what it would in production.
+            laravel_lsp::vendor_index::VendorIndex::build(root)
+                .files()
+                .iter()
+                .map(|f| f.path.clone())
+                .collect(),
         )
         .await
         .expect("actor registers the tempdir project");

--- a/laravel-lsp/src/tests/external_php_loader_containment.rs
+++ b/laravel-lsp/src/tests/external_php_loader_containment.rs
@@ -32,7 +32,7 @@ fn write(path: &Path, contents: &str) -> PathBuf {
 async fn handle_for(root: &Path) -> SalsaHandle {
     let handle = laravel_lsp::salsa_impl::SalsaActor::spawn();
     handle
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .expect("actor registers the tempdir project root");
     handle

--- a/laravel-lsp/src/tests/external_php_ownership_release.rs
+++ b/laravel-lsp/src/tests/external_php_ownership_release.rs
@@ -55,7 +55,7 @@ async fn backend_for(root: &Path) -> LaravelLanguageServer {
     // is about.
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .expect("actor registers the tempdir project root");
     backend

--- a/laravel-lsp/src/tests/factory_goto_def_handler.rs
+++ b/laravel-lsp/src/tests/factory_goto_def_handler.rs
@@ -103,7 +103,7 @@ async fn prime_factory_project(server: &LaravelLanguageServer, root: &Path) -> P
 
     server
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .unwrap();
     for (path, src) in &files {
@@ -183,7 +183,7 @@ async fn factory_call_without_factory_file_does_not_resolve() {
 
     server
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .unwrap();
     for (path, src) in [(&model, MODEL_SRC), (&caller, CALLER_SRC)] {

--- a/laravel-lsp/src/tests/folio_rename.rs
+++ b/laravel-lsp/src/tests/folio_rename.rs
@@ -224,7 +224,6 @@ async fn decl_range_at_returns_the_page_name_span_for_a_folio_cursor() {
 
     let range = decl_range_at(
         &server,
-        Some(root.path()),
         &page,
         CURSOR,
         &SymbolRef::Route("contact".to_string()),
@@ -265,7 +264,6 @@ async fn decl_range_at_returns_the_page_name_span_for_a_non_contact_length_leaf(
 
     let range = decl_range_at(
         &server,
-        Some(root.path()),
         &page,
         CURSOR,
         &SymbolRef::Route("dashboard".to_string()),
@@ -299,7 +297,6 @@ async fn decl_range_at_returns_none_when_cursor_off_the_name_call() {
 
     let range = decl_range_at(
         &server,
-        Some(root.path()),
         &page,
         Position {
             line: 0,

--- a/laravel-lsp/src/tests/livewire_transitive_detection.rs
+++ b/laravel-lsp/src/tests/livewire_transitive_detection.rs
@@ -1,0 +1,369 @@
+//! Livewire must be detected when it arrives as a TRANSITIVE dependency.
+//!
+//! `has_livewire` was decided by `composer.json.contains("\"livewire/livewire\"")`.
+//! `composer.json` lists only DIRECT requirements, but Livewire usually arrives
+//! through something else: `livewire/flux`, `livewire/volt`,
+//! `filament/filament` and `robsontenorio/mary` all depend on it, and Laravel's
+//! own `livewire-starter-kit` — which this repo vendors as `test-project/` —
+//! ships exactly that shape.
+//!
+//! Consequence: `has_livewire` false → `livewire_path` `None` → the
+//! conventional `app/Livewire` scan skipped entirely. `<livewire:` completion
+//! returned ZERO items on a project whose `app/Livewire` is full of components,
+//! and the Livewire directory was never handed to the file watcher.
+//!
+//! Measured before the fix, driving the real binary against `test-project/`:
+//! 0 completion items as shipped, 1 item with `"livewire/livewire"` added to
+//! its `require` block, everything else identical.
+//!
+//! The codebase already knew: `salsa_impl.rs`'s v4 component-namespace loop
+//! carries a comment saying it is "Not gated on `has_livewire`: that flag only
+//! sees direct composer.json requires, while Livewire commonly arrives
+//! transitively (Flux, Filament, MaryUI)". That was a local workaround for one
+//! consumer; this fixes the flag itself.
+//!
+//! Every fixture here uses a `composer.json` that does NOT name Livewire.
+
+use crate::LaravelLanguageServer;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+use tower_lsp::LspService;
+
+/// A starter-kit-shaped `composer.json`: Livewire is nowhere in it, and
+/// arrives through Flux and Volt.
+const COMPOSER_JSON_TRANSITIVE: &str = r#"{
+    "require": {
+        "php": "^8.2",
+        "laravel/framework": "^12.0",
+        "livewire/flux": "^2.9.0",
+        "livewire/volt": "^1.7.0"
+    },
+    "autoload": { "psr-4": { "App\\": "app/" } }
+}"#;
+
+/// The same, with Livewire required directly — the shape that already worked.
+const COMPOSER_JSON_DIRECT: &str = r#"{
+    "require": {
+        "php": "^8.2",
+        "laravel/framework": "^12.0",
+        "livewire/livewire": "^3.0"
+    },
+    "autoload": { "psr-4": { "App\\": "app/" } }
+}"#;
+
+/// A `composer.lock` in which Livewire appears only because Flux pulled it in.
+const COMPOSER_LOCK_WITH_LIVEWIRE: &str = r#"{
+    "packages": [
+        { "name": "livewire/flux", "version": "v2.9.1" },
+        { "name": "livewire/livewire", "version": "v3.6.4" }
+    ],
+    "packages-dev": []
+}"#;
+
+/// A lock with no Livewire at all.
+const COMPOSER_LOCK_WITHOUT_LIVEWIRE: &str = r#"{
+    "packages": [
+        { "name": "laravel/framework", "version": "v12.0.1" }
+    ],
+    "packages-dev": []
+}"#;
+
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// Lay down a project with one Livewire component, and whichever composer
+/// files the caller wants.
+fn seed(root: &Path, composer_json: &str, composer_lock: Option<&str>) {
+    fs::create_dir_all(root.join("app/Livewire")).unwrap();
+    fs::write(root.join("composer.json"), composer_json).unwrap();
+    if let Some(lock) = composer_lock {
+        fs::write(root.join("composer.lock"), lock).unwrap();
+    }
+    fs::write(
+        root.join("app/Livewire/Counter.php"),
+        "<?php\nnamespace App\\Livewire;\nuse Livewire\\Component;\nclass Counter extends Component {}\n",
+    )
+    .unwrap();
+}
+
+/// Register the project's config with the actor and read back the resolved
+/// Laravel config.
+async fn config_for(
+    server: &LaravelLanguageServer,
+    root: &Path,
+) -> laravel_lsp::salsa_impl::LaravelConfigData {
+    *server.root_path.write().await = Some(root.to_path_buf());
+    server
+        .salsa
+        .register_config_files(
+            root.to_path_buf(),
+            fs::read_to_string(root.join("composer.json")).ok(),
+            None,
+            None,
+            fs::read_to_string(root.join("composer.lock")).ok(),
+        )
+        .await
+        .unwrap();
+    server
+        .salsa
+        .get_laravel_config()
+        .await
+        .unwrap()
+        .expect("the actor must return a config for a registered project")
+}
+
+// ---------------------------------------------------------------------------
+// The defect
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_transitive_livewire_is_detected() {
+    // THE regression test. `composer.json` never mentions Livewire; only the
+    // lock does, and only because Flux pulled it in.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(
+        root,
+        COMPOSER_JSON_TRANSITIVE,
+        Some(COMPOSER_LOCK_WITH_LIVEWIRE),
+    );
+    let server = test_server();
+
+    let config = config_for(&server, root).await;
+
+    assert!(
+        config.has_livewire,
+        "Livewire is installed via livewire/flux — reading composer.json alone \
+         reported it absent, which emptied <livewire: completion"
+    );
+    assert_eq!(
+        config.livewire_path,
+        Some(root.join("app/Livewire")),
+        "and the conventional component path must resolve, or the scan is \
+         skipped and completion returns nothing"
+    );
+}
+
+#[tokio::test]
+async fn a_transitive_livewire_yields_component_completions() {
+    // The user-visible half, through the same accessor the completion handler
+    // uses. Asserting on `has_livewire` alone would not prove the components
+    // actually surface.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(
+        root,
+        COMPOSER_JSON_TRANSITIVE,
+        Some(COMPOSER_LOCK_WITH_LIVEWIRE),
+    );
+    let server = test_server();
+    let config = config_for(&server, root).await;
+    *server.cached_config.write().await = Some(std::sync::Arc::new(config));
+
+    let names: Vec<String> = server
+        .cached_livewire_components()
+        .await
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+
+    assert_eq!(
+        names,
+        vec!["counter".to_string()],
+        "the component under app/Livewire must be offered; before the fix this \
+         list was empty on every starter-kit project"
+    );
+}
+
+#[tokio::test]
+async fn a_direct_livewire_requirement_still_works() {
+    // No regression for the projects the old test DID serve.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(
+        root,
+        COMPOSER_JSON_DIRECT,
+        Some(COMPOSER_LOCK_WITH_LIVEWIRE),
+    );
+    let server = test_server();
+
+    let config = config_for(&server, root).await;
+
+    assert!(config.has_livewire);
+    assert_eq!(config.livewire_path, Some(root.join("app/Livewire")));
+}
+
+#[tokio::test]
+async fn a_project_without_livewire_is_still_reported_as_such() {
+    // The discriminator. Without this, "always true" would pass every test
+    // above — and a project with no Livewire would get a phantom component
+    // path and phantom completions.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(
+        root,
+        COMPOSER_JSON_TRANSITIVE,
+        Some(COMPOSER_LOCK_WITHOUT_LIVEWIRE),
+    );
+    let server = test_server();
+
+    let config = config_for(&server, root).await;
+
+    assert!(
+        !config.has_livewire,
+        "a lock with no livewire/livewire means it is not installed"
+    );
+    assert_eq!(config.livewire_path, None);
+}
+
+// ---------------------------------------------------------------------------
+// The absent-lock fallback
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn without_a_lock_a_direct_requirement_is_still_detected() {
+    // Fresh clone, before `composer install`. Falling back to the old
+    // composer.json test is strictly better than assuming "not installed", and
+    // preserves exactly the behaviour these projects had before.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(root, COMPOSER_JSON_DIRECT, None);
+    let server = test_server();
+
+    let config = config_for(&server, root).await;
+
+    assert!(
+        config.has_livewire,
+        "with no lock to read, a direct composer.json requirement must still count"
+    );
+}
+
+#[tokio::test]
+async fn without_a_lock_a_transitive_livewire_is_undetectable() {
+    // Honest limit, pinned so it is a known behaviour rather than a surprise.
+    // Before `composer install` there is no lock and nothing in `vendor/`, so
+    // no evidence of a transitive dependency exists anywhere on disk. The
+    // answer corrects itself the moment the lock appears.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(root, COMPOSER_JSON_TRANSITIVE, None);
+    let server = test_server();
+
+    let config = config_for(&server, root).await;
+
+    assert!(
+        !config.has_livewire,
+        "with no lock and no direct requirement there is no evidence to read"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The file watcher — the second consumer of `livewire_path`
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn the_livewire_directory_is_watched_on_a_transitive_project() {
+    // `build_registration` takes `config.livewire_path`, so a `None` path meant
+    // the Livewire directory was never watched: external edits to components
+    // (a `git pull`, a branch switch) never invalidated anything. Verified
+    // rather than assumed.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(
+        root,
+        COMPOSER_JSON_TRANSITIVE,
+        Some(COMPOSER_LOCK_WITH_LIVEWIRE),
+    );
+    let server = test_server();
+    let config = config_for(&server, root).await;
+
+    let registration = laravel_lsp::file_watcher::build_registration(
+        root,
+        &config.view_paths,
+        config.livewire_path.as_deref(),
+        &[],
+        &[],
+    );
+    let rendered = serde_json::to_string(&registration.register_options).unwrap();
+
+    assert!(
+        rendered.contains("app/Livewire"),
+        "the Livewire directory must be registered with the watcher; got {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn no_livewire_directory_is_watched_without_livewire() {
+    // Discriminates the assertion above from one that passes on any
+    // registration.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(
+        root,
+        COMPOSER_JSON_TRANSITIVE,
+        Some(COMPOSER_LOCK_WITHOUT_LIVEWIRE),
+    );
+    let server = test_server();
+    let config = config_for(&server, root).await;
+
+    let registration = laravel_lsp::file_watcher::build_registration(
+        root,
+        &config.view_paths,
+        config.livewire_path.as_deref(),
+        &[],
+        &[],
+    );
+    let rendered = serde_json::to_string(&registration.register_options).unwrap();
+
+    assert!(
+        !rendered.contains("app/Livewire"),
+        "a project without Livewire must not get a Livewire watcher; got {rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Go-to-definition — checked, not assumed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn goto_definition_never_depended_on_the_livewire_flag() {
+    // I reported goto as "possibly affected" and would not claim either way
+    // without testing. It is NOT affected, and this pins why: goto resolves
+    // through `resolve_livewire_component` → `get_cached_livewire`, which reads
+    // `config/livewire.php` and the installed version directly and never
+    // consults `has_livewire` or `livewire_path`.
+    //
+    // The stale `LaravelConfigData::resolve_livewire_path` — which DID gate on
+    // `livewire_path` — has no production callers left; two comments in
+    // `main.rs` refer to it as "the old" resolver.
+    //
+    // Driven on the worst case: a lock that says Livewire is NOT installed, so
+    // `has_livewire` is false and `livewire_path` is `None`. Resolution must
+    // still find the component on disk.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(
+        root,
+        COMPOSER_JSON_TRANSITIVE,
+        Some(COMPOSER_LOCK_WITHOUT_LIVEWIRE),
+    );
+    let server = test_server();
+    let config = config_for(&server, root).await;
+    assert!(
+        !config.has_livewire && config.livewire_path.is_none(),
+        "fixture check — the flag must be false, or this proves nothing"
+    );
+    *server.cached_config.write().await = Some(std::sync::Arc::new(config));
+
+    let resolved = server.resolve_livewire_primary_path("counter").await;
+
+    assert_eq!(
+        resolved,
+        Some(root.join("app/Livewire/Counter.php")),
+        "goto resolves independently of the Livewire flag, so the defect never \
+         reached it"
+    );
+}

--- a/laravel-lsp/src/tests/macro_goto_def_handler.rs
+++ b/laravel-lsp/src/tests/macro_goto_def_handler.rs
@@ -107,7 +107,7 @@ async fn prime_macro_project(server: &LaravelLanguageServer, root: &Path) -> std
 
     server
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .unwrap();
     server
@@ -198,7 +198,7 @@ class Ids {
 
     server
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .unwrap();
     server

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -72,6 +72,7 @@ mod translation_namespace_check;
 mod translation_namespace_completion;
 mod translation_namespace_navigation;
 mod translation_salsa_cache;
+mod vendor_provider_scan;
 mod view_diagnostic_containment;
 mod view_navigation_containment;
 mod vite_completion_context;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -50,6 +50,7 @@ mod laravel_root_worktree_discovery;
 mod livewire_component_completion;
 mod livewire_component_resolution;
 mod livewire_tag_navigation_containment;
+mod livewire_transitive_detection;
 mod loop_variable_resolution;
 mod macro_goto_def_handler;
 mod module_config_surfaces;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -62,6 +62,7 @@ mod render_index_and_buffer_integrity;
 mod route_binding_resolution;
 mod route_diagnostics;
 mod route_hover;
+mod route_prefix_cache;
 mod routes_dir_gate;
 mod scan_dir_containment;
 mod slot_navigation_containment;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod code_action_create_containment;
 mod code_lens_opt_in;
 mod completion_value_pipeline;
 mod component_ancestor_navigation;
+mod component_completion_cache;
 mod component_file_navigation_containment;
 mod component_member_navigation;
 mod component_navigation_containment;

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod blade_var_rename_handler;
 mod byte_offset_panic_hardening;
 mod cache_root_poisoning;
 mod cast_type_context;
+mod class_hierarchy_freshness;
 mod class_locator_and_properties;
 mod code_action_create_containment;
 mod code_lens_opt_in;

--- a/laravel-lsp/src/tests/module_view_namespaces.rs
+++ b/laravel-lsp/src/tests/module_view_namespaces.rs
@@ -87,7 +87,7 @@ async fn view_namespace_dir_named(
 ) -> Option<PathBuf> {
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .expect("salsa actor accepts config root");
     backend
@@ -106,7 +106,7 @@ async fn view_namespace_dir_named(
 async fn view_namespace_dir(backend: &LaravelLanguageServer, root: &Path) -> Option<PathBuf> {
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .expect("salsa actor accepts config root");
     backend
@@ -434,7 +434,7 @@ class Registrar
 async fn config_for(backend: &LaravelLanguageServer, root: &Path) -> LaravelConfigData {
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .expect("salsa actor accepts config root");
     backend

--- a/laravel-lsp/src/tests/post_warm_open_buffer_guard.rs
+++ b/laravel-lsp/src/tests/post_warm_open_buffer_guard.rs
@@ -93,6 +93,14 @@ async fn bulk_import_skips_open_buffer_and_position_still_resolves() {
             vec![dir.path().join("resources/views")],
             None,
             std::path::PathBuf::from("routes"),
+            // The shared vendor walk the production caller passes in
+            // (issue #371) — built from the same root, so the actor
+            // registers exactly what it would in production.
+            laravel_lsp::vendor_index::VendorIndex::build(dir.path())
+                .files()
+                .iter()
+                .map(|f| f.path.clone())
+                .collect(),
         )
         .await
         .unwrap();

--- a/laravel-lsp/src/tests/render_index_and_buffer_integrity.rs
+++ b/laravel-lsp/src/tests/render_index_and_buffer_integrity.rs
@@ -42,6 +42,14 @@ async fn handle_for(root: &Path) -> SalsaHandle {
             vec![root.join("resources/views")],
             Some(root.join("resources/views/livewire")),
             PathBuf::from("routes"),
+            // The shared vendor walk the production caller passes in
+            // (issue #371) — built from the same root, so the actor
+            // registers exactly what it would in production.
+            laravel_lsp::vendor_index::VendorIndex::build(root)
+                .files()
+                .iter()
+                .map(|f| f.path.clone())
+                .collect(),
         )
         .await
         .expect("actor registers the tempdir project");

--- a/laravel-lsp/src/tests/render_index_and_buffer_integrity.rs
+++ b/laravel-lsp/src/tests/render_index_and_buffer_integrity.rs
@@ -32,7 +32,7 @@ async fn handle_for(root: &Path) -> SalsaHandle {
     // always sets it first — either here or via `RegisterCachedConfig` — so a
     // fixture that skips it is under-registering, not exercising a real state.
     handle
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .expect("actor registers the tempdir project root");
     handle

--- a/laravel-lsp/src/tests/route_prefix_cache.rs
+++ b/laravel-lsp/src/tests/route_prefix_cache.rs
@@ -1,0 +1,594 @@
+//! Regression tests for issue #80 — request handlers must read inherited
+//! external-load route prefixes (issue #43) from the **warm route index**, not
+//! by re-running the project load graph.
+//!
+//! `route_discovery::external_prefixes_for_file` / `external_prefixes_map` both
+//! begin with `discover_route_files`, which `read_to_string`s every `.php` file
+//! under `vendor/` — 16,051 of them in this repo's own `test-project/`. Four
+//! per-request handlers called one of those two on every single request:
+//! `document_symbol`, `references`' declaration walk, `classify_with_decl_
+//! fallback` (references + prepare_rename + rename) and `decl_range_at`
+//! (prepare_rename). Measured cost: `textDocument/documentSymbol` on
+//! `routes/web.php` took 2,214 ms cold and ~510 ms on *every* repeat, against
+//! 0.2–1.0 ms for the same request on `app/Models/User.php`. The whole result
+//! was then discarded for any file with no external prefix, which is nearly
+//! every file.
+//!
+//! Two independent properties are pinned here, because either alone can pass
+//! for the wrong reason:
+//!
+//!   1. **No walk.** `route_discovery::discovery_walk_count()` — a per-thread
+//!      counter bumped at the top of `discover_route_files` — must not move
+//!      across a handler call. This is the direct call-count seam; restoring
+//!      any of the four old call sites makes it move.
+//!   2. **The cache is the source of truth.** The fixtures below deliberately
+//!      put a prefix in the *index* that no on-disk `->group(<path>)` load
+//!      would ever produce. A handler still consulting the filesystem answers
+//!      `""` and drops the prefix; one reading the index answers `admin.`. A
+//!      no-walk assertion alone would also pass if the handler silently stopped
+//!      resolving prefixes at all, so the behaviour has to be pinned too.
+
+use crate::{classify_with_decl_fallback, decl_range_at, LaravelLanguageServer};
+use laravel_lsp::references::SymbolRef;
+use laravel_lsp::route_discovery::{discovery_walk_count, normalize_path, RouteIndex};
+use laravel_lsp::salsa_impl::ParsedPatternsData;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use tower_lsp::lsp_types::{
+    DocumentSymbolParams, DocumentSymbolResponse, PartialResultParams, Position,
+    TextDocumentIdentifier, Url, WorkDoneProgressParams,
+};
+use tower_lsp::{LanguageServer, LspService};
+
+/// `routes/admin.php` as Laravel would have it after being loaded by
+/// `Route::as('admin.')->group(base_path('routes/admin.php'))` from elsewhere.
+/// The file itself carries no hint of that prefix — which is the point: the
+/// prefix can only come from the cross-file load graph, and therefore (post-fix)
+/// only from the warm index.
+///
+/// The `->name(` call sits on line 1, where the opening quote is column 48 —
+/// so the `users.index` content spans columns 49..60 (end exclusive) and a
+/// cursor at column 50 is inside the declaration's argument.
+const ROUTE_SRC: &str = "<?php\nRoute::get('/users', [C::class, 'index'])->name('users.index');\n";
+const NAME_START: u32 = 49;
+const NAME_END: u32 = 60;
+const NAME_CURSOR: Position = Position {
+    line: 1,
+    character: 50,
+};
+
+fn test_server() -> LaravelLanguageServer {
+    let (service, _socket) = LspService::new(LaravelLanguageServer::new);
+    service.inner().clone()
+}
+
+/// Lay down `root/routes/admin.php` containing [`ROUTE_SRC`], plus a `vendor/`
+/// tree holding one route-registering package file.
+///
+/// The vendor file is what the retired walk would have opened and read. It is
+/// not needed to make the counter move (the counter bumps on the walk, not per
+/// file), but it keeps the fixture honest: this is a project where a walk would
+/// have real work to do and a real prefix source to find.
+fn seed_project(root: &Path) -> PathBuf {
+    let routes = root.join("routes");
+    fs::create_dir_all(&routes).unwrap();
+    let file = routes.join("admin.php");
+    fs::write(&file, ROUTE_SRC).unwrap();
+
+    let vendor_routes = root.join("vendor").join("acme").join("pkg").join("routes");
+    fs::create_dir_all(&vendor_routes).unwrap();
+    fs::write(
+        vendor_routes.join("web.php"),
+        "<?php\nRoute::get('/pkg', fn () => null)->name('pkg.home');\n",
+    )
+    .unwrap();
+
+    file
+}
+
+/// A route index whose `external_prefixes` claims `file` inherits `admin.`.
+///
+/// Nothing on disk says so. `external_prefixes_for_file` walking this fixture
+/// would return `[""]`, so any assertion below that observes `admin.` proves
+/// the answer came from here and not from the filesystem.
+fn index_with_prefix(file: &Path) -> RouteIndex {
+    let mut index = RouteIndex::new();
+    index.source_files.insert(normalize_path(file));
+    index.external_prefixes.insert(
+        normalize_path(file),
+        vec![String::new(), "admin.".to_string()],
+    );
+    index
+}
+
+/// Point the server at `root` and install `index` (or leave the index absent).
+async fn prime(server: &LaravelLanguageServer, root: &Path, index: Option<RouteIndex>) {
+    *server.root_path.write().await = Some(root.to_path_buf());
+    *server.route_index.write().await = index;
+}
+
+async fn document_symbol_names(server: &LaravelLanguageServer, file: &Path) -> Vec<String> {
+    let params = DocumentSymbolParams {
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(file).unwrap(),
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+    match server.document_symbol(params).await.unwrap() {
+        Some(DocumentSymbolResponse::Nested(symbols)) => {
+            symbols.into_iter().map(|s| s.name).collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// document_symbol — the handler issue #80 was reported against
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn document_symbol_on_a_routes_file_never_walks_the_project() {
+    // The unprefixed common case: a routes file with no external load at all.
+    // Pre-fix this still paid a full `discover_route_files` — the walk ran
+    // first and its `[""]` result was thrown away one line later.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(RouteIndex::new())).await;
+
+    let before = discovery_walk_count();
+    let _ = document_symbol_names(&server, &file).await;
+    let after = discovery_walk_count();
+
+    assert_eq!(
+        before, after,
+        "document_symbol on a routes file must not run discover_route_files \
+         (it reads every .php file under vendor/); walk count moved {before} → {after}"
+    );
+}
+
+#[tokio::test]
+async fn document_symbol_on_a_routes_file_never_walks_even_when_prefixed() {
+    // The prefixed case must be cache-fed too. If the fix had only short-
+    // circuited the empty case, this fixture would still walk.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(index_with_prefix(&file))).await;
+
+    let before = discovery_walk_count();
+    let _ = document_symbol_names(&server, &file).await;
+    let after = discovery_walk_count();
+
+    assert_eq!(
+        before, after,
+        "an externally-prefixed routes file must resolve its prefix from the \
+         warm index, not a fresh walk; walk count moved {before} → {after}"
+    );
+}
+
+#[tokio::test]
+async fn document_symbol_applies_the_prefix_held_only_by_the_warm_index() {
+    // Behavioural half of the pair: the prefix exists nowhere on disk, so
+    // seeing it in the outline proves the index is the source of truth.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(index_with_prefix(&file))).await;
+
+    let names = document_symbol_names(&server, &file).await;
+
+    assert!(
+        names.iter().any(|n| n.contains("[name=admin.users.index]")),
+        "the outline must carry the index-held `admin.` prefix, got: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn document_symbol_leaves_symbols_unprefixed_when_the_index_holds_none() {
+    // Discriminates the assertion above from one that would pass on any
+    // non-empty outline: same file, same handler, no prefix in the index.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(RouteIndex::new())).await;
+
+    let names = document_symbol_names(&server, &file).await;
+
+    assert!(
+        !names.iter().any(|n| n.contains("admin.")),
+        "with no prefix in the index nothing may be prefixed, got: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn document_symbol_never_walks_before_the_route_index_exists() {
+    // Cold start: `route_index` is still `None` because warm-up hasn't
+    // finished. The handler must degrade to "no prefix", never to a walk —
+    // this is the window in which the walk was most expensive (2,214 ms).
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), None).await;
+
+    let before = discovery_walk_count();
+    let _ = document_symbol_names(&server, &file).await;
+    let after = discovery_walk_count();
+
+    assert_eq!(
+        before, after,
+        "a cold-start document_symbol must not walk the project; \
+         walk count moved {before} → {after}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The cached accessors themselves — all three branches each
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cached_external_prefixes_defaults_to_the_empty_prefix_without_an_index() {
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), None).await;
+
+    assert_eq!(
+        server.cached_external_prefixes(&file).await,
+        vec![String::new()],
+        "an absent index must answer `[\"\"]`, the same default an unreachable \
+         file gets — never a guessed prefix"
+    );
+}
+
+#[tokio::test]
+async fn cached_external_prefixes_defaults_for_a_file_the_index_does_not_hold() {
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(RouteIndex::new())).await;
+
+    assert_eq!(
+        server.cached_external_prefixes(&file).await,
+        vec![String::new()],
+        "a file the load graph never reached is still scanned directly, so the \
+         empty prefix applies"
+    );
+}
+
+#[tokio::test]
+async fn cached_external_prefixes_returns_the_indexed_prefixes() {
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(index_with_prefix(&file))).await;
+
+    assert_eq!(
+        server.cached_external_prefixes(&file).await,
+        vec![String::new(), "admin.".to_string()],
+        "the indexed prefixes must come back verbatim, `\"\"` included"
+    );
+}
+
+#[tokio::test]
+async fn cached_external_prefix_map_is_empty_without_an_index() {
+    let root = TempDir::new().unwrap();
+    let server = test_server();
+    prime(&server, root.path(), None).await;
+
+    assert!(
+        server.cached_external_prefix_map().await.is_empty(),
+        "an absent index yields an empty map, which callers already read as \
+         `[\"\"]` per file"
+    );
+}
+
+#[tokio::test]
+async fn cached_external_prefix_map_mirrors_the_index() {
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(index_with_prefix(&file))).await;
+
+    let map = server.cached_external_prefix_map().await;
+
+    assert_eq!(
+        map.get(&normalize_path(&file)),
+        Some(&vec![String::new(), "admin.".to_string()]),
+        "the map handed to the declaration walks must be the index's own, \
+         keyed by normalized path; got: {map:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// references / prepare_rename / rename — the other three retired call sites
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn classify_with_decl_fallback_resolves_the_prefix_without_walking() {
+    // Drives the shared classifier behind references, prepare_rename and
+    // rename. Empty patterns force the declaration-fallback branch, which is
+    // the one that used to call `external_prefixes_for_file`.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(index_with_prefix(&file))).await;
+    let patterns = ParsedPatternsData::default();
+
+    let before = discovery_walk_count();
+    let symbol =
+        classify_with_decl_fallback(&server, Some(root.path()), &file, &patterns, NAME_CURSOR)
+            .await;
+    let after = discovery_walk_count();
+
+    assert_eq!(
+        symbol,
+        Some(SymbolRef::Route("admin.users.index".to_string())),
+        "the declaration must anchor to the index-held prefixed name"
+    );
+    assert_eq!(
+        before, after,
+        "classifying a route declaration must not walk the project; \
+         walk count moved {before} → {after}"
+    );
+}
+
+#[tokio::test]
+async fn classify_with_decl_fallback_takes_the_first_of_several_prefixes() {
+    // The consumer half of the ordering contract. `compute_effective_prefixes`
+    // guarantees `""` first then lexicographic order; this pins that the
+    // classifier reads position 0 of the non-empty tail, so the two halves
+    // together give one stable project-level name for a file loaded by more
+    // than one prefixed group.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    let mut index = RouteIndex::new();
+    index.source_files.insert(normalize_path(&file));
+    index.external_prefixes.insert(
+        normalize_path(&file),
+        vec![String::new(), "admin.".to_string(), "blog.".to_string()],
+    );
+    prime(&server, root.path(), Some(index)).await;
+    let patterns = ParsedPatternsData::default();
+
+    let symbol =
+        classify_with_decl_fallback(&server, Some(root.path()), &file, &patterns, NAME_CURSOR)
+            .await;
+
+    assert_eq!(
+        symbol,
+        Some(SymbolRef::Route("admin.users.index".to_string())),
+        "the first non-empty prefix wins, and the index guarantees which one \
+         that is"
+    );
+}
+
+#[tokio::test]
+async fn classify_with_decl_fallback_keeps_the_raw_name_without_a_prefix() {
+    // Same cursor, no prefix in the index: the raw in-file name stands. Pins
+    // that the test above is reading the prefix rather than always prepending
+    // something.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(RouteIndex::new())).await;
+    let patterns = ParsedPatternsData::default();
+
+    let symbol =
+        classify_with_decl_fallback(&server, Some(root.path()), &file, &patterns, NAME_CURSOR)
+            .await;
+
+    assert_eq!(
+        symbol,
+        Some(SymbolRef::Route("users.index".to_string())),
+        "with no external prefix the declaration keeps its raw in-file name"
+    );
+}
+
+#[tokio::test]
+async fn decl_range_at_matches_a_prefixed_name_without_walking() {
+    // prepare_rename's highlight range. The symbol carries the project-level
+    // prefixed name; the file on disk only declares the raw leaf, so the range
+    // is only found if the prefix is prepended from the index before matching.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(index_with_prefix(&file))).await;
+
+    let before = discovery_walk_count();
+    let range = decl_range_at(
+        &server,
+        &file,
+        NAME_CURSOR,
+        &SymbolRef::Route("admin.users.index".to_string()),
+    )
+    .await;
+    let after = discovery_walk_count();
+
+    let range = range.expect("a cursor on the `->name(` argument must yield a rename range");
+    assert_eq!(
+        (range.start.line, range.start.character, range.end.character),
+        (1, NAME_START, NAME_END),
+        "the range must cover the `users.index` argument content, quotes excluded"
+    );
+    assert_eq!(
+        before, after,
+        "prepare_rename must not walk the project; walk count moved {before} → {after}"
+    );
+}
+
+#[tokio::test]
+async fn decl_range_at_finds_nothing_for_a_prefix_the_index_does_not_hold() {
+    // Fail-closed companion: without the `admin.` entry, `admin.users.index`
+    // matches no declaration in this file and no range is offered.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(RouteIndex::new())).await;
+
+    let range = decl_range_at(
+        &server,
+        &file,
+        NAME_CURSOR,
+        &SymbolRef::Route("admin.users.index".to_string()),
+    )
+    .await;
+
+    assert_eq!(
+        range, None,
+        "an unindexed prefix must not be invented to force a match"
+    );
+}
+
+#[tokio::test]
+async fn collect_declaration_locations_resolves_prefixes_without_walking() {
+    // references' declaration half. It used to build its per-file prefix map
+    // with `external_prefixes_map`, the map-shaped sibling of the same walk.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(index_with_prefix(&file))).await;
+
+    let before = discovery_walk_count();
+    let locations = crate::collect_declaration_locations(
+        &server,
+        root.path(),
+        &SymbolRef::Route("admin.users.index".to_string()),
+    )
+    .await;
+    let after = discovery_walk_count();
+
+    assert_eq!(
+        locations.len(),
+        1,
+        "the prefixed name must match the raw in-file declaration once the \
+         index-held `admin.` prefix is applied; got: {locations:?}"
+    );
+    assert_eq!(
+        (
+            locations[0].range.start.line,
+            locations[0].range.start.character
+        ),
+        (1, NAME_START),
+        "the location must point at the `->name(` argument content"
+    );
+    assert_eq!(
+        before, after,
+        "find-references must not walk the project; walk count moved {before} → {after}"
+    );
+}
+
+#[tokio::test]
+async fn collect_declaration_locations_finds_nothing_for_an_unindexed_prefix() {
+    // Fail-closed companion: no `admin.` in the index, no match invented.
+    let root = TempDir::new().unwrap();
+    seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(RouteIndex::new())).await;
+
+    let locations = crate::collect_declaration_locations(
+        &server,
+        root.path(),
+        &SymbolRef::Route("admin.users.index".to_string()),
+    )
+    .await;
+
+    assert!(
+        locations.is_empty(),
+        "an unindexed prefix must not resolve to a declaration; got: {locations:?}"
+    );
+}
+
+#[tokio::test]
+async fn collect_route_declaration_targets_resolves_prefixes_without_walking() {
+    // rename's declaration half — the fourth and last retired call site. The
+    // rewritten segment is the LEAF only, so the `admin.` prefix is never
+    // written back into the source.
+    let root = TempDir::new().unwrap();
+    let file = seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(index_with_prefix(&file))).await;
+
+    let before = discovery_walk_count();
+    let targets = crate::collect_route_declaration_targets(
+        &server,
+        root.path(),
+        "admin.users.index",
+        "admin.users.list",
+    )
+    .await;
+    let after = discovery_walk_count();
+
+    assert_eq!(
+        targets.len(),
+        1,
+        "the prefixed target must match the raw declaration; got: {targets:?}"
+    );
+    assert_eq!(
+        (
+            targets[0].line,
+            targets[0].start_column,
+            targets[0].end_column
+        ),
+        (1, NAME_START, NAME_END),
+        "the edit must span the `users.index` argument content"
+    );
+    assert_eq!(
+        targets[0].new_text, "users.list",
+        "only the leaf is rewritten — the inherited `admin.` prefix has no \
+         source text in this file to double"
+    );
+    assert_eq!(
+        before, after,
+        "rename must not walk the project; walk count moved {before} → {after}"
+    );
+}
+
+#[tokio::test]
+async fn collect_route_declaration_targets_skips_an_unindexed_prefix() {
+    // Fail-closed companion.
+    let root = TempDir::new().unwrap();
+    seed_project(root.path());
+    let server = test_server();
+    prime(&server, root.path(), Some(RouteIndex::new())).await;
+
+    let targets = crate::collect_route_declaration_targets(
+        &server,
+        root.path(),
+        "admin.users.index",
+        "admin.users.list",
+    )
+    .await;
+
+    assert!(
+        targets.is_empty(),
+        "an unindexed prefix must not produce an edit; got: {targets:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The seam itself
+// ---------------------------------------------------------------------------
+
+#[test]
+fn discovery_walk_count_moves_when_a_walk_actually_happens() {
+    // Canary for the instrumentation every assertion above rests on: a green
+    // suite never exercises the counter's increment, so pin it directly. If
+    // this ever stops moving, every "must not walk" test above has quietly
+    // become unfalsifiable.
+    let root = TempDir::new().unwrap();
+    seed_project(root.path());
+
+    let before = discovery_walk_count();
+    let _ = laravel_lsp::route_discovery::discover_route_files(root.path());
+    let after = discovery_walk_count();
+
+    assert_eq!(
+        after,
+        before + 1,
+        "discover_route_files must bump the per-thread walk counter exactly once"
+    );
+}

--- a/laravel-lsp/src/tests/vendor_provider_scan.rs
+++ b/laravel-lsp/src/tests/vendor_provider_scan.rs
@@ -1,0 +1,258 @@
+//! Equivalence tests for the shared vendor service-provider scan (issue #371).
+//!
+//! `register_service_provider_files_with_salsa` and `rescan_vendor_providers`
+//! each ran the same two `WalkDir` legs — `vendor/laravel/framework/src/
+//! Illuminate` at depth 10 for `*ServiceProvider.php`, and `vendor/` at depth 6
+//! for `*ServiceProvider.php` plus `Http/**/Kernel.php` — inline in an
+//! `async fn`, blocking a Tokio worker for the whole scan. Both now filter the
+//! shared vendor walk through [`vendor_provider_priority`], with the reads in
+//! `spawn_blocking`.
+//!
+//! The tests compare that predicate against an executable copy of the two
+//! former legs. Keeping the old implementation is the only way to test a claim
+//! about the old implementation.
+
+use crate::{collect_vendor_provider_sources, vendor_provider_priority};
+use laravel_lsp::vendor_index::VendorIndex;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use walkdir::WalkDir;
+
+/// The two vendor legs exactly as they were written before the shared walk,
+/// reduced to the `path -> priority` decision they drove.
+fn provider_priorities_two_walks(root: &Path) -> HashMap<PathBuf, u8> {
+    let mut out = HashMap::new();
+
+    let framework_path = root.join("vendor/laravel/framework/src/Illuminate");
+    if framework_path.exists() {
+        for entry in WalkDir::new(&framework_path)
+            .max_depth(10)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if path.is_file()
+                && path.extension().is_some_and(|ext| ext == "php")
+                && path
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy().ends_with("ServiceProvider.php"))
+            {
+                out.insert(path.to_path_buf(), 0);
+            }
+        }
+    }
+
+    let vendor_path = root.join("vendor");
+    if vendor_path.exists() {
+        for entry in WalkDir::new(&vendor_path)
+            .max_depth(6)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let path = entry.path();
+            if path.starts_with(&framework_path) {
+                continue;
+            }
+            if path.is_file() && path.extension().is_some_and(|ext| ext == "php") {
+                let file_name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                let path_str = path.to_string_lossy();
+                let is_service_provider = file_name.ends_with("ServiceProvider.php");
+                let is_http_kernel = file_name == "Kernel.php"
+                    && (path_str.contains("/Http/") || path_str.contains("\\Http\\"));
+                if is_service_provider || is_http_kernel {
+                    out.insert(path.to_path_buf(), 1);
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// What the shared path decides, in the same shape.
+fn provider_priorities_shared(root: &Path, vendor: &VendorIndex) -> HashMap<PathBuf, u8> {
+    let framework_root = root.join("vendor/laravel/framework/src/Illuminate");
+    vendor
+        .files()
+        .iter()
+        .filter_map(|f| vendor_provider_priority(&framework_root, f).map(|p| (f.path.clone(), p)))
+        .collect()
+}
+
+/// A vendor tree covering every branch of the decision: framework providers
+/// inside and outside the depth-10 budget, package providers inside and outside
+/// the depth-6 budget, an `Http/Kernel.php`, a `Kernel.php` NOT under `Http/`,
+/// a framework-owned `Http/Kernel.php` (which neither leg ever took), and
+/// ordinary PHP that is none of the above.
+fn seed(root: &Path) {
+    let files = [
+        // Framework leg, depth 1 below the framework root.
+        "vendor/laravel/framework/src/Illuminate/FooServiceProvider.php",
+        // Framework leg, depth 10 — the last depth it admitted.
+        "vendor/laravel/framework/src/Illuminate/a/b/c/d/e/f/g/h/i/DeepServiceProvider.php",
+        // Framework leg, depth 11 — past it.
+        "vendor/laravel/framework/src/Illuminate/a/b/c/d/e/f/g/h/i/j/PastServiceProvider.php",
+        // A framework Http/Kernel.php: the framework leg took only providers,
+        // and the package leg skipped framework paths outright.
+        "vendor/laravel/framework/src/Illuminate/Http/Kernel.php",
+        // Package leg, well inside depth 6.
+        "vendor/acme/pkg/AcmeServiceProvider.php",
+        "vendor/acme/pkg/src/Http/Kernel.php",
+        // Package leg, depth 6 exactly.
+        "vendor/acme/pkg/a/b/c/EdgeServiceProvider.php",
+        // Package leg, depth 7 — past it.
+        "vendor/acme/pkg/a/b/c/d/PastServiceProvider.php",
+        // A Kernel.php not under Http/ — never admitted.
+        "vendor/acme/pkg/src/Console/Kernel.php",
+        // Ordinary vendor PHP.
+        "vendor/acme/pkg/src/Plain.php",
+    ];
+    for rel in files {
+        let p = root.join(rel);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, "<?php\n// provider\n").unwrap();
+    }
+}
+
+#[test]
+fn shared_walk_selects_the_same_provider_files_as_the_two_walks() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(root);
+    let vendor = VendorIndex::build(root);
+
+    let shared = provider_priorities_shared(root, &vendor);
+    let oracle = provider_priorities_two_walks(root);
+
+    let mut shared_sorted: Vec<_> = shared.iter().collect();
+    let mut oracle_sorted: Vec<_> = oracle.iter().collect();
+    shared_sorted.sort();
+    oracle_sorted.sort();
+
+    assert_eq!(
+        shared_sorted, oracle_sorted,
+        "the shared predicate must select exactly the files, and the tiers, \
+         that the two former walks did"
+    );
+    assert!(
+        !oracle.is_empty(),
+        "fixture check — an empty oracle would make the equality vacuous"
+    );
+}
+
+#[test]
+fn each_branch_of_the_provider_decision_is_pinned() {
+    // Discriminates the equality above: it would still hold if both sides were
+    // wrong in the same way, since only the shared side is under test here.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(root);
+    let vendor = VendorIndex::build(root);
+    let shared = provider_priorities_shared(root, &vendor);
+    let at = |rel: &str| shared.get(&root.join(rel)).copied();
+
+    assert_eq!(
+        at("vendor/laravel/framework/src/Illuminate/FooServiceProvider.php"),
+        Some(0),
+        "a framework provider is tier 0"
+    );
+    assert_eq!(
+        at("vendor/laravel/framework/src/Illuminate/a/b/c/d/e/f/g/h/i/DeepServiceProvider.php"),
+        Some(0),
+        "depth 10 below the FRAMEWORK root is inside its budget — measuring \
+         that budget from vendor/ instead would cut it off here"
+    );
+    assert_eq!(
+        at("vendor/laravel/framework/src/Illuminate/a/b/c/d/e/f/g/h/i/j/PastServiceProvider.php"),
+        None,
+        "depth 11 is past it"
+    );
+    assert_eq!(
+        at("vendor/laravel/framework/src/Illuminate/Http/Kernel.php"),
+        None,
+        "a framework Http/Kernel.php belongs to neither leg: the framework leg \
+         took only providers, the package leg skipped framework paths"
+    );
+    assert_eq!(
+        at("vendor/acme/pkg/AcmeServiceProvider.php"),
+        Some(1),
+        "a package provider is tier 1"
+    );
+    assert_eq!(
+        at("vendor/acme/pkg/src/Http/Kernel.php"),
+        Some(1),
+        "a package Http/Kernel.php is taken for its middleware definitions"
+    );
+    assert_eq!(
+        at("vendor/acme/pkg/a/b/c/EdgeServiceProvider.php"),
+        Some(1),
+        "depth 6 below vendor/ is inside the package budget"
+    );
+    assert_eq!(
+        at("vendor/acme/pkg/a/b/c/d/PastServiceProvider.php"),
+        None,
+        "depth 7 is past it"
+    );
+    assert_eq!(
+        at("vendor/acme/pkg/src/Console/Kernel.php"),
+        None,
+        "a Kernel.php outside Http/ was never a middleware source"
+    );
+    assert_eq!(
+        at("vendor/acme/pkg/src/Plain.php"),
+        None,
+        "ordinary vendor PHP is not a provider"
+    );
+}
+
+#[test]
+fn collect_reads_only_the_selected_files() {
+    // The read budget: ~73 of 16,051 files on a real project. If the predicate
+    // and the collector ever disagreed, this scan would go from a few dozen
+    // reads to the whole tree.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(root);
+    let vendor = VendorIndex::build(root);
+
+    let sources = collect_vendor_provider_sources(root, &vendor);
+    let selected = provider_priorities_shared(root, &vendor);
+
+    assert_eq!(
+        sources.len(),
+        selected.len(),
+        "one source per selected file, and nothing else read"
+    );
+    assert!(
+        sources.len() < vendor.len(),
+        "fixture check — the scan must read strictly fewer files ({}) than the \
+         tree holds ({})",
+        sources.len(),
+        vendor.len()
+    );
+    for source in &sources {
+        assert_eq!(
+            selected.get(&source.path).copied(),
+            Some(source.priority),
+            "each collected source carries the tier the predicate assigned it"
+        );
+        assert!(source.content.contains("<?php"), "and the file's real text");
+    }
+}
+
+#[test]
+fn a_project_without_vendor_yields_no_provider_sources() {
+    // Both former functions guarded each leg on `exists()`. The shared index is
+    // simply empty instead — the scan must degrade the same way, not panic on
+    // the empty vendor root.
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("app")).unwrap();
+    let vendor = VendorIndex::build(tmp.path());
+
+    assert!(collect_vendor_provider_sources(tmp.path(), &vendor).is_empty());
+}

--- a/laravel-lsp/src/tests/watched_files_magic.rs
+++ b/laravel-lsp/src/tests/watched_files_magic.rs
@@ -824,6 +824,14 @@ async fn incremental_batch_runs_regardless_of_project_size() {
             vec![root.join("resources/views")],
             None,
             PathBuf::from("routes"),
+            // The shared vendor walk the production caller passes in
+            // (issue #371) — built from the same root, so the actor
+            // registers exactly what it would in production.
+            laravel_lsp::vendor_index::VendorIndex::build(root)
+                .files()
+                .iter()
+                .map(|f| f.path.clone())
+                .collect(),
         )
         .await
         .unwrap();

--- a/laravel-lsp/src/tests/watched_files_magic.rs
+++ b/laravel-lsp/src/tests/watched_files_magic.rs
@@ -1289,3 +1289,173 @@ async fn a_watched_provider_change_drops_the_cached_livewire_config() {
         "a provider change on disk must invalidate the Livewire namespace map"
     );
 }
+
+// === Parse budget in the watched batch (issue #371) =========================
+//
+// The warm pass refuses to parse `*.json.php` blobs and anything over 256 KB
+// (0.4–2.2 s per file; 1,735 blobs under `aws-sdk-php` alone). This path had
+// neither rule, so a `composer install` — which rewrites thousands of vendor
+// files — drained them all serially through the single Salsa actor thread,
+// uncapped. It was also inconsistent: files the warm pass deliberately left
+// unindexed were being pulled in by a watched change.
+//
+// The observable is convergence. A dependent gains `headline` only when the
+// batch actually parsed the model declaring `getHeadlineAttribute`, so a
+// consumer that stays empty is a model that was not parsed. Each exclusion test
+// is paired with a control differing ONLY in the excluded property, so a test
+// that stayed green because the fixture never converged at all would fail its
+// control.
+
+/// Pad `src` past the parse budget with a trailing PHP comment, leaving the
+/// class declaration byte-identical to the unpadded control.
+fn padded_past_budget(src: &str) -> String {
+    let cap = laravel_lsp::parse_budget::MAX_PARSED_FILE_SIZE_BYTES as usize;
+    let mut out = String::from(src);
+    out.push_str("\n// ");
+    out.push_str(&"x".repeat(cap + 1));
+    out.push('\n');
+    out
+}
+
+/// Drive one file through `run_magic_batch_once` as a present, changed file,
+/// and report the members the consumer resolved.
+async fn batch_and_read_consumer(
+    backend: &LaravelLanguageServer,
+    model: &Path,
+    consumer: &Path,
+) -> HashSet<String> {
+    let mut batch = HashMap::new();
+    batch.insert(
+        model.to_path_buf(),
+        PendingWatchedChange {
+            old_surfaces: HashMap::new(),
+            old_render_views: Vec::new(),
+            deleted: false,
+        },
+    );
+    backend.run_magic_batch_once(batch).await;
+    member_names(backend, consumer).await
+}
+
+#[tokio::test]
+async fn the_batch_parses_a_model_within_the_budget() {
+    // Control for both exclusion tests below. Same model, same consumer, same
+    // batch — only the size and the filename differ there.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    let post_src = post_with_accessors(&["Headline"]);
+    let post = write_file(root, "app/Models/Post.php", &post_src);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    seed(&backend, &consumer, CONSUMER).await;
+
+    let members = batch_and_read_consumer(&backend, &post, &consumer).await;
+
+    assert!(
+        members.contains("headline"),
+        "a model inside the parse budget must still converge its dependent — \
+         without this the exclusion tests below would pass for the wrong \
+         reason; got {members:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_batch_skips_a_model_over_the_size_cap() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    // Byte-identical class declaration to the control, padded past the cap.
+    let post_src = padded_past_budget(&post_with_accessors(&["Headline"]));
+    let post = write_file(root, "app/Models/Post.php", &post_src);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    seed(&backend, &consumer, CONSUMER).await;
+
+    let members = batch_and_read_consumer(&backend, &post, &consumer).await;
+
+    assert!(
+        !members.contains("headline"),
+        "a model past the 256 KB cap must not be parsed by the batch — the warm \
+         pass excludes it, and parsing it here both costs 0.4–2.2 s and pulls \
+         in a file the rest of the pipeline ignores; got {members:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_batch_skips_a_json_php_blob() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    // Small enough to pass the size cap, so only the `.json.php` rule can
+    // exclude it.
+    let post_src = post_with_accessors(&["Headline"]);
+    let post = write_file(root, "app/Models/Post.json.php", &post_src);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    seed(&backend, &consumer, CONSUMER).await;
+    assert!(
+        post_src.len() < laravel_lsp::parse_budget::MAX_PARSED_FILE_SIZE_BYTES as usize,
+        "fixture check — this file must be excluded for its NAME, not its size"
+    );
+
+    let members = batch_and_read_consumer(&backend, &post, &consumer).await;
+
+    assert!(
+        !members.contains("headline"),
+        "a `.json.php` data blob must not be parsed by the batch; got {members:?}"
+    );
+}
+
+#[tokio::test]
+async fn an_excluded_file_withdraws_its_earlier_contributions() {
+    // The rarer case the delete-shaped handling exists for: a file indexed
+    // while small, then grown past the cap by a `composer install`. Its
+    // contributions can no longer be maintained, so they are withdrawn and
+    // rippled to dependents rather than left to rot.
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    let backend = backend_for(root).await;
+    write_file(root, "composer.json", COMPOSER);
+
+    // Post reads its OWN accessor, so it holds a `by_file` dependency
+    // contribution — the thing the withdrawal has to purge. `post_with_accessors`
+    // alone only declares the accessor and contributes nothing.
+    let small_src = "<?php\nnamespace App\\Models;\nuse Illuminate\\Database\\Eloquent\\Model;\nclass Post extends Model {\n    public function getHeadlineAttribute(): string { return ''; }\n    public function describe(): string { return $this->headline; }\n}\n".to_string();
+    let post = write_file(root, "app/Models/Post.php", &small_src);
+    let consumer = write_file(root, "app/Http/Controllers/PostController.php", CONSUMER);
+    seed(&backend, &post, &small_src).await;
+    seed(&backend, &consumer, CONSUMER).await;
+    assert!(
+        member_names(&backend, &consumer).await.contains("headline"),
+        "fixture check — the dependent must be converged BEFORE the file grows"
+    );
+    assert!(magic_deps_has(&backend, &post));
+
+    // The file grows past the cap on disk, then a watched change arrives.
+    fs::write(&post, padded_past_budget(&small_src)).unwrap();
+    let old_surfaces = backend
+        .salsa
+        .file_class_surfaces(post.clone())
+        .await
+        .unwrap();
+    let mut batch = HashMap::new();
+    batch.insert(
+        post.clone(),
+        PendingWatchedChange {
+            old_surfaces,
+            old_render_views: Vec::new(),
+            deleted: false,
+        },
+    );
+    backend.run_magic_batch_once(batch).await;
+
+    assert!(
+        !magic_deps_has(&backend, &post),
+        "a file that has left the parse budget must have its dependency \
+         contributions purged, not stranded"
+    );
+}

--- a/laravel-lsp/src/tests/watched_files_magic.rs
+++ b/laravel-lsp/src/tests/watched_files_magic.rs
@@ -184,7 +184,7 @@ class AppServiceProvider extends ServiceProvider {
     let provider = write_file(root, "app/Providers/AppServiceProvider.php", provider_v1);
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .unwrap();
     backend
@@ -261,7 +261,7 @@ class AppServiceProvider extends ServiceProvider {
     let provider = write_file(root, "app/Providers/AppServiceProvider.php", provider_v1);
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .unwrap();
     backend
@@ -368,7 +368,7 @@ class AppServiceProvider extends ServiceProvider {
     let provider = write_file(root, "app/Providers/AppServiceProvider.php", provider_src);
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .unwrap();
     backend
@@ -455,7 +455,7 @@ class AppServiceProvider extends ServiceProvider {
     let provider = write_file(root, "app/Providers/AppServiceProvider.php", provider_v1);
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .unwrap();
     backend
@@ -542,7 +542,7 @@ class AppServiceProvider extends ServiceProvider {
     let provider = write_file(root, "app/Providers/AppServiceProvider.php", provider_src);
     backend
         .salsa
-        .register_config_files(root.to_path_buf(), None, None, None)
+        .register_config_files(root.to_path_buf(), None, None, None, None)
         .await
         .unwrap();
     backend

--- a/laravel-lsp/src/vendor_index.rs
+++ b/laravel-lsp/src/vendor_index.rs
@@ -1,0 +1,204 @@
+//! One walk of `<root>/vendor`, shared by every subsystem that used to walk it
+//! for itself (issue #371).
+//!
+//! Five independent `WalkDir` passes over the Composer tree existed, none
+//! sharing results. On this repo's `test-project/` (16,051 vendor `.php`
+//! files) they cost, per startup:
+//!
+//! | Walk | Depth | Pruned | Files walked | Files read |
+//! |---|---|---|---|---|
+//! | `salsa_impl::handle_register_project_files` | unbounded | `.git` | 16,051 | 0 |
+//! | `main::register_service_provider_files_with_salsa` | 10 + 6 | none | 10,374 | 73 |
+//! | `main::rescan_vendor_providers` | 10 + 6 | none | 10,374 | 73 |
+//! | `command_index::build_command_index` | unbounded | `SKIP_DIRS` | 16,202 | 16,202 |
+//! | `route_discovery::discover_route_files` | 8 | none | 15,225 | ~15,219 |
+//!
+//! A bare stat walk of that tree costs ~0.25 s warm; reading all 16,051
+//! contents adds ~0.15 s on top, before any per-file parsing. So both the
+//! duplicated traversals and the ~31,400 duplicated reads were worth removing.
+//!
+//! # How the sharing preserves behaviour exactly
+//!
+//! The walk here is the **union** of all five: unbounded depth, nothing
+//! pruned. Each consumer then re-applies its own former limits as a *path
+//! predicate* over the shared result, so every consumer sees precisely the
+//! file set it saw before. That substitution is only sound because none of
+//! those limits depended on traversal state:
+//!
+//! * Depth is a function of the path alone ([`VendorFile::depth`] counts
+//!   components below `vendor/`, matching `WalkDir`'s convention where the
+//!   walk root is depth 0).
+//! * `WalkDir::filter_entry` pruning of a directory is equivalent, for files,
+//!   to "no ancestor component is named X" — see [`has_pruned_ancestor`].
+//! * Filtering preserves relative order, and [`VendorIndex`] keeps the walk
+//!   order it discovered. That matters because `command_index::insert_entry`
+//!   breaks a same-tier duplicate in favour of the first file walked. Tier is
+//!   itself path-derived (`App` ⟺ not under `vendor/`), so a same-tier
+//!   collision can never span the project/vendor split, and preserving order
+//!   *within* the vendor leg is enough to preserve the winner.
+//!
+//! `route_discovery`'s vendor predicates (`is_under_routes_dir`,
+//! `priority_for_vendor_path`) are likewise path-only, and `promote` merges by
+//! maximum priority rather than by arrival, so it is order-independent too.
+
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+/// One vendor PHP file, with the walk depth that former callers bounded on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VendorFile {
+    /// Absolute path to the file.
+    pub path: PathBuf,
+    /// Components below the `vendor/` directory, so `vendor/a/b.php` is 2.
+    /// Matches `WalkDir::max_depth`, where the walk root itself is depth 0 —
+    /// a caller that used `.max_depth(8)` keeps `depth <= 8`.
+    pub depth: usize,
+}
+
+/// Every `*.php` file under `<root>/vendor`, discovered once.
+///
+/// `*.blade.php` is included: its extension is still `php`, which is exactly
+/// how the former walks admitted it.
+#[derive(Debug, Clone, Default)]
+pub struct VendorIndex {
+    /// The `<root>/vendor` directory this index describes. Empty-pathed when
+    /// the project has no `vendor/` at all.
+    vendor_root: PathBuf,
+    /// Discovered files, in walk order. Order is load-bearing — see the module
+    /// docs on same-tier command duplicates.
+    files: Vec<VendorFile>,
+}
+
+/// True when any directory component of `path` **below `base`** is named in
+/// `pruned`.
+///
+/// This is the path-predicate form of `WalkDir::filter_entry`: pruning a
+/// directory removes that directory and its whole subtree, so a file survives
+/// exactly when none of its ancestors was pruned. Each consumer passes its own
+/// former `filter_entry` list, so there is no copy of anyone's list here to
+/// drift.
+///
+/// Two details the equivalence depends on:
+///
+/// * **`base` is not optional.** A `WalkDir` only ever sees components below
+///   its own root, so components of the absolute prefix must not be considered
+///   — otherwise a project living in `/home/me/public/app` would have its
+///   entire tree "pruned" by a `public` entry it never contained. A `path`
+///   outside `base` is treated as pruned, which fails closed.
+/// * **The file's own name is excluded.** `filter_entry` predicates in this
+///   crate only ever reject directories, so a *file* named `public` was always
+///   kept.
+pub fn has_pruned_ancestor(path: &Path, base: &Path, pruned: &[&str]) -> bool {
+    let Ok(relative) = path.strip_prefix(base) else {
+        return true;
+    };
+    let mut components: Vec<_> = relative.components().collect();
+    components.pop(); // the file name itself is never a pruned directory
+    components
+        .iter()
+        .any(|c| c.as_os_str().to_str().is_some_and(|n| pruned.contains(&n)))
+}
+
+impl VendorIndex {
+    /// Walk `<root>/vendor` once, collecting every `*.php` file.
+    ///
+    /// Unbounded depth and no pruning, deliberately: this is the union of what
+    /// the five former walks each saw, and consumers narrow it themselves.
+    /// A project with no `vendor/` yields an empty index rather than an error —
+    /// every consumer's former code simply skipped the walk in that case.
+    pub fn build(root: &Path) -> Self {
+        let vendor_root = root.join("vendor");
+        if !vendor_root.is_dir() {
+            return Self::default();
+        }
+        let files = WalkDir::new(&vendor_root)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "php"))
+            .map(|e| VendorFile {
+                depth: e.depth(),
+                path: e.path().to_path_buf(),
+            })
+            .collect();
+        Self { vendor_root, files }
+    }
+
+    /// Build an index directly from `(path, depth)` pairs. Test seam only —
+    /// production always goes through [`VendorIndex::build`].
+    pub fn from_files(vendor_root: PathBuf, files: Vec<VendorFile>) -> Self {
+        Self { vendor_root, files }
+    }
+
+    /// The `<root>/vendor` directory, or an empty path when absent.
+    pub fn vendor_root(&self) -> &Path {
+        &self.vendor_root
+    }
+
+    /// True when the project has no `vendor/`, or it holds no PHP at all.
+    /// Consumers use this to keep their former "skip the whole branch" guard.
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    /// Every discovered file, in walk order.
+    pub fn files(&self) -> &[VendorFile] {
+        &self.files
+    }
+
+    /// Files at or below `max_depth`, in walk order — the replacement for a
+    /// former `WalkDir::new(vendor).max_depth(max_depth)`.
+    pub fn within_depth(&self, max_depth: usize) -> impl Iterator<Item = &Path> {
+        self.files
+            .iter()
+            .filter(move |f| f.depth <= max_depth)
+            .map(|f| f.path.as_path())
+    }
+
+    /// Read each file `wants` accepts, at most once, in walk order, and hand
+    /// its text to `visit`.
+    ///
+    /// The point of the two-callback shape: several consumers want overlapping
+    /// but unequal subsets of the tree, and the expensive part is the read, not
+    /// the predicate. `wants` is evaluated first for every file, and a file no
+    /// consumer wants is never opened — so this performs exactly the union of
+    /// its callers' former reads, never more.
+    ///
+    /// Unreadable files are skipped silently, matching every former call site
+    /// (all of them used `if let Ok(content) = read_to_string(..)`).
+    pub fn for_each_source(
+        &self,
+        wants: impl Fn(&VendorFile) -> bool,
+        mut visit: impl FnMut(&VendorFile, &str),
+    ) {
+        for file in &self.files {
+            if !wants(file) {
+                continue;
+            }
+            if let Ok(text) = std::fs::read_to_string(&file.path) {
+                visit(file, &text);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;
+
+/// Components of `path` below `base`, matching `WalkDir::max_depth` for a walk
+/// rooted at `base`. `None` when `path` is not under `base`.
+///
+/// Lets a consumer whose former walk was rooted *inside* `vendor/` — the
+/// service-provider scan's `vendor/laravel/framework/src/Illuminate` leg —
+/// re-apply its depth budget against its own root rather than against
+/// `vendor/`, so the budget does not silently shift with the package layout.
+pub fn depth_below(path: &Path, base: &Path) -> Option<usize> {
+    path.strip_prefix(base)
+        .ok()
+        .map(|rest| rest.components().count())
+}

--- a/laravel-lsp/src/vendor_index/tests.rs
+++ b/laravel-lsp/src/vendor_index/tests.rs
@@ -1,0 +1,462 @@
+//! Tests for the shared vendor walk (issue #371).
+//!
+//! The load-bearing claim of this module is an *equivalence*: every consumer
+//! that used to run its own `WalkDir` now filters a shared result and must see
+//! precisely the same files. So most of these tests compare the shared index,
+//! narrowed by a consumer's former limits, against a live `WalkDir` configured
+//! the way that consumer used to configure it — rather than against a
+//! hand-written expected list, which would only re-state my own assumptions.
+
+use super::*;
+use std::collections::HashSet;
+use std::fs;
+use tempfile::TempDir;
+
+/// A vendor tree with the shapes every consumer's limits key on:
+/// deep nesting (past depth 6 and 8), a package `routes/` dir, a service
+/// provider, an `Http/Kernel.php`, framework-owned files, a `.blade.php`, a
+/// non-PHP file, and subtrees named for each of `command_index`'s pruned dirs.
+fn seed_vendor(root: &Path) {
+    let files = [
+        // depth 2
+        "vendor/autoload.php",
+        // depth 3
+        "vendor/acme/pkg.php",
+        // depth 4-5: provider + kernel shapes
+        "vendor/acme/pkg/AcmeServiceProvider.php",
+        "vendor/acme/pkg/Http/Kernel.php",
+        "vendor/acme/pkg/routes/web.php",
+        // framework tier
+        "vendor/laravel/framework/src/Illuminate/Foo/FooServiceProvider.php",
+        // depth 7 — inside the route walk's depth 8 budget
+        "vendor/acme/pkg/src/a/b/Deep.php",
+        // depth 9 — outside it, inside the command walk's unbounded one
+        "vendor/acme/pkg/src/a/b/c/d/Deeper.php",
+        // pruned subtrees (command_index skips these, others do not)
+        "vendor/acme/pkg/node_modules/Bundled.php",
+        "vendor/acme/pkg/public/Asset.php",
+        "vendor/acme/pkg/storage/Cached.php",
+        "vendor/acme/pkg/.git/Hook.php",
+        // a blade template and a non-PHP file
+        "vendor/acme/pkg/views/card.blade.php",
+        "vendor/acme/pkg/README.md",
+    ];
+    for rel in files {
+        let p = root.join(rel);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, "<?php\n").unwrap();
+    }
+}
+
+fn paths(index: &VendorIndex) -> HashSet<PathBuf> {
+    index.files().iter().map(|f| f.path.clone()).collect()
+}
+
+/// What a `WalkDir` configured the old way would have found, as a set.
+fn walk_like_consumer(
+    dir: &Path,
+    max_depth: Option<usize>,
+    pruned: &'static [&'static str],
+) -> HashSet<PathBuf> {
+    let mut w = WalkDir::new(dir);
+    if let Some(d) = max_depth {
+        w = w.max_depth(d);
+    }
+    w.into_iter()
+        .filter_entry(|e| {
+            !(e.file_type().is_dir() && e.file_name().to_str().is_some_and(|n| pruned.contains(&n)))
+        })
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "php"))
+        .map(|e| e.path().to_path_buf())
+        .collect()
+}
+
+#[test]
+fn build_collects_every_php_file_including_blade_and_excluding_others() {
+    let tmp = TempDir::new().unwrap();
+    seed_vendor(tmp.path());
+    let index = VendorIndex::build(tmp.path());
+    let found = paths(&index);
+
+    assert!(
+        found.contains(&tmp.path().join("vendor/acme/pkg/views/card.blade.php")),
+        "`.blade.php` has extension `php` and was admitted by every former \
+         walk, so it must be here too"
+    );
+    assert!(
+        !found.contains(&tmp.path().join("vendor/acme/pkg/README.md")),
+        "non-PHP files were never collected"
+    );
+    assert!(
+        found.contains(&tmp.path().join("vendor/acme/pkg/node_modules/Bundled.php")),
+        "the shared walk prunes NOTHING — it is the union of all five former \
+         walks, and the route/provider walks descended into node_modules"
+    );
+}
+
+#[test]
+fn build_yields_an_empty_index_without_a_vendor_dir() {
+    // Every former consumer guarded its walk with an `exists()`/`is_dir()`
+    // check and skipped the whole branch. `is_empty()` is how they keep it.
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("app")).unwrap();
+    let index = VendorIndex::build(tmp.path());
+
+    assert!(index.is_empty(), "no vendor/ means nothing to share");
+    assert_eq!(index.len(), 0);
+    assert_eq!(
+        index.vendor_root(),
+        Path::new(""),
+        "an absent vendor/ reports no root rather than a path that does not exist"
+    );
+}
+
+#[test]
+fn depth_matches_walkdir_max_depth_semantics() {
+    // The whole per-consumer narrowing rests on this: `depth` must mean what
+    // `WalkDir::max_depth` meant, or every restored bound is off by one.
+    let tmp = TempDir::new().unwrap();
+    seed_vendor(tmp.path());
+    let index = VendorIndex::build(tmp.path());
+
+    let depth_of = |rel: &str| {
+        index
+            .files()
+            .iter()
+            .find(|f| f.path == tmp.path().join(rel))
+            .unwrap_or_else(|| panic!("{rel} not indexed"))
+            .depth
+    };
+
+    // `vendor` is the walk root at depth 0, so its direct children are 1.
+    assert_eq!(depth_of("vendor/autoload.php"), 1);
+    assert_eq!(depth_of("vendor/acme/pkg.php"), 2);
+    assert_eq!(depth_of("vendor/acme/pkg/src/a/b/Deep.php"), 6);
+    assert_eq!(depth_of("vendor/acme/pkg/src/a/b/c/d/Deeper.php"), 8);
+}
+
+#[test]
+fn within_depth_reproduces_the_route_walks_file_set() {
+    // `discover_route_files` used `WalkDir::new(vendor).max_depth(8)` with no
+    // pruning. Narrowing the shared index must give the identical set.
+    let tmp = TempDir::new().unwrap();
+    seed_vendor(tmp.path());
+    let index = VendorIndex::build(tmp.path());
+
+    let shared: HashSet<PathBuf> = index.within_depth(8).map(|p| p.to_path_buf()).collect();
+    let live = walk_like_consumer(&tmp.path().join("vendor"), Some(8), &[]);
+
+    assert_eq!(
+        shared, live,
+        "depth-8 narrowing must equal a live max_depth(8) walk"
+    );
+}
+
+#[test]
+fn within_depth_excludes_what_the_bound_excludes() {
+    // Discriminates the equality above: if `within_depth` ignored its argument
+    // and returned everything, the comparison would still need this to fail.
+    let tmp = TempDir::new().unwrap();
+    seed_vendor(tmp.path());
+    let index = VendorIndex::build(tmp.path());
+
+    let shallow: HashSet<PathBuf> = index.within_depth(6).map(|p| p.to_path_buf()).collect();
+
+    assert!(
+        shallow.contains(&tmp.path().join("vendor/acme/pkg/src/a/b/Deep.php")),
+        "depth 6 is inside a max_depth(6) budget"
+    );
+    assert!(
+        !shallow.contains(&tmp.path().join("vendor/acme/pkg/src/a/b/c/d/Deeper.php")),
+        "depth 8 is outside it — the bound must actually bind"
+    );
+    assert!(
+        index.within_depth(usize::MAX).count() > shallow.len(),
+        "an unbounded narrowing must return strictly more than a depth-6 one"
+    );
+}
+
+#[test]
+fn pruned_ancestor_predicate_reproduces_filter_entry_pruning() {
+    // `build_command_index` pruned SKIP_DIRS with `filter_entry`. Replacing a
+    // subtree prune with an ancestor-name test is only valid if the two agree
+    // on every file — including files deep inside a pruned subtree.
+    let tmp = TempDir::new().unwrap();
+    seed_vendor(tmp.path());
+    let index = VendorIndex::build(tmp.path());
+
+    let shared: HashSet<PathBuf> = index
+        .files()
+        .iter()
+        .filter(|f| {
+            !has_pruned_ancestor(
+                &f.path,
+                index.vendor_root(),
+                crate::command_index::SKIP_DIRS,
+            )
+        })
+        .map(|f| f.path.clone())
+        .collect();
+    let live = walk_like_consumer(
+        &tmp.path().join("vendor"),
+        None,
+        crate::command_index::SKIP_DIRS,
+    );
+
+    assert_eq!(
+        shared, live,
+        "ancestor-name filtering must equal live filter_entry pruning"
+    );
+    assert!(
+        !shared.contains(&tmp.path().join("vendor/acme/pkg/node_modules/Bundled.php")),
+        "fixture check — the comparison is worthless if nothing was pruned"
+    );
+}
+
+#[test]
+fn pruned_ancestor_ignores_the_files_own_name() {
+    // `filter_entry` in this crate only ever rejects directories, so a FILE
+    // named `public` was always kept. An ancestor test that looked at the whole
+    // path would wrongly drop it.
+    let base = Path::new("/p/vendor");
+    assert!(
+        !has_pruned_ancestor(Path::new("/p/vendor/acme/public"), base, &["public"]),
+        "a file named `public` is not inside a pruned directory"
+    );
+    assert!(
+        has_pruned_ancestor(Path::new("/p/vendor/acme/public/x.php"), base, &["public"]),
+        "a file inside `public/` is"
+    );
+    assert!(
+        has_pruned_ancestor(
+            Path::new("/p/vendor/public/deep/nested/x.php"),
+            base,
+            &["public"]
+        ),
+        "pruning removes the whole subtree, not just direct children"
+    );
+    assert!(
+        !has_pruned_ancestor(Path::new("/p/vendor/acme/x.php"), base, &["public"]),
+        "an unrelated path is untouched"
+    );
+}
+
+#[test]
+fn pruned_ancestor_ignores_components_above_the_base() {
+    // A `WalkDir` only ever sees components below its own root, so the
+    // predicate must too. Before this was scoped, a project checked out under
+    // a directory that happened to be called `public` — or `storage`, or
+    // `node_modules` — had its ENTIRE vendor tree classified as pruned, and
+    // the command index would have silently indexed nothing from it.
+    let base = Path::new("/home/me/public/app/vendor");
+    assert!(
+        !has_pruned_ancestor(
+            Path::new("/home/me/public/app/vendor/acme/Cmd.php"),
+            base,
+            crate::command_index::SKIP_DIRS
+        ),
+        "a `public` ancestor ABOVE the walk root was never visible to WalkDir"
+    );
+    assert!(
+        has_pruned_ancestor(
+            Path::new("/home/me/public/app/vendor/acme/public/Cmd.php"),
+            base,
+            crate::command_index::SKIP_DIRS
+        ),
+        "a `public` directory BELOW the walk root still prunes"
+    );
+}
+
+#[test]
+fn pruned_ancestor_fails_closed_outside_the_base() {
+    // A path that is not under `base` cannot be described by a walk rooted at
+    // `base`. Reporting it as pruned keeps a caller from silently indexing
+    // something the shared walk never covered.
+    assert!(
+        has_pruned_ancestor(
+            Path::new("/somewhere/else/x.php"),
+            Path::new("/p/vendor"),
+            &["public"]
+        ),
+        "an out-of-base path is treated as pruned"
+    );
+}
+
+#[test]
+fn walk_order_is_preserved() {
+    // `command_index::insert_entry` keeps the FIRST file walked on a same-tier
+    // duplicate, so a consumer replaying the shared list must see vendor files
+    // in the order a `WalkDir` produced them.
+    let tmp = TempDir::new().unwrap();
+    seed_vendor(tmp.path());
+    let index = VendorIndex::build(tmp.path());
+
+    let live: Vec<PathBuf> = WalkDir::new(tmp.path().join("vendor"))
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "php"))
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    let shared: Vec<PathBuf> = index.files().iter().map(|f| f.path.clone()).collect();
+
+    assert_eq!(shared, live, "the index must keep walk order, not sort");
+    assert!(
+        shared.len() > 1,
+        "fixture check — order needs >1 file to mean anything"
+    );
+}
+
+#[test]
+fn for_each_source_reads_only_what_a_consumer_wants() {
+    // The read budget claim: a file no consumer wants is never opened. Counted
+    // via the `wants` predicate, which is called for every file, against the
+    // `visit` callback, which fires only after a successful read.
+    let tmp = TempDir::new().unwrap();
+    seed_vendor(tmp.path());
+    let index = VendorIndex::build(tmp.path());
+
+    // `wants` is an `Fn`, deliberately — a predicate with side effects would
+    // make the read budget unauditable. `Cell` is how a test counts calls
+    // through one without needing `FnMut`.
+    let considered = std::cell::Cell::new(0usize);
+    let mut read = Vec::new();
+    index.for_each_source(
+        |f| {
+            considered.set(considered.get() + 1);
+            f.depth <= 2
+        },
+        |f, text| {
+            read.push(f.path.clone());
+            assert_eq!(text, "<?php\n", "the visitor receives the file's text");
+        },
+    );
+
+    assert_eq!(
+        considered.get(),
+        index.len(),
+        "every file is offered to the predicate"
+    );
+    assert_eq!(
+        read.into_iter().collect::<HashSet<_>>(),
+        index.within_depth(2).map(|p| p.to_path_buf()).collect(),
+        "exactly the wanted files were read — no more, no fewer"
+    );
+}
+
+#[test]
+fn for_each_source_reads_a_file_shared_by_two_consumers_once() {
+    // The reason this method exists: two consumers with overlapping subsets
+    // must cost one read, not two.
+    let tmp = TempDir::new().unwrap();
+    seed_vendor(tmp.path());
+    let index = VendorIndex::build(tmp.path());
+
+    // Consumer A wants depth <= 8; consumer B wants everything unpruned. Most
+    // files satisfy both.
+    let wants_a = |f: &VendorFile| f.depth <= 8;
+    let wants_b = |f: &VendorFile| {
+        !has_pruned_ancestor(
+            &f.path,
+            index.vendor_root(),
+            crate::command_index::SKIP_DIRS,
+        )
+    };
+
+    let mut reads = 0usize;
+    let mut seen_a = 0usize;
+    let mut seen_b = 0usize;
+    index.for_each_source(
+        |f| wants_a(f) || wants_b(f),
+        |f, _| {
+            reads += 1;
+            if wants_a(f) {
+                seen_a += 1;
+            }
+            if wants_b(f) {
+                seen_b += 1;
+            }
+        },
+    );
+
+    let overlap = index
+        .files()
+        .iter()
+        .filter(|f| wants_a(f) && wants_b(f))
+        .count();
+    assert!(
+        overlap > 0,
+        "fixture check — the consumers must actually overlap"
+    );
+    assert!(
+        reads < seen_a + seen_b,
+        "sharing must cost fewer reads ({reads}) than the two consumers \
+         separately ({seen_a} + {seen_b})"
+    );
+    assert_eq!(
+        reads,
+        index
+            .files()
+            .iter()
+            .filter(|f| wants_a(f) || wants_b(f))
+            .count(),
+        "reads equal the union of the two consumers' sets"
+    );
+}
+
+#[test]
+fn for_each_source_skips_an_unreadable_file_without_failing() {
+    // Every former call site used `if let Ok(content) = read_to_string(..)`, so
+    // a directory-shaped or vanished entry was skipped, not fatal. A path in
+    // the index that no longer exists on disk is the reachable version of that.
+    let tmp = TempDir::new().unwrap();
+    let vendor = tmp.path().join("vendor");
+    fs::create_dir_all(&vendor).unwrap();
+    fs::write(vendor.join("real.php"), "<?php\n").unwrap();
+
+    let index = VendorIndex::from_files(
+        vendor.clone(),
+        vec![
+            VendorFile {
+                path: vendor.join("gone.php"),
+                depth: 1,
+            },
+            VendorFile {
+                path: vendor.join("real.php"),
+                depth: 1,
+            },
+        ],
+    );
+
+    let mut visited = Vec::new();
+    index.for_each_source(|_| true, |f, _| visited.push(f.path.clone()));
+
+    assert_eq!(
+        visited,
+        vec![vendor.join("real.php")],
+        "the missing file is skipped and the walk continues past it"
+    );
+}
+
+#[test]
+fn depth_below_matches_a_walk_rooted_at_the_base() {
+    // The provider scan's framework leg used `WalkDir::new(<framework>)
+    // .max_depth(10)`, so its budget counts from the framework directory, not
+    // from `vendor/`. Measuring against the wrong base would move the cutoff
+    // by however deep the framework happens to sit.
+    let base = Path::new("/p/vendor/laravel/framework/src/Illuminate");
+    assert_eq!(depth_below(&base.join("Foo.php"), base), Some(1));
+    assert_eq!(depth_below(&base.join("Foo/Bar/Baz.php"), base), Some(3));
+    assert_eq!(
+        depth_below(base, base),
+        Some(0),
+        "the base itself is depth 0"
+    );
+    assert_eq!(
+        depth_below(Path::new("/p/vendor/acme/Foo.php"), base),
+        None,
+        "a path outside the base has no depth in that walk"
+    );
+}

--- a/laravel-lsp/src/vendor_scan.rs
+++ b/laravel-lsp/src/vendor_scan.rs
@@ -13,10 +13,12 @@
 //! layering acyclic: `vendor_index` is a leaf, `route_discovery` and
 //! `command_index` depend on it, and only this module depends on all three.
 
-use std::path::Path;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
+use crate::command_disk_cache::CommandScanCache;
 use crate::command_index::{
-    index_command_file, index_project_commands, vendor_command_needs_source, CommandIndex,
+    consider_project_commands, record_source, try_cached, vendor_command_needs_source, CommandScan,
 };
 use crate::route_discovery::{
     accept_vendor_route_source, collect_conventional_vendor_route_files,
@@ -38,23 +40,39 @@ use crate::vendor_index::VendorIndex;
 pub fn build_route_files_and_command_index(
     root: &Path,
     vendor: &VendorIndex,
-) -> (Vec<RouteFile>, CommandIndex) {
+    command_cache: Option<&CommandScanCache>,
+) -> (Vec<RouteFile>, CommandScan) {
     let mut routes = RouteFileSet::default();
-    let mut commands = CommandIndex::default();
+    let mut commands = CommandScan::default();
 
     collect_project_route_files(root, &mut routes);
     collect_conventional_vendor_route_files(vendor, &mut routes);
-    index_project_commands(root, &mut commands);
+    consider_project_commands(root, command_cache, &mut commands);
 
     let vendor_root = vendor.vendor_root().to_path_buf();
+
+    // Pre-pass: settle the command side from the scan cache wherever it can be
+    // settled, so the read pass below knows which files still have to be
+    // opened for it. Costs one `metadata` per command-wanted file, which the
+    // verdict check needs anyway, and saves the read for the overwhelming
+    // majority whose mtime has not moved (issue #371).
+    let mut command_needs_read: HashSet<PathBuf> = HashSet::new();
+    for file in vendor.files() {
+        if vendor_command_needs_source(&vendor_root, file)
+            && !try_cached(&mut commands, command_cache, &file.path)
+        {
+            command_needs_read.insert(file.path.clone());
+        }
+    }
+
     vendor.for_each_source(
-        |file| vendor_route_needs_source(file) || vendor_command_needs_source(&vendor_root, file),
+        |file| vendor_route_needs_source(file) || command_needs_read.contains(&file.path),
         |file, content| {
             if vendor_route_needs_source(file) {
                 accept_vendor_route_source(&mut routes, &file.path, content);
             }
-            if vendor_command_needs_source(&vendor_root, file) {
-                index_command_file(&mut commands, &file.path, content);
+            if command_needs_read.contains(&file.path) {
+                record_source(&mut commands, &file.path, content);
             }
         },
     );

--- a/laravel-lsp/src/vendor_scan.rs
+++ b/laravel-lsp/src/vendor_scan.rs
@@ -1,0 +1,66 @@
+//! Warm-start composition: build the route-file list and the command index
+//! from **one** pass over the vendor tree (issue #371).
+//!
+//! [`crate::route_discovery::discover_route_files_with_vendor`] and
+//! [`crate::command_index::build_command_index_with_vendor`] each share the
+//! *walk* via [`VendorIndex`], but calling them in sequence still reads every
+//! vendor file twice — ~31,400 reads on this repo's `test-project/`, where a
+//! single pass costs ~16,200. This module is the one place that knows both
+//! consumers, so it can offer each file's text to both classifiers while it is
+//! in hand.
+//!
+//! It lives in its own module rather than inside either consumer to keep the
+//! layering acyclic: `vendor_index` is a leaf, `route_discovery` and
+//! `command_index` depend on it, and only this module depends on all three.
+
+use std::path::Path;
+
+use crate::command_index::{
+    index_command_file, index_project_commands, vendor_command_needs_source, CommandIndex,
+};
+use crate::route_discovery::{
+    accept_vendor_route_source, collect_conventional_vendor_route_files,
+    collect_project_route_files, vendor_route_needs_source, RouteFile, RouteFileSet,
+};
+use crate::vendor_index::VendorIndex;
+
+/// Build both vendor-derived indexes, reading each vendor file at most once.
+///
+/// Output is identical to calling
+/// [`crate::route_discovery::discover_route_files_with_vendor`] and
+/// [`crate::command_index::build_command_index_with_vendor`] separately —
+/// each consumer applies its own predicates to the same shared walk, and
+/// neither classifier can observe the other. Only the read count differs.
+///
+/// The non-vendor legs run first, exactly as each consumer runs them, so the
+/// project/vendor ordering the command index's same-tier tie-break depends on
+/// is preserved.
+pub fn build_route_files_and_command_index(
+    root: &Path,
+    vendor: &VendorIndex,
+) -> (Vec<RouteFile>, CommandIndex) {
+    let mut routes = RouteFileSet::default();
+    let mut commands = CommandIndex::default();
+
+    collect_project_route_files(root, &mut routes);
+    collect_conventional_vendor_route_files(vendor, &mut routes);
+    index_project_commands(root, &mut commands);
+
+    let vendor_root = vendor.vendor_root().to_path_buf();
+    vendor.for_each_source(
+        |file| vendor_route_needs_source(file) || vendor_command_needs_source(&vendor_root, file),
+        |file, content| {
+            if vendor_route_needs_source(file) {
+                accept_vendor_route_source(&mut routes, &file.path, content);
+            }
+            if vendor_command_needs_source(&vendor_root, file) {
+                index_command_file(&mut commands, &file.path, content);
+            }
+        },
+    );
+
+    (routes.into_files(), commands)
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/vendor_scan/tests.rs
+++ b/laravel-lsp/src/vendor_scan/tests.rs
@@ -1,0 +1,201 @@
+//! Tests for the combined warm-start pass (issue #371).
+//!
+//! Two claims to pin, and they pull in opposite directions — which is why both
+//! are needed:
+//!
+//! 1. **Identical output.** Sharing the read must not change either index.
+//! 2. **Fewer reads.** If it did not, the module would be pure overhead.
+
+use super::*;
+use crate::command_index::{build_command_index_with_vendor, CommandPriority};
+use crate::route_discovery::discover_route_files_with_vendor;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+/// A project where the route and command classifiers both have real work, and
+/// where their wanted file sets overlap but do not coincide: a vendor command
+/// past the route depth budget, a route file inside `node_modules` (which the
+/// command leg prunes), and a file that is neither.
+fn seed(root: &Path) {
+    let route_src = "<?php\nRoute::get('/x', fn () => 'ok')->name('x');\n";
+    // Each command gets a DISTINCT signature. Reusing one name would let the
+    // App-tier declaration win the priority merge and silently erase every
+    // vendor command this test is about.
+    let cmd_src = |class: &str, sig: &str| {
+        format!(
+            "<?php\nuse Illuminate\\Console\\Command;\nclass {class} extends Command\n{{\n    protected $signature = '{sig}';\n}}\n"
+        )
+    };
+    // One file both classifiers accept: route registration AND a command class
+    // in the same PHP block, so a single read has to serve both.
+    let both = "<?php\nuse Illuminate\\Console\\Command;\nRoute::get('/b', fn () => 'ok')->name('b');\nclass Both extends Command\n{\n    protected $signature = 'both:cmd';\n}\n";
+    let write = |rel: &str, body: &str| {
+        let p = root.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, body).unwrap();
+    };
+    write("routes/web.php", route_src);
+    write(
+        "app/Console/Commands/App.php",
+        &cmd_src("AppCmd", "app:cmd"),
+    );
+    write("vendor/acme/pkg/routes/web.php", route_src);
+    write("vendor/acme/pkg/src/Provider.php", route_src);
+    write("vendor/acme/pkg/src/Both.php", both);
+    write("vendor/acme/pkg/src/Neither.php", "<?php\nclass N {}\n");
+    // Past the route depth budget (8), still inside the command leg.
+    write(
+        "vendor/acme/pkg/a/b/c/d/e/f/Deep.php",
+        &cmd_src("DeepCmd", "deep:cmd"),
+    );
+    // Pruned by the command leg, still visible to the route leg.
+    write("vendor/acme/pkg/node_modules/Bundled.php", route_src);
+}
+
+fn route_pairs(files: &[RouteFile]) -> Vec<(PathBuf, u8)> {
+    let mut v: Vec<_> = files.iter().map(|f| (f.path.clone(), f.priority)).collect();
+    v.sort();
+    v
+}
+
+fn command_pairs(index: &CommandIndex) -> Vec<(String, PathBuf, CommandPriority)> {
+    let mut v: Vec<_> = index
+        .entries()
+        .map(|e| (e.name.clone(), e.file.clone(), e.priority))
+        .collect();
+    v.sort();
+    v
+}
+
+#[test]
+fn combined_pass_produces_the_same_two_indexes_as_building_them_separately() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(root);
+    let vendor = VendorIndex::build(root);
+
+    let (routes, commands) = build_route_files_and_command_index(root, &vendor);
+    let routes_alone = discover_route_files_with_vendor(root, &vendor);
+    let commands_alone = build_command_index_with_vendor(root, &vendor);
+
+    assert_eq!(
+        route_pairs(&routes),
+        route_pairs(&routes_alone),
+        "sharing the read must not change route discovery"
+    );
+    assert_eq!(
+        command_pairs(&commands),
+        command_pairs(&commands_alone),
+        "sharing the read must not change the command index"
+    );
+
+    // Fixture checks — the equalities are worthless on an inert project.
+    assert!(
+        routes
+            .iter()
+            .any(|f| f.path == root.join("vendor/acme/pkg/src/Both.php")),
+        "the shared file must reach the route classifier"
+    );
+    assert!(
+        commands
+            .entries()
+            .any(|e| e.file == root.join("vendor/acme/pkg/src/Both.php")),
+        "and the same text must reach the command classifier"
+    );
+    assert!(
+        !routes
+            .iter()
+            .any(|f| f.path == root.join("vendor/acme/pkg/src/Neither.php")),
+        "a file neither classifier accepts stays out of both"
+    );
+}
+
+#[test]
+fn combined_pass_keeps_each_consumers_own_limits() {
+    // The two consumers disagree about two files by construction. If the
+    // combined pass applied one consumer's predicate to both — the easy bug —
+    // one of these assertions fails.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(root);
+    let vendor = VendorIndex::build(root);
+
+    let (routes, commands) = build_route_files_and_command_index(root, &vendor);
+
+    assert!(
+        commands
+            .entries()
+            .any(|e| e.file == root.join("vendor/acme/pkg/a/b/c/d/e/f/Deep.php")),
+        "the command leg has no depth budget and must still see a deep file"
+    );
+    assert!(
+        !routes
+            .iter()
+            .any(|f| f.path == root.join("vendor/acme/pkg/a/b/c/d/e/f/Deep.php")),
+        "the route leg's depth-8 budget must still bind in the shared pass"
+    );
+    assert!(
+        routes
+            .iter()
+            .any(|f| f.path == root.join("vendor/acme/pkg/node_modules/Bundled.php")),
+        "route discovery never pruned node_modules"
+    );
+    assert!(
+        !commands
+            .entries()
+            .any(|e| e.file == root.join("vendor/acme/pkg/node_modules/Bundled.php")),
+        "the command leg still prunes it"
+    );
+}
+
+#[test]
+fn combined_pass_reads_each_vendor_file_once() {
+    // The reason the module exists. Counted by instrumenting `for_each_source`
+    // with the same predicates the production pass uses, then comparing against
+    // what the two consumers ask for separately.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed(root);
+    let vendor = VendorIndex::build(root);
+    let vendor_root = vendor.vendor_root().to_path_buf();
+
+    let route_wants = vendor
+        .files()
+        .iter()
+        .filter(|f| crate::route_discovery::vendor_route_needs_source(f))
+        .count();
+    let command_wants = vendor
+        .files()
+        .iter()
+        .filter(|f| crate::command_index::vendor_command_needs_source(&vendor_root, f))
+        .count();
+
+    let mut shared_reads = 0usize;
+    vendor.for_each_source(
+        |file| {
+            crate::route_discovery::vendor_route_needs_source(file)
+                || crate::command_index::vendor_command_needs_source(&vendor_root, file)
+        },
+        |_, _| shared_reads += 1,
+    );
+
+    assert!(
+        route_wants > 0 && command_wants > 0,
+        "fixture check — both consumers must want something ({route_wants}, {command_wants})"
+    );
+    assert!(
+        shared_reads < route_wants + command_wants,
+        "one shared pass ({shared_reads}) must cost fewer reads than two \
+         separate ones ({route_wants} + {command_wants})"
+    );
+    assert_eq!(
+        shared_reads,
+        vendor
+            .files()
+            .iter()
+            .filter(|f| crate::route_discovery::vendor_route_needs_source(f)
+                || crate::command_index::vendor_command_needs_source(&vendor_root, f))
+            .count(),
+        "and exactly the union of what they want — never a file neither asked for"
+    );
+}

--- a/laravel-lsp/src/vendor_scan/tests.rs
+++ b/laravel-lsp/src/vendor_scan/tests.rs
@@ -7,7 +7,7 @@
 //! 2. **Fewer reads.** If it did not, the module would be pure overhead.
 
 use super::*;
-use crate::command_index::{build_command_index_with_vendor, CommandPriority};
+use crate::command_index::{build_command_index_with_vendor, CommandIndex, CommandPriority};
 use crate::route_discovery::discover_route_files_with_vendor;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -74,7 +74,8 @@ fn combined_pass_produces_the_same_two_indexes_as_building_them_separately() {
     seed(root);
     let vendor = VendorIndex::build(root);
 
-    let (routes, commands) = build_route_files_and_command_index(root, &vendor);
+    let (routes, commands) = build_route_files_and_command_index(root, &vendor, None);
+    let commands = commands.index;
     let routes_alone = discover_route_files_with_vendor(root, &vendor);
     let commands_alone = build_command_index_with_vendor(root, &vendor);
 
@@ -120,7 +121,8 @@ fn combined_pass_keeps_each_consumers_own_limits() {
     seed(root);
     let vendor = VendorIndex::build(root);
 
-    let (routes, commands) = build_route_files_and_command_index(root, &vendor);
+    let (routes, commands) = build_route_files_and_command_index(root, &vendor, None);
+    let commands = commands.index;
 
     assert!(
         commands


### PR DESCRIPTION
Closes #80. Closes #371.

The reported symptom was the language server pegging 100% of one CPU core, with laptops overheating. Profiling found one dominant cause, and the review that followed found four more project-scale costs plus an unrelated correctness bug.

## The root cause

`textDocument/documentSymbol` on any file classified as a routes file walked the **entire `vendor/` tree** and read every PHP file in it — on every request, uncached. In this repository's `test-project/` that is 16,051 file reads per request.

The expensive call also ran *before* the check that decided whether its result was needed, so for almost every project the answer was computed and then discarded one line later.

Zed re-requests document symbols after every buffer change to drive the outline and breadcrumbs. So editing a routes file asked for a 16,000-file disk scan roughly once a second.

Note that #80's original acceptance criteria described save-path incrementality, which had already shipped in #82 back in June. That work was done and was not the problem. The issue stayed open against a solved cause while the real one went unexamined.

## Measurements

Apple M1 Ultra, macOS 27.0, release builds, `test-project/` (16,051 vendor PHP files). Disk cache cleared before each run. `origin/main` `6b15282` versus this branch.

**`textDocument/documentSymbol` on `routes/web.php`**, milliseconds:

| | first | 5 repeats |
|---|---|---|
| before | 592.89 | 501.64, 554.92, 486.68, 487.79, 487.58 |
| after | 5.04 | 0.98, 0.77, 0.70, 0.76, 0.75 |

Median warm repeat **495 ms to 0.76 ms, about 650x**. No repeat was ever cheaper than the first before the fix, because there was no cache — every request re-read the tree.

Control, same request in the same sessions, on `app/Models/User.php`: 0.06-0.14 ms before, 0.23-0.57 ms after. Both sub-millisecond in every sample; the difference is noise at that scale. The point is that the routes file joined the same order of magnitude as every other PHP file.

**`textDocument/completion` per keystroke**, median of 7 repeats:

| context | before | after |
|---|---|---|
| `<x-` (628 items) | 21.35 ms | 4.09 ms |
| `<flux:` (460 items) | 15.15 ms | 3.21 ms |

**Startup**, time until both vendor-derived indexes are built:

| | cold cache | warm cache |
|---|---|---|
| before | 2.50 s | 1.72 s, 1.82 s |
| after | 1.86 s | 1.19 s, 1.35 s |

One cold run each, so treat the cold figure as indicative. The command index also stopped trailing the route index by about 0.6 s, because both now come out of the same pass.

## What changed

| Commit | |
|---|---|
| `9d4feda` | Route-prefix questions answered from the warm index instead of a vendor walk. Four call sites: `document_symbol`, `collect_declaration_locations`, `classify_with_decl_fallback`, `decl_range_at` |
| `6af59ca` | One shared vendor walk replacing four independent ones; provider scans moved off the Tokio worker thread |
| `caf6dd6` | Component-completion cache, watcher-invalidated with a short TTL as a backstop |
| `0e6eba1` | Parse budget applied to the watched-file magic batch, matching the startup path |
| `6e2876a` | Per-file mtime skip for the Artisan command scan |
| `60e15cb` | Removed the class-hierarchy index's write-only dirty set |
| `d77b527` | Livewire detection reads `composer.lock`, so transitive installs are seen |

### Two fixes that are not performance

**A nondeterminism in find-references and rename.** `compute_effective_prefixes` iterated a `HashMap`, so a route file reachable under two external prefixes got its prefixes in hasher-seed order — differing between two calls in a single process. `classify_with_decl_fallback` takes the first non-empty prefix, so find-references and rename could anchor to different symbols on an unedited project. Found by an equivalence test written to prove the performance change was behaviour-preserving. Fixed at the source by sorting.

**Livewire features silently disabled on most Livewire projects.** Detection string-matched `composer.json` for `"livewire/livewire"`, so any project acquiring Livewire transitively — through Flux, Volt, Filament, Jetstream, or an official starter kit — was treated as not having Livewire at all. Both `<livewire:` completion and the Livewire file watcher were dead. Verified on this repository's own `test-project/`, which is `laravel/livewire-starter-kit`: `<livewire:` returned 0 items, and returns 1 after the fix. Detection now reads `composer.lock` and stays exact-name, so `livewire/flux` alone does not satisfy it.

Go-to-definition was checked and is *not* affected — it resolves through a path that never consults the flag. That is covered by a test driving resolution with the flag deliberately false, rather than left as an assumption.

## Verification

3,752 tests passing. `cargo fmt --check` and `cargo clippy --all-targets` clean.

Every behaviour claim has a test, and every assertion was mutation-verified: its target was reverted and the test confirmed to fail. That includes reverting each of the four route-prefix call sites individually, and forcing Livewire detection both always-false and always-true to confirm the negative cases discriminate.

## Not included

Parallelism is deliberately out of scope and tracked separately in #373. The work here removes redundant work; #373 covers distributing the work that legitimately remains, starting with the fact that tree-sitter parsing on the watched-file path happens inside the single Salsa actor thread.

One known limitation, pre-existing and unchanged: `composer.lock` is not in the file-watcher globs, so a mid-session `composer install` does not refresh Livewire detection until the config cache is invalidated by another route. The defect fixed here is the permanent one that persists from startup.