### PR TITLE
perf: use idle cores — remove the parse serialization point, then parallelize the vendor pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,29 @@ jobs:
       - name: cargo test
         run: cargo test --all-features
 
+      - name: Perf measurement (issue #373)
+        # OUTPUT ONLY — this step is a debugging aid, not a gate. The bench
+        # asserts nothing about timings, so it can only fail on a genuine
+        # panic; a runner without a vendor/ tree prints a skip notice and
+        # exits 0. Read the numbers in the log, do not tune anything to them.
+        #
+        # It runs here, in the matrix, because this is the only place the
+        # project has Windows and Linux hardware, and the vendor pass's
+        # read-vs-CPU split is exactly what varies by platform: macOS pays far
+        # more per-file syscall overhead than Linux, and the Windows runner's
+        # filesystem is a third shape again. A parallelization decision made on
+        # one platform's ratio would be a guess on the other two.
+        #
+        # `--bench vendor_parallelism` builds only this target, not the two
+        # synthetic benches, which need no real project and gain nothing from
+        # running per-PR.
+        env:
+          # Trimmed from the local default (250,1000,4000) so a slow Windows
+          # runner does not spend a minute on the largest batch. The per-file
+          # column is what makes two runs comparable, and 250/1000 give it.
+          PARSE_BENCH_BATCHES: 250,1000
+        run: cargo bench --bench vendor_parallelism
+
   extension:
     name: Extension — wasm check, fmt, clippy
     runs-on: ubuntu-latest

--- a/laravel-lsp/Cargo.toml
+++ b/laravel-lsp/Cargo.toml
@@ -122,6 +122,16 @@ harness = false
 name = "magic_members"
 harness = false
 
+# Step-0 measurement for issue #373 — splits the shared vendor pass into walk /
+# stat / read / classify so the parallelizable fraction is measured rather than
+# assumed, and times the single-threaded Salsa parse funnel a dependency change
+# drives. Unlike the two benches above it needs a REAL `vendor/` tree (it skips
+# cleanly without one). Same custom timing harness; run with
+# `cargo bench --bench vendor_parallelism`.
+[[bench]]
+name = "vendor_parallelism"
+harness = false
+
 [profile.release]
 lto = true
 opt-level = 3

--- a/laravel-lsp/benches/vendor_parallelism.rs
+++ b/laravel-lsp/benches/vendor_parallelism.rs
@@ -1,0 +1,486 @@
+//! Step-0 measurement bench for issue #373 — where the remaining warm-start
+//! and dependency-change time actually goes, before anything is parallelized.
+//!
+//! #373 names two paths as the only ones with room left, and asks for both to
+//! be timed **in isolation** before an implementation is written, because this
+//! project has twice guessed the wrong target from architecture and been
+//! corrected by measurement. This bench is that measurement.
+//!
+//! # What it measures
+//!
+//! 1. **The shared vendor pass** —
+//!    [`laravel_lsp::vendor_scan::build_route_files_and_command_index`], broken
+//!    into its four stages so the parallelizable fraction is visible rather
+//!    than inferred:
+//!
+//!    | Stage | Work | Parallelizes? |
+//!    |---|---|---|
+//!    | walk | [`VendorIndex::build`] — one directory traversal | no (single walk) |
+//!    | pre-pass | one `metadata` per command-wanted file | I/O bound |
+//!    | read | `read_to_string` per wanted file | I/O bound |
+//!    | classify (route) | `accept_vendor_route_source` — pure CPU | yes |
+//!    | classify (command) | `record_source` — CPU **plus one `metadata`** | partly |
+//!
+//!    That last row is the reason the split is measured rather than assumed:
+//!    `record_source` (`command_index.rs`) stats each file before classifying
+//!    it, so a naive "everything after the read is CPU" reading would overstate
+//!    what threading can win.
+//!
+//! 2. **The serialized parse point** — `SalsaHandle::get_patterns` driven in a
+//!    serial loop, which is exactly what `run_magic_batch_once` does per vendor
+//!    file after a `composer install`. Every one of those parses funnels
+//!    through the single Salsa actor thread, so this measures the funnel, at
+//!    several batch sizes.
+//!
+//! # What it does NOT measure
+//!
+//! The rest of `run_magic_batch_once` — the registration diff, the surface
+//! diff, and the dependent ripple. `Backend` is private to `main.rs`, which is
+//! the binary crate, so a bench cannot reach it. What is measured is the stage
+//! #373 identifies as the bottleneck, not the whole function.
+//!
+//! # Honesty notes
+//!
+//! * **Reads are warm-page-cache.** An untimed full pass runs first, so every
+//!   timed stage sees the same warm filesystem cache, the same compiled lazy
+//!   regexes, and a settled allocator. Without that levelling the first timed
+//!   stage would absorb all three costs and the split would be fiction. The
+//!   consequence is that a genuinely cold first start reads slower than the
+//!   `read` row here — this bench measures the steady state, which is the
+//!   state the parallelization work is aimed at.
+//! * **No command scan cache is passed** (`None` everywhere), so the pre-pass
+//!   never settles a file from cache and every command-wanted file is read.
+//!   That is the cold-cache shape — the worst case, and the one a
+//!   `composer install` produces.
+//! * **Each parse batch gets a fresh Salsa actor**, so a larger batch never
+//!   reads the smaller batch's warm pattern cache. Sharing one actor across
+//!   batch sizes would make every batch after the first measure cache hits.
+//!
+//! # Running
+//!
+//! ```text
+//! cargo bench --bench vendor_parallelism
+//! VENDOR_BENCH_ROOT=/path/to/laravel/app cargo bench --bench vendor_parallelism
+//! PARSE_BENCH_BATCHES=100,500 cargo bench --bench vendor_parallelism
+//! ```
+//!
+//! It needs a real `vendor/` tree. `test-project/vendor` is gitignored, so the
+//! bench prints a skip notice and exits cleanly when the tree is absent rather
+//! than failing — CI installs it with `composer update`, a fresh clone does
+//! not.
+
+use std::collections::HashSet;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use laravel_lsp::command_index::{
+    record_source, try_cached, vendor_command_needs_source, CommandScan,
+};
+use laravel_lsp::parse_budget::skip_reason_on_disk;
+use laravel_lsp::route_discovery::{
+    accept_vendor_route_source, vendor_route_needs_source, RouteFileSet,
+};
+use laravel_lsp::salsa_impl::SalsaActor;
+use laravel_lsp::vendor_index::VendorIndex;
+use laravel_lsp::vendor_scan::build_route_files_and_command_index;
+
+/// Batch sizes for the parse-funnel measurement, overridable with
+/// `PARSE_BENCH_BATCHES`. Chosen to bracket a real dependency change: a single
+/// package update rewrites a few hundred files, a `composer update` rewrites
+/// thousands.
+const DEFAULT_BATCHES: &[usize] = &[250, 1000, 4000];
+
+/// Resolve the project root to measure: `VENDOR_BENCH_ROOT` if set, else the
+/// repo's own `test-project/` beside the `laravel-lsp/` manifest.
+fn bench_root() -> PathBuf {
+    if let Ok(explicit) = std::env::var("VENDOR_BENCH_ROOT") {
+        return PathBuf::from(explicit);
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(|repo| repo.join("test-project"))
+        .unwrap_or_else(|| PathBuf::from("test-project"))
+}
+
+fn batch_sizes() -> Vec<usize> {
+    match std::env::var("PARSE_BENCH_BATCHES") {
+        Ok(raw) => raw
+            .split(',')
+            .filter_map(|s| s.trim().parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .collect(),
+        Err(_) => DEFAULT_BATCHES.to_vec(),
+    }
+}
+
+/// Milliseconds, for a column that stays readable across three orders of
+/// magnitude (`{:?}` on a `Duration` switches units mid-table).
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+/// Microseconds per item, or `0.0` for an empty set — the per-file column that
+/// makes two runs on differently-sized vendor trees comparable.
+fn us_each(d: Duration, n: usize) -> f64 {
+    if n == 0 {
+        return 0.0;
+    }
+    d.as_secs_f64() * 1_000_000.0 / n as f64
+}
+
+/// One wanted vendor file, read once so the classify stages can replay it
+/// without paying the read again.
+struct Sample {
+    path: PathBuf,
+    wants_route: bool,
+    wants_command: bool,
+    content: String,
+}
+
+/// The `metadata` + `modified` pair `record_source` performs through its
+/// private `file_mtime` helper. Timed on its own so the command classifier's
+/// CPU can be separated from the stat it hides.
+fn stat_mtime(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .map(|_| true)
+        .unwrap_or(false)
+}
+
+fn main() {
+    let root = bench_root();
+    let vendor_dir = root.join("vendor");
+
+    println!("vendor-parallelism measurement bench (issue #373, step 0)");
+    println!("root: {}", root.display());
+
+    println!("\n== environment ==");
+    println!(
+        "  os / arch     : {} / {}",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    );
+    println!(
+        "  parallelism   : {}",
+        std::thread::available_parallelism()
+            .map(|n| n.get().to_string())
+            .unwrap_or_else(|_| "unknown".to_string())
+    );
+
+    if !vendor_dir.is_dir() {
+        println!("\nSKIPPED: no vendor/ tree at {}.", vendor_dir.display());
+        println!("This bench measures a real dependency tree, and test-project/vendor");
+        println!("is gitignored. Run `composer update` in test-project/, or point");
+        println!("VENDOR_BENCH_ROOT at a Laravel project, then re-run.");
+        return;
+    }
+
+    // ---- corpus -----------------------------------------------------------
+    //
+    // The walk is timed here rather than inside stage 1 because every later
+    // stage consumes the same `VendorIndex`; re-walking per stage would
+    // measure the walk three times and the stages never.
+    let walk_start = Instant::now();
+    let vendor = VendorIndex::build(&root);
+    let walk = walk_start.elapsed();
+
+    if vendor.is_empty() {
+        println!("\nSKIPPED: {} holds no PHP files.", vendor_dir.display());
+        return;
+    }
+
+    let vendor_root = vendor.vendor_root().to_path_buf();
+
+    // Untimed levelling pass. This warms the page cache, compiles every lazy
+    // regex the classifiers use, and settles the allocator, so the first timed
+    // stage below is not the one that pays for all three. See the module docs.
+    let warmup = build_route_files_and_command_index(&root, &vendor, None);
+    black_box(&warmup);
+    drop(warmup);
+
+    // ---- stage: command pre-pass -----------------------------------------
+    //
+    // Mirrors vendor_scan's own pre-pass with no scan cache, so every
+    // command-wanted file falls through to "needs a read".
+    let prepass_start = Instant::now();
+    let mut prepass_scan = CommandScan::default();
+    let mut command_needs_read: HashSet<PathBuf> = HashSet::new();
+    for file in vendor.files() {
+        if vendor_command_needs_source(&vendor_root, file)
+            && !try_cached(&mut prepass_scan, None, &file.path)
+        {
+            command_needs_read.insert(file.path.clone());
+        }
+    }
+    let prepass = prepass_start.elapsed();
+
+    let wants = |file: &laravel_lsp::vendor_index::VendorFile| {
+        vendor_route_needs_source(file) || command_needs_read.contains(&file.path)
+    };
+
+    // ---- stage: read ------------------------------------------------------
+    //
+    // Pure read cost: the content is measured and dropped, with no copy into a
+    // collection, so the number is `read_to_string` and nothing else.
+    let mut wanted_files = 0usize;
+    let mut bytes_read = 0u64;
+    let read_start = Instant::now();
+    vendor.for_each_source(wants, |_file, content| {
+        wanted_files += 1;
+        bytes_read += content.len() as u64;
+        black_box(content.len());
+    });
+    let read = read_start.elapsed();
+
+    // Untimed: collect the same content so the classify stages replay it from
+    // memory. Reads are already warm, so this second pass distorts nothing.
+    let mut samples: Vec<Sample> = Vec::with_capacity(wanted_files);
+    vendor.for_each_source(wants, |file, content| {
+        samples.push(Sample {
+            path: file.path.clone(),
+            wants_route: vendor_route_needs_source(file),
+            wants_command: command_needs_read.contains(&file.path),
+            content: content.to_string(),
+        });
+    });
+
+    let route_samples = samples.iter().filter(|s| s.wants_route).count();
+    let command_samples = samples.iter().filter(|s| s.wants_command).count();
+
+    // ---- stage: classify (route) -----------------------------------------
+    //
+    // Pure CPU. `accept_vendor_route_source` inspects the text and touches no
+    // filesystem, so all of this parallelizes.
+    let route_start = Instant::now();
+    let mut routes = RouteFileSet::default();
+    for sample in samples.iter().filter(|s| s.wants_route) {
+        accept_vendor_route_source(&mut routes, &sample.path, &sample.content);
+    }
+    let route_classify = route_start.elapsed();
+    black_box(routes.into_files().len());
+
+    // ---- stage: classify (command) ---------------------------------------
+    //
+    // CPU **plus** one `metadata` per file, inside `record_source`. Only the
+    // CPU half parallelizes cleanly, so the stat is measured on its own next.
+    let command_start = Instant::now();
+    let mut commands = CommandScan::default();
+    for sample in samples.iter().filter(|s| s.wants_command) {
+        record_source(&mut commands, &sample.path, &sample.content);
+    }
+    let command_classify = command_start.elapsed();
+    black_box(commands.files.len());
+
+    // ---- stage: the stat hidden inside the command classifier -------------
+    let stat_start = Instant::now();
+    let mut stat_hits = 0usize;
+    for sample in samples.iter().filter(|s| s.wants_command) {
+        if stat_mtime(&sample.path) {
+            stat_hits += 1;
+        }
+    }
+    let command_stats = stat_start.elapsed();
+    black_box(stat_hits);
+
+    // ---- cross-check: the whole pass, end to end -------------------------
+    //
+    // The stages above are a decomposition, not a model. If they do not add up
+    // to the real function, the decomposition is wrong and the split below
+    // should not be trusted.
+    let whole_start = Instant::now();
+    let (whole_routes, whole_commands) = build_route_files_and_command_index(&root, &vendor, None);
+    let whole = whole_start.elapsed();
+
+    let staged = prepass + read + route_classify + command_classify;
+    let cpu_only = route_classify + command_classify.saturating_sub(command_stats);
+    let io_only = prepass + read + command_classify.min(command_stats);
+
+    println!("\n== corpus ==");
+    println!("  vendor php files    : {}", vendor.len());
+    println!("  wanted (read once)  : {wanted_files}");
+    println!("    for routes        : {route_samples}");
+    println!("    for commands      : {command_samples}");
+    println!(
+        "  bytes read          : {:.1} MiB",
+        bytes_read as f64 / (1024.0 * 1024.0)
+    );
+    println!("  route files found   : {}", whole_routes.len());
+    println!("  commands scanned    : {}", whole_commands.files.len());
+
+    println!("\n== 1. shared vendor pass (vendor_scan::build_route_files_and_command_index) ==");
+    println!("  {:<26} {:>10}  {:>12}", "stage", "total ms", "us / file");
+    println!("  {:-<26} {:->10}  {:->12}", "", "", "");
+    println!(
+        "  {:<26} {:>10.2}  {:>12.2}",
+        "walk (VendorIndex)",
+        ms(walk),
+        us_each(walk, vendor.len())
+    );
+    println!(
+        "  {:<26} {:>10.2}  {:>12.2}",
+        "pre-pass (stat)",
+        ms(prepass),
+        us_each(prepass, vendor.len())
+    );
+    println!(
+        "  {:<26} {:>10.2}  {:>12.2}",
+        "read (warm cache)",
+        ms(read),
+        us_each(read, wanted_files)
+    );
+    println!(
+        "  {:<26} {:>10.2}  {:>12.2}",
+        "classify: route (CPU)",
+        ms(route_classify),
+        us_each(route_classify, route_samples)
+    );
+    println!(
+        "  {:<26} {:>10.2}  {:>12.2}",
+        "classify: command",
+        ms(command_classify),
+        us_each(command_classify, command_samples)
+    );
+    println!(
+        "  {:<26} {:>10.2}  {:>12.2}",
+        "  of which: stat",
+        ms(command_stats),
+        us_each(command_stats, command_samples)
+    );
+    println!("  {:-<26} {:->10}  {:->12}", "", "", "");
+    println!("  {:<26} {:>10.2}", "staged sum", ms(staged));
+    println!("  {:<26} {:>10.2}", "whole pass (measured)", ms(whole));
+    println!(
+        "  {:<26} {:>10.1}%",
+        "staged / whole",
+        if whole.as_secs_f64() > 0.0 {
+            staged.as_secs_f64() / whole.as_secs_f64() * 100.0
+        } else {
+            0.0
+        }
+    );
+
+    println!("\n  split (walk excluded — a single traversal, not divisible):");
+    println!(
+        "    CPU, parallelizable : {:>8.2} ms  ({:>4.1}% of staged)",
+        ms(cpu_only),
+        if staged.as_secs_f64() > 0.0 {
+            cpu_only.as_secs_f64() / staged.as_secs_f64() * 100.0
+        } else {
+            0.0
+        }
+    );
+    println!(
+        "    I/O, stat + read    : {:>8.2} ms  ({:>4.1}% of staged)",
+        ms(io_only),
+        if staged.as_secs_f64() > 0.0 {
+            io_only.as_secs_f64() / staged.as_secs_f64() * 100.0
+        } else {
+            0.0
+        }
+    );
+
+    // ---- 2. the serialized parse funnel -----------------------------------
+    parse_funnel(&vendor);
+
+    println!("\n== notes ==");
+    println!("  * Reads are WARM page cache — an untimed full pass runs first so");
+    println!("    every stage is levelled. A cold first start reads slower.");
+    println!("  * No command scan cache is passed, so every command-wanted file");
+    println!("    is read. That is the cold-cache shape a composer install makes.");
+    println!("  * 'staged / whole' below ~100% means the decomposition misses");
+    println!("    work (the non-vendor legs the whole pass also runs); far from");
+    println!("    100% means the split above should not be trusted.");
+}
+
+/// Measure the single-threaded Salsa parse funnel: N vendor files pushed
+/// serially through `get_patterns`, which is what `run_magic_batch_once` does
+/// per vendor file after a dependency change.
+fn parse_funnel(vendor: &VendorIndex) {
+    // Only files the parse budget admits — `run_magic_batch_once` skips the
+    // rest (`*.json.php` and anything over the size cap), so including them
+    // would measure work production never does.
+    let mut eligible: Vec<PathBuf> = Vec::new();
+    let mut excluded = 0usize;
+    for file in vendor.files() {
+        if skip_reason_on_disk(&file.path).is_some() {
+            excluded += 1;
+        } else {
+            eligible.push(file.path.clone());
+        }
+    }
+
+    println!("\n== 2. serialized parse point (SalsaHandle::get_patterns, serial loop) ==");
+    println!("  eligible vendor files : {}", eligible.len());
+    println!("  excluded by budget    : {excluded}");
+
+    if eligible.len() < 2 {
+        println!("  SKIPPED: not enough eligible files to measure.");
+        return;
+    }
+
+    // Reserved as each fresh actor's untimed first request, so the actor's
+    // one-time query-cache prewarm never lands inside a measured batch. It is
+    // taken from the END of the list and every batch is measured from the
+    // front, so no measured file is ever served from the warm-up's cache.
+    let warmup_path = eligible
+        .pop()
+        .expect("eligible has at least two entries here");
+
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            println!("  SKIPPED: could not build a tokio runtime: {e}");
+            return;
+        }
+    };
+
+    println!(
+        "\n  {:<10} {:>10}  {:>12}  {:>14}",
+        "batch", "total ms", "us / file", "files / sec"
+    );
+    println!("  {:-<10} {:->10}  {:->12}  {:->14}", "", "", "", "");
+
+    for size in batch_sizes() {
+        let n = size.min(eligible.len());
+        if n == 0 {
+            continue;
+        }
+        let batch: Vec<PathBuf> = eligible[..n].to_vec();
+
+        // A FRESH actor per batch. Sharing one would let every batch after the
+        // first read the previous batch's warm pattern cache, which measures
+        // cache hits rather than parses.
+        let handle = SalsaActor::spawn();
+        let warm = warmup_path.clone();
+
+        let elapsed = runtime.block_on(async move {
+            let _ = handle.get_patterns(warm).await;
+
+            let start = Instant::now();
+            for path in batch {
+                black_box(handle.get_patterns(path).await.ok());
+            }
+            start.elapsed()
+        });
+
+        println!(
+            "  {:<10} {:>10.2}  {:>12.2}  {:>14.0}",
+            n,
+            ms(elapsed),
+            us_each(elapsed, n),
+            n as f64 / elapsed.as_secs_f64()
+        );
+
+        if n == eligible.len() {
+            // Every later size would measure the same batch.
+            break;
+        }
+    }
+
+    println!("\n  Every parse above runs on the ONE Salsa actor thread. A composer");
+    println!("  install rewrites thousands of vendor files straight into this loop.");
+}

--- a/laravel-lsp/benches/vendor_parallelism.rs
+++ b/laravel-lsp/benches/vendor_parallelism.rs
@@ -12,18 +12,15 @@
 //! 1. **The shared vendor pass** —
 //!    [`laravel_lsp::vendor_scan::build_route_files_and_command_index`], broken
 //!    into its stages so the parallelizable fraction is visible rather than
-//!    inferred. **Every stage is timed serially, one file at a time**, even
-//!    though production now runs the pass across a worker pool — the point of
-//!    the decomposition is the *shape* of the work, and only a serial timing
-//!    can attribute cost per stage:
+//!    inferred:
 //!
 //!    | Stage | Work | Parallelizes? |
 //!    |---|---|---|
 //!    | walk | [`VendorIndex::build`] — one directory traversal | no (single walk) |
 //!    | pre-pass | one `metadata` per command-wanted file | yes (I/O bound) |
 //!    | read | `read_to_string` per wanted file | yes (I/O bound) |
-//!    | classify (route) | `vendor_route_verdict` — pure CPU | yes |
-//!    | classify (command) | `command_entry_for` — pure CPU | yes |
+//!    | classify (route) | `accept_vendor_route_source` — pure CPU | yes |
+//!    | classify (command) | `record_source` — pure CPU | yes |
 //!
 //!    The `[removed] 2nd stat/file` row is why measuring beat estimating.
 //!    `record_source` used to stat each file again before classifying it — a
@@ -34,15 +31,27 @@
 //!
 //!    The answer the measurement gave: the classifiers are 2-6% of the pass on
 //!    every platform, not the majority #373 estimated, while the stat and read
-//!    stages are 93-97%. **The pass is I/O.** So #373's third item was built
-//!    against that finding rather than its own estimate — the parallel map
-//!    covers the reads and stats, not merely the classifiers it named, which
-//!    would have won 7-13 ms of a 151-604 ms pass.
+//!    stages are 93-97%. **The pass is I/O.**
 //!
-//!    **Read `staged / whole` accordingly.** The staged sum is serial and the
-//!    whole pass is parallel, so the ratio now runs *above* 100% by design:
-//!    that excess is the parallel speedup, and a ratio back near 100% means the
-//!    pass has fallen back to running serially.
+//!    ## Why this bench cannot settle whether to parallelize the pass
+//!
+//!    It can't, and it said the opposite. Parallelizing the whole pass measures
+//!    **2.1x here** (397.7 → 191.3 ms) and made real startup *worse*, so it was
+//!    built and backed out — see `vendor_scan`'s module docs for the numbers.
+//!    Two reasons this bench cannot see that, both worth knowing before
+//!    trusting its figures for a threading decision:
+//!
+//!    * It passes **`None` for the command scan cache**, so every wanted file is
+//!      read. Production only sees that shape on a cold start; on a warm one the
+//!      cache settles nearly every file in the stat pre-pass and there is almost
+//!      nothing left to read.
+//!    * It runs the pass **alone**. In production it runs beside the warm parse
+//!      pass and the disk-cache load, and it finishes about a second before the
+//!      parse does — so its duration is off the critical path exactly when this
+//!      bench says there is most to win.
+//!
+//!    Use it for *where the time goes*. Use an end-to-end startup measurement
+//!    for *whether a change helps*.
 //!
 //! 2. **The serialized parse point** — `SalsaHandle::get_patterns` driven in a
 //!    serial loop, which is exactly what `run_magic_batch_once` does per vendor
@@ -224,13 +233,12 @@ fn main() {
 
     // Every stage below is measured `PASSES` times and reported at its
     // MINIMUM. A single timed run of a 400 ms filesystem-heavy pass varies
-    // 10-15% between runs on an idle machine — measured on the serial pass,
-    // that was enough to swing `staged / whole` from 89% to 110% with no code
-    // change at all, which would make the cross-platform comparison this bench
-    // exists for unreadable. The minimum is the run least disturbed by the
-    // scheduler and by other processes, and it is the standard choice for
-    // exactly this reason: noise only ever adds time, so the floor is the
-    // honest figure.
+    // 10-15% between runs on an idle machine — enough to swing `staged / whole`
+    // from 89% to 110% with no code change at all, which would make the
+    // cross-platform comparison this bench exists for unreadable. The minimum
+    // is the run least disturbed by the scheduler and by other processes, and
+    // it is the standard choice for exactly this reason: noise only ever adds
+    // time, so the floor is the honest figure.
     let mut best = StageTimings::worst();
     let mut corpus = Corpus::default();
     for _ in 0..PASSES {
@@ -588,13 +596,15 @@ fn notes() {
     println!("    every stage is levelled. A cold first start reads slower.");
     println!("  * No command scan cache is passed, so every command-wanted file");
     println!("    is read. That is the cold-cache shape a composer install makes.");
-    println!("  * The stages above are timed SERIALLY, one file at a time, but");
-    println!("    the whole pass now runs across the bounded worker pool (#373).");
-    println!("    So 'staged / whole' is expected ABOVE 100%, and the excess IS");
-    println!("    the parallel speedup: 100% means the pass has fallen back to");
-    println!("    running serially. The stage split still says where the work");
-    println!("    is — that conclusion is an order of magnitude, not a few");
-    println!("    percent — but the ratio is no longer a decomposition check.");
+    println!("  * 'staged / whole' is a sanity check on the decomposition, not a");
+    println!("    precision instrument. Near 100% means the stages account for");
+    println!("    the real function; far from it means the split is not to be");
+    println!("    trusted. It does not need to be exact for the CPU-vs-I/O");
+    println!("    conclusion, which is an order of magnitude, not a few percent.");
+    println!("  * This bench runs the pass ALONE and with NO command scan cache.");
+    println!("    Both flatter parallelism, which is why #373's attempt at it");
+    println!("    measured 2.1x here and lost time in real startup. Decide");
+    println!("    threading end-to-end, not from these rows.");
 }
 
 /// Register a handle against `root` the way production does, so

--- a/laravel-lsp/benches/vendor_parallelism.rs
+++ b/laravel-lsp/benches/vendor_parallelism.rs
@@ -90,7 +90,7 @@ use laravel_lsp::route_discovery::{
     accept_vendor_route_source, collect_conventional_vendor_route_files,
     collect_project_route_files, vendor_route_needs_source, RouteFileSet,
 };
-use laravel_lsp::salsa_impl::SalsaActor;
+use laravel_lsp::salsa_impl::{SalsaActor, SalsaHandle};
 use laravel_lsp::vendor_index::VendorIndex;
 use laravel_lsp::vendor_scan::build_route_files_and_command_index;
 
@@ -583,9 +583,93 @@ fn notes() {
     println!("    conclusion, which is an order of magnitude, not a few percent.");
 }
 
-/// Measure the single-threaded Salsa parse funnel: N vendor files pushed
-/// serially through `get_patterns`, which is what `run_magic_batch_once` does
-/// per vendor file after a dependency change.
+/// Register a handle against `root` the way production does, so
+/// `bulk_import_patterns` has a published pattern cache to write into.
+///
+/// Both regimes below get a registered handle, not just the one that needs it:
+/// registration records the file list and sizes the cache but parses nothing,
+/// so it leaves neither regime with warm data — and giving only one of them a
+/// registered actor would be an uncontrolled difference between them.
+async fn registered_handle(root: &Path, vendor_paths: Vec<PathBuf>) -> SalsaHandle {
+    let handle = SalsaActor::spawn();
+    let _ = handle
+        .register_config_files(root.to_path_buf(), None, None, None, None)
+        .await;
+    let _ = handle
+        .register_project_files(
+            root.to_path_buf(),
+            vec![PathBuf::from("app")],
+            vec![root.join("resources/views")],
+            None,
+            PathBuf::from("routes"),
+            vendor_paths,
+        )
+        .await;
+    handle
+}
+
+/// Parse `batch` the way `Backend::preparse_batch_off_actor` does — in
+/// parallel, off the actor, then handed over as finished results.
+///
+/// A deliberate copy of the production method rather than a call to it:
+/// `Backend` is private to `main.rs`, so a bench cannot reach it. The shape it
+/// mirrors is the semaphore, the `spawn_blocking` read-and-parse, and the two
+/// bulk imports; if that method changes, this must change with it.
+async fn preparse_like_production(handle: &SalsaHandle, batch: Vec<PathBuf>) {
+    type Parsed = (
+        PathBuf,
+        std::sync::Arc<laravel_lsp::salsa_impl::ParsedPatternsData>,
+        Vec<laravel_lsp::class_hierarchy_index::ClassNode>,
+    );
+
+    let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(
+        laravel_lsp::parallelism::bounded_pool_size(),
+    ));
+    let mut set: tokio::task::JoinSet<Option<Parsed>> = tokio::task::JoinSet::new();
+    for path in batch {
+        let permit_owner = semaphore.clone();
+        set.spawn(async move {
+            let _permit = permit_owner.acquire_owned().await.ok()?;
+            let for_task = path.clone();
+            let parsed = tokio::task::spawn_blocking(move || {
+                let text = std::fs::read_to_string(&for_task).ok()?;
+                Some(laravel_lsp::pattern_indexer::parse_owned_with_hierarchy(
+                    &for_task, &text,
+                ))
+            })
+            .await
+            .ok()
+            .flatten()?;
+            Some((path, parsed.0, parsed.1))
+        });
+    }
+
+    let mut patterns = Vec::new();
+    let mut hierarchy = Vec::new();
+    while let Some(res) = set.join_next().await {
+        if let Ok(Some((path, data, nodes))) = res {
+            patterns.push((path.clone(), data));
+            hierarchy.push((path, nodes));
+        }
+    }
+    if patterns.is_empty() {
+        return;
+    }
+    if handle.bulk_import_patterns(patterns).await.is_err() {
+        return;
+    }
+    let _ = handle.bulk_import_hierarchy(hierarchy).await;
+}
+
+/// Measure the single-threaded Salsa parse funnel — N vendor files pushed
+/// serially through `get_patterns`, which is what `run_magic_batch_once` did
+/// per vendor file after a dependency change — against the off-actor parallel
+/// path that replaced it (issue #373 item 1).
+///
+/// **Each regime gets its own fresh actor**, which is the whole reason this
+/// comparison is trustworthy. Both write into an actor-owned pattern cache; if
+/// they shared one, the second regime measured would be reading the first's
+/// results and would look arbitrarily fast.
 fn parse_funnel(vendor: &VendorIndex) {
     // Only files the parse budget admits — `run_magic_batch_once` skips the
     // rest (`*.json.php` and anything over the size cap), so including them
@@ -600,9 +684,13 @@ fn parse_funnel(vendor: &VendorIndex) {
         }
     }
 
-    println!("\n== 2. serialized parse point (SalsaHandle::get_patterns, serial loop) ==");
+    println!("\n== 2. the parse funnel: serial-in-actor vs parallel-off-actor ==");
     println!("  eligible vendor files : {}", eligible.len());
     println!("  excluded by budget    : {excluded}");
+    println!(
+        "  off-actor workers     : {}",
+        laravel_lsp::parallelism::bounded_pool_size()
+    );
 
     if eligible.len() < 2 {
         println!("  SKIPPED: not enough eligible files to measure.");
@@ -628,11 +716,17 @@ fn parse_funnel(vendor: &VendorIndex) {
         }
     };
 
+    let root = bench_root();
+    let vendor_paths: Vec<PathBuf> = vendor.files().iter().map(|f| f.path.clone()).collect();
+
     println!(
-        "\n  {:<10} {:>10}  {:>12}  {:>14}",
-        "batch", "total ms", "us / file", "files / sec"
+        "\n  {:<8} {:>12}  {:>12}  {:>12}  {:>9}",
+        "batch", "serial ms", "off-actor ms", "serial f/s", "speedup"
     );
-    println!("  {:-<10} {:->10}  {:->12}  {:->14}", "", "", "", "");
+    println!(
+        "  {:-<8} {:->12}  {:->12}  {:->12}  {:->9}",
+        "", "", "", "", ""
+    );
 
     for size in batch_sizes() {
         let n = size.min(eligible.len());
@@ -641,28 +735,54 @@ fn parse_funnel(vendor: &VendorIndex) {
         }
         let batch: Vec<PathBuf> = eligible[..n].to_vec();
 
-        // A FRESH actor per batch. Sharing one would let every batch after the
-        // first read the previous batch's warm pattern cache, which measures
-        // cache hits rather than parses.
-        let handle = SalsaActor::spawn();
-        let warm = warmup_path.clone();
+        // The NEW path runs FIRST, deliberately. Whichever regime runs second
+        // reads a filesystem cache the first one has just touched, and that
+        // advantage cannot be removed without dropping the page cache (which
+        // needs root). Running the new path first means any residual advantage
+        // falls to the OLD one, so the speedup below is a floor rather than a
+        // flattering number. The bench's levelling pass has already read the
+        // whole tree once, so the effect should be small either way.
+        //
+        // Each regime gets its OWN fresh actor. Sharing one would let the
+        // second read the first's imported entries and report a cache hit as a
+        // parse.
+        let off_actor = {
+            let handle = runtime.block_on(registered_handle(&root, vendor_paths.clone()));
+            let warm = warmup_path.clone();
+            let batch = batch.clone();
+            runtime.block_on(async move {
+                // Untimed first request, so the actor's one-time query-cache
+                // prewarm never lands inside the measured window. Taken from
+                // the END of the eligible list while every batch is measured
+                // from the front, so no measured file is served from its cache.
+                let _ = handle.get_patterns(warm).await;
+                let start = Instant::now();
+                preparse_like_production(&handle, batch).await;
+                start.elapsed()
+            })
+        };
 
-        let elapsed = runtime.block_on(async move {
-            let _ = handle.get_patterns(warm).await;
-
-            let start = Instant::now();
-            for path in batch {
-                black_box(handle.get_patterns(path).await.ok());
-            }
-            start.elapsed()
-        });
+        // The OLD path: every parse queued through the one actor thread.
+        let serial = {
+            let handle = runtime.block_on(registered_handle(&root, vendor_paths.clone()));
+            let warm = warmup_path.clone();
+            runtime.block_on(async move {
+                let _ = handle.get_patterns(warm).await;
+                let start = Instant::now();
+                for path in batch {
+                    black_box(handle.get_patterns(path).await.ok());
+                }
+                start.elapsed()
+            })
+        };
 
         println!(
-            "  {:<10} {:>10.2}  {:>12.2}  {:>14.0}",
+            "  {:<8} {:>12.2}  {:>12.2}  {:>12.0}  {:>8.1}x",
             n,
-            ms(elapsed),
-            us_each(elapsed, n),
-            n as f64 / elapsed.as_secs_f64()
+            ms(serial),
+            ms(off_actor),
+            n as f64 / serial.as_secs_f64(),
+            serial.as_secs_f64() / off_actor.as_secs_f64().max(f64::MIN_POSITIVE)
         );
 
         if n == eligible.len() {
@@ -671,6 +791,21 @@ fn parse_funnel(vendor: &VendorIndex) {
         }
     }
 
-    println!("\n  Every parse above runs on the ONE Salsa actor thread. A composer");
-    println!("  install rewrites thousands of vendor files straight into this loop.");
+    println!("\n  'serial' is the old path: every parse queued through the ONE Salsa");
+    println!("  actor thread, which is where a composer install's thousands of vendor");
+    println!("  files used to funnel. 'off-actor' is what run_magic_batch_once does");
+    println!("  now — parse in parallel outside the actor, hand it finished results.");
+    println!();
+    println!("  The speedup EXCEEDS the worker count, which is not a measurement");
+    println!("  error: the two paths differ in more than parallelism. The serial one");
+    println!("  pays an mpsc send plus a oneshot reply per file, and parses through");
+    println!("  Salsa's tracked-query machinery (a SourceFile input, interning,");
+    println!("  dependency tracking) for every one. The off-actor path calls the");
+    println!("  parser directly and sends two bulk messages for the whole batch. So");
+    println!("  the win is the worker count multiplied by the per-file overhead it");
+    println!("  no longer pays.");
+    println!();
+    println!("  The new path is timed FIRST at every batch size, so any leftover");
+    println!("  filesystem-cache advantage goes to the OLD one. The speedup is a");
+    println!("  floor.");
 }

--- a/laravel-lsp/benches/vendor_parallelism.rs
+++ b/laravel-lsp/benches/vendor_parallelism.rs
@@ -19,12 +19,19 @@
 //!    | pre-pass | one `metadata` per command-wanted file | I/O bound |
 //!    | read | `read_to_string` per wanted file | I/O bound |
 //!    | classify (route) | `accept_vendor_route_source` — pure CPU | yes |
-//!    | classify (command) | `record_source` — CPU **plus one `metadata`** | partly |
+//!    | classify (command) | `record_source` — pure CPU | yes |
 //!
-//!    That last row is the reason the split is measured rather than assumed:
-//!    `record_source` (`command_index.rs`) stats each file before classifying
-//!    it, so a naive "everything after the read is CPU" reading would overstate
-//!    what threading can win.
+//!    That last row is why measuring beat estimating. `record_source` used to
+//!    stat each file again before classifying it — a stat the pre-pass had
+//!    already paid — so "everything after the read is CPU" would have
+//!    overstated what threading could win by 5x. The bench found it, and #373
+//!    removed the second stat rather than parallelizing around it. The
+//!    `[removed] 2nd stat/file` row still measures what it used to cost, so a
+//!    regression that brings it back is legible in the log.
+//!
+//!    The answer the measurement gave: the classifiers are 2-6% of the pass on
+//!    every platform, not the majority #373 estimated. Parallelizing them would
+//!    win 8-18 ms of a 198-962 ms pass. The pass is I/O.
 //!
 //! 2. **The serialized parse point** — `SalsaHandle::get_patterns` driven in a
 //!    serial loop, which is exactly what `run_magic_batch_once` does per vendor
@@ -69,17 +76,19 @@
 //! than failing — CI installs it with `composer update`, a fresh clone does
 //! not.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::hint::black_box;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use laravel_lsp::command_index::{
-    record_source, try_cached, vendor_command_needs_source, CommandScan,
+    consider_project_commands, record_source, try_cached, vendor_command_needs_source,
+    CacheVerdict, CommandScan,
 };
 use laravel_lsp::parse_budget::skip_reason_on_disk;
 use laravel_lsp::route_discovery::{
-    accept_vendor_route_source, vendor_route_needs_source, RouteFileSet,
+    accept_vendor_route_source, collect_conventional_vendor_route_files,
+    collect_project_route_files, vendor_route_needs_source, RouteFileSet,
 };
 use laravel_lsp::salsa_impl::SalsaActor;
 use laravel_lsp::vendor_index::VendorIndex;
@@ -134,13 +143,16 @@ fn us_each(d: Duration, n: usize) -> f64 {
 struct Sample {
     path: PathBuf,
     wants_route: bool,
-    wants_command: bool,
+    /// `Some(mtime)` when the command side wants this file, carrying the value
+    /// the pre-pass stat'd — the same hand-off the real pass now makes.
+    command_mtime: Option<(u64, u32)>,
     content: String,
 }
 
-/// The `metadata` + `modified` pair `record_source` performs through its
-/// private `file_mtime` helper. Timed on its own so the command classifier's
-/// CPU can be separated from the stat it hides.
+/// The `metadata` + `modified` pair `record_source` USED to perform through
+/// `command_index`'s private `file_mtime` helper, before #373 handed it the
+/// pre-pass's value instead. Still timed, so the size of that saving stays in
+/// the log and a regression that reintroduces the stat is visible.
 fn stat_mtime(path: &Path) -> bool {
     std::fs::metadata(path)
         .and_then(|m| m.modified())
@@ -199,24 +211,133 @@ fn main() {
     black_box(&warmup);
     drop(warmup);
 
+    // Every stage below is measured `PASSES` times and reported at its
+    // MINIMUM. A single timed run of a 400 ms filesystem-heavy pass varies
+    // 10-15% between runs on an idle machine — enough to swing `staged / whole`
+    // from 89% to 110% with no code change at all, which would make the
+    // cross-platform comparison this bench exists for unreadable. The minimum
+    // is the run least disturbed by the scheduler and by other processes, and
+    // it is the standard choice for exactly this reason: noise only ever adds
+    // time, so the floor is the honest figure.
+    let mut best = StageTimings::worst();
+    let mut corpus = Corpus::default();
+    for _ in 0..PASSES {
+        let (timings, counts) = measure_stages(&root, &vendor, &vendor_root);
+        best = best.min_with(&timings);
+        corpus = counts;
+    }
+    report(&vendor, walk, &best, &corpus);
+
+    // ---- 2. the serialized parse funnel -----------------------------------
+    parse_funnel(&vendor);
+    notes();
+}
+
+/// How many times each stage is timed before the minimum is taken. Three is
+/// enough to shed a single scheduler hiccup without tripling a CI step that
+/// already spends most of its time in the parse funnel below.
+const PASSES: usize = 3;
+
+/// Per-stage wall clock for one full measurement pass.
+#[derive(Clone, Copy)]
+struct StageTimings {
+    legs: Duration,
+    prepass: Duration,
+    read: Duration,
+    route_classify: Duration,
+    command_classify: Duration,
+    /// Not part of the pass any more — the stat #373 removed, still timed so
+    /// the saving stays visible.
+    command_stats: Duration,
+    whole: Duration,
+}
+
+impl StageTimings {
+    /// A starting point every real measurement beats, so the fold below needs
+    /// no `Option` and no special first iteration.
+    fn worst() -> Self {
+        let max = Duration::MAX;
+        Self {
+            legs: max,
+            prepass: max,
+            read: max,
+            route_classify: max,
+            command_classify: max,
+            command_stats: max,
+            whole: max,
+        }
+    }
+
+    /// Per-stage minimum. Taken field by field rather than picking one whole
+    /// "best pass": each stage's floor is an independent estimate of that
+    /// stage's true cost, and nothing here compares stages against each other
+    /// within a single run.
+    fn min_with(self, other: &Self) -> Self {
+        Self {
+            legs: self.legs.min(other.legs),
+            prepass: self.prepass.min(other.prepass),
+            read: self.read.min(other.read),
+            route_classify: self.route_classify.min(other.route_classify),
+            command_classify: self.command_classify.min(other.command_classify),
+            command_stats: self.command_stats.min(other.command_stats),
+            whole: self.whole.min(other.whole),
+        }
+    }
+}
+
+/// Counts describing the corpus. Identical on every pass — recorded alongside
+/// the timings only so one function can produce both.
+#[derive(Default, Clone, Copy)]
+struct Corpus {
+    wanted_files: usize,
+    bytes_read: u64,
+    route_samples: usize,
+    command_samples: usize,
+    leg_command_files: usize,
+    whole_route_files: usize,
+    whole_command_files: usize,
+}
+
+/// One full measurement pass over the vendor tree: every stage of
+/// `build_route_files_and_command_index`, plus the whole function as a
+/// cross-check.
+fn measure_stages(root: &Path, vendor: &VendorIndex, vendor_root: &Path) -> (StageTimings, Corpus) {
+    // ---- stage: the non-vendor legs --------------------------------------
+    //
+    // The real function runs these before it touches the vendor tree, and they
+    // do their own reads and stats over the project's own PHP. Measured so the
+    // decomposition accounts for the whole pass rather than most of it.
+    let legs_start = Instant::now();
+    let mut leg_routes = RouteFileSet::default();
+    let mut leg_commands = CommandScan::default();
+    collect_project_route_files(root, &mut leg_routes);
+    collect_conventional_vendor_route_files(vendor, &mut leg_routes);
+    consider_project_commands(root, None, &mut leg_commands);
+    let legs = legs_start.elapsed();
+    let leg_route_files = leg_routes.into_files().len();
+    let leg_command_files = leg_commands.files.len();
+    black_box((leg_route_files, leg_command_files));
+
     // ---- stage: command pre-pass -----------------------------------------
     //
     // Mirrors vendor_scan's own pre-pass with no scan cache, so every
     // command-wanted file falls through to "needs a read".
     let prepass_start = Instant::now();
     let mut prepass_scan = CommandScan::default();
-    let mut command_needs_read: HashSet<PathBuf> = HashSet::new();
+    let mut command_needs_read: HashMap<PathBuf, (u64, u32)> = HashMap::new();
     for file in vendor.files() {
-        if vendor_command_needs_source(&vendor_root, file)
-            && !try_cached(&mut prepass_scan, None, &file.path)
+        if !vendor_command_needs_source(vendor_root, file) {
+            continue;
+        }
+        if let CacheVerdict::NeedsSource { mtime } = try_cached(&mut prepass_scan, None, &file.path)
         {
-            command_needs_read.insert(file.path.clone());
+            command_needs_read.insert(file.path.clone(), mtime);
         }
     }
     let prepass = prepass_start.elapsed();
 
     let wants = |file: &laravel_lsp::vendor_index::VendorFile| {
-        vendor_route_needs_source(file) || command_needs_read.contains(&file.path)
+        vendor_route_needs_source(file) || command_needs_read.contains_key(&file.path)
     };
 
     // ---- stage: read ------------------------------------------------------
@@ -240,13 +361,13 @@ fn main() {
         samples.push(Sample {
             path: file.path.clone(),
             wants_route: vendor_route_needs_source(file),
-            wants_command: command_needs_read.contains(&file.path),
+            command_mtime: command_needs_read.get(&file.path).copied(),
             content: content.to_string(),
         });
     });
 
     let route_samples = samples.iter().filter(|s| s.wants_route).count();
-    let command_samples = samples.iter().filter(|s| s.wants_command).count();
+    let command_samples = samples.iter().filter(|s| s.command_mtime.is_some()).count();
 
     // ---- stage: classify (route) -----------------------------------------
     //
@@ -262,20 +383,27 @@ fn main() {
 
     // ---- stage: classify (command) ---------------------------------------
     //
-    // CPU **plus** one `metadata` per file, inside `record_source`. Only the
-    // CPU half parallelizes cleanly, so the stat is measured on its own next.
+    // Pure CPU, since #373 removed the stat this used to hide: `record_source`
+    // is now stamped with the mtime the pre-pass already read.
     let command_start = Instant::now();
     let mut commands = CommandScan::default();
-    for sample in samples.iter().filter(|s| s.wants_command) {
-        record_source(&mut commands, &sample.path, &sample.content);
+    for sample in samples.iter() {
+        if let Some(mtime) = sample.command_mtime {
+            record_source(&mut commands, &sample.path, mtime, &sample.content);
+        }
     }
     let command_classify = command_start.elapsed();
     black_box(commands.files.len());
 
-    // ---- stage: the stat hidden inside the command classifier -------------
+    // ---- reference: the stat #373 removed ---------------------------------
+    //
+    // NOT part of the pass any more — measured so the saving stays visible and
+    // a regression that reintroduces the second stat is legible in the log
+    // rather than silent. This is what `record_source` used to add on top of
+    // the classify row above.
     let stat_start = Instant::now();
     let mut stat_hits = 0usize;
-    for sample in samples.iter().filter(|s| s.wants_command) {
+    for sample in samples.iter().filter(|s| s.command_mtime.is_some()) {
         if stat_mtime(&sample.path) {
             stat_hits += 1;
         }
@@ -289,12 +417,57 @@ fn main() {
     // to the real function, the decomposition is wrong and the split below
     // should not be trusted.
     let whole_start = Instant::now();
-    let (whole_routes, whole_commands) = build_route_files_and_command_index(&root, &vendor, None);
+    let (whole_routes, whole_commands) = build_route_files_and_command_index(root, vendor, None);
     let whole = whole_start.elapsed();
 
-    let staged = prepass + read + route_classify + command_classify;
-    let cpu_only = route_classify + command_classify.saturating_sub(command_stats);
-    let io_only = prepass + read + command_classify.min(command_stats);
+    (
+        StageTimings {
+            legs,
+            prepass,
+            read,
+            route_classify,
+            command_classify,
+            command_stats,
+            whole,
+        },
+        Corpus {
+            wanted_files,
+            bytes_read,
+            route_samples,
+            command_samples,
+            leg_command_files,
+            whole_route_files: whole_routes.len(),
+            whole_command_files: whole_commands.files.len(),
+        },
+    )
+}
+
+/// Print the stage table, the cross-check and the split.
+fn report(vendor: &VendorIndex, walk: Duration, best: &StageTimings, corpus: &Corpus) {
+    let StageTimings {
+        legs,
+        prepass,
+        read,
+        route_classify,
+        command_classify,
+        command_stats,
+        whole,
+    } = *best;
+    let Corpus {
+        wanted_files,
+        bytes_read,
+        route_samples,
+        command_samples,
+        leg_command_files,
+        whole_route_files,
+        whole_command_files,
+    } = *corpus;
+
+    let staged = legs + prepass + read + route_classify + command_classify;
+    // Both classify stages are pure CPU now that #373 removed the stat inside
+    // `record_source`, so the split needs no subtraction to separate them.
+    let cpu_only = route_classify + command_classify;
+    let io_only = prepass + read;
 
     println!("\n== corpus ==");
     println!("  vendor php files    : {}", vendor.len());
@@ -305,8 +478,8 @@ fn main() {
         "  bytes read          : {:.1} MiB",
         bytes_read as f64 / (1024.0 * 1024.0)
     );
-    println!("  route files found   : {}", whole_routes.len());
-    println!("  commands scanned    : {}", whole_commands.files.len());
+    println!("  route files found   : {whole_route_files}");
+    println!("  commands scanned    : {whole_command_files}");
 
     println!("\n== 1. shared vendor pass (vendor_scan::build_route_files_and_command_index) ==");
     println!("  {:<26} {:>10}  {:>12}", "stage", "total ms", "us / file");
@@ -316,6 +489,12 @@ fn main() {
         "walk (VendorIndex)",
         ms(walk),
         us_each(walk, vendor.len())
+    );
+    println!(
+        "  {:<26} {:>10.2}  {:>12.2}",
+        "non-vendor legs",
+        ms(legs),
+        us_each(legs, leg_command_files.max(1))
     );
     println!(
         "  {:<26} {:>10.2}  {:>12.2}",
@@ -337,15 +516,9 @@ fn main() {
     );
     println!(
         "  {:<26} {:>10.2}  {:>12.2}",
-        "classify: command",
+        "classify: command (CPU)",
         ms(command_classify),
         us_each(command_classify, command_samples)
-    );
-    println!(
-        "  {:<26} {:>10.2}  {:>12.2}",
-        "  of which: stat",
-        ms(command_stats),
-        us_each(command_stats, command_samples)
     );
     println!("  {:-<26} {:->10}  {:->12}", "", "", "");
     println!("  {:<26} {:>10.2}", "staged sum", ms(staged));
@@ -358,6 +531,18 @@ fn main() {
         } else {
             0.0
         }
+    );
+
+    // Outside the sum by design: this stat is no longer performed. It is what
+    // `record_source` used to add to the command-classify row before #373
+    // handed it the pre-pass's mtime, and it is printed so the saving stays
+    // visible and a regression that brings the stat back is legible here.
+    println!(
+        "\n  not paid any more — the 2nd stat/file #373 removed:\n    \
+         {:>8.2} ms  ({:>5.2} us/file, over {} files)",
+        ms(command_stats),
+        us_each(command_stats, command_samples),
+        command_samples
     );
 
     println!("\n  split (walk excluded — a single traversal, not divisible):");
@@ -379,18 +564,23 @@ fn main() {
             0.0
         }
     );
+}
 
-    // ---- 2. the serialized parse funnel -----------------------------------
-    parse_funnel(&vendor);
-
+/// What a reader has to know before trusting any number above.
+fn notes() {
     println!("\n== notes ==");
+    println!("  * Every stage is the MINIMUM of {PASSES} timed runs. A single run of");
+    println!("    this pass varies 10-15% on an idle machine, enough to swing");
+    println!("    'staged / whole' by 20 points with no code change at all.");
     println!("  * Reads are WARM page cache — an untimed full pass runs first so");
     println!("    every stage is levelled. A cold first start reads slower.");
     println!("  * No command scan cache is passed, so every command-wanted file");
     println!("    is read. That is the cold-cache shape a composer install makes.");
-    println!("  * 'staged / whole' below ~100% means the decomposition misses");
-    println!("    work (the non-vendor legs the whole pass also runs); far from");
-    println!("    100% means the split above should not be trusted.");
+    println!("  * 'staged / whole' is a sanity check on the decomposition, not a");
+    println!("    precision instrument. Near 100% means the stages account for");
+    println!("    the real function; far from it means the split is not to be");
+    println!("    trusted. It does not need to be exact for the CPU-vs-I/O");
+    println!("    conclusion, which is an order of magnitude, not a few percent.");
 }
 
 /// Measure the single-threaded Salsa parse funnel: N vendor files pushed

--- a/laravel-lsp/benches/vendor_parallelism.rs
+++ b/laravel-lsp/benches/vendor_parallelism.rs
@@ -1,37 +1,48 @@
-//! Step-0 measurement bench for issue #373 — where the remaining warm-start
-//! and dependency-change time actually goes, before anything is parallelized.
+//! Measurement bench for issue #373 — where the remaining warm-start and
+//! dependency-change time actually goes.
 //!
 //! #373 names two paths as the only ones with room left, and asks for both to
 //! be timed **in isolation** before an implementation is written, because this
 //! project has twice guessed the wrong target from architecture and been
-//! corrected by measurement. This bench is that measurement.
+//! corrected by measurement. This bench is that measurement, and it kept
+//! earning its keep afterwards: it decided what #373's third item became.
 //!
 //! # What it measures
 //!
 //! 1. **The shared vendor pass** —
 //!    [`laravel_lsp::vendor_scan::build_route_files_and_command_index`], broken
-//!    into its four stages so the parallelizable fraction is visible rather
-//!    than inferred:
+//!    into its stages so the parallelizable fraction is visible rather than
+//!    inferred. **Every stage is timed serially, one file at a time**, even
+//!    though production now runs the pass across a worker pool — the point of
+//!    the decomposition is the *shape* of the work, and only a serial timing
+//!    can attribute cost per stage:
 //!
 //!    | Stage | Work | Parallelizes? |
 //!    |---|---|---|
 //!    | walk | [`VendorIndex::build`] — one directory traversal | no (single walk) |
-//!    | pre-pass | one `metadata` per command-wanted file | I/O bound |
-//!    | read | `read_to_string` per wanted file | I/O bound |
-//!    | classify (route) | `accept_vendor_route_source` — pure CPU | yes |
-//!    | classify (command) | `record_source` — pure CPU | yes |
+//!    | pre-pass | one `metadata` per command-wanted file | yes (I/O bound) |
+//!    | read | `read_to_string` per wanted file | yes (I/O bound) |
+//!    | classify (route) | `vendor_route_verdict` — pure CPU | yes |
+//!    | classify (command) | `command_entry_for` — pure CPU | yes |
 //!
-//!    That last row is why measuring beat estimating. `record_source` used to
-//!    stat each file again before classifying it — a stat the pre-pass had
-//!    already paid — so "everything after the read is CPU" would have
-//!    overstated what threading could win by 5x. The bench found it, and #373
-//!    removed the second stat rather than parallelizing around it. The
-//!    `[removed] 2nd stat/file` row still measures what it used to cost, so a
-//!    regression that brings it back is legible in the log.
+//!    The `[removed] 2nd stat/file` row is why measuring beat estimating.
+//!    `record_source` used to stat each file again before classifying it — a
+//!    stat the pre-pass had already paid — so "everything after the read is
+//!    CPU" would have overstated what threading could win by 5x. #373 removed
+//!    that stat, and the row still times what it used to cost, so a regression
+//!    that brings it back is legible in the log.
 //!
 //!    The answer the measurement gave: the classifiers are 2-6% of the pass on
-//!    every platform, not the majority #373 estimated. Parallelizing them would
-//!    win 8-18 ms of a 198-962 ms pass. The pass is I/O.
+//!    every platform, not the majority #373 estimated, while the stat and read
+//!    stages are 93-97%. **The pass is I/O.** So #373's third item was built
+//!    against that finding rather than its own estimate — the parallel map
+//!    covers the reads and stats, not merely the classifiers it named, which
+//!    would have won 7-13 ms of a 151-604 ms pass.
+//!
+//!    **Read `staged / whole` accordingly.** The staged sum is serial and the
+//!    whole pass is parallel, so the ratio now runs *above* 100% by design:
+//!    that excess is the parallel speedup, and a ratio back near 100% means the
+//!    pass has fallen back to running serially.
 //!
 //! 2. **The serialized parse point** — `SalsaHandle::get_patterns` driven in a
 //!    serial loop, which is exactly what `run_magic_batch_once` does per vendor
@@ -213,12 +224,13 @@ fn main() {
 
     // Every stage below is measured `PASSES` times and reported at its
     // MINIMUM. A single timed run of a 400 ms filesystem-heavy pass varies
-    // 10-15% between runs on an idle machine — enough to swing `staged / whole`
-    // from 89% to 110% with no code change at all, which would make the
-    // cross-platform comparison this bench exists for unreadable. The minimum
-    // is the run least disturbed by the scheduler and by other processes, and
-    // it is the standard choice for exactly this reason: noise only ever adds
-    // time, so the floor is the honest figure.
+    // 10-15% between runs on an idle machine — measured on the serial pass,
+    // that was enough to swing `staged / whole` from 89% to 110% with no code
+    // change at all, which would make the cross-platform comparison this bench
+    // exists for unreadable. The minimum is the run least disturbed by the
+    // scheduler and by other processes, and it is the standard choice for
+    // exactly this reason: noise only ever adds time, so the floor is the
+    // honest figure.
     let mut best = StageTimings::worst();
     let mut corpus = Corpus::default();
     for _ in 0..PASSES {
@@ -576,11 +588,13 @@ fn notes() {
     println!("    every stage is levelled. A cold first start reads slower.");
     println!("  * No command scan cache is passed, so every command-wanted file");
     println!("    is read. That is the cold-cache shape a composer install makes.");
-    println!("  * 'staged / whole' is a sanity check on the decomposition, not a");
-    println!("    precision instrument. Near 100% means the stages account for");
-    println!("    the real function; far from it means the split is not to be");
-    println!("    trusted. It does not need to be exact for the CPU-vs-I/O");
-    println!("    conclusion, which is an order of magnitude, not a few percent.");
+    println!("  * The stages above are timed SERIALLY, one file at a time, but");
+    println!("    the whole pass now runs across the bounded worker pool (#373).");
+    println!("    So 'staged / whole' is expected ABOVE 100%, and the excess IS");
+    println!("    the parallel speedup: 100% means the pass has fallen back to");
+    println!("    running serially. The stage split still says where the work");
+    println!("    is — that conclusion is an order of magnitude, not a few");
+    println!("    percent — but the ratio is no longer a decomposition check.");
 }
 
 /// Register a handle against `root` the way production does, so

--- a/laravel-lsp/src/command_index.rs
+++ b/laravel-lsp/src/command_index.rs
@@ -258,13 +258,13 @@ pub fn consider_project_commands(
 
 /// Index one file, reusing the cached verdict when its mtime is unchanged.
 fn consider_file(scan: &mut CommandScan, cache: Option<&CommandScanCache>, path: &Path) {
-    if try_cached(scan, cache, path) {
+    let CacheVerdict::NeedsSource { mtime } = try_cached(scan, cache, path) else {
         return;
-    }
+    };
     let Ok(content) = std::fs::read_to_string(path) else {
         return;
     };
-    record_source(scan, path, &content);
+    record_source(scan, path, mtime, &content);
 }
 
 /// A file's mtime as `(secs, nanos)`, matching the disk cache's representation.
@@ -341,21 +341,42 @@ pub fn command_entry_for(path: &Path, content: &str) -> Option<CommandEntry> {
     })
 }
 
+/// What [`try_cached`] decided about a file, and the mtime it already read.
+///
+/// The mtime is carried out rather than discarded because the caller's next
+/// step, [`record_source`], needs exactly that value. Returning a bare `bool`
+/// meant `record_source` stat'd the same file a second time — 225 ms of the
+/// 962 ms shared vendor pass on a Windows runner, and about a fifth of it on
+/// Linux and macOS too (issue #373).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheVerdict {
+    /// Nothing more to do: either the scan cache answered for this file, or it
+    /// could not be stat'd and so is deliberately left unread.
+    Settled,
+    /// The file still has to be read. `mtime` is the value already on hand, to
+    /// be handed straight to [`record_source`].
+    NeedsSource { mtime: (u64, u32) },
+}
+
 /// Try to satisfy `path` from the scan cache, recording its verdict when the
-/// mtime is unchanged. Returns `true` when the file needs no read.
+/// mtime is unchanged.
 ///
 /// Public so the combined warm-start pass in [`crate::vendor_scan`] can decide
 /// whether a vendor file still has to be read for the command index before it
 /// reads it for the route index.
-pub fn try_cached(scan: &mut CommandScan, cache: Option<&CommandScanCache>, path: &Path) -> bool {
+pub fn try_cached(
+    scan: &mut CommandScan,
+    cache: Option<&CommandScanCache>,
+    path: &Path,
+) -> CacheVerdict {
     let Some(mtime) = file_mtime(path) else {
         // Unstattable: do not read it either. A verdict recorded without a
         // usable mtime could never be validated, so it would be trusted
         // forever.
-        return true;
+        return CacheVerdict::Settled;
     };
     let Some(verdict) = cache.and_then(|c| c.verdict(path, mtime)) else {
-        return false;
+        return CacheVerdict::NeedsSource { mtime };
     };
     if let Some(entry) = verdict {
         scan.index.insert_entry(entry.clone());
@@ -366,14 +387,21 @@ pub fn try_cached(scan: &mut CommandScan, cache: Option<&CommandScanCache>, path
         path: path.to_path_buf(),
         entry: verdict.cloned(),
     });
-    true
+    CacheVerdict::Settled
 }
 
-/// Record a freshly-read file's verdict into `scan`.
-pub fn record_source(scan: &mut CommandScan, path: &Path, content: &str) {
-    let Some(mtime) = file_mtime(path) else {
-        return;
-    };
+/// Record a freshly-read file's verdict into `scan`, stamped with the `mtime`
+/// [`try_cached`] already read for it.
+///
+/// **Taking the mtime rather than reading one is also the more careful
+/// choice**, not only the cheaper one. The stored mtime is what the next scan
+/// validates the verdict against, and `content` was read *after* this mtime
+/// was taken. Stamping the entry with a *later* mtime — which is what a fresh
+/// stat here would produce — would mean a file rewritten between the read and
+/// the stat gets its stale verdict stored under the new mtime, and the next
+/// scan trusts it. Stamping the earlier mtime can only cause a needless
+/// re-read, never a stale hit.
+pub fn record_source(scan: &mut CommandScan, path: &Path, mtime: (u64, u32), content: &str) {
     let entry = command_entry_for(path, content);
     if let Some(entry) = entry.clone() {
         scan.index.insert_entry(entry);

--- a/laravel-lsp/src/command_index.rs
+++ b/laravel-lsp/src/command_index.rs
@@ -358,6 +358,47 @@ pub enum CacheVerdict {
     NeedsSource { mtime: (u64, u32) },
 }
 
+/// What the scan cache and one `metadata` call say about a file, as **owned**
+/// data that no longer borrows the cache.
+///
+/// The pure half of [`try_cached`], split out so the shared vendor pass in
+/// [`crate::vendor_scan`] can run the stat and the lookup for every file across
+/// a worker pool and fold the answers afterwards (issue #373). Owned rather
+/// than borrowed because a verdict outlives the parallel map that produced it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrepassVerdict {
+    /// The file could not be stat'd, so it is deliberately left unread and
+    /// **nothing at all is recorded** for it. A verdict stored without a usable
+    /// mtime could never be validated against a later scan, so it would be
+    /// trusted forever.
+    Unstattable,
+    /// The cache answered. Fold with [`record_verdict`]; no read is needed.
+    Settled {
+        mtime: (u64, u32),
+        entry: Option<CommandEntry>,
+    },
+    /// The file still has to be read. `mtime` is the value already on hand, to
+    /// be handed straight to [`record_verdict`] once the content is classified.
+    NeedsSource { mtime: (u64, u32) },
+}
+
+/// Stat `path` and ask `cache` about it, without touching a scan.
+///
+/// Does no I/O beyond the single `metadata` call, and takes no `&mut`, so it is
+/// safe to call concurrently for many files.
+pub fn cached_verdict(cache: Option<&CommandScanCache>, path: &Path) -> PrepassVerdict {
+    let Some(mtime) = file_mtime(path) else {
+        return PrepassVerdict::Unstattable;
+    };
+    match cache.and_then(|c| c.verdict(path, mtime)) {
+        Some(entry) => PrepassVerdict::Settled {
+            mtime,
+            entry: entry.cloned(),
+        },
+        None => PrepassVerdict::NeedsSource { mtime },
+    }
+}
+
 /// Try to satisfy `path` from the scan cache, recording its verdict when the
 /// mtime is unchanged.
 ///
@@ -369,25 +410,38 @@ pub fn try_cached(
     cache: Option<&CommandScanCache>,
     path: &Path,
 ) -> CacheVerdict {
-    let Some(mtime) = file_mtime(path) else {
-        // Unstattable: do not read it either. A verdict recorded without a
-        // usable mtime could never be validated, so it would be trusted
-        // forever.
-        return CacheVerdict::Settled;
-    };
-    let Some(verdict) = cache.and_then(|c| c.verdict(path, mtime)) else {
-        return CacheVerdict::NeedsSource { mtime };
-    };
-    if let Some(entry) = verdict {
-        scan.index.insert_entry(entry.clone());
+    match cached_verdict(cache, path) {
+        PrepassVerdict::Unstattable => CacheVerdict::Settled,
+        PrepassVerdict::NeedsSource { mtime } => CacheVerdict::NeedsSource { mtime },
+        PrepassVerdict::Settled { mtime, entry } => {
+            record_verdict(scan, path, mtime, entry);
+            CacheVerdict::Settled
+        }
+    }
+}
+
+/// Fold one already-classified verdict into `scan`.
+///
+/// **The single place the scan's order-dependence lives.**
+/// [`CommandIndex::insert_entry`] keeps the first file inserted on a same-tier
+/// duplicate, and `scan.files` is persisted in insertion order, so every
+/// producer — the cache hit, the fresh read, and the parallel vendor pass —
+/// must funnel through here *in walk order*.
+pub fn record_verdict(
+    scan: &mut CommandScan,
+    path: &Path,
+    mtime: (u64, u32),
+    entry: Option<CommandEntry>,
+) {
+    if let Some(entry) = entry.clone() {
+        scan.index.insert_entry(entry);
     }
     scan.files.push(ScannedFile {
         mtime_secs: mtime.0,
         mtime_nanos: mtime.1,
         path: path.to_path_buf(),
-        entry: verdict.cloned(),
+        entry,
     });
-    CacheVerdict::Settled
 }
 
 /// Record a freshly-read file's verdict into `scan`, stamped with the `mtime`
@@ -402,16 +456,7 @@ pub fn try_cached(
 /// scan trusts it. Stamping the earlier mtime can only cause a needless
 /// re-read, never a stale hit.
 pub fn record_source(scan: &mut CommandScan, path: &Path, mtime: (u64, u32), content: &str) {
-    let entry = command_entry_for(path, content);
-    if let Some(entry) = entry.clone() {
-        scan.index.insert_entry(entry);
-    }
-    scan.files.push(ScannedFile {
-        mtime_secs: mtime.0,
-        mtime_nanos: mtime.1,
-        path: path.to_path_buf(),
-        entry,
-    });
+    record_verdict(scan, path, mtime, command_entry_for(path, content));
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/command_index/tests.rs
+++ b/laravel-lsp/src/command_index/tests.rs
@@ -529,3 +529,78 @@ fn an_unusable_cache_degrades_to_a_full_scan() {
         "fixture check — nothing has been saved for this project yet"
     );
 }
+
+// === the mtime hand-off between try_cached and record_source (issue #373) ===
+//
+// `record_source` used to stat the file itself, so every file that needed a
+// read was stat'd twice: once by `try_cached` deciding it needed reading, and
+// again by `record_source` stamping the entry. That second stat was 225 ms of
+// the shared vendor pass's 962 ms on a Windows CI runner, and roughly a fifth
+// of it on Linux and macOS. It is now passed across instead.
+
+/// The value `record_source` stamps must be the one it is HANDED. Fabricating
+/// an mtime the file cannot possibly have is what makes this discriminate: a
+/// `record_source` that stats again would record the real one and go red.
+#[test]
+fn record_source_stamps_the_mtime_it_is_given_rather_than_statting_again() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = tmp.path().join("MakeThing.php");
+    let src = command_class("MakeThing", "make:thing");
+    std::fs::write(&path, &src).unwrap();
+
+    // Far in the past, and a nanosecond value a real filesystem stamp would
+    // not land on by chance.
+    let fabricated = (1_234_567_890u64, 424_242u32);
+    let real = file_mtime(&path).expect("the fixture is stattable");
+    assert_ne!(
+        real, fabricated,
+        "fixture check — the fabricated mtime must differ from the real one"
+    );
+
+    let mut scan = CommandScan::default();
+    record_source(&mut scan, &path, fabricated, &src);
+
+    let recorded = scan
+        .files
+        .iter()
+        .find(|f| f.path == path)
+        .expect("the file is recorded");
+    assert_eq!(
+        (recorded.mtime_secs, recorded.mtime_nanos),
+        fabricated,
+        "record_source stat'd the file instead of using the mtime it was given"
+    );
+}
+
+/// The other half: the mtime `try_cached` hands out has to be the file's real
+/// one, or every entry would be stamped with a value the next scan can never
+/// match and the disk cache would never hit.
+#[test]
+fn try_cached_hands_back_the_real_mtime_when_a_read_is_needed() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = tmp.path().join("MakeThing.php");
+    std::fs::write(&path, command_class("MakeThing", "make:thing")).unwrap();
+
+    let mut scan = CommandScan::default();
+    let verdict = try_cached(&mut scan, None, &path);
+
+    let CacheVerdict::NeedsSource { mtime } = verdict else {
+        panic!("no cache was passed, so the file must need its source read");
+    };
+    assert_eq!(mtime, file_mtime(&path).expect("the fixture is stattable"));
+}
+
+/// An unstattable path is settled, not read. A verdict recorded without a
+/// usable mtime could never be validated, so it would be trusted forever.
+#[test]
+fn try_cached_settles_a_path_it_cannot_stat() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let missing = tmp.path().join("does/not/exist/Ghost.php");
+
+    let mut scan = CommandScan::default();
+    assert_eq!(try_cached(&mut scan, None, &missing), CacheVerdict::Settled);
+    assert!(
+        scan.files.is_empty(),
+        "an unstattable path must leave no verdict behind"
+    );
+}

--- a/laravel-lsp/src/lib.rs
+++ b/laravel-lsp/src/lib.rs
@@ -95,6 +95,7 @@ pub mod magic_dependency_index;
 pub mod magic_disk_cache;
 pub mod markdown_safety;
 pub mod naming;
+pub mod parallelism;
 pub mod parse_budget;
 pub mod parser;
 pub mod path_containment;

--- a/laravel-lsp/src/main.rs
+++ b/laravel-lsp/src/main.rs
@@ -7876,6 +7876,12 @@ impl LaravelLanguageServer {
     /// `refresh_magic_dependents` blast radius as a save, excluding the present
     /// files already refreshed here.
     async fn run_magic_batch_once(&self, batch: HashMap<PathBuf, PendingWatchedChange>) {
+        // Parse the whole batch OFF the actor thread first, so the serial pass
+        // below reads warm caches instead of parsing (issue #373). Nothing
+        // about the pass changes — it is the same loop, over the same files,
+        // in the same order.
+        self.preparse_batch_off_actor(&batch).await;
+
         let mut changed_classes: HashSet<String> = HashSet::new();
         let mut changed_views: HashSet<String> = HashSet::new();
         let mut refreshed: HashSet<PathBuf> = HashSet::new();
@@ -8007,6 +8013,143 @@ impl LaravelLanguageServer {
             changed_views.into_iter().collect(),
         )
         .await;
+    }
+
+    /// Parse every file in `batch` OFF the Salsa actor thread, in parallel,
+    /// and hand the actor finished results (issue #373).
+    ///
+    /// # The problem this removes
+    ///
+    /// `run_magic_batch_once` queries `get_patterns` per file in a serial
+    /// loop. On a cache miss that call does the file read AND the tree-sitter
+    /// parse *inside* `SalsaActor`, which is a single dedicated thread. A
+    /// `composer install` rewrites thousands of vendor files straight into
+    /// that loop, so every one of those parses queues behind the last — the
+    /// "100% of one core, sustained, for minutes" symptom from issue #80.
+    /// Measured before this change: ~600 files/sec, so a 16,000-file
+    /// dependency install spent ~26 seconds pinned to one core of a 20-core
+    /// machine (`benches/vendor_parallelism.rs`).
+    ///
+    /// The fix is not a thread count. It is to move the parse **out** of the
+    /// actor, which is how the warm-start path has always worked — a
+    /// semaphore plus a `JoinSet` of `spawn_blocking` tasks, bulk-imported at
+    /// the end. That asymmetry is exactly why cold start was fast while this
+    /// path was not.
+    ///
+    /// # Why the pass below needs no other change
+    ///
+    /// Both imports land where the serial loop already looks. Patterns go
+    /// straight into the shared `DashMap` the actor reads first, so each
+    /// `get_patterns` becomes a cache hit. Hierarchy goes into the
+    /// actor-owned index that `file_class_surfaces` reads, in one message for
+    /// the whole batch rather than one parse per file.
+    ///
+    /// `bulk_import_hierarchy` performs the same `remove_file` +
+    /// `insert_file` the actor's own miss path performs, and `insert_file`
+    /// no-ops on an empty node list, so a file that declares no class is
+    /// handled identically either way. The only divergence is that the bulk
+    /// path always drops the `class_files_snapshot` where the miss path drops
+    /// it only when a file's FQCN set changed — strictly more conservative,
+    /// and correct for a batch that is about to change many files.
+    ///
+    /// # Two exclusions, both load-bearing
+    ///
+    /// * **Files the parse budget rejects.** The pass below treats an
+    ///   excluded file exactly like a deleted one and never parses it, so
+    ///   parsing it here would do work production does not — and would drag
+    ///   back the `*.json.php` blobs and oversized files issue #371
+    ///   deliberately removed.
+    /// * **Files open in the editor.** The buffer is authoritative for an
+    ///   open file, and a disk parse would describe different text.
+    ///   `bulk_import_patterns` already refuses to overwrite an open path,
+    ///   but `bulk_import_hierarchy` has no such guard, so filtering here is
+    ///   what keeps the two imports describing the same bytes. The serial
+    ///   pass still handles these files, through the actor, exactly as before.
+    async fn preparse_batch_off_actor(&self, batch: &HashMap<PathBuf, PendingWatchedChange>) {
+        let open = self.salsa.open_buffer_paths().await;
+        let candidates: Vec<PathBuf> = batch
+            .keys()
+            .filter(|path| !open.contains(*path))
+            .filter(|path| laravel_lsp::parse_budget::skip_reason_on_disk(path).is_none())
+            .cloned()
+            .collect();
+
+        // One file has no parallelism to win, and the two bulk imports would
+        // cost more than the single actor parse they replace. Below the
+        // threshold the old path is simply the faster one.
+        if candidates.len() < 2 {
+            return;
+        }
+
+        // Bounded, with the reason in `parallelism::bounded_pool_size`. A
+        // watched-file batch fires while the user is working — often right
+        // after a `git checkout` or a `composer install` they are waiting on —
+        // so this pool must not take the machine the editor is running on.
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(
+            laravel_lsp::parallelism::bounded_pool_size(),
+        ));
+
+        type ParsedFile = (
+            PathBuf,
+            Arc<laravel_lsp::salsa_impl::ParsedPatternsData>,
+            Vec<laravel_lsp::class_hierarchy_index::ClassNode>,
+        );
+
+        let mut parse_set: tokio::task::JoinSet<Option<ParsedFile>> = tokio::task::JoinSet::new();
+        for path in candidates {
+            let permit_owner = semaphore.clone();
+            parse_set.spawn(async move {
+                let _permit = permit_owner.acquire_owned().await.ok()?;
+                let path_for_task = path.clone();
+                // tree-sitter is CPU-bound and would block the async runtime
+                // if run directly in a tokio task, so the read and the parse
+                // both go to the blocking pool — the same shape the warm pass
+                // uses.
+                let parsed = tokio::task::spawn_blocking(move || {
+                    let text = std::fs::read_to_string(&path_for_task).ok()?;
+                    Some(laravel_lsp::pattern_indexer::parse_owned_with_hierarchy(
+                        &path_for_task,
+                        &text,
+                    ))
+                })
+                .await
+                .ok()
+                .flatten()?;
+                Some((path, parsed.0, parsed.1))
+            });
+        }
+
+        // Drained in completion order, which is all this loop needs: both
+        // imports are order-independent (a `DashMap` insert and a per-file
+        // hierarchy replace), unlike the command index's same-tier tie-break
+        // elsewhere in the tree. A file that vanished between the watcher
+        // event and the read yields `None` and is dropped here — the serial
+        // pass re-reads it and takes its deletion branch, which is the one
+        // authoritative existence check.
+        let mut patterns: Vec<(PathBuf, Arc<laravel_lsp::salsa_impl::ParsedPatternsData>)> =
+            Vec::new();
+        let mut hierarchy: Vec<(PathBuf, Vec<laravel_lsp::class_hierarchy_index::ClassNode>)> =
+            Vec::new();
+        while let Some(res) = parse_set.join_next().await {
+            if let Ok(Some((path, data, nodes))) = res {
+                patterns.push((path.clone(), data));
+                hierarchy.push((path, nodes));
+            }
+        }
+
+        if patterns.is_empty() {
+            return;
+        }
+
+        // Patterns first, and the hierarchy only if they landed. The pattern
+        // import fails when no project is registered yet, and in that case the
+        // serial pass falls back to parsing in the actor — importing a
+        // hierarchy for parses the cache will not serve would leave the two
+        // describing different work.
+        if self.salsa.bulk_import_patterns(patterns).await.is_err() {
+            return;
+        }
+        let _ = self.salsa.bulk_import_hierarchy(hierarchy).await;
     }
 
     /// Read a file's authoritative content for a magic refresh: the open editor

--- a/laravel-lsp/src/parallelism.rs
+++ b/laravel-lsp/src/parallelism.rs
@@ -11,6 +11,12 @@
 //!
 //! So every pool is bounded, and bounded the same way.
 
+use std::sync::OnceLock;
+
+/// Built on first use and reused for the process lifetime — a pool is threads,
+/// and rebuilding one per call would cost more than the work it fans out.
+static POOL: OnceLock<Option<rayon::ThreadPool>> = OnceLock::new();
+
 /// Worker count for a pool that fans project-file work across cores.
 ///
 /// `min(8, max(2, available_parallelism() / 2))`, which reads as three rules:
@@ -38,6 +44,45 @@ pub fn bounded_pool_size() -> usize {
         .unwrap_or(FLOOR);
 
     half.clamp(FLOOR, CEILING)
+}
+
+/// The server's own rayon pool, built once at [`bounded_pool_size`] threads.
+///
+/// `None` only if rayon refuses to build it, which in practice means the
+/// process cannot spawn threads at all.
+fn pool() -> Option<&'static rayon::ThreadPool> {
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(bounded_pool_size())
+            .thread_name(|i| format!("laravel-lsp-cpu-{i}"))
+            .build()
+            .ok()
+    })
+    .as_ref()
+}
+
+/// Run `op` on the server's bounded rayon pool, so any `par_iter` inside it
+/// fans across [`bounded_pool_size`] threads rather than rayon's global pool.
+///
+/// **Why not the global pool.** rayon's default is one thread per core. On a
+/// 20-core workstation that is 20 threads of work; on a 4-core laptop it takes
+/// all four, and the editor competes with its own language server for the
+/// machine. The global pool is also shared with every other rayon user linked
+/// into this binary (salsa among them), so resizing it would reach past this
+/// server's own work. A dedicated pool bounds ours and leaves theirs alone.
+///
+/// Expect no speedup from this — it is a contention fix. The passes it wraps
+/// are partly I/O-bound, so the threads it removes were buying little.
+///
+/// Falls back to running `op` on the calling thread if the pool could not be
+/// built. Work inside would then reach the global pool, which is the
+/// unbounded behaviour this replaces — worse, but not wrong, and better than
+/// refusing to load the cache at all.
+pub fn install<R: Send>(op: impl FnOnce() -> R + Send) -> R {
+    match pool() {
+        Some(pool) => pool.install(op),
+        None => op(),
+    }
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/parallelism.rs
+++ b/laravel-lsp/src/parallelism.rs
@@ -1,0 +1,44 @@
+//! One bound for every worker pool in the server, and one place that says why
+//! (issue #373).
+//!
+//! The complaint that started issue #80 was a laptop overheating under
+//! sustained single-core load. Spreading that work across several cores is
+//! actually *kinder* to the machine — the same energy, less time, and the
+//! machine returns to idle sooner. The failure mode that matters is different:
+//! on a small machine, a pool that takes every core makes the editor stutter,
+//! because the editor, this server's own async runtime, and the user's other
+//! work all need a share.
+//!
+//! So every pool is bounded, and bounded the same way.
+
+/// Worker count for a pool that fans project-file work across cores.
+///
+/// `min(8, max(2, available_parallelism() / 2))`, which reads as three rules:
+///
+/// * **Never more than 8.** The warm-start parse pass settled on 8 through
+///   measurement (`MAX_CONCURRENT_PARSES` in `main.rs`) and the pass is partly
+///   I/O-bound, so threads past that buy little. This function does not change
+///   that pass — it has its own tuned semaphore and #373 does not ask to move
+///   it — it adopts its ceiling for the pools that had none.
+/// * **Never more than half the machine.** Half rather than all so the editor
+///   and the async runtime keep headroom. On a 4-core laptop this is 2, where
+///   rayon's default global pool would have taken all four.
+/// * **Never fewer than 2.** Below that there is no parallelism left to bound,
+///   and a single worker would be slower than the serial code it replaced.
+///
+/// `available_parallelism()` fails on some containerized platforms; that falls
+/// back to the floor rather than the ceiling, because a machine that cannot
+/// report its core count is more likely to be constrained than large.
+pub fn bounded_pool_size() -> usize {
+    const CEILING: usize = 8;
+    const FLOOR: usize = 2;
+
+    let half = std::thread::available_parallelism()
+        .map(|n| n.get() / 2)
+        .unwrap_or(FLOOR);
+
+    half.clamp(FLOOR, CEILING)
+}
+
+#[cfg(test)]
+mod tests;

--- a/laravel-lsp/src/parallelism/tests.rs
+++ b/laravel-lsp/src/parallelism/tests.rs
@@ -32,6 +32,7 @@ fn the_formula_halves_small_machines_and_caps_large_ones() {
         (cores / 2).clamp(2, 8)
     }
 
+    // Note the sizes below are the formula, not this machine.
     assert_eq!(bound(1), 2, "single core still gets the floor");
     assert_eq!(bound(2), 2, "two cores get the floor, not one");
     assert_eq!(bound(4), 2, "a 4-core laptop keeps half the machine free");
@@ -39,4 +40,56 @@ fn the_formula_halves_small_machines_and_caps_large_ones() {
     assert_eq!(bound(16), 8, "the ceiling binds before half does");
     assert_eq!(bound(20), 8, "an M1 Ultra is capped at the warm path's 8");
     assert_eq!(bound(128), 8, "a big server is still capped at 8");
+}
+
+/// The bound is only worth anything if the work actually lands on the bounded
+/// pool. `rayon::current_num_threads()` reports the pool the caller is running
+/// inside, so reading it through `install` is a direct check that a `par_iter`
+/// in there fans across our threads rather than rayon's global ones.
+#[test]
+fn install_runs_its_closure_on_the_bounded_pool() {
+    let inside = install(rayon::current_num_threads);
+    assert_eq!(
+        inside,
+        bounded_pool_size(),
+        "work inside install() must see the bounded pool's width"
+    );
+}
+
+/// The failure this guards is silent: dropping the `install` wrapper leaves the
+/// code compiling, passing, and quietly back on the global pool. Comparing
+/// against the width outside `install` catches that on any machine where the
+/// two differ — every machine with more than 2×8 cores, and every machine with
+/// fewer than 4.
+#[test]
+fn the_global_pool_is_not_what_the_load_pass_runs_on() {
+    let outside = rayon::current_num_threads();
+    let inside = install(rayon::current_num_threads);
+
+    if outside == bounded_pool_size() {
+        // This host's global pool happens to match the bound, so the
+        // comparison proves nothing here. The assertion above still holds it.
+        return;
+    }
+    assert_ne!(
+        inside, outside,
+        "install() handed the closure the global pool ({outside} threads)"
+    );
+}
+
+/// A pool is threads; rebuilding one per call would cost more than the work it
+/// fans out. Two calls must land on the same pool.
+#[test]
+fn the_pool_is_built_once_and_reused() {
+    let first = pool().map(|p| p.current_num_threads());
+    let second = pool().map(|p| p.current_num_threads());
+
+    assert_eq!(first, second);
+    assert!(
+        std::ptr::eq(
+            pool().expect("pool builds") as *const _,
+            pool().expect("pool builds") as *const _
+        ),
+        "each call rebuilt the pool instead of reusing the OnceLock"
+    );
 }

--- a/laravel-lsp/src/parallelism/tests.rs
+++ b/laravel-lsp/src/parallelism/tests.rs
@@ -1,0 +1,42 @@
+use super::*;
+
+/// The three rules the bound exists to enforce, checked against whatever
+/// machine the test runs on. Asserting a literal would only re-state the
+/// hardware, and would flip between a CI runner and a workstation.
+#[test]
+fn bounded_pool_size_stays_within_its_three_rules() {
+    let size = bounded_pool_size();
+
+    assert!(size >= 2, "never fewer than 2 workers, got {size}");
+    assert!(size <= 8, "never more than 8 workers, got {size}");
+
+    if let Ok(cores) = std::thread::available_parallelism() {
+        let cores = cores.get();
+        // Never more than half the machine — except where the floor lifts it,
+        // which is the point of the floor. A 2-core runner gets 2, not 1.
+        assert!(
+            size <= (cores / 2).max(2),
+            "took more than half of {cores} cores: {size}"
+        );
+    }
+}
+
+/// A 4-core laptop is the case the bound exists for: rayon's default global
+/// pool would take all four and leave the editor competing with the server.
+/// The formula has to yield 2 there, and 8 on a large workstation.
+#[test]
+fn the_formula_halves_small_machines_and_caps_large_ones() {
+    // The pure arithmetic, exercised at the sizes that matter without
+    // depending on the host's core count.
+    fn bound(cores: usize) -> usize {
+        (cores / 2).clamp(2, 8)
+    }
+
+    assert_eq!(bound(1), 2, "single core still gets the floor");
+    assert_eq!(bound(2), 2, "two cores get the floor, not one");
+    assert_eq!(bound(4), 2, "a 4-core laptop keeps half the machine free");
+    assert_eq!(bound(8), 4);
+    assert_eq!(bound(16), 8, "the ceiling binds before half does");
+    assert_eq!(bound(20), 8, "an M1 Ultra is capped at the warm path's 8");
+    assert_eq!(bound(128), 8, "a big server is still capped at 8");
+}

--- a/laravel-lsp/src/pattern_disk_cache.rs
+++ b/laravel-lsp/src/pattern_disk_cache.rs
@@ -271,10 +271,18 @@ pub fn load_into(
 /// independent mtime stat (a filesystem `metadata` call — the dominant
 /// cost on a cold FS cache) plus a position-index rebuild. Serially that
 /// was a multi-second startup stall; `into_par_iter` fans it across the
-/// rayon pool. The result is identical to a serial pass — DashMap inserts
+/// pool. The result is identical to a serial pass — DashMap inserts
 /// are lock-free, the counters are atomics, and the surfaced hierarchy is
 /// order-independent (the caller bulk-imports it as a set) — so the only
 /// observable change is that it finishes sooner.
+///
+/// The pass runs on the server's own bounded pool via
+/// [`crate::parallelism::install`], not rayon's global one (issue #373).
+/// The global pool is one thread per core, so on a 4-core laptop this
+/// stat pass took all four while the user was waiting on the editor that
+/// spawned it. Bounding it changes no result and is not expected to
+/// change the wall clock — the pass is stat-bound, so the threads it
+/// gives back were buying little. It is a contention fix.
 pub fn load_into_reporting(
     pattern_cache: &Arc<DashMap<PathBuf, (i32, Arc<ParsedPatternsData>)>>,
     project_root: &Path,
@@ -320,41 +328,44 @@ pub fn load_into_reporting(
     // doesn't matter — it's imported as a set.
     let restored = AtomicUsize::new(0);
     let dropped = AtomicUsize::new(0);
-    let hierarchy: Vec<(PathBuf, Vec<ClassNode>)> = cache
-        .entries
-        .into_par_iter()
-        .filter_map(|(path, entry)| {
-            // Stat the file. If it's gone, or its mtime differs from the
-            // cached value, drop the entry — warming will re-parse it.
-            let node_entry = match read_mtime(&path) {
-                Some((s, n)) if s == entry.mtime_secs && n == entry.mtime_nanos => {
-                    // Fresh: insert as-is. The position index isn't rebuilt
-                    // here — it's derived data (skipped on serialize, see
-                    // `ParsedPatternsData::sorted_positions`) that
-                    // `find_at_position` now builds lazily on its own first
-                    // call, so a 40k-entry warm restore no longer pays an
-                    // eager sort for every file, only the handful the cursor
-                    // actually visits.
-                    let patterns = entry.patterns;
-                    // Surface the file's hierarchy nodes so the caller can
-                    // re-import them — the index is otherwise empty on a warm
-                    // start (no parse runs for disk-restored files).
-                    let node_entry = (!entry.nodes.is_empty()).then(|| (path.clone(), entry.nodes));
-                    pattern_cache.insert(path, (0, Arc::new(patterns)));
-                    restored.fetch_add(1, Ordering::Relaxed);
-                    node_entry
+    let entries = cache.entries;
+    let hierarchy: Vec<(PathBuf, Vec<ClassNode>)> = crate::parallelism::install(|| {
+        entries
+            .into_par_iter()
+            .filter_map(|(path, entry)| {
+                // Stat the file. If it's gone, or its mtime differs from the
+                // cached value, drop the entry — warming will re-parse it.
+                let node_entry = match read_mtime(&path) {
+                    Some((s, n)) if s == entry.mtime_secs && n == entry.mtime_nanos => {
+                        // Fresh: insert as-is. The position index isn't rebuilt
+                        // here — it's derived data (skipped on serialize, see
+                        // `ParsedPatternsData::sorted_positions`) that
+                        // `find_at_position` now builds lazily on its own first
+                        // call, so a 40k-entry warm restore no longer pays an
+                        // eager sort for every file, only the handful the cursor
+                        // actually visits.
+                        let patterns = entry.patterns;
+                        // Surface the file's hierarchy nodes so the caller can
+                        // re-import them — the index is otherwise empty on a warm
+                        // start (no parse runs for disk-restored files).
+                        let node_entry =
+                            (!entry.nodes.is_empty()).then(|| (path.clone(), entry.nodes));
+                        pattern_cache.insert(path, (0, Arc::new(patterns)));
+                        restored.fetch_add(1, Ordering::Relaxed);
+                        node_entry
+                    }
+                    _ => {
+                        dropped.fetch_add(1, Ordering::Relaxed);
+                        None
+                    }
+                };
+                if let Some(p) = progress {
+                    p.done.fetch_add(1, Ordering::Relaxed);
                 }
-                _ => {
-                    dropped.fetch_add(1, Ordering::Relaxed);
-                    None
-                }
-            };
-            if let Some(p) = progress {
-                p.done.fetch_add(1, Ordering::Relaxed);
-            }
-            node_entry
-        })
-        .collect();
+                node_entry
+            })
+            .collect()
+    });
 
     LoadResult {
         restored: restored.into_inner(),

--- a/laravel-lsp/src/route_discovery.rs
+++ b/laravel-lsp/src/route_discovery.rs
@@ -216,6 +216,18 @@ pub fn collect_conventional_vendor_route_files(vendor: &VendorIndex, out: &mut R
     }
 }
 
+/// Decide whether an already-read vendor file is a route file, and at what
+/// priority, without touching an accumulator.
+///
+/// The pure half of [`accept_vendor_route_source`], split out so the shared
+/// vendor pass in [`crate::vendor_scan`] can run this per file across a worker
+/// pool and fold the answers afterwards (issue #373). Every classification
+/// still happens here, so the two callers cannot drift.
+pub fn vendor_route_verdict(path: &Path, content: &str) -> Option<(PathBuf, u8)> {
+    content_registers_named_routes(content)
+        .then(|| (path.to_path_buf(), priority_for_vendor_path(path)))
+}
+
 /// Record an already-read vendor file if its text shows route-registration
 /// shape (a router token AND a `->name(` call).
 ///
@@ -223,8 +235,8 @@ pub fn collect_conventional_vendor_route_files(vendor: &VendorIndex, out: &mut R
 /// service-provider `boot()` registrations, and Filament-style
 /// `Panel::routes(fn () => ...)` panels.
 pub fn accept_vendor_route_source(out: &mut RouteFileSet, path: &Path, content: &str) {
-    if content_registers_named_routes(content) {
-        out.promote(path.to_path_buf(), priority_for_vendor_path(path));
+    if let Some((path, priority)) = vendor_route_verdict(path, content) {
+        out.promote(path, priority);
     }
 }
 

--- a/laravel-lsp/src/salsa_impl.rs
+++ b/laravel-lsp/src/salsa_impl.rs
@@ -7023,13 +7023,22 @@ impl SalsaHandle {
     }
 
     /// Snapshot the paths of every currently open buffer as a `HashSet`,
-    /// once, for O(1) membership checks. The sole consumer is
-    /// `bulk_import_patterns`, which must not let a disk-parsed warm entry
-    /// overwrite a path the user has open (and possibly edited) — see
-    /// there. Called from async context (the warming task that calls
-    /// `bulk_import_patterns` is itself a `tokio::spawn`ed future, not the
-    /// actor thread), so a plain `.read().await` is correct here.
-    async fn open_buffer_paths(&self) -> std::collections::HashSet<PathBuf> {
+    /// once, for O(1) membership checks.
+    ///
+    /// Two consumers, both needing the same rule: a disk parse must never
+    /// overwrite what the user has open and possibly edited.
+    /// `bulk_import_patterns` applies it to its own writes (see there). The
+    /// watched-file batch's off-actor pre-parse (`preparse_batch_off_actor`
+    /// in `main.rs`, issue #373) applies it a step earlier, to decide which
+    /// files to read from disk at all — it imports patterns AND hierarchy,
+    /// and only the pattern half is guarded downstream, so an open buffer
+    /// filtered out here is what keeps the two halves describing the same
+    /// text.
+    ///
+    /// Public for that second caller. Called from async context (both callers
+    /// run inside `tokio::spawn`ed futures, not on the actor thread), so a
+    /// plain `.read().await` is correct here.
+    pub async fn open_buffer_paths(&self) -> std::collections::HashSet<PathBuf> {
         match self.documents.get() {
             Some(documents) => documents
                 .read()

--- a/laravel-lsp/src/tests/mod.rs
+++ b/laravel-lsp/src/tests/mod.rs
@@ -58,6 +58,7 @@ mod module_livewire_namespaces;
 mod module_view_namespaces;
 mod mutex_poison_recovery;
 mod nested_module_root_correction;
+mod off_actor_batch_parse;
 mod post_warm_open_buffer_guard;
 mod query_chain_completion_handler;
 mod rename_integration;

--- a/laravel-lsp/src/tests/off_actor_batch_parse.rs
+++ b/laravel-lsp/src/tests/off_actor_batch_parse.rs
@@ -1,0 +1,260 @@
+//! Equivalence of the off-actor batch pre-parse to the actor's own parse
+//! (issue #373, item 1).
+//!
+//! `run_magic_batch_once` used to query `get_patterns` per file in a serial
+//! loop, which parsed each file *inside* the single Salsa actor thread. It now
+//! parses the whole batch outside the actor first
+//! (`Backend::preparse_batch_off_actor`) and hands the actor finished results
+//! through `bulk_import_patterns` + `bulk_import_hierarchy`, so those queries
+//! become cache hits.
+//!
+//! That is only a speed change if the two producers agree. Two of them have to:
+//!
+//! * `pattern_indexer::parse_owned_with_hierarchy` (off-actor) must produce the
+//!   same `ParsedPatternsData` the actor's `handle_get_patterns` produces, or a
+//!   watched change would index a file differently from a save;
+//! * `bulk_import_hierarchy` must leave `file_class_surfaces` reporting what an
+//!   in-actor parse leaves it reporting, or the batch's surface diff — the
+//!   thing that decides which dependents get rippled — would fire on files that
+//!   did not change, or miss files that did.
+//!
+//! Each test below drives two independent actors over the same fixture, one per
+//! route, and compares them. `Backend` is private to `main.rs`, so these
+//! exercise the seam the pre-parse writes through rather than the method
+//! itself.
+
+use laravel_lsp::salsa_impl::SalsaHandle;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// A model with a base class, a trait and an interface, so the hierarchy has
+/// every edge kind `insert_file` records — a fixture that declares only a bare
+/// class would pass even if `extends` / `implements` / trait edges were dropped.
+const MODEL: &str = r#"<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Auth\Authenticatable;
+use App\Concerns\HasTeams;
+
+class User extends Model implements Authenticatable
+{
+    use HasTeams;
+
+    protected $fillable = ['name', 'email'];
+
+    public function teams()
+    {
+        return view('users.teams');
+    }
+}
+"#;
+
+fn write(path: &Path, contents: &str) -> PathBuf {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+    path.to_path_buf()
+}
+
+/// A registered handle, which is what publishes the shared pattern cache that
+/// `bulk_import_patterns` writes into. Without registration that call fails
+/// with "pattern cache not published", which is the state the production code
+/// treats as "fall back to parsing in the actor".
+async fn handle_for(root: &Path) -> SalsaHandle {
+    let handle = laravel_lsp::salsa_impl::SalsaActor::spawn();
+    handle
+        .register_config_files(root.to_path_buf(), None, None, None, None)
+        .await
+        .expect("actor registers the tempdir project root");
+    handle
+        .register_project_files(
+            root.to_path_buf(),
+            vec![PathBuf::from("app")],
+            vec![root.join("resources/views")],
+            None,
+            PathBuf::from("routes"),
+            laravel_lsp::vendor_index::VendorIndex::build(root)
+                .files()
+                .iter()
+                .map(|f| f.path.clone())
+                .collect(),
+        )
+        .await
+        .expect("actor registers the tempdir project");
+    handle
+}
+
+/// Parse off the actor exactly as `preparse_batch_off_actor` does, then import
+/// both halves — the production sequence, minus the `JoinSet` that only decides
+/// how many run at once.
+async fn import_off_actor(handle: &SalsaHandle, path: &Path) {
+    let text = fs::read_to_string(path).expect("fixture is readable");
+    let (data, nodes) = laravel_lsp::pattern_indexer::parse_owned_with_hierarchy(path, &text);
+    handle
+        .bulk_import_patterns(vec![(path.to_path_buf(), data)])
+        .await
+        .expect("pattern cache is published for a registered project");
+    handle
+        .bulk_import_hierarchy(vec![(path.to_path_buf(), nodes)])
+        .await
+        .expect("hierarchy import round-trips the actor");
+}
+
+#[tokio::test]
+async fn the_off_actor_import_leaves_the_same_class_surfaces_as_an_actor_parse() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let model = write(&root.join("app/Models/User.php"), MODEL);
+
+    // Route A: the actor parses the file itself, which is what the serial loop
+    // did before this change.
+    let in_actor = handle_for(root).await;
+    in_actor
+        .get_patterns(model.clone())
+        .await
+        .expect("actor answers")
+        .expect("the model parses");
+    let actor_surfaces = in_actor
+        .file_class_surfaces(model.clone())
+        .await
+        .expect("actor answers");
+
+    // Route B: parsed outside and imported, which is what the batch does now.
+    let off_actor = handle_for(root).await;
+    import_off_actor(&off_actor, &model).await;
+    let imported_surfaces = off_actor
+        .file_class_surfaces(model.clone())
+        .await
+        .expect("actor answers");
+
+    assert!(
+        !actor_surfaces.is_empty(),
+        "the fixture must declare a class, or this test proves nothing"
+    );
+    assert_eq!(
+        actor_surfaces, imported_surfaces,
+        "the batch's surface diff decides which dependents ripple — an \
+         off-actor parse that surfaces different signatures would ripple the \
+         wrong files"
+    );
+}
+
+#[tokio::test]
+async fn a_file_with_no_class_surfaces_empty_through_both_routes() {
+    // `insert_file` early-returns on an empty node list while the actor's miss
+    // path skips the call entirely. The two are only equivalent because of that
+    // early return, so pin it: a plain function file must surface nothing
+    // either way, and must not leave a phantom entry behind.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let helper = write(
+        &root.join("app/helpers.php"),
+        "<?php\n\nfunction app_path_helper() { return config('app.name'); }\n",
+    );
+
+    let in_actor = handle_for(root).await;
+    in_actor.get_patterns(helper.clone()).await.unwrap();
+    let actor_surfaces = in_actor.file_class_surfaces(helper.clone()).await.unwrap();
+
+    let off_actor = handle_for(root).await;
+    import_off_actor(&off_actor, &helper).await;
+    let imported_surfaces = off_actor.file_class_surfaces(helper.clone()).await.unwrap();
+
+    assert!(actor_surfaces.is_empty());
+    assert_eq!(actor_surfaces, imported_surfaces);
+}
+
+#[tokio::test]
+async fn the_off_actor_parse_extracts_what_the_actor_parse_extracts() {
+    // Compared WITHOUT going through the import, deliberately. Importing first
+    // and then reading back through `get_patterns` cannot fail: a dropped
+    // import is a cache miss, the actor parses the file itself, and the test
+    // ends up comparing the actor's parse to the actor's parse. The claim that
+    // needs pinning is that the two PRODUCERS agree, so both are called
+    // directly.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let model = write(&root.join("app/Models/User.php"), MODEL);
+
+    let in_actor = handle_for(root).await;
+    let actor_parsed = in_actor
+        .get_patterns(model.clone())
+        .await
+        .unwrap()
+        .expect("the model parses");
+
+    let text = fs::read_to_string(&model).unwrap();
+    let (off_actor_parsed, _) =
+        laravel_lsp::pattern_indexer::parse_owned_with_hierarchy(&model, &text);
+
+    // `view('users.teams')` is the observable pattern in the fixture. Comparing
+    // name AND position catches both a missing extraction and a shifted column,
+    // and position is what hover and go-to-definition navigate on — an imported
+    // entry is served to them verbatim, so a shifted column is a wrong jump.
+    let extract = |data: &laravel_lsp::salsa_impl::ParsedPatternsData| -> Vec<_> {
+        data.views
+            .iter()
+            .map(|v| (v.name.clone(), v.line, v.column, v.end_column))
+            .collect()
+    };
+
+    let actor_views = extract(&actor_parsed);
+    assert!(
+        !actor_views.is_empty(),
+        "the fixture must contain a view() call, or this test proves nothing"
+    );
+    assert_eq!(actor_views, extract(&off_actor_parsed));
+}
+
+#[tokio::test]
+async fn an_imported_entry_is_served_without_the_actor_reparsing() {
+    // The import is only a saving if the actor SERVES it. Proven by importing
+    // patterns for a path whose file no longer exists: the actor's miss path
+    // would have to read it from disk and would fail, so an answer here can
+    // only have come from the imported entry.
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let model = write(&root.join("app/Models/User.php"), MODEL);
+
+    let handle = handle_for(root).await;
+    let text = fs::read_to_string(&model).unwrap();
+    let (data, _) = laravel_lsp::pattern_indexer::parse_owned_with_hierarchy(&model, &text);
+    let expected_views = data.views.len();
+    handle
+        .bulk_import_patterns(vec![(model.clone(), data)])
+        .await
+        .expect("pattern cache is published for a registered project");
+
+    fs::remove_file(&model).expect("fixture is removable");
+
+    let served = handle
+        .get_patterns(model)
+        .await
+        .unwrap()
+        .expect("the imported entry answers for a file that is no longer on disk");
+
+    assert!(expected_views > 0, "the fixture must contain a view() call");
+    assert_eq!(served.views.len(), expected_views);
+}
+
+#[tokio::test]
+async fn an_unregistered_actor_refuses_the_pattern_import() {
+    // The pre-parse gives up when this fails, leaving the serial pass to parse
+    // in the actor. That fallback is only reachable if the failure is real, so
+    // pin that an unregistered actor rejects the import rather than silently
+    // dropping the entries.
+    let dir = tempfile::tempdir().unwrap();
+    let model = write(&dir.path().join("app/Models/User.php"), MODEL);
+
+    let bare = laravel_lsp::salsa_impl::SalsaActor::spawn();
+    let text = fs::read_to_string(&model).unwrap();
+    let (data, _) = laravel_lsp::pattern_indexer::parse_owned_with_hierarchy(&model, &text);
+
+    assert!(
+        bare.bulk_import_patterns(vec![(model, data)])
+            .await
+            .is_err(),
+        "no project registered means no published pattern cache to import into"
+    );
+}

--- a/laravel-lsp/src/vendor_scan.rs
+++ b/laravel-lsp/src/vendor_scan.rs
@@ -12,20 +12,37 @@
 //! It lives in its own module rather than inside either consumer to keep the
 //! layering acyclic: `vendor_index` is a leaf, `route_discovery` and
 //! `command_index` depend on it, and only this module depends on all three.
+//!
+//! # Shape: map in parallel, fold in order (issue #373)
+//!
+//! Both halves of the pass — the stat pre-pass and the read pass — run their
+//! per-file work across the server's bounded pool and then fold the answers
+//! sequentially. The fold is not an implementation detail: the command index
+//! resolves a same-tier duplicate to the *first file walked*, so the answers
+//! have to be applied in walk order no matter which worker produced them
+//! first. See [`map_in_parallel`].
+//!
+//! Measured on `test-project/` (16,050 vendor files, macOS, 8 workers), the
+//! whole pass went from 397.7 ms to 191.3 ms — **2.1x**. The per-stage serial
+//! timings in `benches/vendor_parallelism.rs` are unchanged either side of it
+//! (384.1 ms against 387.0 ms), which is the control: the work is the same, only
+//! its execution changed.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use rayon::prelude::*;
+
 use crate::command_disk_cache::CommandScanCache;
 use crate::command_index::{
-    consider_project_commands, record_source, try_cached, vendor_command_needs_source,
-    CacheVerdict, CommandScan,
+    cached_verdict, command_entry_for, consider_project_commands, record_verdict,
+    vendor_command_needs_source, CommandEntry, CommandScan, PrepassVerdict,
 };
 use crate::route_discovery::{
-    accept_vendor_route_source, collect_conventional_vendor_route_files,
-    collect_project_route_files, vendor_route_needs_source, RouteFile, RouteFileSet,
+    collect_conventional_vendor_route_files, collect_project_route_files,
+    vendor_route_needs_source, vendor_route_verdict, RouteFile, RouteFileSet,
 };
-use crate::vendor_index::VendorIndex;
+use crate::vendor_index::{VendorFile, VendorIndex};
 
 /// Build both vendor-derived indexes, reading each vendor file at most once.
 ///
@@ -58,37 +75,116 @@ pub fn build_route_files_and_command_index(
     // verdict check needs anyway, and saves the read for the overwhelming
     // majority whose mtime has not moved (issue #371).
     //
-    // The mtime is KEPT, not just the decision. `record_source` used to stat
-    // each file again to stamp its entry, so every file that needed a read was
-    // stat'd twice — 225 ms of this pass's 962 ms on a Windows CI runner, and
-    // about a fifth of it on Linux and macOS (issue #373, measured by
-    // `benches/vendor_parallelism.rs`). Carrying the value across removes the
-    // second stat outright.
+    // The mtime is KEPT, not just the decision, and carried to the fold below.
+    // The command side used to stat each file again to stamp its entry, so
+    // every file that needed a read was stat'd twice — 225 ms of this pass's
+    // 962 ms on a Windows CI runner, and about a fifth of it on Linux and macOS
+    // (issue #373, measured by `benches/vendor_parallelism.rs`). Carrying the
+    // value across removes the second stat outright.
+    let wanted: Vec<&VendorFile> = vendor
+        .files()
+        .iter()
+        .filter(|file| vendor_command_needs_source(&vendor_root, file))
+        .collect();
+
+    let prepass = map_in_parallel(&wanted, |file| cached_verdict(command_cache, &file.path));
+
     let mut command_needs_read: HashMap<PathBuf, (u64, u32)> = HashMap::new();
-    for file in vendor.files() {
-        if !vendor_command_needs_source(&vendor_root, file) {
-            continue;
-        }
-        if let CacheVerdict::NeedsSource { mtime } =
-            try_cached(&mut commands, command_cache, &file.path)
-        {
-            command_needs_read.insert(file.path.clone(), mtime);
+    for (file, verdict) in wanted.iter().zip(prepass) {
+        match verdict {
+            // Nothing recorded, and deliberately not read either.
+            PrepassVerdict::Unstattable => {}
+            PrepassVerdict::Settled { mtime, entry } => {
+                record_verdict(&mut commands, &file.path, mtime, entry)
+            }
+            PrepassVerdict::NeedsSource { mtime } => {
+                command_needs_read.insert(file.path.clone(), mtime);
+            }
         }
     }
 
-    vendor.for_each_source(
-        |file| vendor_route_needs_source(file) || command_needs_read.contains_key(&file.path),
-        |file, content| {
-            if vendor_route_needs_source(file) {
-                accept_vendor_route_source(&mut routes, &file.path, content);
-            }
-            if let Some(mtime) = command_needs_read.get(&file.path) {
-                record_source(&mut commands, &file.path, *mtime, content);
-            }
-        },
-    );
+    // Read pass. Same two classifiers as before, now run per file across the
+    // worker pool instead of one at a time.
+    let to_read: Vec<&VendorFile> = vendor
+        .files()
+        .iter()
+        .filter(|file| {
+            vendor_route_needs_source(file) || command_needs_read.contains_key(&file.path)
+        })
+        .collect();
+
+    let classified = map_in_parallel(&to_read, |file| {
+        // An unreadable file contributes nothing to either index — the same
+        // outcome `VendorIndex::for_each_source` produces by skipping its
+        // `visit` call, and the behaviour
+        // `for_each_source_skips_an_unreadable_file_without_failing` pins.
+        let content = std::fs::read_to_string(&file.path).ok()?;
+        Some(FileVerdict {
+            route: vendor_route_needs_source(file)
+                .then(|| vendor_route_verdict(&file.path, &content))
+                .flatten(),
+            // `Some(None)` and `None` are different answers: the first is "the
+            // command side read this file and it declares nothing", which must
+            // still be recorded so the next scan can skip it; the second is
+            // "the command side never wanted this file".
+            command: command_needs_read
+                .contains_key(&file.path)
+                .then(|| command_entry_for(&file.path, &content)),
+        })
+    });
+
+    for (file, verdict) in to_read.iter().zip(classified) {
+        let Some(verdict) = verdict else { continue };
+        if let Some((path, priority)) = verdict.route {
+            routes.promote(path, priority);
+        }
+        if let Some(entry) = verdict.command {
+            let mtime = command_needs_read[&file.path];
+            record_verdict(&mut commands, &file.path, mtime, entry);
+        }
+    }
 
     (routes.into_files(), commands)
+}
+
+/// What one file's read pass decided, for both consumers.
+struct FileVerdict {
+    /// `Some` when the file is a route file, carrying the priority to promote
+    /// it at. `None` covers both "not a route file" and "the route side did
+    /// not want this file" — the two are indistinguishable to the fold, which
+    /// does nothing in either case.
+    route: Option<(PathBuf, u8)>,
+    /// `Some` when the command side wanted this file, carrying its
+    /// classification (`None` inside means "declares no command").
+    command: Option<Option<CommandEntry>>,
+}
+
+/// Run `classify` over `files` on the server's bounded pool, returning one
+/// answer per file **in input order**.
+///
+/// Order is the whole reason this is a `map` and a separate fold rather than a
+/// `for_each` mutating shared state. `CommandIndex::insert_entry` keeps the
+/// first file walked on a same-tier duplicate — pinned by
+/// `shared_vendor_walk_keeps_the_same_winner_on_a_same_tier_collision` — and
+/// `CommandScan::files` is persisted in insertion order. rayon's indexed
+/// `collect` preserves input order regardless of which worker finished when,
+/// so folding the result sequentially reproduces the walk exactly.
+///
+/// The route side needs no such care (`RouteFileSet` merges by maximum
+/// priority, so it is order-independent by construction), but it rides the
+/// same pass because both classifiers want the same bytes.
+///
+/// **The reads run here too, not just the CPU.** Issue #373 proposed
+/// parallelizing only the classifiers, on an estimate that they dominated the
+/// pass. Measurement said otherwise — they are 2-5% of it, and the stat and
+/// read stages are 93-96% — so parallelizing the classifiers alone would have
+/// chased the smallest term. Per-worker memory stays at one file's content
+/// because each worker reads, classifies and drops before taking the next.
+fn map_in_parallel<T: Send>(
+    files: &[&VendorFile],
+    classify: impl Fn(&VendorFile) -> T + Sync,
+) -> Vec<T> {
+    crate::parallelism::install(|| files.par_iter().map(|file| classify(file)).collect())
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/vendor_scan.rs
+++ b/laravel-lsp/src/vendor_scan.rs
@@ -13,36 +13,53 @@
 //! layering acyclic: `vendor_index` is a leaf, `route_discovery` and
 //! `command_index` depend on it, and only this module depends on all three.
 //!
-//! # Shape: map in parallel, fold in order (issue #373)
+//! # Shape: classify, then fold in walk order
 //!
-//! Both halves of the pass — the stat pre-pass and the read pass — run their
-//! per-file work across the server's bounded pool and then fold the answers
-//! sequentially. The fold is not an implementation detail: the command index
-//! resolves a same-tier duplicate to the *first file walked*, so the answers
-//! have to be applied in walk order no matter which worker produced them
-//! first. See [`map_in_parallel`].
+//! Each file is classified by a pure function ([`cached_verdict`],
+//! [`vendor_route_verdict`], [`command_entry_for`]) and the answer is folded
+//! into the accumulators by [`record_verdict`] and `RouteFileSet::promote`.
+//! The fold order is not an implementation detail: `CommandIndex::insert_entry`
+//! resolves a same-tier duplicate to the **first file walked**, and
+//! `CommandScan::files` is persisted in insertion order and replayed into
+//! `insert_entry` on the next startup. Both are pinned by tests in this module.
 //!
-//! Measured on `test-project/` (16,050 vendor files, macOS, 8 workers), the
-//! whole pass went from 397.7 ms to 191.3 ms — **2.1x**. The per-stage serial
-//! timings in `benches/vendor_parallelism.rs` are unchanged either side of it
-//! (384.1 ms against 387.0 ms), which is the control: the work is the same, only
-//! its execution changed.
+//! # This pass is deliberately NOT parallel (issue #373)
+//!
+//! #373 asked for the classifiers to be parallelized, estimating ~0.5 s. It was
+//! built, measured, and removed. Keep it serial unless the numbers below change:
+//!
+//! * **In isolation it looks like a clear win** — 397.7 ms → 191.3 ms, 2.1x, on
+//!   16,050 vendor files. `benches/vendor_parallelism.rs` still measures the
+//!   stage split that predicts it.
+//! * **It bought nothing on cold start, because this pass is not on the
+//!   critical path.** It finishes about a second before the warm parse pass
+//!   does, and startup ends when that parse ends. Swept against real startup,
+//!   serial was 2,701 ms and the best parallel width 2,684 ms — 17 ms, against
+//!   a ~137 ms run-to-run noise floor.
+//! * **It cost 33-236 ms on warm start**, where the command disk cache settles
+//!   nearly every file in the pre-pass. With almost nothing left to read, the
+//!   parallelized work is ~16k `metadata` calls, which get *worse* with more
+//!   threads and contend with `pattern_disk_cache`'s own load.
+//! * **On the shared bounded pool it also stole ~139 ms from the parse pass**
+//!   it runs beside.
+//!
+//! The bench misleads here because it passes `None` for the command scan cache,
+//! so it always measures the all-reads shape — which production sees only on a
+//! cold start, the one regime where this pass's duration does not matter.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use rayon::prelude::*;
-
 use crate::command_disk_cache::CommandScanCache;
 use crate::command_index::{
     cached_verdict, command_entry_for, consider_project_commands, record_verdict,
-    vendor_command_needs_source, CommandEntry, CommandScan, PrepassVerdict,
+    vendor_command_needs_source, CommandScan, PrepassVerdict,
 };
 use crate::route_discovery::{
     collect_conventional_vendor_route_files, collect_project_route_files,
     vendor_route_needs_source, vendor_route_verdict, RouteFile, RouteFileSet,
 };
-use crate::vendor_index::{VendorFile, VendorIndex};
+use crate::vendor_index::VendorIndex;
 
 /// Build both vendor-derived indexes, reading each vendor file at most once.
 ///
@@ -81,17 +98,12 @@ pub fn build_route_files_and_command_index(
     // 962 ms on a Windows CI runner, and about a fifth of it on Linux and macOS
     // (issue #373, measured by `benches/vendor_parallelism.rs`). Carrying the
     // value across removes the second stat outright.
-    let wanted: Vec<&VendorFile> = vendor
-        .files()
-        .iter()
-        .filter(|file| vendor_command_needs_source(&vendor_root, file))
-        .collect();
-
-    let prepass = map_in_parallel(&wanted, |file| cached_verdict(command_cache, &file.path));
-
     let mut command_needs_read: HashMap<PathBuf, (u64, u32)> = HashMap::new();
-    for (file, verdict) in wanted.iter().zip(prepass) {
-        match verdict {
+    for file in vendor.files() {
+        if !vendor_command_needs_source(&vendor_root, file) {
+            continue;
+        }
+        match cached_verdict(command_cache, &file.path) {
             // Nothing recorded, and deliberately not read either.
             PrepassVerdict::Unstattable => {}
             PrepassVerdict::Settled { mtime, entry } => {
@@ -103,88 +115,30 @@ pub fn build_route_files_and_command_index(
         }
     }
 
-    // Read pass. Same two classifiers as before, now run per file across the
-    // worker pool instead of one at a time.
-    let to_read: Vec<&VendorFile> = vendor
-        .files()
-        .iter()
-        .filter(|file| {
-            vendor_route_needs_source(file) || command_needs_read.contains_key(&file.path)
-        })
-        .collect();
-
-    let classified = map_in_parallel(&to_read, |file| {
-        // An unreadable file contributes nothing to either index — the same
-        // outcome `VendorIndex::for_each_source` produces by skipping its
-        // `visit` call, and the behaviour
-        // `for_each_source_skips_an_unreadable_file_without_failing` pins.
-        let content = std::fs::read_to_string(&file.path).ok()?;
-        Some(FileVerdict {
-            route: vendor_route_needs_source(file)
-                .then(|| vendor_route_verdict(&file.path, &content))
-                .flatten(),
-            // `Some(None)` and `None` are different answers: the first is "the
-            // command side read this file and it declares nothing", which must
-            // still be recorded so the next scan can skip it; the second is
-            // "the command side never wanted this file".
-            command: command_needs_read
-                .contains_key(&file.path)
-                .then(|| command_entry_for(&file.path, &content)),
-        })
-    });
-
-    for (file, verdict) in to_read.iter().zip(classified) {
-        let Some(verdict) = verdict else { continue };
-        if let Some((path, priority)) = verdict.route {
-            routes.promote(path, priority);
-        }
-        if let Some(entry) = verdict.command {
-            let mtime = command_needs_read[&file.path];
-            record_verdict(&mut commands, &file.path, mtime, entry);
-        }
-    }
+    // Read pass: classify each file, then fold the verdict, in walk order.
+    vendor.for_each_source(
+        |file| vendor_route_needs_source(file) || command_needs_read.contains_key(&file.path),
+        |file, content| {
+            if vendor_route_needs_source(file) {
+                if let Some((path, priority)) = vendor_route_verdict(&file.path, content) {
+                    routes.promote(path, priority);
+                }
+            }
+            // Reached only for a file the command side asked for, so the
+            // "declares nothing" verdict is recorded here too — that is what
+            // lets the next scan skip the file rather than re-read it.
+            if let Some(mtime) = command_needs_read.get(&file.path) {
+                record_verdict(
+                    &mut commands,
+                    &file.path,
+                    *mtime,
+                    command_entry_for(&file.path, content),
+                );
+            }
+        },
+    );
 
     (routes.into_files(), commands)
-}
-
-/// What one file's read pass decided, for both consumers.
-struct FileVerdict {
-    /// `Some` when the file is a route file, carrying the priority to promote
-    /// it at. `None` covers both "not a route file" and "the route side did
-    /// not want this file" — the two are indistinguishable to the fold, which
-    /// does nothing in either case.
-    route: Option<(PathBuf, u8)>,
-    /// `Some` when the command side wanted this file, carrying its
-    /// classification (`None` inside means "declares no command").
-    command: Option<Option<CommandEntry>>,
-}
-
-/// Run `classify` over `files` on the server's bounded pool, returning one
-/// answer per file **in input order**.
-///
-/// Order is the whole reason this is a `map` and a separate fold rather than a
-/// `for_each` mutating shared state. `CommandIndex::insert_entry` keeps the
-/// first file walked on a same-tier duplicate — pinned by
-/// `shared_vendor_walk_keeps_the_same_winner_on_a_same_tier_collision` — and
-/// `CommandScan::files` is persisted in insertion order. rayon's indexed
-/// `collect` preserves input order regardless of which worker finished when,
-/// so folding the result sequentially reproduces the walk exactly.
-///
-/// The route side needs no such care (`RouteFileSet` merges by maximum
-/// priority, so it is order-independent by construction), but it rides the
-/// same pass because both classifiers want the same bytes.
-///
-/// **The reads run here too, not just the CPU.** Issue #373 proposed
-/// parallelizing only the classifiers, on an estimate that they dominated the
-/// pass. Measurement said otherwise — they are 2-5% of it, and the stat and
-/// read stages are 93-96% — so parallelizing the classifiers alone would have
-/// chased the smallest term. Per-worker memory stays at one file's content
-/// because each worker reads, classifies and drops before taking the next.
-fn map_in_parallel<T: Send>(
-    files: &[&VendorFile],
-    classify: impl Fn(&VendorFile) -> T + Sync,
-) -> Vec<T> {
-    crate::parallelism::install(|| files.par_iter().map(|file| classify(file)).collect())
 }
 
 #[cfg(test)]

--- a/laravel-lsp/src/vendor_scan.rs
+++ b/laravel-lsp/src/vendor_scan.rs
@@ -13,12 +13,13 @@
 //! layering acyclic: `vendor_index` is a leaf, `route_discovery` and
 //! `command_index` depend on it, and only this module depends on all three.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::command_disk_cache::CommandScanCache;
 use crate::command_index::{
-    consider_project_commands, record_source, try_cached, vendor_command_needs_source, CommandScan,
+    consider_project_commands, record_source, try_cached, vendor_command_needs_source,
+    CacheVerdict, CommandScan,
 };
 use crate::route_discovery::{
     accept_vendor_route_source, collect_conventional_vendor_route_files,
@@ -56,23 +57,33 @@ pub fn build_route_files_and_command_index(
     // opened for it. Costs one `metadata` per command-wanted file, which the
     // verdict check needs anyway, and saves the read for the overwhelming
     // majority whose mtime has not moved (issue #371).
-    let mut command_needs_read: HashSet<PathBuf> = HashSet::new();
+    //
+    // The mtime is KEPT, not just the decision. `record_source` used to stat
+    // each file again to stamp its entry, so every file that needed a read was
+    // stat'd twice — 225 ms of this pass's 962 ms on a Windows CI runner, and
+    // about a fifth of it on Linux and macOS (issue #373, measured by
+    // `benches/vendor_parallelism.rs`). Carrying the value across removes the
+    // second stat outright.
+    let mut command_needs_read: HashMap<PathBuf, (u64, u32)> = HashMap::new();
     for file in vendor.files() {
-        if vendor_command_needs_source(&vendor_root, file)
-            && !try_cached(&mut commands, command_cache, &file.path)
+        if !vendor_command_needs_source(&vendor_root, file) {
+            continue;
+        }
+        if let CacheVerdict::NeedsSource { mtime } =
+            try_cached(&mut commands, command_cache, &file.path)
         {
-            command_needs_read.insert(file.path.clone());
+            command_needs_read.insert(file.path.clone(), mtime);
         }
     }
 
     vendor.for_each_source(
-        |file| vendor_route_needs_source(file) || command_needs_read.contains(&file.path),
+        |file| vendor_route_needs_source(file) || command_needs_read.contains_key(&file.path),
         |file, content| {
             if vendor_route_needs_source(file) {
                 accept_vendor_route_source(&mut routes, &file.path, content);
             }
-            if command_needs_read.contains(&file.path) {
-                record_source(&mut commands, &file.path, content);
+            if let Some(mtime) = command_needs_read.get(&file.path) {
+                record_source(&mut commands, &file.path, *mtime, content);
             }
         },
     );

--- a/laravel-lsp/src/vendor_scan/tests.rs
+++ b/laravel-lsp/src/vendor_scan/tests.rs
@@ -6,11 +6,13 @@
 //! 1. **Identical output.** Sharing the read must not change either index.
 //! 2. **Fewer reads.** If it did not, the module would be pure overhead.
 //!
-//! #373 parallelized the pass, which adds a third: **order survives it.** The
-//! command index resolves a same-tier duplicate to the first file walked and
-//! persists `CommandScan::files` in insertion order, so a map that returned its
-//! answers out of order, or a fold that ran concurrently, would be wrong in a
-//! way no equality-of-contents assertion catches.
+//! #373 tried to parallelize the pass and backed it out on measurement, but
+//! left these behind: **the fold order is load-bearing.** The command index
+//! resolves a same-tier duplicate to the first file walked and persists
+//! `CommandScan::files` in insertion order, so a fold that reordered the walk —
+//! or ran concurrently — would be wrong in a way no equality-of-contents
+//! assertion catches. The module docs record why parallelizing this pass did
+//! not pay; these tests are what makes a second attempt safe to evaluate.
 
 use super::*;
 use crate::command_index::{build_command_index_with_vendor, CommandIndex, CommandPriority};
@@ -210,7 +212,7 @@ fn combined_pass_reads_each_vendor_file_once() {
 }
 
 // ---------------------------------------------------------------------------
-// Order survives the parallel map (issue #373)
+// The fold must reproduce walk order (issue #373)
 // ---------------------------------------------------------------------------
 
 /// A vendor tree of `n` packages that all declare the SAME command name at the
@@ -229,11 +231,11 @@ fn seed_colliding_packages(root: &Path, n: usize) {
 }
 
 #[test]
-fn the_parallel_pass_keeps_the_first_walked_winner_on_a_same_tier_collision() {
+fn the_pass_keeps_the_first_walked_winner_on_a_same_tier_collision() {
     // `CommandIndex::insert_entry` keeps the FIRST entry inserted when two
-    // declarations share a name and a tier. Folding the parallel map's output
-    // in input order is what preserves that; a `for_each` over the pool, or an
-    // unordered collect, would hand the win to whichever worker finished first.
+    // declarations share a name and a tier. Folding in walk order is what
+    // preserves that; a fold that reordered the walk, or a `for_each` over a
+    // worker pool, would hand the win to whichever file landed first.
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();
     seed_colliding_packages(root, 200);
@@ -262,11 +264,13 @@ fn the_parallel_pass_keeps_the_first_walked_winner_on_a_same_tier_collision() {
 }
 
 #[test]
-fn the_parallel_pass_is_deterministic_across_repeated_runs() {
-    // The failure mode a single run cannot see: a pass that resolves the
-    // collision by whichever worker won the race is right about half the time.
-    // Ten runs over 200 colliding files would have to lose every race the same
-    // way to pass by luck.
+fn the_pass_is_deterministic_across_repeated_runs() {
+    // The guard against reintroducing concurrency here without the ordered
+    // fold. A pass that resolves the collision by whichever worker won the race
+    // is right about half the time, and a single run cannot see that; ten runs
+    // over 200 colliding files would have to lose every race the same way to
+    // pass by luck. Verified able to fail: it reddens against a `par_iter()
+    // .for_each()` writing into a shared `Mutex<Vec<_>>`.
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();
     seed_colliding_packages(root, 200);
@@ -295,9 +299,9 @@ fn the_parallel_pass_is_deterministic_across_repeated_runs() {
 fn scanned_files_are_recorded_in_walk_order() {
     // `CommandScan::files` is what `command_disk_cache` persists, and the next
     // scan replays it into `insert_entry` — so its ORDER carries the same
-    // first-wins rule the index does. Sorting it, or letting the pool append
-    // as workers finish, would survive every contents-equality assertion here
-    // and corrupt the collision winner one startup later.
+    // first-wins rule the index does. Sorting it, or appending as a pool's
+    // workers finish, would survive every contents-equality assertion here and
+    // corrupt the collision winner one startup later.
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();
     seed_colliding_packages(root, 200);
@@ -335,6 +339,7 @@ fn a_file_that_vanishes_between_the_walk_and_the_read_contributes_nothing() {
     // in between is unstattable for the pre-pass and unreadable for the read
     // pass, and BOTH must leave the scan untouched: an entry stored without a
     // usable mtime could never be invalidated, so it would be trusted forever.
+    // `cached_verdict` returning `Unstattable` is what keeps it out.
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();
     let vendor_root = root.join("vendor");
@@ -381,11 +386,10 @@ fn a_file_that_vanishes_between_the_walk_and_the_read_contributes_nothing() {
 
 #[test]
 fn a_command_wanted_file_declaring_nothing_is_still_recorded_but_a_route_only_one_is_not() {
-    // `Some(None)` and `None` are different answers in the read pass, and the
-    // difference is the whole point of the scan cache's schema: "read, and
-    // declares nothing" must be recorded so the next scan can skip the file,
-    // while "the command side never wanted this file" must not be, or the
-    // cache would claim coverage it never had.
+    // "Read, and declares nothing" and "never wanted" are different answers,
+    // and the difference is the whole point of the scan cache's schema: the
+    // first must be recorded so the next scan can skip the file, the second
+    // must not be, or the cache would claim coverage it never had.
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();
     let write = |rel: &str, body: &str| {

--- a/laravel-lsp/src/vendor_scan/tests.rs
+++ b/laravel-lsp/src/vendor_scan/tests.rs
@@ -1,14 +1,21 @@
-//! Tests for the combined warm-start pass (issue #371).
+//! Tests for the combined warm-start pass (issues #371 and #373).
 //!
-//! Two claims to pin, and they pull in opposite directions — which is why both
-//! are needed:
+//! Two claims to pin from #371, and they pull in opposite directions — which is
+//! why both are needed:
 //!
 //! 1. **Identical output.** Sharing the read must not change either index.
 //! 2. **Fewer reads.** If it did not, the module would be pure overhead.
+//!
+//! #373 parallelized the pass, which adds a third: **order survives it.** The
+//! command index resolves a same-tier duplicate to the first file walked and
+//! persists `CommandScan::files` in insertion order, so a map that returned its
+//! answers out of order, or a fold that ran concurrently, would be wrong in a
+//! way no equality-of-contents assertion catches.
 
 use super::*;
 use crate::command_index::{build_command_index_with_vendor, CommandIndex, CommandPriority};
 use crate::route_discovery::discover_route_files_with_vendor;
+use crate::vendor_index::VendorFile;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
@@ -199,5 +206,226 @@ fn combined_pass_reads_each_vendor_file_once() {
                 || crate::command_index::vendor_command_needs_source(&vendor_root, f))
             .count(),
         "and exactly the union of what they want — never a file neither asked for"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Order survives the parallel map (issue #373)
+// ---------------------------------------------------------------------------
+
+/// A vendor tree of `n` packages that all declare the SAME command name at the
+/// SAME tier, plus a route registration in each. One same-tier collision is
+/// enough to state the rule; `n` of them is what makes an out-of-order fold
+/// almost certain to show, rather than merely possible.
+fn seed_colliding_packages(root: &Path, n: usize) {
+    let body = "<?php\nuse Illuminate\\Console\\Command;\n\
+                Route::get('/c', fn () => 'ok')->name('c');\n\
+                class Dup extends Command\n{\n    protected $signature = 'dup:cmd';\n}\n";
+    for i in 0..n {
+        let p = root.join(format!("vendor/acme/pkg{i:03}/src/Dup.php"));
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, body).unwrap();
+    }
+}
+
+#[test]
+fn the_parallel_pass_keeps_the_first_walked_winner_on_a_same_tier_collision() {
+    // `CommandIndex::insert_entry` keeps the FIRST entry inserted when two
+    // declarations share a name and a tier. Folding the parallel map's output
+    // in input order is what preserves that; a `for_each` over the pool, or an
+    // unordered collect, would hand the win to whichever worker finished first.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed_colliding_packages(root, 200);
+    let vendor = VendorIndex::build(root);
+
+    let first_walked = vendor
+        .files()
+        .iter()
+        .map(|f| f.path.clone())
+        .find(|p| p.ends_with("Dup.php"))
+        .expect("fixture check — the walk must see the colliding files");
+
+    let (_, commands) = build_route_files_and_command_index(root, &vendor, None);
+
+    assert_eq!(
+        commands.index.resolve("dup:cmd").map(|e| e.file.clone()),
+        Some(first_walked),
+        "the first file walked must win the same-tier collision"
+    );
+    assert_eq!(
+        commands.index.resolve("dup:cmd").map(|e| e.priority),
+        Some(CommandPriority::Package),
+        "fixture check — the collisions must really be same-tier, or this \
+         test proves nothing about order"
+    );
+}
+
+#[test]
+fn the_parallel_pass_is_deterministic_across_repeated_runs() {
+    // The failure mode a single run cannot see: a pass that resolves the
+    // collision by whichever worker won the race is right about half the time.
+    // Ten runs over 200 colliding files would have to lose every race the same
+    // way to pass by luck.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed_colliding_packages(root, 200);
+    let vendor = VendorIndex::build(root);
+
+    let run = || {
+        let (routes, commands) = build_route_files_and_command_index(root, &vendor, None);
+        (
+            route_pairs(&routes),
+            commands.index.resolve("dup:cmd").map(|e| e.file.clone()),
+            commands
+                .files
+                .iter()
+                .map(|f| f.path.clone())
+                .collect::<Vec<_>>(),
+        )
+    };
+
+    let first = run();
+    for i in 1..10 {
+        assert_eq!(run(), first, "run {i} disagreed with the first run");
+    }
+}
+
+#[test]
+fn scanned_files_are_recorded_in_walk_order() {
+    // `CommandScan::files` is what `command_disk_cache` persists, and the next
+    // scan replays it into `insert_entry` — so its ORDER carries the same
+    // first-wins rule the index does. Sorting it, or letting the pool append
+    // as workers finish, would survive every contents-equality assertion here
+    // and corrupt the collision winner one startup later.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    seed_colliding_packages(root, 200);
+    let vendor = VendorIndex::build(root);
+    let vendor_root = vendor.vendor_root().to_path_buf();
+
+    let (_, commands) = build_route_files_and_command_index(root, &vendor, None);
+
+    let expected: Vec<PathBuf> = vendor
+        .files()
+        .iter()
+        .filter(|f| crate::command_index::vendor_command_needs_source(&vendor_root, f))
+        .map(|f| f.path.clone())
+        .collect();
+    let recorded: Vec<PathBuf> = commands.files.iter().map(|f| f.path.clone()).collect();
+
+    assert!(
+        expected.len() >= 200,
+        "fixture check — {} files is too few to expose an ordering bug",
+        expected.len()
+    );
+    assert_eq!(
+        recorded, expected,
+        "scanned files must be recorded in walk order, not completion order"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The two "no answer" paths (issue #373)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_file_that_vanishes_between_the_walk_and_the_read_contributes_nothing() {
+    // The walk lists files; the stat and the read happen later. A file deleted
+    // in between is unstattable for the pre-pass and unreadable for the read
+    // pass, and BOTH must leave the scan untouched: an entry stored without a
+    // usable mtime could never be invalidated, so it would be trusted forever.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let vendor_root = root.join("vendor");
+    std::fs::create_dir_all(vendor_root.join("acme/pkg/src")).unwrap();
+    std::fs::write(
+        vendor_root.join("acme/pkg/src/Real.php"),
+        "<?php\nRoute::get('/r', fn () => 'ok')->name('r');\n",
+    )
+    .unwrap();
+
+    let gone = vendor_root.join("acme/pkg/src/Gone.php");
+    let vendor = VendorIndex::from_files(
+        vendor_root.clone(),
+        vec![
+            VendorFile {
+                path: gone.clone(),
+                depth: 4,
+            },
+            VendorFile {
+                path: vendor_root.join("acme/pkg/src/Real.php"),
+                depth: 4,
+            },
+        ],
+    );
+
+    let (routes, commands) = build_route_files_and_command_index(root, &vendor, None);
+
+    assert!(
+        !routes.iter().any(|f| f.path == gone),
+        "a vanished file must not enter route discovery"
+    );
+    assert!(
+        !commands.files.iter().any(|f| f.path == gone),
+        "and must not be recorded as scanned — a verdict with no valid mtime \
+         would be trusted forever"
+    );
+    assert!(
+        routes
+            .iter()
+            .any(|f| f.path == vendor_root.join("acme/pkg/src/Real.php")),
+        "fixture check — the pass must continue past the missing file"
+    );
+}
+
+#[test]
+fn a_command_wanted_file_declaring_nothing_is_still_recorded_but_a_route_only_one_is_not() {
+    // `Some(None)` and `None` are different answers in the read pass, and the
+    // difference is the whole point of the scan cache's schema: "read, and
+    // declares nothing" must be recorded so the next scan can skip the file,
+    // while "the command side never wanted this file" must not be, or the
+    // cache would claim coverage it never had.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let write = |rel: &str, body: &str| {
+        let p = root.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, body).unwrap();
+    };
+    // Wanted by the command leg, declares no command.
+    write("vendor/acme/pkg/src/Plain.php", "<?php\nclass Plain {}\n");
+    // Pruned by the command leg, still read for routes.
+    write(
+        "vendor/acme/pkg/node_modules/Bundled.php",
+        "<?php\nRoute::get('/b', fn () => 'ok')->name('b');\n",
+    );
+    let vendor = VendorIndex::build(root);
+
+    let (routes, commands) = build_route_files_and_command_index(root, &vendor, None);
+    let recorded = |rel: &str| commands.files.iter().any(|f| f.path == root.join(rel));
+
+    assert!(
+        recorded("vendor/acme/pkg/src/Plain.php"),
+        "a file the command leg read must be recorded even when it declares \
+         nothing — that verdict is what lets the next scan skip it"
+    );
+    assert!(
+        commands
+            .files
+            .iter()
+            .find(|f| f.path == root.join("vendor/acme/pkg/src/Plain.php"))
+            .is_some_and(|f| f.entry.is_none()),
+        "and recorded as declaring nothing, not as a command"
+    );
+    assert!(
+        !recorded("vendor/acme/pkg/node_modules/Bundled.php"),
+        "a file only the route leg wanted must not be recorded as scanned"
+    );
+    assert!(
+        routes
+            .iter()
+            .any(|f| f.path == root.join("vendor/acme/pkg/node_modules/Bundled.php")),
+        "fixture check — that file must really have been read, for routes"
     );
 }


### PR DESCRIPTION
Closes #373.

Step 0 was run first, as the issue asks. It confirmed item 1, and **contradicted item 3 on all three platforms** — so item 3 was replaced with what the measurement actually pointed at, per the issue's own instruction to follow the numbers.

## What landed

| Commit | Item | Effect |
|---|---|---|
| `287177c` | Step 0 | The measurement bench, plus an output-only CI step on all 3 OSes |
| `f5bde03` | 1 | Parse watched-file batches off the Salsa actor thread |
| `aaa0645` | 2 | Bound the disk-cache load to the server's own rayon pool |
| `c7aca8e` | 3 (rescoped) | Stop statting every vendor file twice |
| `da224c4` | Done-when | Before/after for item 1 |
| `0c4e9fe` | 3 (as written) | Parallelize the vendor pass — **backed out, see 3b** |
| `945fe09` | 3 (as written) | Remove the parallelism, keep the split and its tests |

## 1. The parse funnel — confirmed, and the big win

`run_magic_batch_once` queried `get_patterns` per file in a serial loop, and on a miss that call did the read AND the tree-sitter parse *inside* the single `SalsaActor` thread. The whole batch is now parsed outside the actor, on the blocking pool behind a bounded semaphore, and handed over as finished results.

Same batch, two regimes, 16,037 eligible vendor files, macOS, 8 workers:

| Batch | Serial (old) | Off-actor (new) | Speedup |
|---:|---:|---:|---:|
| 250 | 373.6 ms | 24.8 ms | **15.1x** |
| 1,000 | 1,893.2 ms | 111.7 ms | **16.9x** |
| 4,000 | 6,329.1 ms | 383.7 ms | **16.5x** |

Extrapolated to a full 16,037-file `composer install`: **~25 s → ~1.5 s**, and no longer pinned to one core.

**Cross-platform, from CI.** The same comparison runs in the 3-OS matrix (run `33764040543`, 13,278 eligible files). Those runners report **2** workers where the local machine has 8, so these are the low end of the range, not the headline:

| Platform | Workers | Batch | Serial | Off-actor | Speedup |
|---|---:|---:|---:|---:|---:|
| Windows | 2 | 250 | 1,430.1 ms | 353.3 ms | 4.0x |
| Windows | 2 | 1,000 | 2,091.2 ms | 558.1 ms | 3.7x |
| Linux | 2 | 250 | 677.0 ms | 171.2 ms | 4.0x |
| Linux | 2 | 1,000 | 2,544.4 ms | 710.6 ms | 3.6x |

This is the issue's Windows question answered directly. It asks that any parallel read path be checked there, because parallel reads on a Defender-scanned filesystem can thrash on seeks and come out slower than sequential. They do not: Windows gains as much as Linux at the same worker count, and the gain holds as the batch grows.

That is above the issue's estimated 5-8x, and above the worker count, so it needed explaining rather than reporting. The two paths differ in more than parallelism: the serial one pays an mpsc send plus a oneshot reply per file and parses through Salsa's tracked-query machinery for each, while the off-actor path calls the parser directly and sends two bulk messages for the whole batch. The win is the worker count multiplied by the per-file overhead it stops paying.

Three controls, because this is the A/B shape that fails quietly:

- a **fresh actor per regime** — sharing one would let the second read the first's imported entries and time a cache hit as a parse;
- both regimes registered, both given the same untimed prewarm request;
- the **new path is timed first**, so any residual filesystem-cache advantage falls to the old one and the speedup is a floor. Reversing the order moved the smallest batch 17.5x → 15.1x and left the other two unchanged, so it is not a page-cache artifact.

## 2. Every pool bounded

`pattern_disk_cache`'s freshness pass fanned across rayon's **global** pool, one thread per core: 20 threads on a workstation, all four on a laptop whose editor spawned it. It now runs on a dedicated pool of `min(8, max(2, available_parallelism() / 2))`.

A dedicated pool rather than a resized global one — the global pool is shared with every other rayon user linked in, salsa included, and `build_global` can only be called once. **No speedup is expected or claimed**: the pass is stat-bound, so the threads it gives back were buying little. It is a contention fix.

## 3a. Item 3's estimate was wrong, and the measurement found something better

The issue estimated the shared vendor pass was mostly classifier CPU, worth ~0.5 s from parallelizing. Measured on the same 13,284-file CI tree:

| Stage | Linux | macOS | Windows |
|---|---:|---:|---:|
| walk | 44.0 ms | 526.7 ms | 130.3 ms |
| pre-pass **stat** | 51.6 ms | 49.0 ms | **255.1 ms** |
| read | 93.0 ms | 205.4 ms | 450.1 ms |
| classify: route (CPU) | 3.5 ms | 3.6 ms | 4.4 ms |
| classify: command | 45.2 ms | 34.7 ms | 239.0 ms |
| ↳ of which **stat** | 36.9 ms | 30.1 ms | **225.3 ms** |
| **parallelizable CPU** | **6.1%** | **2.8%** | **1.9%** |

Classifier CPU is 1.9%-6.1% of the pass everywhere. Parallelizing it as specified would win 8-18 ms of a 198-962 ms pass, at the cost of a fold-in-order accumulator and a tie-break hazard.

The stats were the story. **Every file that needed a read was stat'd twice** — once by `try_cached` deciding it needed reading, then again by `record_source` stamping the entry. `try_cached` now returns `CacheVerdict::NeedsSource { mtime }` and `record_source` takes that value. Both double-statting call paths are fixed by it.

| | before | after | attributable saving |
|---|---:|---:|---:|
| Windows `classify: command` | 239.00 ms | **7.63 ms** | **231 ms** |
| Linux `classify: command` | 45.24 ms | **6.22 ms** | **39 ms** |

Corroborated independently: the bench still times the removed stat and measures it at 235.76 ms (Windows) and 18.93 ms (Linux), matching the stage deltas.

**It is also the more careful stamp.** The stored mtime is what the next scan validates against, and the content is read *after* the pre-pass stat. Stamping a *later* mtime — what a fresh stat produced — means a file rewritten between the read and the stat gets its stale verdict stored under the new mtime, and the next scan trusts it. Stamping the earlier one can only cause a needless re-read.

## 3b. Then item 3 as literally specified was built, measured, and removed

The rescope above was accepted on the stage split, but the specified change was never actually tried. It has now been tried, in `0c4e9fe`, and backed out in `945fe09`. The result is worth the two commits of history:

| Measurement | Result |
|---|---:|
| The pass, in isolation (`benches/vendor_parallelism.rs`) | 397.7 ms → **191.3 ms, 2.1x** |
| Real cold startup | 2,698 → **3,449 ms** |
| Real warm startup | 978 → **1,363 ms** |

Faster at the pass, and materially slower at the thing the user waits for. A worker-count sweep — one temporary env knob, one release build, four settings against real startup — separated the causes:

| Workers | Cold total | Cold `parse` stage | Warm total |
|---|---:|---:|---:|
| 1 (serial) | 2,701 ms | 1,798 ms | **989 ms** |
| 2 (private pool) | 2,689 ms | 1,794 ms | 1,022 ms |
| 4 (private pool) | **2,684 ms** | 1,791 ms | 1,090 ms |
| 8 (shared pool, as built) | 2,835 ms | 1,930 ms | 1,225 ms |

- **Cold: the pass is not on the critical path.** It finishes about a second before the warm parse pass it runs beside, and startup ends when that parse ends. The best parallel width beats serial by 17 ms against a ~137 ms noise floor.
- **Warm: there is almost nothing to read.** The command disk cache settles nearly every file in the stat pre-pass, so the parallel work is ~16k `metadata` calls. Those get monotonically worse with more threads and contend with `pattern_disk_cache`'s own load.
- **The shared pool also cost the parse pass ~139 ms.** A private 2-4 thread pool fixes that and still gains nothing.

**Why the bench said otherwise, which is the transferable part.** It passes `None` for the command scan cache, so it always measures the all-reads shape, and it runs the pass alone. Production sees the all-reads shape only on a cold start — the one regime where this pass's duration does not reach the total. The bench measured the only case where parallelism helps the pass, and that is the case where helping the pass does not help the user. Both blind spots are now written into its module docs.

**What was kept.** The parallelism is gone; the split it required is not. `cached_verdict` → `PrepassVerdict`, `record_verdict` and `vendor_route_verdict` are pure, and `try_cached`, `record_source` and `accept_vendor_route_source` route through them — so the ordering rule has one owner. Five mutation-verified tests pin it, because that rule is subtle and a future attempt should not have to rediscover it:

- `insert_entry` keeps the first file walked on a same-tier duplicate;
- `CommandScan::files` is persisted in insertion order and replayed into `insert_entry` on the next startup, so its order carries the same rule one startup later.

Startup after the revert, same harness: cold 2,740 ms against `main`'s 2,769 ms, warm 1,096 ms against 1,061 ms. Both inside the noise floor — parity restored.

**This is not a verdict on parallelism generally.** Item 1 parallelized the parse funnel in this same PR and won 15-17x. The rule that separates them is whether the work is on the critical path: the parse funnel is what everything waits for, and this pass is not.

**What would reopen it:** the pass becoming the critical path; slow storage (there is no Windows or spinning-disk hardware here, and item 1 measured parallel reads at 4.0x on the Windows runner, so the cold read-heavy shape there is genuinely unmeasured); or the warm command scan cache ceasing to cover the pass.

## Startup: before and after

The done-when list asks for one aggregate covering startup as well as the batch. **Startup does not move, cold or warm.** That is the expected result for what landed, and it is measured rather than assumed.

`origin/main` (`b8f2995`, which already contains #374) against this branch, both release builds, `test-project/` at 16,051 vendor PHP files, macOS. Startup is timed from the server's first log line to the last of `pattern cache warmed`, `Vendor rescan complete` and `App rescan complete`. Those three run concurrently, so the aggregate is the last of them, not their sum.

| Regime | Before | After | Delta | Spread within one binary |
|---|---:|---:|---:|---:|
| Cold cache | 2,701.5 ms | 2,729.9 ms | +28.4 ms | 137 ms |
| Warm cache | 1,025.3 ms | 999.5 ms | −25.8 ms | 136 ms |

Both deltas are a fifth of the spread across a single binary's own three runs. Nothing moved in either direction.

Why that is the right outcome:

- **Item 2 claims no speedup, and shows none.** It changes which threads do the work, not how much work there is. What this measures is that it costs nothing either, which was the only open risk in it.
- **Item 3a's saving is real but below this instrument's floor on macOS.** The stat dedup is worth ~30 ms here, against 137 ms of startup variance. On Windows the same change is worth 231 ms and would clear the floor comfortably — there is no Windows hardware outside CI to run this harness on, so that stays a CI-log number.
- **Item 1 is not a startup path.** It fires on watched-file batches, which is what the section 1 tables measure.

Method, and its limits:

- The **after** binary was measured first at every regime, so any residual filesystem-cache advantage falls to **before**.
- Each regime discarded one untimed levelling run, then timed three and kept the minimum.
- Cold wiped the project's whole LSP cache directory. Warm ran against the cache the cold run had just written.
- No document is opened. A `didOpen` costs ~400 ms of diagnostics work that interleaves with indexing and is not what the issue means by startup.
- **These are not comparable to the issue's 1.86 s and 1.19 s.** Those were measured at `60e15cb`, before #374 landed, with a different harness. Only the before/after pair in each row here is like-for-like.

## The CI step

`cargo bench --bench vendor_parallelism` runs in the existing 3-OS matrix job. **Output only** — it asserts nothing about timings, so it can only fail on a genuine panic, and a runner without a `vendor/` tree prints a skip notice and exits 0. It runs in the matrix because the read-vs-CPU split is exactly what varies by platform, and this is the only place the project has Windows and Linux hardware.

## Honest caveats

- **Whole-pass before/after totals mix two changes.** The before-numbers were single-run; the after-numbers are best-of-3. Linux's `read` stage moved 93.02 → 46.59 ms purely from that. The dedup's attributable saving is the `classify: command` delta above, not the full whole-pass drop.
- **The bench needed a variance fix to be readable.** A single timed run varied 10-15%, enough to swing `staged / whole` from 88.9% to 109.8% with no code change. Stages are now the minimum of 3 runs, which puts the ratio at 98.3-99.2% across all three platforms — the decomposition accounts for the real function.
- **Measurement 2 times the funnel, not the whole batch.** `Backend` is private to `main.rs`, so the registration diff, surface diff and dependent ripple are excluded. The bench also *copies* `preparse_batch_off_actor` rather than calling it, for the same reason — a real maintenance hazard, labelled as one in the source.
- **The startup aggregate cannot resolve item 3 on macOS.** A ~30 ms saving does not clear 137 ms of run-to-run variance. The stage-level `classify: command` delta is the number that carries item 3, not the startup row.
- **macOS CI's 527 ms walk is a runner-filesystem outlier** (Linux does the same walk in 44 ms), not something this PR addresses.
- **Reads are warm-page-cache throughout.** A genuinely cold first start reads slower than the `read` row.

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-features` clean; 3,765 tests pass.
- Every item has a test. Two mutation-verified: making `bulk_import_hierarchy` skip its insert turns the surface-equivalence test red, and reintroducing the stat in `record_source` turns the mtime-stamp test red.
- One test was rewritten after it turned out not to discriminate — comparing an imported entry against a re-read cannot fail, because a dropped import is a cache miss and the actor parses the file anyway. It now compares the two producers directly.
- CI green on Linux, macOS and Windows.


